### PR TITLE
Support parsing OpenGauss create/alter index sql

### DIFF
--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacketTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacketTest.java
@@ -59,14 +59,14 @@ class PostgreSQLDataRowPacketTest {
     
     @Test
     void assertWriteWithNull() {
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singletonList(null));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(null));
         actual.write(payload);
         verify(payload).writeInt4(0xFFFFFFFF);
     }
     
     @Test
     void assertWriteWithBytes() {
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singletonList(new byte[]{'a'}));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(new byte[]{'a'}));
         actual.write(payload);
         verify(payload).writeInt4(new byte[]{'a'}.length);
         verify(payload).writeBytes(new byte[]{'a'});
@@ -75,7 +75,7 @@ class PostgreSQLDataRowPacketTest {
     @Test
     void assertWriteWithSQLXML() throws SQLException {
         when(sqlxml.getString()).thenReturn("value");
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singletonList(sqlxml));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(sqlxml));
         actual.write(payload);
         byte[] valueBytes = "value".getBytes(StandardCharsets.UTF_8);
         verify(payload).writeInt4(valueBytes.length);
@@ -84,8 +84,8 @@ class PostgreSQLDataRowPacketTest {
     
     @Test
     void assertWriteWithString() {
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singletonList("value"));
-        assertThat(actual.getData(), is(Collections.singletonList("value")));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton("value"));
+        assertThat(actual.getData(), is(Collections.singleton("value")));
         actual.write(payload);
         byte[] valueBytes = "value".getBytes(StandardCharsets.UTF_8);
         verify(payload).writeInt4(valueBytes.length);
@@ -95,14 +95,14 @@ class PostgreSQLDataRowPacketTest {
     @Test
     void assertWriteWithSQLXML4Error() throws SQLException {
         when(sqlxml.getString()).thenThrow(new SQLException("mock"));
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singletonList(sqlxml));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(sqlxml));
         assertThrows(RuntimeException.class, () -> actual.write(payload));
         verify(payload, times(0)).writeStringEOF(any());
     }
     
     @Test
     void assertWriteBinaryNull() {
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singletonList(new BinaryCell(PostgreSQLColumnType.INT4, null)));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(new BinaryCell(PostgreSQLColumnType.INT4, null)));
         actual.write(payload);
         verify(payload).writeInt2(1);
         verify(payload).writeInt4(0xFFFFFFFF);
@@ -111,7 +111,7 @@ class PostgreSQLDataRowPacketTest {
     @Test
     void assertWriteBinaryInt4() {
         final int value = 12345678;
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singletonList(new BinaryCell(PostgreSQLColumnType.INT4, value)));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(new BinaryCell(PostgreSQLColumnType.INT4, value)));
         actual.write(payload);
         verify(payload).writeInt2(1);
         verify(payload).writeInt4(4);

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLRowDescriptionPacketTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLRowDescriptionPacketTest.java
@@ -41,7 +41,7 @@ class PostgreSQLRowDescriptionPacketTest {
     @Test
     void assertWrite() {
         PostgreSQLColumnDescription description = new PostgreSQLColumnDescription("name", 1, Types.VARCHAR, 4, null);
-        PostgreSQLRowDescriptionPacket packet = new PostgreSQLRowDescriptionPacket(Collections.singletonList(description));
+        PostgreSQLRowDescriptionPacket packet = new PostgreSQLRowDescriptionPacket(Collections.singleton(description));
         packet.write(payload);
         verify(payload, times(2)).writeInt2(1);
         verify(payload).writeStringNul("name");

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptIndexColumnTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptIndexColumnTokenGenerator.java
@@ -89,6 +89,6 @@ public final class EncryptIndexColumnTokenGenerator implements CollectionSQLToke
     }
     
     private Collection<Projection> getColumnProjections(final String columnName, final QuoteCharacter quoteCharacter) {
-        return Collections.singletonList(new ColumnProjection(null, new IdentifierValue(columnName, quoteCharacter), null, databaseType));
+        return Collections.singleton(new ColumnProjection(null, new IdentifierValue(columnName, quoteCharacter), null, databaseType));
     }
 }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptPredicateColumnTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptPredicateColumnTokenGenerator.java
@@ -142,6 +142,6 @@ public final class EncryptPredicateColumnTokenGenerator implements CollectionSQL
     }
     
     private Collection<Projection> createColumnProjections(final String columnName, final QuoteCharacter quoteCharacter) {
-        return Collections.singletonList(new ColumnProjection(null, new IdentifierValue(columnName, quoteCharacter), null, databaseType));
+        return Collections.singleton(new ColumnProjection(null, new IdentifierValue(columnName, quoteCharacter), null, databaseType));
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/checker/EncryptRuleConfigurationCheckerTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/checker/EncryptRuleConfigurationCheckerTest.java
@@ -48,8 +48,8 @@ class EncryptRuleConfigurationCheckerTest {
         EncryptRuleConfiguration result = mock(EncryptRuleConfiguration.class);
         when(result.getEncryptors()).thenReturn(Collections.singletonMap("aes_encryptor", mock(AlgorithmConfiguration.class)));
         EncryptColumnRuleConfiguration columnRuleConfig = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_cipher", "aes_encryptor"));
-        Collection<EncryptColumnRuleConfiguration> columns = Collections.singletonList(columnRuleConfig);
-        when(result.getTables()).thenReturn(Collections.singletonList(new EncryptTableRuleConfiguration("t_encrypt", columns)));
+        Collection<EncryptColumnRuleConfiguration> columns = Collections.singleton(columnRuleConfig);
+        when(result.getTables()).thenReturn(Collections.singleton(new EncryptTableRuleConfiguration("t_encrypt", columns)));
         return result;
     }
     
@@ -65,8 +65,8 @@ class EncryptRuleConfigurationCheckerTest {
         EncryptRuleConfiguration result = mock(EncryptRuleConfiguration.class);
         when(result.getEncryptors()).thenReturn(Collections.emptyMap());
         EncryptColumnRuleConfiguration columnRuleConfig = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_cipher", "aes_encryptor"));
-        Collection<EncryptColumnRuleConfiguration> columns = Collections.singletonList(columnRuleConfig);
-        when(result.getTables()).thenReturn(Collections.singletonList(new EncryptTableRuleConfiguration("t_encrypt", columns)));
+        Collection<EncryptColumnRuleConfiguration> columns = Collections.singleton(columnRuleConfig);
+        when(result.getTables()).thenReturn(Collections.singleton(new EncryptTableRuleConfiguration("t_encrypt", columns)));
         return result;
     }
     
@@ -82,9 +82,9 @@ class EncryptRuleConfigurationCheckerTest {
         EncryptRuleConfiguration result = mock(EncryptRuleConfiguration.class);
         when(result.getEncryptors()).thenReturn(Collections.emptyMap());
         EncryptColumnRuleConfiguration columnRuleConfig = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_cipher", "aes_encryptor"));
-        Collection<EncryptColumnRuleConfiguration> columns = Collections.singletonList(columnRuleConfig);
+        Collection<EncryptColumnRuleConfiguration> columns = Collections.singleton(columnRuleConfig);
         columnRuleConfig.setAssistedQuery(new EncryptColumnItemRuleConfiguration("user_assisted", "aes_assisted_encryptor"));
-        when(result.getTables()).thenReturn(Collections.singletonList(new EncryptTableRuleConfiguration("t_encrypt", columns)));
+        when(result.getTables()).thenReturn(Collections.singleton(new EncryptTableRuleConfiguration("t_encrypt", columns)));
         return result;
     }
     
@@ -100,9 +100,9 @@ class EncryptRuleConfigurationCheckerTest {
         EncryptRuleConfiguration result = mock(EncryptRuleConfiguration.class);
         when(result.getEncryptors()).thenReturn(Collections.emptyMap());
         EncryptColumnRuleConfiguration columnRuleConfig = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_cipher", "aes_encryptor"));
-        Collection<EncryptColumnRuleConfiguration> columns = Collections.singletonList(columnRuleConfig);
+        Collection<EncryptColumnRuleConfiguration> columns = Collections.singleton(columnRuleConfig);
         columnRuleConfig.setLikeQuery(new EncryptColumnItemRuleConfiguration("user_like", "like_cn_encryptor"));
-        when(result.getTables()).thenReturn(Collections.singletonList(new EncryptTableRuleConfiguration("t_encrypt", columns)));
+        when(result.getTables()).thenReturn(Collections.singleton(new EncryptTableRuleConfiguration("t_encrypt", columns)));
         return result;
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dal/show/DecoratedEncryptShowColumnsMergedResultTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dal/show/DecoratedEncryptShowColumnsMergedResultTest.java
@@ -135,7 +135,7 @@ class DecoratedEncryptShowColumnsMergedResultTest {
     
     private DecoratedEncryptShowColumnsMergedResult createDecoratedEncryptShowColumnsMergedResult(final MergedResult mergedResult, final EncryptRule encryptRule) {
         ShowColumnsStatementContext showColumnsStatementContext = mock(ShowColumnsStatementContext.class);
-        when(showColumnsStatementContext.getAllTables()).thenReturn(Collections.singletonList(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_encrypt")))));
+        when(showColumnsStatementContext.getAllTables()).thenReturn(Collections.singleton(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_encrypt")))));
         return new DecoratedEncryptShowColumnsMergedResult(mergedResult, showColumnsStatementContext, encryptRule);
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dal/show/DecoratedEncryptShowCreateTableMergedResultTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dal/show/DecoratedEncryptShowCreateTableMergedResultTest.java
@@ -72,7 +72,7 @@ class DecoratedEncryptShowCreateTableMergedResultTest {
                         + "`user_id_assisted` VARCHAR(100) NOT NULL, `order_id` VARCHAR(30) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
         EncryptColumnRuleConfiguration columnRuleConfig = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_id_cipher", "foo_encryptor"));
         columnRuleConfig.setAssistedQuery(new EncryptColumnItemRuleConfiguration("user_id_assisted", "foo_assist_query_encryptor"));
-        DecoratedEncryptShowCreateTableMergedResult actual = createDecoratedEncryptShowCreateTableMergedResult(mergedResult, mockEncryptRule(Collections.singletonList(columnRuleConfig)));
+        DecoratedEncryptShowCreateTableMergedResult actual = createDecoratedEncryptShowCreateTableMergedResult(mergedResult, mockEncryptRule(Collections.singleton(columnRuleConfig)));
         assertTrue(actual.next());
         assertThat(actual.getValue(2, String.class),
                 is("CREATE TABLE `t_encrypt` (`id` INT NOT NULL, `user_id` VARCHAR(100) NOT NULL, `order_id` VARCHAR(30) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;"));
@@ -86,7 +86,7 @@ class DecoratedEncryptShowCreateTableMergedResultTest {
                         + "`user_id_like` VARCHAR(100) NOT NULL, `order_id` VARCHAR(30) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
         EncryptColumnRuleConfiguration columnRuleConfig = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_id_cipher", "foo_encryptor"));
         columnRuleConfig.setLikeQuery(new EncryptColumnItemRuleConfiguration("user_id_like", "foo_like_encryptor"));
-        DecoratedEncryptShowCreateTableMergedResult actual = createDecoratedEncryptShowCreateTableMergedResult(mergedResult, mockEncryptRule(Collections.singletonList(columnRuleConfig)));
+        DecoratedEncryptShowCreateTableMergedResult actual = createDecoratedEncryptShowCreateTableMergedResult(mergedResult, mockEncryptRule(Collections.singleton(columnRuleConfig)));
         assertTrue(actual.next());
         assertThat(actual.getValue(2, String.class),
                 is("CREATE TABLE `t_encrypt` (`id` INT NOT NULL, `user_id` VARCHAR(100) NOT NULL, `order_id` VARCHAR(30) NOT NULL,"
@@ -129,7 +129,7 @@ class DecoratedEncryptShowCreateTableMergedResultTest {
         IdentifierValue identifierValue = new IdentifierValue("t_encrypt");
         TableNameSegment tableNameSegment = new TableNameSegment(1, 4, identifierValue);
         SimpleTableSegment simpleTableSegment = new SimpleTableSegment(tableNameSegment);
-        when(sqlStatementContext.getAllTables()).thenReturn(Collections.singletonList(simpleTableSegment));
+        when(sqlStatementContext.getAllTables()).thenReturn(Collections.singleton(simpleTableSegment));
         when(sqlStatementContext.getDatabaseType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
         return new DecoratedEncryptShowCreateTableMergedResult(mergedResult, sqlStatementContext, encryptRule);
     }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dal/show/MergedEncryptShowColumnsMergedResultTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dal/show/MergedEncryptShowColumnsMergedResultTest.java
@@ -135,7 +135,7 @@ class MergedEncryptShowColumnsMergedResultTest {
     
     private MergedEncryptShowColumnsMergedResult createMergedEncryptColumnsMergedResult(final QueryResult queryResult, final EncryptRule encryptRule) {
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class);
-        when(sqlStatementContext.getAllTables()).thenReturn(Collections.singletonList(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_encrypt")))));
+        when(sqlStatementContext.getAllTables()).thenReturn(Collections.singleton(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_encrypt")))));
         return new MergedEncryptShowColumnsMergedResult(queryResult, sqlStatementContext, encryptRule);
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dal/show/MergedEncryptShowCreateTableMergedResultTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dal/show/MergedEncryptShowCreateTableMergedResultTest.java
@@ -71,7 +71,7 @@ class MergedEncryptShowCreateTableMergedResultTest {
                         + "`user_id_assisted` VARCHAR(100) NOT NULL, `order_id` VARCHAR(30) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
         EncryptColumnRuleConfiguration columnRuleConfig = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_id_cipher", "foo_encryptor"));
         columnRuleConfig.setAssistedQuery(new EncryptColumnItemRuleConfiguration("user_id_assisted", "foo_assist_query_encryptor"));
-        MergedEncryptShowCreateTableMergedResult actual = createMergedEncryptShowCreateTableMergedResult(queryResult, mockEncryptRule(Collections.singletonList(columnRuleConfig)));
+        MergedEncryptShowCreateTableMergedResult actual = createMergedEncryptShowCreateTableMergedResult(queryResult, mockEncryptRule(Collections.singleton(columnRuleConfig)));
         assertTrue(actual.next());
         assertThat(actual.getValue(2, String.class),
                 is("CREATE TABLE `t_encrypt` (`id` INT NOT NULL, `user_id` VARCHAR(100) NOT NULL, `order_id` VARCHAR(30) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;"));
@@ -85,7 +85,7 @@ class MergedEncryptShowCreateTableMergedResultTest {
                         + "`user_id_like` VARCHAR(100) NOT NULL, `order_id` VARCHAR(30) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
         EncryptColumnRuleConfiguration columnRuleConfig = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_id_cipher", "foo_encryptor"));
         columnRuleConfig.setLikeQuery(new EncryptColumnItemRuleConfiguration("user_id_like", "foo_like_encryptor"));
-        MergedEncryptShowCreateTableMergedResult actual = createMergedEncryptShowCreateTableMergedResult(queryResult, mockEncryptRule(Collections.singletonList(columnRuleConfig)));
+        MergedEncryptShowCreateTableMergedResult actual = createMergedEncryptShowCreateTableMergedResult(queryResult, mockEncryptRule(Collections.singleton(columnRuleConfig)));
         assertTrue(actual.next());
         assertThat(actual.getValue(2, String.class),
                 is("CREATE TABLE `t_encrypt` (`id` INT NOT NULL, `user_id` VARCHAR(100) NOT NULL, `order_id` VARCHAR(30) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;"));
@@ -108,7 +108,7 @@ class MergedEncryptShowCreateTableMergedResultTest {
         IdentifierValue identifierValue = new IdentifierValue("t_encrypt");
         TableNameSegment tableNameSegment = new TableNameSegment(1, 4, identifierValue);
         SimpleTableSegment simpleTableSegment = new SimpleTableSegment(tableNameSegment);
-        when(sqlStatementContext.getAllTables()).thenReturn(Collections.singletonList(simpleTableSegment));
+        when(sqlStatementContext.getAllTables()).thenReturn(Collections.singleton(simpleTableSegment));
         when(sqlStatementContext.getDatabaseType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
         return new MergedEncryptShowCreateTableMergedResult(queryResult, sqlStatementContext, encryptRule);
     }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/parameter/EncryptParameterRewriterBuilderTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/parameter/EncryptParameterRewriterBuilderTest.java
@@ -44,7 +44,7 @@ class EncryptParameterRewriterBuilderTest {
         EncryptRule encryptRule = mock(EncryptRule.class, RETURNS_DEEP_STUBS);
         when(encryptRule.findEncryptTable("t_order").isPresent()).thenReturn(true);
         SQLStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_order"));
+        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singleton("t_order"));
         Collection<ParameterRewriter> actual = new EncryptParameterRewriterBuilder(
                 encryptRule, DefaultDatabase.LOGIC_NAME, Collections.singletonMap("test", mock(ShardingSphereSchema.class)), sqlStatementContext, Collections.emptyList()).getParameterRewriters();
         assertThat(actual.size(), is(1));
@@ -55,7 +55,7 @@ class EncryptParameterRewriterBuilderTest {
     void assertGetParameterRewritersWhenPredicateIsNotNeedRewrite() {
         EncryptRule encryptRule = mock(EncryptRule.class, RETURNS_DEEP_STUBS);
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_order"));
+        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singleton("t_order"));
         when(sqlStatementContext.getWhereSegments()).thenReturn(Collections.emptyList());
         assertTrue(new EncryptParameterRewriterBuilder(encryptRule,
                 DefaultDatabase.LOGIC_NAME, Collections.singletonMap("test", mock(ShardingSphereSchema.class)), sqlStatementContext, Collections.emptyList()).getParameterRewriters().isEmpty());

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/pojo/EncryptPredicateEqualRightValueTokenTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/pojo/EncryptPredicateEqualRightValueTokenTest.java
@@ -39,7 +39,7 @@ class EncryptPredicateEqualRightValueTokenTest {
     
     @Test
     void assertToStringWithPlaceholderWithoutTableOwnerWithEqual() {
-        EncryptPredicateEqualRightValueToken actual = new EncryptPredicateEqualRightValueToken(0, 0, Collections.emptyMap(), Collections.singletonList(0));
+        EncryptPredicateEqualRightValueToken actual = new EncryptPredicateEqualRightValueToken(0, 0, Collections.emptyMap(), Collections.singleton(0));
         assertThat(actual.toString(), is("?"));
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/pojo/EncryptPredicateInRightValueTokenTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/pojo/EncryptPredicateInRightValueTokenTest.java
@@ -40,7 +40,7 @@ class EncryptPredicateInRightValueTokenTest {
     
     @Test
     void assertToStringWithPlaceholderWithoutTableOwnerWithIn() {
-        EncryptPredicateInRightValueToken actual = new EncryptPredicateInRightValueToken(0, 0, Collections.emptyMap(), Collections.singletonList(0));
+        EncryptPredicateInRightValueToken actual = new EncryptPredicateInRightValueToken(0, 0, Collections.emptyMap(), Collections.singleton(0));
         assertThat(actual.toString(), is("(?)"));
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/EncryptTokenGenerateBuilderTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/EncryptTokenGenerateBuilderTest.java
@@ -55,8 +55,8 @@ class EncryptTokenGenerateBuilderTest {
     void assertGetSQLTokenGenerators() {
         SelectStatementContext selectStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(selectStatementContext.getAllTables().isEmpty()).thenReturn(false);
-        when(selectStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("table"));
-        when(selectStatementContext.getOrderByContext().getItems()).thenReturn(Collections.singletonList(mock(OrderByItem.class)));
+        when(selectStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singleton("table"));
+        when(selectStatementContext.getOrderByContext().getItems()).thenReturn(Collections.singleton(mock(OrderByItem.class)));
         when(selectStatementContext.getGroupByContext().getItems()).thenReturn(Collections.emptyList());
         when(selectStatementContext.getWhereSegments()).thenReturn(Collections.emptyList());
         EncryptTokenGenerateBuilder encryptTokenGenerateBuilder = new EncryptTokenGenerateBuilder(encryptRule, selectStatementContext, Collections.emptyList(), DefaultDatabase.LOGIC_NAME);

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptCreateTableTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptCreateTableTokenGeneratorTest.java
@@ -103,7 +103,7 @@ class EncryptCreateTableTokenGeneratorTest {
         CreateTableStatementContext result = mock(CreateTableStatementContext.class, RETURNS_DEEP_STUBS);
         when(result.getSqlStatement().getTable().getTableName().getIdentifier().getValue()).thenReturn("t_encrypt");
         ColumnDefinitionSegment segment = new ColumnDefinitionSegment(25, 78, new ColumnSegment(25, 42, new IdentifierValue("certificate_number")), new DataTypeSegment(), false, false);
-        when(result.getSqlStatement().getColumnDefinitions()).thenReturn(Collections.singletonList(segment));
+        when(result.getSqlStatement().getColumnDefinitions()).thenReturn(Collections.singleton(segment));
         return result;
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptProjectionTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptProjectionTokenGeneratorTest.java
@@ -88,7 +88,7 @@ class EncryptProjectionTokenGeneratorTest {
                 new IdentifierValue("mobile")));
         column.setOwner(new OwnerSegment(0, 0, new IdentifierValue("a")));
         ProjectionsSegment projections = mock(ProjectionsSegment.class);
-        when(projections.getProjections()).thenReturn(Collections.singletonList(new ColumnProjectionSegment(column)));
+        when(projections.getProjections()).thenReturn(Collections.singleton(new ColumnProjectionSegment(column)));
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getSubqueryType()).thenReturn(null);
         when(sqlStatementContext.getDatabaseType()).thenReturn(databaseType);
@@ -96,7 +96,7 @@ class EncryptProjectionTokenGeneratorTest {
         when(sqlStatementContext.getSubqueryContexts().values()).thenReturn(Collections.emptyList());
         SimpleTableSegment doctorOneTable = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("doctor1")));
         when(sqlStatementContext.getTablesContext()).thenReturn(new TablesContext(Arrays.asList(doctorTable, doctorOneTable), databaseType));
-        when(sqlStatementContext.getProjectionsContext().getProjections()).thenReturn(Collections.singletonList(new ColumnProjection("a", "mobile", null, databaseType)));
+        when(sqlStatementContext.getProjectionsContext().getProjections()).thenReturn(Collections.singleton(new ColumnProjection("a", "mobile", null, databaseType)));
         Collection<SQLToken> actual = generator.generateSQLTokens(sqlStatementContext);
         assertThat(actual.size(), is(1));
     }
@@ -110,7 +110,7 @@ class EncryptProjectionTokenGeneratorTest {
                 new IdentifierValue("mobile")));
         column.setOwner(new OwnerSegment(0, 0, new IdentifierValue("a")));
         ProjectionsSegment projections = mock(ProjectionsSegment.class);
-        when(projections.getProjections()).thenReturn(Collections.singletonList(new ColumnProjectionSegment(column)));
+        when(projections.getProjections()).thenReturn(Collections.singleton(new ColumnProjectionSegment(column)));
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getSubqueryType()).thenReturn(null);
         when(sqlStatementContext.getDatabaseType()).thenReturn(databaseType);
@@ -118,7 +118,7 @@ class EncryptProjectionTokenGeneratorTest {
         when(sqlStatementContext.getSubqueryContexts().values()).thenReturn(Collections.emptyList());
         SimpleTableSegment sameDoctorTable = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("doctor")));
         when(sqlStatementContext.getTablesContext()).thenReturn(new TablesContext(Arrays.asList(doctorTable, sameDoctorTable), databaseType));
-        when(sqlStatementContext.getProjectionsContext().getProjections()).thenReturn(Collections.singletonList(new ColumnProjection("a", "mobile", null, databaseType)));
+        when(sqlStatementContext.getProjectionsContext().getProjections()).thenReturn(Collections.singleton(new ColumnProjection("a", "mobile", null, databaseType)));
         Collection<SQLToken> actual = generator.generateSQLTokens(sqlStatementContext);
         assertThat(actual.size(), is(1));
     }
@@ -128,7 +128,7 @@ class EncryptProjectionTokenGeneratorTest {
         ColumnSegment column = new ColumnSegment(0, 0, new IdentifierValue("mobile"));
         column.setOwner(new OwnerSegment(0, 0, new IdentifierValue("doctor")));
         ProjectionsSegment projections = mock(ProjectionsSegment.class);
-        when(projections.getProjections()).thenReturn(Collections.singletonList(new ColumnProjectionSegment(column)));
+        when(projections.getProjections()).thenReturn(Collections.singleton(new ColumnProjectionSegment(column)));
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getSubqueryType()).thenReturn(null);
         when(sqlStatementContext.getDatabaseType()).thenReturn(databaseType);
@@ -137,7 +137,7 @@ class EncryptProjectionTokenGeneratorTest {
         SimpleTableSegment doctorTable = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("doctor")));
         SimpleTableSegment doctorOneTable = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("doctor1")));
         when(sqlStatementContext.getTablesContext()).thenReturn(new TablesContext(Arrays.asList(doctorTable, doctorOneTable), databaseType));
-        when(sqlStatementContext.getProjectionsContext().getProjections()).thenReturn(Collections.singletonList(new ColumnProjection("doctor", "mobile", null, databaseType)));
+        when(sqlStatementContext.getProjectionsContext().getProjections()).thenReturn(Collections.singleton(new ColumnProjection("doctor", "mobile", null, databaseType)));
         Collection<SQLToken> actual = generator.generateSQLTokens(sqlStatementContext);
         assertThat(actual.size(), is(1));
     }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rule/builder/EncryptRuleBuilderTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rule/builder/EncryptRuleBuilderTest.java
@@ -36,7 +36,7 @@ class EncryptRuleBuilderTest {
     @Test
     void assertBuild() {
         EncryptRuleConfiguration ruleConfig = mock(EncryptRuleConfiguration.class);
-        DatabaseRuleBuilder builder = OrderedSPILoader.getServices(DatabaseRuleBuilder.class, Collections.singletonList(ruleConfig)).get(ruleConfig);
+        DatabaseRuleBuilder builder = OrderedSPILoader.getServices(DatabaseRuleBuilder.class, Collections.singleton(ruleConfig)).get(ruleConfig);
         assertThat(builder.build(ruleConfig, "", Collections.emptyMap(), Collections.emptyList(), mock(InstanceContext.class)), instanceOf(EncryptRule.class));
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/yaml/swapper/YamlCompatibleEncryptRuleConfigurationSwapperTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/yaml/swapper/YamlCompatibleEncryptRuleConfigurationSwapperTest.java
@@ -47,7 +47,7 @@ class YamlCompatibleEncryptRuleConfigurationSwapperTest {
     }
     
     private CompatibleEncryptRuleConfiguration createEncryptRuleConfiguration() {
-        Collection<EncryptTableRuleConfiguration> tables = Collections.singletonList(new EncryptTableRuleConfiguration("tbl", Collections.emptyList()));
+        Collection<EncryptTableRuleConfiguration> tables = Collections.singleton(new EncryptTableRuleConfiguration("tbl", Collections.emptyList()));
         Map<String, AlgorithmConfiguration> encryptors = Collections.singletonMap("myEncryptor", new AlgorithmConfiguration("FIXTURE", new Properties()));
         return new CompatibleEncryptRuleConfiguration(tables, encryptors);
     }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/yaml/swapper/YamlEncryptRuleConfigurationSwapperTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/yaml/swapper/YamlEncryptRuleConfigurationSwapperTest.java
@@ -46,7 +46,7 @@ class YamlEncryptRuleConfigurationSwapperTest {
     }
     
     private EncryptRuleConfiguration createEncryptRuleConfiguration() {
-        Collection<EncryptTableRuleConfiguration> tables = Collections.singletonList(new EncryptTableRuleConfiguration("tbl", Collections.emptyList()));
+        Collection<EncryptTableRuleConfiguration> tables = Collections.singleton(new EncryptTableRuleConfiguration("tbl", Collections.emptyList()));
         Map<String, AlgorithmConfiguration> encryptors = Collections.singletonMap("myEncryptor", new AlgorithmConfiguration("FIXTURE", new Properties()));
         return new EncryptRuleConfiguration(tables, encryptors);
     }

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/merge/dql/MaskAlgorithmMetaDataTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/merge/dql/MaskAlgorithmMetaDataTest.java
@@ -60,7 +60,7 @@ class MaskAlgorithmMetaDataTest {
         columnProjection.setOriginalColumn(new IdentifierValue("order_id"));
         columnProjection.setOriginalTable(new IdentifierValue("t_order"));
         when(selectStatementContext.getProjectionsContext().getExpandProjections()).thenReturn(Collections.singletonList(columnProjection));
-        when(selectStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_order"));
+        when(selectStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singleton("t_order"));
         Optional<MaskAlgorithm> actual = new MaskAlgorithmMetaData(database, maskRule, selectStatementContext).findMaskAlgorithmByColumnIndex(1);
         assertTrue(actual.isPresent());
         assertThat(actual.get().getType(), is("MD5"));

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/yaml/swapper/YamlMaskRuleConfigurationSwapperTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/yaml/swapper/YamlMaskRuleConfigurationSwapperTest.java
@@ -46,7 +46,7 @@ class YamlMaskRuleConfigurationSwapperTest {
     }
     
     private MaskRuleConfiguration createMaskRuleConfiguration() {
-        Collection<MaskTableRuleConfiguration> tables = Collections.singletonList(new MaskTableRuleConfiguration("tbl", Collections.emptyList()));
+        Collection<MaskTableRuleConfiguration> tables = Collections.singleton(new MaskTableRuleConfiguration("tbl", Collections.emptyList()));
         Map<String, AlgorithmConfiguration> encryptors = Collections.singletonMap("myMaskAlgorithm", new AlgorithmConfiguration("MD5", new Properties()));
         return new MaskRuleConfiguration(tables, encryptors);
     }

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/checker/ReadwriteSplittingRuleConfigurationCheckerTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/checker/ReadwriteSplittingRuleConfigurationCheckerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -87,7 +88,7 @@ class ReadwriteSplittingRuleConfigurationCheckerTest {
     @Test
     void assertCheckWeightLoadBalanceInvalidDataSourceName() {
         ReadwriteSplittingRuleConfiguration config = mock(ReadwriteSplittingRuleConfiguration.class);
-        List<ReadwriteSplittingDataSourceRuleConfiguration> configs = Collections.singletonList(createDataSourceRuleConfig("write_ds_0", Arrays.asList("read_ds_0", "read_ds_1")));
+        Collection<ReadwriteSplittingDataSourceRuleConfiguration> configs = Collections.singleton(createDataSourceRuleConfig("write_ds_0", Arrays.asList("read_ds_0", "read_ds_1")));
         when(config.getDataSources()).thenReturn(configs);
         AlgorithmConfiguration algorithm = new AlgorithmConfiguration("WEIGHT", PropertiesBuilder.build(new Property("read_ds_2", "1"), new Property("read_ds_1", "2")));
         when(config.getLoadBalancers()).thenReturn(Collections.singletonMap("weight_ds", algorithm));
@@ -111,7 +112,7 @@ class ReadwriteSplittingRuleConfigurationCheckerTest {
         when(dataSourceConfig.getName()).thenReturn("readwrite_ds");
         when(dataSourceConfig.getWriteDataSourceName()).thenReturn("otherDatasourceName");
         when(dataSourceConfig.getReadDataSourceNames()).thenReturn(Arrays.asList("read_ds_0", "read_ds_1"));
-        when(result.getDataSources()).thenReturn(Collections.singletonList(dataSourceConfig));
+        when(result.getDataSources()).thenReturn(Collections.singleton(dataSourceConfig));
         return result;
     }
     

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/route/ReadwriteSplittingSQLRouterTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/route/ReadwriteSplittingSQLRouterTest.java
@@ -235,7 +235,7 @@ class ReadwriteSplittingSQLRouterTest {
     
     private RouteContext mockRouteContext() {
         RouteContext result = new RouteContext();
-        RouteUnit routeUnit = new RouteUnit(new RouteMapper(DATASOURCE_NAME, DATASOURCE_NAME), Collections.singletonList(new RouteMapper("table", "table_0")));
+        RouteUnit routeUnit = new RouteUnit(new RouteMapper(DATASOURCE_NAME, DATASOURCE_NAME), Collections.singleton(new RouteMapper("table", "table_0")));
         result.getRouteUnits().add(routeUnit);
         result.getRouteUnits().add(new RouteUnit(new RouteMapper(NONE_READWRITE_SPLITTING_DATASOURCE_NAME, NONE_READWRITE_SPLITTING_DATASOURCE_NAME), Collections.emptyList()));
         return result;

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/builder/ReadwriteSplittingRuleBuilderTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/builder/ReadwriteSplittingRuleBuilderTest.java
@@ -36,10 +36,8 @@ class ReadwriteSplittingRuleBuilderTest {
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Test
     void assertBuild() {
-        ReadwriteSplittingRuleConfiguration ruleConfig = new ReadwriteSplittingRuleConfiguration(
-                Collections.singletonList(new ReadwriteSplittingDataSourceRuleConfiguration("name", "writeDataSourceName",
-                        Collections.singletonList("readDataSourceName"), "loadBalancerName")),
-                Collections.emptyMap());
+        ReadwriteSplittingRuleConfiguration ruleConfig = new ReadwriteSplittingRuleConfiguration(Collections.singleton(
+                new ReadwriteSplittingDataSourceRuleConfiguration("name", "writeDataSourceName", Collections.singletonList("readDataSourceName"), "loadBalancerName")), Collections.emptyMap());
         DatabaseRuleBuilder builder = OrderedSPILoader.getServices(DatabaseRuleBuilder.class, Collections.singleton(ruleConfig)).get(ruleConfig);
         assertThat(builder.build(ruleConfig, "", Collections.emptyMap(), Collections.emptyList(), mock(InstanceContext.class)), instanceOf(ReadwriteSplittingRule.class));
     }

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/yaml/swapper/YamlReadwriteSplittingRuleConfigurationSwapperTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/yaml/swapper/YamlReadwriteSplittingRuleConfigurationSwapperTest.java
@@ -60,7 +60,7 @@ class YamlReadwriteSplittingRuleConfigurationSwapperTest {
     }
     
     private ReadwriteSplittingRuleConfiguration creatReadwriteSplittingRuleConfiguration() {
-        Collection<ReadwriteSplittingDataSourceRuleConfiguration> dataSources = Collections.singletonList(
+        Collection<ReadwriteSplittingDataSourceRuleConfiguration> dataSources = Collections.singleton(
                 new ReadwriteSplittingDataSourceRuleConfiguration("readwrite", "write_ds", Arrays.asList("read_ds_0", "read_ds_1"), "random"));
         Map<String, AlgorithmConfiguration> loadBalancers = Collections.singletonMap("myLoadBalancer", new AlgorithmConfiguration("RANDOM", new Properties()));
         return new ReadwriteSplittingRuleConfiguration(dataSources, loadBalancers);

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/engine/determiner/HintShadowAlgorithmDeterminerTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/engine/determiner/HintShadowAlgorithmDeterminerTest.java
@@ -48,7 +48,7 @@ class HintShadowAlgorithmDeterminerTest {
     private ShadowRuleConfiguration createShadowRuleConfiguration() {
         ShadowRuleConfiguration result = new ShadowRuleConfiguration();
         result.setDataSources(createDataSources());
-        result.setTables(Collections.singletonMap("t_order", new ShadowTableConfiguration(Collections.singletonList("shadow-data-source-0"), Collections.singleton("sql-hint-algorithm"))));
+        result.setTables(Collections.singletonMap("t_order", new ShadowTableConfiguration(Collections.singleton("shadow-data-source-0"), Collections.singleton("sql-hint-algorithm"))));
         result.setShadowAlgorithms(Collections.singletonMap("sql-hint-algorithm", new AlgorithmConfiguration("SQL_HINT", new Properties())));
         return result;
     }

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/engine/impl/ShadowNonDMLStatementRoutingEngineTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/engine/impl/ShadowNonDMLStatementRoutingEngineTest.java
@@ -83,8 +83,8 @@ class ShadowNonDMLStatementRoutingEngineTest {
     
     private ShadowRuleConfiguration createShadowRuleConfiguration() {
         ShadowRuleConfiguration result = new ShadowRuleConfiguration();
-        result.setDataSources(Collections.singletonList(new ShadowDataSourceConfiguration("shadow-data-source", "ds", "ds_shadow")));
-        result.setTables(Collections.singletonMap("t_order", new ShadowTableConfiguration(Collections.singletonList("shadow-data-source"), Collections.singleton("sql-hint-algorithm"))));
+        result.setDataSources(Collections.singleton(new ShadowDataSourceConfiguration("shadow-data-source", "ds", "ds_shadow")));
+        result.setTables(Collections.singletonMap("t_order", new ShadowTableConfiguration(Collections.singleton("shadow-data-source"), Collections.singleton("sql-hint-algorithm"))));
         result.setShadowAlgorithms(createShadowAlgorithms());
         return result;
     }

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/rule/ShadowRuleTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/rule/ShadowRuleTest.java
@@ -68,8 +68,8 @@ class ShadowRuleTest {
     
     private Map<String, ShadowTableConfiguration> createTables() {
         Map<String, ShadowTableConfiguration> result = new LinkedHashMap<>();
-        result.put("t_user", new ShadowTableConfiguration(Collections.singletonList("shadow-data-source-0"), createShadowAlgorithmNames("t_user")));
-        result.put("t_order", new ShadowTableConfiguration(Collections.singletonList("shadow-data-source-1"), createShadowAlgorithmNames("t_order")));
+        result.put("t_user", new ShadowTableConfiguration(Collections.singleton("shadow-data-source-0"), createShadowAlgorithmNames("t_user")));
+        result.put("t_order", new ShadowTableConfiguration(Collections.singleton("shadow-data-source-1"), createShadowAlgorithmNames("t_order")));
         return result;
     }
     

--- a/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/query/ShowShadowRuleExecutorTest.java
+++ b/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/query/ShowShadowRuleExecutorTest.java
@@ -92,8 +92,8 @@ class ShowShadowRuleExecutorTest {
         ShadowRuleConfiguration result = new ShadowRuleConfiguration();
         result.getDataSources().add(new ShadowDataSourceConfiguration("shadow_rule", "source", "shadow"));
         result.getShadowAlgorithms().put("user_id_select_match_algorithm", new AlgorithmConfiguration("REGEX_MATCH", new Properties()));
-        result.getTables().put("t_order", new ShadowTableConfiguration(Collections.singletonList("shadow_rule"), Collections.singletonList("user_id_select_match_algorithm")));
-        result.getTables().put("t_order_item", new ShadowTableConfiguration(Collections.singletonList("shadow_rule"), Collections.singletonList("user_id_select_match_algorithm")));
+        result.getTables().put("t_order", new ShadowTableConfiguration(Collections.singleton("shadow_rule"), Collections.singleton("user_id_select_match_algorithm")));
+        result.getTables().put("t_order_item", new ShadowTableConfiguration(Collections.singleton("shadow_rule"), Collections.singleton("user_id_select_match_algorithm")));
         return result;
     }
 }

--- a/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/update/AlterShadowRuleStatementUpdaterTest.java
+++ b/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/update/AlterShadowRuleStatementUpdaterTest.java
@@ -107,7 +107,7 @@ class AlterShadowRuleStatementUpdaterTest {
         ShadowAlgorithmSegment segment = new ShadowAlgorithmSegment("algorithmName", new AlgorithmSegment("name", PropertiesBuilder.build(new Property("type", "value"))));
         AlterShadowRuleStatement sqlStatement = new AlterShadowRuleStatement(Arrays.asList(
                 new ShadowRuleSegment("initRuleName1", "ds", null, Collections.singletonMap("t_order", Collections.singleton(segment))),
-                new ShadowRuleSegment("initRuleName2", "ds1", null, Collections.singletonMap("t_order_1", Collections.singletonList(segment)))));
+                new ShadowRuleSegment("initRuleName2", "ds1", null, Collections.singletonMap("t_order_1", Collections.singleton(segment)))));
         assertThrows(AlgorithmInUsedException.class, () -> updater.checkSQLStatement(database, sqlStatement, currentConfig));
     }
     
@@ -116,7 +116,7 @@ class AlterShadowRuleStatementUpdaterTest {
         ShadowAlgorithmSegment segment = new ShadowAlgorithmSegment("algorithmName", new AlgorithmSegment("name", PropertiesBuilder.build(new Property("type", "value"))));
         AlterShadowRuleStatement sqlStatement = new AlterShadowRuleStatement(Arrays.asList(
                 new ShadowRuleSegment("initRuleName1", "ds", null, Collections.singletonMap("t_order", Collections.singleton(segment))),
-                new ShadowRuleSegment("initRuleName2", "ds1", null, Collections.singletonMap("t_order_1", Collections.singletonList(segment)))));
+                new ShadowRuleSegment("initRuleName2", "ds1", null, Collections.singletonMap("t_order_1", Collections.singleton(segment)))));
         assertThrows(AlgorithmInUsedException.class, () -> updater.checkSQLStatement(database, sqlStatement, currentConfig));
     }
     
@@ -127,7 +127,7 @@ class AlterShadowRuleStatementUpdaterTest {
         ShadowAlgorithmSegment segment2 = new ShadowAlgorithmSegment("algorithmName2", new AlgorithmSegment("SQL_HINT", props));
         AlterShadowRuleStatement sqlStatement = new AlterShadowRuleStatement(Arrays.asList(
                 new ShadowRuleSegment("initRuleName1", "ds", null, Collections.singletonMap("t_order", Collections.singleton(segment1))),
-                new ShadowRuleSegment("initRuleName2", "ds1", null, Collections.singletonMap("t_order_1", Collections.singletonList(segment2)))));
+                new ShadowRuleSegment("initRuleName2", "ds1", null, Collections.singletonMap("t_order_1", Collections.singleton(segment2)))));
         updater.checkSQLStatement(database, sqlStatement, currentConfig);
     }
     
@@ -137,7 +137,7 @@ class AlterShadowRuleStatementUpdaterTest {
         ShadowAlgorithmSegment segment2 = new ShadowAlgorithmSegment("algorithmName2", new AlgorithmSegment("SQL_HINT", null));
         AlterShadowRuleStatement sqlStatement = new AlterShadowRuleStatement(Arrays.asList(
                 new ShadowRuleSegment("initRuleName1", "ds", null, Collections.singletonMap("t_order", Collections.singleton(segment1))),
-                new ShadowRuleSegment("initRuleName2", "ds1", null, Collections.singletonMap("t_order_1", Collections.singletonList(segment2)))));
+                new ShadowRuleSegment("initRuleName2", "ds1", null, Collections.singletonMap("t_order_1", Collections.singleton(segment2)))));
         updater.checkSQLStatement(database, sqlStatement, currentConfig);
     }
 }

--- a/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/update/CreateShadowRuleStatementUpdaterTest.java
+++ b/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/update/CreateShadowRuleStatementUpdaterTest.java
@@ -81,7 +81,7 @@ class CreateShadowRuleStatementUpdaterTest {
     
     @Test
     void assertExecuteWithDuplicateRuleNameInMetaData() {
-        when(currentConfig.getDataSources()).thenReturn(Collections.singletonList(new ShadowDataSourceConfiguration("ruleName", "ds", "ds_shadow")));
+        when(currentConfig.getDataSources()).thenReturn(Collections.singleton(new ShadowDataSourceConfiguration("ruleName", "ds", "ds_shadow")));
         ShadowRuleSegment ruleSegment = new ShadowRuleSegment("ruleName", null, null, null);
         assertThrows(DuplicateRuleException.class, () -> updater.checkSQLStatement(database, new CreateShadowRuleStatement(false, Collections.singleton(ruleSegment)), currentConfig));
     }
@@ -107,7 +107,7 @@ class CreateShadowRuleStatementUpdaterTest {
         ShadowAlgorithmSegment segment = new ShadowAlgorithmSegment("algorithmName", new AlgorithmSegment("name", PropertiesBuilder.build(new Property("type", "value"))));
         CreateShadowRuleStatement sqlStatement = new CreateShadowRuleStatement(false, Arrays.asList(
                 new ShadowRuleSegment("ruleName", "ds", null, Collections.singletonMap("t_order", Collections.singleton(segment))),
-                new ShadowRuleSegment("ruleName", "ds1", null, Collections.singletonMap("t_order_1", Collections.singletonList(segment)))));
+                new ShadowRuleSegment("ruleName", "ds1", null, Collections.singletonMap("t_order_1", Collections.singleton(segment)))));
         assertThrows(DuplicateRuleException.class, () -> updater.checkSQLStatement(database, sqlStatement, currentConfig));
     }
     
@@ -116,7 +116,7 @@ class CreateShadowRuleStatementUpdaterTest {
         ShadowAlgorithmSegment segment = new ShadowAlgorithmSegment("algorithmName", new AlgorithmSegment("name", PropertiesBuilder.build(new Property("type", "value"))));
         CreateShadowRuleStatement sqlStatement = new CreateShadowRuleStatement(false, Arrays.asList(
                 new ShadowRuleSegment("ruleName", "ds", null, Collections.singletonMap("t_order", Collections.singleton(segment))),
-                new ShadowRuleSegment("ruleName1", "ds1", null, Collections.singletonMap("t_order_1", Collections.singletonList(segment)))));
+                new ShadowRuleSegment("ruleName1", "ds1", null, Collections.singletonMap("t_order_1", Collections.singleton(segment)))));
         assertThrows(DuplicateRuleException.class, () -> updater.checkSQLStatement(database, sqlStatement, null));
     }
     

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRoutingEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRoutingEngineTest.java
@@ -97,7 +97,7 @@ class ShardingStandardRoutingEngineTest {
     @Test
     void assertRouteByHint() {
         SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_hint_test"));
+        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singleton("t_hint_test"));
         ShardingStandardRoutingEngine standardRoutingEngine = createShardingStandardRoutingEngine("t_hint_test",
                 new ShardingConditions(Collections.emptyList(), sqlStatementContext, mock(ShardingRule.class)), sqlStatementContext, new HintValueContext());
         HintManager hintManager = HintManager.getInstance();
@@ -115,7 +115,7 @@ class ShardingStandardRoutingEngineTest {
     @Test
     void assertRouteByMixedWithHintDataSource() {
         SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_hint_ds_test"));
+        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singleton("t_hint_ds_test"));
         ShardingStandardRoutingEngine standardRoutingEngine = createShardingStandardRoutingEngine("t_hint_ds_test",
                 ShardingRoutingEngineFixtureBuilder.createShardingConditions("t_hint_ds_test"), sqlStatementContext, new HintValueContext());
         HintManager hintManager = HintManager.getInstance();
@@ -132,7 +132,7 @@ class ShardingStandardRoutingEngineTest {
     @Test
     void assertRouteByMixedWithHintDataSourceOnly() {
         SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_hint_ds_test"));
+        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singleton("t_hint_ds_test"));
         ShardingStandardRoutingEngine standardRoutingEngine = createShardingStandardRoutingEngine("t_hint_ds_test",
                 new ShardingConditions(Collections.emptyList(), sqlStatementContext, mock(ShardingRule.class)), sqlStatementContext, new HintValueContext());
         HintManager hintManager = HintManager.getInstance();
@@ -153,7 +153,7 @@ class ShardingStandardRoutingEngineTest {
     @Test
     void assertRouteByMixedWithHintTable() {
         SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_hint_table_test"));
+        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singleton("t_hint_table_test"));
         ShardingStandardRoutingEngine standardRoutingEngine = createShardingStandardRoutingEngine("t_hint_table_test",
                 ShardingRoutingEngineFixtureBuilder.createShardingConditions("t_hint_table_test"), sqlStatementContext, new HintValueContext());
         HintManager hintManager = HintManager.getInstance();
@@ -170,7 +170,7 @@ class ShardingStandardRoutingEngineTest {
     @Test
     void assertRouteByMixedWithHintTableOnly() {
         SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_hint_table_test"));
+        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singleton("t_hint_table_test"));
         ShardingStandardRoutingEngine standardRoutingEngine = createShardingStandardRoutingEngine("t_hint_table_test",
                 new ShardingConditions(Collections.emptyList(), sqlStatementContext, mock(ShardingRule.class)), sqlStatementContext, new HintValueContext());
         HintManager hintManager = HintManager.getInstance();
@@ -191,7 +191,7 @@ class ShardingStandardRoutingEngineTest {
     @Test
     void assertRouteByIntervalTableShardingStrategyOnly() {
         SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_interval_test"));
+        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singleton("t_interval_test"));
         ShardingStandardRoutingEngine standardRoutingEngine = createShardingStandardRoutingEngine("t_interval_test",
                 ShardingRoutingEngineFixtureBuilder.createIntervalShardingConditions("t_interval_test"), sqlStatementContext, new HintValueContext());
         RouteContext routeContext = standardRoutingEngine.route(ShardingRoutingEngineFixtureBuilder.createIntervalTableShardingRule());

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/assertion/ShardingRouteAssert.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/assertion/ShardingRouteAssert.java
@@ -70,7 +70,7 @@ public final class ShardingRouteAssert {
     public static RouteContext assertRoute(final String sql, final List<Object> params) {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
         ShardingRule shardingRule = ShardingRoutingEngineFixtureBuilder.createAllShardingRule();
-        SingleRule singleRule = ShardingRoutingEngineFixtureBuilder.createSingleRule(Collections.singletonList(shardingRule));
+        SingleRule singleRule = ShardingRoutingEngineFixtureBuilder.createSingleRule(Collections.singleton(shardingRule));
         TimestampServiceRule timestampServiceRule = ShardingRoutingEngineFixtureBuilder.createTimeServiceRule();
         Map<String, ShardingSphereSchema> schemas = buildSchemas();
         ConfigurationProperties props = new ConfigurationProperties(new Properties());

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/unicast/ShardingUnicastRoutingEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/unicast/ShardingUnicastRoutingEngineTest.java
@@ -90,7 +90,7 @@ class ShardingUnicastRoutingEngineTest {
     
     @Test
     void assertRoutingForBroadcastTableWithPreferredDataSource() {
-        ConnectionContext connectionContext = new ConnectionContext(() -> Collections.singletonList("ds_1"));
+        ConnectionContext connectionContext = new ConnectionContext(() -> Collections.singleton("ds_1"));
         RouteContext actual = new ShardingUnicastRoutingEngine(mock(SelectStatementContext.class), Collections.singleton("t_config"), connectionContext).route(shardingRule);
         assertThat(actual.getRouteUnits().size(), is(1));
         assertThat(actual.getRouteUnits().iterator().next().getDataSourceMapper().getActualName(), is("ds_1"));

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingDropTableStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingDropTableStatementValidatorTest.java
@@ -127,8 +127,8 @@ class ShardingDropTableStatementValidatorTest {
         when(shardingRule.isShardingTable("t_order")).thenReturn(true);
         when(shardingRule.getTableRule("t_order")).thenReturn(new TableRule(Arrays.asList("ds_0", "ds_1"), "t_order"));
         Collection<RouteUnit> routeUnits = new LinkedList<>();
-        routeUnits.add(new RouteUnit(new RouteMapper("ds_0", "ds_0"), Collections.singletonList(new RouteMapper("t_order", "t_order_0"))));
-        routeUnits.add(new RouteUnit(new RouteMapper("ds_1", "ds_1"), Collections.singletonList(new RouteMapper("t_order", "t_order_0"))));
+        routeUnits.add(new RouteUnit(new RouteMapper("ds_0", "ds_0"), Collections.singleton(new RouteMapper("t_order", "t_order_0"))));
+        routeUnits.add(new RouteUnit(new RouteMapper("ds_1", "ds_1"), Collections.singleton(new RouteMapper("t_order", "t_order_0"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertDoesNotThrow(() -> new ShardingDropTableStatementValidator().postValidate(
                 shardingRule, new DropTableStatementContext(sqlStatement), new HintValueContext(), Collections.emptyList(),
@@ -142,7 +142,7 @@ class ShardingDropTableStatementValidatorTest {
         when(shardingRule.isShardingTable("t_order")).thenReturn(true);
         when(shardingRule.getTableRule("t_order")).thenReturn(new TableRule(Arrays.asList("ds_0", "ds_1"), "t_order"));
         Collection<RouteUnit> routeUnits = new LinkedList<>();
-        routeUnits.add(new RouteUnit(new RouteMapper("ds_0", "ds_0"), Collections.singletonList(new RouteMapper("t_order", "t_order_0"))));
+        routeUnits.add(new RouteUnit(new RouteMapper("ds_0", "ds_0"), Collections.singleton(new RouteMapper("t_order", "t_order_0"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertThrows(ShardingDDLRouteException.class,
                 () -> new ShardingDropTableStatementValidator().postValidate(shardingRule, new DropTableStatementContext(sqlStatement), new HintValueContext(),
@@ -155,8 +155,8 @@ class ShardingDropTableStatementValidatorTest {
         sqlStatement.getTables().add(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_config"))));
         when(shardingRule.getTableRule("t_config")).thenReturn(new TableRule(Arrays.asList("ds_0", "ds_1"), "t_config"));
         Collection<RouteUnit> routeUnits = new LinkedList<>();
-        routeUnits.add(new RouteUnit(new RouteMapper("ds_0", "ds_0"), Collections.singletonList(new RouteMapper("t_config", "t_config"))));
-        routeUnits.add(new RouteUnit(new RouteMapper("ds_1", "ds_1"), Collections.singletonList(new RouteMapper("t_config", "t_config"))));
+        routeUnits.add(new RouteUnit(new RouteMapper("ds_0", "ds_0"), Collections.singleton(new RouteMapper("t_config", "t_config"))));
+        routeUnits.add(new RouteUnit(new RouteMapper("ds_1", "ds_1"), Collections.singleton(new RouteMapper("t_config", "t_config"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertDoesNotThrow(() -> new ShardingDropTableStatementValidator().postValidate(
                 shardingRule, new DropTableStatementContext(sqlStatement), new HintValueContext(),

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
@@ -486,7 +486,7 @@ class ShardingRuleTest {
         shardingRuleConfig.setDefaultTableShardingStrategy(new StandardShardingStrategyConfiguration("table_id", "standard"));
         shardingRuleConfig.setDefaultShardingColumn("table_id");
         shardingRuleConfig.setDefaultKeyGenerateStrategy(new KeyGenerateStrategyConfiguration("id", "default"));
-        shardingRuleConfig.setDefaultAuditStrategy(new ShardingAuditStrategyConfiguration(Collections.singletonList("audit_algorithm"), false));
+        shardingRuleConfig.setDefaultAuditStrategy(new ShardingAuditStrategyConfiguration(Collections.singleton("audit_algorithm"), false));
         shardingRuleConfig.getShardingAlgorithms().put("core_standard_fixture", new AlgorithmConfiguration("CORE.STANDARD.FIXTURE", new Properties()));
         shardingRuleConfig.getKeyGenerators().put("uuid", new AlgorithmConfiguration("UUID", new Properties()));
         shardingRuleConfig.getKeyGenerators().put("default", new AlgorithmConfiguration("UUID", new Properties()));
@@ -635,7 +635,7 @@ class ShardingRuleTest {
         when(sqlStatementContext.isContainsJoinQuery()).thenReturn(true);
         when(sqlStatementContext.getDatabaseType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
         when(sqlStatementContext.getTablesContext().getSchemaName()).thenReturn(Optional.empty());
-        when(sqlStatementContext.getWhereSegments()).thenReturn(Collections.singletonList(new WhereSegment(0, 0, condition)));
+        when(sqlStatementContext.getWhereSegments()).thenReturn(Collections.singleton(new WhereSegment(0, 0, condition)));
         ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
         when(sqlStatementContext.getTablesContext().findTableNamesByColumnSegment(Arrays.asList(leftDatabaseJoin, rightDatabaseJoin), schema)).thenReturn(createColumnTableNameMap());
         when(sqlStatementContext.getTablesContext().findTableNamesByColumnSegment(Arrays.asList(leftTableJoin, rightTableJoin), schema)).thenReturn(createColumnTableNameMap());

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/checker/ShardingRuleStatementCheckerTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/checker/ShardingRuleStatementCheckerTest.java
@@ -127,19 +127,19 @@ class ShardingRuleStatementCheckerTest {
     
     @Test
     void assertCheckCreationWithIdentical() {
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(new AutoTableRuleSegment("t_order", Arrays.asList("ds_0", "ds_1")));
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(new AutoTableRuleSegment("t_order", Arrays.asList("ds_0", "ds_1")));
         assertThrows(DuplicateRuleException.class, () -> ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig));
     }
     
     @Test
     void assertCheckAlterationWithRuleRequiredMissed() {
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(new AutoTableRuleSegment("t_order_required_missed", Arrays.asList("ds_0", "ds_1")));
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(new AutoTableRuleSegment("t_order_required_missed", Arrays.asList("ds_0", "ds_1")));
         assertThrows(MissingRequiredRuleException.class, () -> ShardingTableRuleStatementChecker.checkAlteration(database, rules, shardingRuleConfig));
     }
     
     @Test
     void assertCheckCreationWithResourceRequiredMissed() {
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(new AutoTableRuleSegment("t_product", Arrays.asList("ds_required_missed", "ds_1")));
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(new AutoTableRuleSegment("t_product", Arrays.asList("ds_required_missed", "ds_1")));
         assertThrows(MissingRequiredStorageUnitsException.class, () -> ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig));
     }
     
@@ -154,7 +154,7 @@ class ShardingRuleStatementCheckerTest {
     @Test
     void assertCheckCreationWithInvalidAuditAlgorithm() {
         AutoTableRuleSegment autoTableRuleSegment = new AutoTableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"));
-        autoTableRuleSegment.setAuditStrategySegment(new AuditStrategySegment(Collections.singletonList(new ShardingAuditorSegment("sharding_key_required_auditor",
+        autoTableRuleSegment.setAuditStrategySegment(new AuditStrategySegment(Collections.singleton(new ShardingAuditorSegment("sharding_key_required_auditor",
                 new AlgorithmSegment("invalid", new Properties()))), true));
         assertThrows(ServiceProviderNotFoundException.class,
                 () -> ShardingTableRuleStatementChecker.checkCreation(database, Collections.singleton(autoTableRuleSegment), false, shardingRuleConfig));
@@ -165,7 +165,7 @@ class ShardingRuleStatementCheckerTest {
         AutoTableRuleSegment autoTableRuleSegment = new AutoTableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"));
         autoTableRuleSegment.setShardingColumn("product_id");
         autoTableRuleSegment.setShardingAlgorithmSegment(new AlgorithmSegment("not_exist", PropertiesBuilder.build(new Property("", ""))));
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(autoTableRuleSegment);
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(autoTableRuleSegment);
         assertThrows(InvalidAlgorithmConfigurationException.class, () -> ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig));
     }
     
@@ -174,7 +174,7 @@ class ShardingRuleStatementCheckerTest {
         AutoTableRuleSegment autoTableRuleSegment = new AutoTableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"));
         autoTableRuleSegment.setShardingColumn("product_id");
         autoTableRuleSegment.setShardingAlgorithmSegment(new AlgorithmSegment("complex", PropertiesBuilder.build(new Property("", ""))));
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(autoTableRuleSegment);
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(autoTableRuleSegment);
         assertThrows(InvalidAlgorithmConfigurationException.class, () -> ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig));
     }
     
@@ -183,7 +183,7 @@ class ShardingRuleStatementCheckerTest {
         KeyGenerateStrategySegment keyGenerateStrategy = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", new Properties()));
         TableRuleSegment tableRuleSegment = new TableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"), keyGenerateStrategy, null);
         tableRuleSegment.setTableStrategySegment(new ShardingStrategySegment("invalid", "product_id", null));
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(tableRuleSegment);
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(tableRuleSegment);
         assertThrows(UnsupportedSQLOperationException.class, () -> ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig));
     }
     
@@ -192,7 +192,7 @@ class ShardingRuleStatementCheckerTest {
         KeyGenerateStrategySegment keyGenerateStrategy = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", new Properties()));
         TableRuleSegment tableRuleSegment = new TableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"), keyGenerateStrategy, null);
         tableRuleSegment.setTableStrategySegment(new ShardingStrategySegment("complex", "product_id", null));
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(tableRuleSegment);
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(tableRuleSegment);
         assertThrows(InvalidAlgorithmConfigurationException.class, () -> ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig));
     }
     
@@ -201,7 +201,7 @@ class ShardingRuleStatementCheckerTest {
         KeyGenerateStrategySegment keyGenerateStrategy = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", new Properties()));
         TableRuleSegment tableRuleSegment = new TableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"), keyGenerateStrategy, null);
         tableRuleSegment.setTableStrategySegment(new ShardingStrategySegment("standard", "product_id,user_id", null));
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(tableRuleSegment);
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(tableRuleSegment);
         assertThrows(InvalidAlgorithmConfigurationException.class, () -> ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig));
     }
     
@@ -211,7 +211,7 @@ class ShardingRuleStatementCheckerTest {
         KeyGenerateStrategySegment keyGenerateStrategy = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", new Properties()));
         TableRuleSegment tableRuleSegment = new TableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"), keyGenerateStrategy, null);
         tableRuleSegment.setTableStrategySegment(new ShardingStrategySegment("standard", "user_id", databaseAlgorithmSegment));
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(tableRuleSegment);
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(tableRuleSegment);
         assertThrows(InvalidAlgorithmConfigurationException.class, () -> ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig));
     }
     
@@ -220,7 +220,7 @@ class ShardingRuleStatementCheckerTest {
         KeyGenerateStrategySegment keyGenerateStrategy = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", new Properties()));
         TableRuleSegment tableRuleSegment = new TableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"), keyGenerateStrategy, null);
         tableRuleSegment.setTableStrategySegment(new ShardingStrategySegment("hint", "product_id", null));
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(tableRuleSegment);
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(tableRuleSegment);
         assertThrows(InvalidAlgorithmConfigurationException.class, () -> ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig));
     }
     
@@ -229,7 +229,7 @@ class ShardingRuleStatementCheckerTest {
         KeyGenerateStrategySegment keyGenerateStrategy = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", new Properties()));
         TableRuleSegment tableRuleSegment = new TableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"), keyGenerateStrategy, null);
         tableRuleSegment.setTableStrategySegment(new ShardingStrategySegment("hint", "product_id", null));
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(tableRuleSegment);
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(tableRuleSegment);
         assertThrows(InvalidAlgorithmConfigurationException.class, () -> ShardingTableRuleStatementChecker.checkCreation(database, rules, false, null));
     }
     
@@ -239,7 +239,7 @@ class ShardingRuleStatementCheckerTest {
         KeyGenerateStrategySegment keyGenerateStrategy = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", new Properties()));
         TableRuleSegment tableRuleSegment = new TableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"), keyGenerateStrategy, null);
         tableRuleSegment.setTableStrategySegment(new ShardingStrategySegment("standard", "product_id", databaseAlgorithmSegment));
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(tableRuleSegment);
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(tableRuleSegment);
         ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig);
     }
     
@@ -248,7 +248,7 @@ class ShardingRuleStatementCheckerTest {
         KeyGenerateStrategySegment keyGenerateStrategy = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", new Properties()));
         TableRuleSegment tableRuleSegment = new TableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"), keyGenerateStrategy, null);
         tableRuleSegment.setTableStrategySegment(new ShardingStrategySegment("standard", "product_id", null));
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(tableRuleSegment);
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(tableRuleSegment);
         assertThrows(InvalidAlgorithmConfigurationException.class, () -> ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig));
     }
     
@@ -256,7 +256,7 @@ class ShardingRuleStatementCheckerTest {
     void assertCheckAutoTableRuleWithStandardShardingAlgorithm() {
         AutoTableRuleSegment autoTableRuleSegment = new AutoTableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"));
         autoTableRuleSegment.setShardingAlgorithmSegment(new AlgorithmSegment("INLINE", PropertiesBuilder.build(new Property("algorithm-expression", "ds_${product_id % 2}"))));
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(autoTableRuleSegment);
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(autoTableRuleSegment);
         assertThrows(InvalidAlgorithmConfigurationException.class, () -> ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig));
     }
     
@@ -264,7 +264,7 @@ class ShardingRuleStatementCheckerTest {
     void assertCheckAutoTableRuleWithAutoShardingAlgorithm() {
         AutoTableRuleSegment autoTableRuleSegment = new AutoTableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"));
         autoTableRuleSegment.setShardingAlgorithmSegment(new AlgorithmSegment("CORE.AUTO.FIXTURE", PropertiesBuilder.build(new Property("sharding-count", "4"))));
-        List<AbstractTableRuleSegment> rules = Collections.singletonList(autoTableRuleSegment);
+        Collection<AbstractTableRuleSegment> rules = Collections.singleton(autoTableRuleSegment);
         ShardingTableRuleStatementChecker.checkCreation(database, rules, false, shardingRuleConfig);
     }
     
@@ -323,7 +323,7 @@ class ShardingRuleStatementCheckerTest {
     private TableRuleSegment createCompleteTableRule() {
         Properties props = new Properties();
         KeyGenerateStrategySegment keyGenerator = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", props));
-        TableRuleSegment result = new TableRuleSegment("t_product_1", Collections.singletonList("ds_${0..1}.t_order${0..1}"), keyGenerator, null);
+        TableRuleSegment result = new TableRuleSegment("t_product_1", Collections.singleton("ds_${0..1}.t_order${0..1}"), keyGenerator, null);
         result.setTableStrategySegment(new ShardingStrategySegment("hint", null, new AlgorithmSegment("CORE.HINT.FIXTURE", props)));
         result.setDatabaseStrategySegment(new ShardingStrategySegment("hint", null, new AlgorithmSegment("CORE.HINT.FIXTURE", props)));
         return result;
@@ -332,7 +332,7 @@ class ShardingRuleStatementCheckerTest {
     private TableRuleSegment createWrongTableRuleWithNoneTypeStrategy() {
         Properties props = new Properties();
         KeyGenerateStrategySegment keyGenerator = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", props));
-        TableRuleSegment result = new TableRuleSegment("t_product_1", Collections.singletonList("ds_${0..1}.t_order${0..1}"), keyGenerator, null);
+        TableRuleSegment result = new TableRuleSegment("t_product_1", Collections.singleton("ds_${0..1}.t_order${0..1}"), keyGenerator, null);
         result.setDatabaseStrategySegment(new ShardingStrategySegment("none", null, null));
         result.setTableStrategySegment(new ShardingStrategySegment("none", null, null));
         return result;
@@ -341,7 +341,7 @@ class ShardingRuleStatementCheckerTest {
     private TableRuleSegment createCompleteTableRuleWithNoneTypeStrategy() {
         Properties props = PropertiesBuilder.build(new Property("algorithm-expression", "t_order_${order_id % 2}"));
         KeyGenerateStrategySegment keyGenerator = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", props));
-        TableRuleSegment result = new TableRuleSegment("t_product_1", Collections.singletonList("ds_0.t_order${0..1}"), keyGenerator, null);
+        TableRuleSegment result = new TableRuleSegment("t_product_1", Collections.singleton("ds_0.t_order${0..1}"), keyGenerator, null);
         result.setDatabaseStrategySegment(new ShardingStrategySegment("none", null, null));
         result.setTableStrategySegment(new ShardingStrategySegment("standard", "order_id", new AlgorithmSegment("inline", props)));
         return result;

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/CountShardingRuleExecutorTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/CountShardingRuleExecutorTest.java
@@ -70,7 +70,7 @@ class CountShardingRuleExecutorTest {
     private ShardingSphereDatabase mockDatabase() {
         ShardingSphereDatabase result = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(result.getName()).thenReturn("db_1");
-        RuleMetaData ruleMetaData = new RuleMetaData(Collections.singletonList(mockShardingRule()));
+        RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(mockShardingRule()));
         when(result.getRuleMetaData()).thenReturn(ruleMetaData);
         return result;
     }

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/AlterShardingTableReferenceRuleStatementUpdaterTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/AlterShardingTableReferenceRuleStatementUpdaterTest.java
@@ -71,7 +71,7 @@ class AlterShardingTableReferenceRuleStatementUpdaterTest {
     }
     
     private AlterShardingTableReferenceRuleStatement createSQLStatement(final String name, final String reference) {
-        return new AlterShardingTableReferenceRuleStatement(Collections.singletonList(new TableReferenceRuleSegment(name, reference)));
+        return new AlterShardingTableReferenceRuleStatement(Collections.singleton(new TableReferenceRuleSegment(name, reference)));
     }
     
     private ShardingRuleConfiguration createCurrentRuleConfiguration() {

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/AlterShardingTableRuleStatementUpdaterTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/AlterShardingTableRuleStatementUpdaterTest.java
@@ -159,7 +159,7 @@ class AlterShardingTableRuleStatementUpdaterTest {
     
     private TableRuleSegment createCompleteTableRule(final String logicTableName) {
         KeyGenerateStrategySegment keyGenerator = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", new Properties()));
-        TableRuleSegment result = new TableRuleSegment(logicTableName, Collections.singletonList("ds_${0..1}.t_order${0..1}"), keyGenerator, null);
+        TableRuleSegment result = new TableRuleSegment(logicTableName, Collections.singleton("ds_${0..1}.t_order${0..1}"), keyGenerator, null);
         result.setTableStrategySegment(new ShardingStrategySegment("standard", "product_id", new AlgorithmSegment("CORE.STANDARD.FIXTURE", new Properties())));
         AlgorithmSegment databaseAlgorithmSegment = new AlgorithmSegment("inline", PropertiesBuilder.build(new Property("algorithm-expression", "ds_${user_id % 2}")));
         result.setDatabaseStrategySegment(new ShardingStrategySegment("standard", "product_id", databaseAlgorithmSegment));

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/CreateShardingTableRuleStatementUpdaterTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/CreateShardingTableRuleStatementUpdaterTest.java
@@ -240,7 +240,7 @@ class CreateShardingTableRuleStatementUpdaterTest {
     }
     
     private AutoTableRuleSegment createCompleteAutoTableRule() {
-        AutoTableRuleSegment result = new AutoTableRuleSegment("t_order_item_input", Collections.singletonList("logic_ds"));
+        AutoTableRuleSegment result = new AutoTableRuleSegment("t_order_item_input", Collections.singleton("logic_ds"));
         result.setKeyGenerateStrategySegment(new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", new Properties())));
         result.setShardingColumn("order_id");
         result.setShardingAlgorithmSegment(new AlgorithmSegment("FOO.DISTSQL.FIXTURE", PropertiesBuilder.build(new Property("", ""))));
@@ -249,7 +249,7 @@ class CreateShardingTableRuleStatementUpdaterTest {
     
     private TableRuleSegment createCompleteTableRule() {
         KeyGenerateStrategySegment keyGenerator = new KeyGenerateStrategySegment("product_id", new AlgorithmSegment("DISTSQL.FIXTURE", new Properties()));
-        TableRuleSegment result = new TableRuleSegment("t_order_input", Collections.singletonList("ds_${0..1}.t_order_${0..1}"), keyGenerator, null);
+        TableRuleSegment result = new TableRuleSegment("t_order_input", Collections.singleton("ds_${0..1}.t_order_${0..1}"), keyGenerator, null);
         result.setTableStrategySegment(new ShardingStrategySegment("standard", "product_id", new AlgorithmSegment("CORE.STANDARD.FIXTURE", new Properties())));
         AlgorithmSegment databaseAlgorithmSegment = new AlgorithmSegment("inline", PropertiesBuilder.build(new Property("algorithm-expression", "ds_${user_id % 2}")));
         result.setDatabaseStrategySegment(new ShardingStrategySegment("standard", "product_id", databaseAlgorithmSegment));

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/DropShardingAuditorStatementUpdaterTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/DropShardingAuditorStatementUpdaterTest.java
@@ -64,7 +64,7 @@ class DropShardingAuditorStatementUpdaterTest {
     
     @Test
     void assertExecuteWithNotExistWithIfExists() {
-        DropShardingAuditorStatement sqlStatement = new DropShardingAuditorStatement(true, Collections.singletonList("sharding_key_required_auditor"));
+        DropShardingAuditorStatement sqlStatement = new DropShardingAuditorStatement(true, Collections.singleton("sharding_key_required_auditor"));
         updater.checkSQLStatement(database, sqlStatement, new ShardingRuleConfiguration());
     }
     
@@ -86,7 +86,7 @@ class DropShardingAuditorStatementUpdaterTest {
     
     private ShardingAutoTableRuleConfiguration createShardingAutoTableRuleConfiguration() {
         ShardingAutoTableRuleConfiguration result = new ShardingAutoTableRuleConfiguration("auto_table", null);
-        result.setAuditStrategy(new ShardingAuditStrategyConfiguration(Collections.singletonList("sharding_key_required_auditor"), true));
+        result.setAuditStrategy(new ShardingAuditStrategyConfiguration(Collections.singleton("sharding_key_required_auditor"), true));
         return result;
     }
     

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/DropShardingKeyGeneratorStatementUpdaterTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/DropShardingKeyGeneratorStatementUpdaterTest.java
@@ -46,7 +46,7 @@ class DropShardingKeyGeneratorStatementUpdaterTest {
     
     @Test
     void assertExecuteWithNotExistWithIfExists() {
-        DropShardingKeyGeneratorStatement sqlStatement = new DropShardingKeyGeneratorStatement(true, Collections.singletonList("uuid_key_generator"));
+        DropShardingKeyGeneratorStatement sqlStatement = new DropShardingKeyGeneratorStatement(true, Collections.singleton("uuid_key_generator"));
         new DropShardingKeyGeneratorStatementUpdater().checkSQLStatement(mock(ShardingSphereDatabase.class), sqlStatement, new ShardingRuleConfiguration());
     }
     

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/spi/AbsolutePathURLProvider.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/spi/AbsolutePathURLProvider.java
@@ -18,8 +18,8 @@
 package org.apache.shardingsphere.driver.jdbc.core.driver.spi;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import lombok.SneakyThrows;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.shardingsphere.driver.jdbc.core.driver.ShardingSphereURLProvider;
 
 import java.io.BufferedReader;
@@ -39,7 +39,7 @@ public final class AbsolutePathURLProvider implements ShardingSphereURLProvider 
     
     @Override
     public boolean accept(final String url) {
-        return StringUtils.isNotBlank(url) && url.contains(PATH_TYPE);
+        return !Strings.isNullOrEmpty(url) && url.contains(PATH_TYPE);
     }
     
     @Override

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/spi/ApolloURLProvider.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/spi/ApolloURLProvider.java
@@ -21,7 +21,7 @@ import com.ctrip.framework.apollo.ConfigFile;
 import com.ctrip.framework.apollo.ConfigService;
 import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang3.StringUtils;
+import com.google.common.base.Strings;
 import org.apache.shardingsphere.driver.jdbc.core.driver.ShardingSphereURLProvider;
 
 import java.nio.charset.StandardCharsets;
@@ -35,7 +35,7 @@ public final class ApolloURLProvider implements ShardingSphereURLProvider {
     
     @Override
     public boolean accept(final String url) {
-        return StringUtils.isNotBlank(url) && url.contains(APOLLO_TYPE);
+        return !Strings.isNullOrEmpty(url) && url.contains(APOLLO_TYPE);
     }
     
     @Override

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/spi/ClasspathURLProvider.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/spi/ClasspathURLProvider.java
@@ -18,8 +18,8 @@
 package org.apache.shardingsphere.driver.jdbc.core.driver.spi;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import lombok.SneakyThrows;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.shardingsphere.driver.jdbc.core.driver.ShardingSphereURLProvider;
 
 import java.io.BufferedReader;
@@ -37,7 +37,7 @@ public final class ClasspathURLProvider implements ShardingSphereURLProvider {
     
     @Override
     public boolean accept(final String url) {
-        return StringUtils.isNotBlank(url) && url.contains(CLASSPATH_TYPE);
+        return !Strings.isNullOrEmpty(url) && url.contains(CLASSPATH_TYPE);
     }
     
     @Override

--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/executor/batch/BatchPreparedStatementExecutorTest.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/executor/batch/BatchPreparedStatementExecutorTest.java
@@ -125,7 +125,7 @@ class BatchPreparedStatementExecutorTest {
     void assertNoPreparedStatement() throws SQLException {
         PreparedStatement preparedStatement = getPreparedStatement();
         when(preparedStatement.executeBatch()).thenReturn(new int[]{0, 0});
-        setExecutionGroups(Collections.singletonList(preparedStatement));
+        setExecutionGroups(Collections.singleton(preparedStatement));
         assertThat(executor.executeBatch(sqlStatementContext), is(new int[]{0, 0}));
     }
     
@@ -133,7 +133,7 @@ class BatchPreparedStatementExecutorTest {
     void assertExecuteBatchForSinglePreparedStatementSuccess() throws SQLException {
         PreparedStatement preparedStatement = getPreparedStatement();
         when(preparedStatement.executeBatch()).thenReturn(new int[]{10, 20});
-        setExecutionGroups(Collections.singletonList(preparedStatement));
+        setExecutionGroups(Collections.singleton(preparedStatement));
         assertThat(executor.executeBatch(sqlStatementContext), is(new int[]{10, 20}));
         verify(preparedStatement).executeBatch();
     }
@@ -155,7 +155,7 @@ class BatchPreparedStatementExecutorTest {
         PreparedStatement preparedStatement = getPreparedStatement();
         SQLException ex = new SQLException("");
         when(preparedStatement.executeBatch()).thenThrow(ex);
-        setExecutionGroups(Collections.singletonList(preparedStatement));
+        setExecutionGroups(Collections.singleton(preparedStatement));
         assertThrows(SQLException.class, () -> executor.executeBatch(sqlStatementContext));
         verify(preparedStatement).executeBatch();
     }
@@ -176,7 +176,7 @@ class BatchPreparedStatementExecutorTest {
         return result;
     }
     
-    private void setExecutionGroups(final List<PreparedStatement> preparedStatements) {
+    private void setExecutionGroups(final Collection<PreparedStatement> preparedStatements) {
         Collection<ExecutionGroup<JDBCExecutionUnit>> executionGroups = new LinkedList<>();
         List<JDBCExecutionUnit> executionUnits = new LinkedList<>();
         executionGroups.add(new ExecutionGroup<>(executionUnits));

--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/datasource/metadata/ShardingSphereDatabaseMetaDataTest.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/datasource/metadata/ShardingSphereDatabaseMetaDataTest.java
@@ -99,8 +99,8 @@ class ShardingSphereDatabaseMetaDataTest {
     private ShardingRule mockShardingRule() {
         ShardingRuleConfiguration ruleConfig = new ShardingRuleConfiguration();
         ShardingTableRuleConfiguration shardingTableRuleConfig = new ShardingTableRuleConfiguration(TABLE_NAME, DATA_SOURCE_NAME + "." + TABLE_NAME);
-        ruleConfig.setTables(Collections.singletonList(shardingTableRuleConfig));
-        return new ShardingRule(ruleConfig, Collections.singletonList(DATA_SOURCE_NAME), mock(InstanceContext.class));
+        ruleConfig.setTables(Collections.singleton(shardingTableRuleConfig));
+        return new ShardingRule(ruleConfig, Collections.singleton(DATA_SOURCE_NAME), mock(InstanceContext.class));
     }
     
     @Test

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/common/metadata/generator/PipelineDDLGenerator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/common/metadata/generator/PipelineDDLGenerator.java
@@ -17,10 +17,9 @@
 
 package org.apache.shardingsphere.data.pipeline.common.metadata.generator;
 
+import com.google.common.base.Strings;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.shardingsphere.data.pipeline.spi.ddlgenerator.CreateTableSQLGenerator;
-import org.apache.shardingsphere.infra.binder.engine.SQLBindEngine;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.AlterTableStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.CommentStatementContext;
@@ -29,6 +28,7 @@ import org.apache.shardingsphere.infra.binder.context.statement.ddl.CreateTableS
 import org.apache.shardingsphere.infra.binder.context.type.ConstraintAvailable;
 import org.apache.shardingsphere.infra.binder.context.type.IndexAvailable;
 import org.apache.shardingsphere.infra.binder.context.type.TableAvailable;
+import org.apache.shardingsphere.infra.binder.engine.SQLBindEngine;
 import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.schema.util.IndexMetaDataUtils;
@@ -87,7 +87,7 @@ public final class PipelineDDLGenerator {
     
     private Optional<String> decorate(final DatabaseType databaseType, final DataSource dataSource, final String schemaName, final String targetTableName,
                                       final SQLParserEngine parserEngine, final String sql) throws SQLException {
-        if (StringUtils.isBlank(sql)) {
+        if (Strings.isNullOrEmpty(sql)) {
             return Optional.empty();
         }
         String databaseName;

--- a/mode/type/cluster/repository/provider/nacos/src/main/java/org/apache/shardingsphere/mode/repository/cluster/nacos/NacosRepository.java
+++ b/mode/type/cluster/repository/provider/nacos/src/main/java/org/apache/shardingsphere/mode/repository/cluster/nacos/NacosRepository.java
@@ -22,7 +22,6 @@ import com.alibaba.nacos.api.naming.NamingFactory;
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.api.naming.PreservedMetadataKeys;
 import com.alibaba.nacos.api.naming.pojo.Instance;
-import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import lombok.SneakyThrows;
@@ -336,9 +335,9 @@ public final class NacosRepository implements ClusterPersistRepository {
             ServiceMetaData service = serviceController.getService(entry.getKey());
             Map<String, List<Instance>> instanceMap = client.getAllInstances(service.getServiceName(), false).stream().collect(Collectors.groupingBy(NacosMetaDataUtils::getKey));
             keyValues.removeIf(keyValue -> {
-                Collection<Instance> instances = instanceMap.get(keyValue.getKey());
+                String key = keyValue.getKey();
                 String value = keyValue.getValue();
-                return CollectionUtils.isNotEmpty(instances) ? instances.stream().anyMatch(instance -> Objects.equals(NacosMetaDataUtils.getValue(instance), value)) : null == value;
+                return instanceMap.containsKey(key) ? instanceMap.get(key).stream().anyMatch(each -> Objects.equals(NacosMetaDataUtils.getValue(each), value)) : null == value;
             });
         }
         return keyValues.isEmpty();

--- a/mode/type/cluster/repository/provider/nacos/src/main/java/org/apache/shardingsphere/mode/repository/cluster/nacos/NacosRepository.java
+++ b/mode/type/cluster/repository/provider/nacos/src/main/java/org/apache/shardingsphere/mode/repository/cluster/nacos/NacosRepository.java
@@ -23,7 +23,6 @@ import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.api.naming.PreservedMetadataKeys;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.common.utils.CollectionUtils;
-import com.alibaba.nacos.common.utils.StringUtils;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import lombok.SneakyThrows;
@@ -97,7 +96,7 @@ public final class NacosRepository implements ClusterPersistRepository {
             serviceController = new ServiceController();
             for (ServiceMetaData each : serviceController.getAllServices()) {
                 Integer port = client.getAllInstances(each.getServiceName(), false).stream()
-                        .filter(instance -> StringUtils.equals(instance.getIp(), ip)).map(Instance::getPort).max(Comparator.naturalOrder()).orElse(Integer.MIN_VALUE);
+                        .filter(instance -> ip.equals(instance.getIp())).map(Instance::getPort).max(Comparator.naturalOrder()).orElse(Integer.MIN_VALUE);
                 each.setIp(ip);
                 each.setPort(new AtomicInteger(port));
             }
@@ -292,7 +291,7 @@ public final class NacosRepository implements ClusterPersistRepository {
                 Collection<Instance> instances = findExistedInstance(each.isEphemeral()).stream()
                         .filter(instance -> {
                             String fullPath = NacosMetaDataUtils.getKey(instance);
-                            return fullPath.startsWith(key + PATH_SEPARATOR) || StringUtils.equals(fullPath, key);
+                            return fullPath.startsWith(key + PATH_SEPARATOR) || key.equals(fullPath);
                         })
                         .sorted(Comparator.comparing(NacosMetaDataUtils::getKey).reversed()).collect(Collectors.toList());
                 Collection<KeyValue> keyValues = new LinkedList<>();
@@ -339,7 +338,7 @@ public final class NacosRepository implements ClusterPersistRepository {
             keyValues.removeIf(keyValue -> {
                 Collection<Instance> instances = instanceMap.get(keyValue.getKey());
                 String value = keyValue.getValue();
-                return CollectionUtils.isNotEmpty(instances) ? instances.stream().anyMatch(instance -> StringUtils.equals(NacosMetaDataUtils.getValue(instance), value)) : null == value;
+                return CollectionUtils.isNotEmpty(instances) ? instances.stream().anyMatch(instance -> Objects.equals(NacosMetaDataUtils.getValue(instance), value)) : null == value;
             });
         }
         return keyValues.isEmpty();

--- a/mode/type/cluster/repository/provider/nacos/src/test/java/org/apache/shardingsphere/mode/repository/cluster/nacos/NacosRepositoryTest.java
+++ b/mode/type/cluster/repository/provider/nacos/src/test/java/org/apache/shardingsphere/mode/repository/cluster/nacos/NacosRepositoryTest.java
@@ -24,10 +24,9 @@ import com.alibaba.nacos.api.naming.listener.Event;
 import com.alibaba.nacos.api.naming.listener.EventListener;
 import com.alibaba.nacos.api.naming.listener.NamingEvent;
 import com.alibaba.nacos.api.naming.pojo.Instance;
-import com.alibaba.nacos.common.utils.StringUtils;
 import com.google.common.util.concurrent.SettableFuture;
-import org.apache.shardingsphere.mode.repository.cluster.exception.ClusterPersistRepositoryException;
 import org.apache.shardingsphere.mode.event.DataChangedEvent;
+import org.apache.shardingsphere.mode.repository.cluster.exception.ClusterPersistRepositoryException;
 import org.apache.shardingsphere.mode.repository.cluster.nacos.entity.ServiceController;
 import org.apache.shardingsphere.mode.repository.cluster.nacos.entity.ServiceMetaData;
 import org.apache.shardingsphere.mode.repository.cluster.nacos.props.NacosProperties;
@@ -50,6 +49,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -361,7 +361,7 @@ class NacosRepositoryTest {
     private VoidAnswer2<String, Instance> getRegisterInstanceAnswer() {
         return (serviceName, instance) -> {
             List<Instance> instances = client.getAllInstances(serviceName, false);
-            instances.removeIf(each -> StringUtils.equals(each.getIp(), instance.getIp()) && each.getPort() == instance.getPort());
+            instances.removeIf(each -> Objects.equals(each.getIp(), instance.getIp()) && each.getPort() == instance.getPort());
             instances.add(instance);
             when(client.getAllInstances(serviceName, false)).thenReturn(instances);
         };

--- a/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/StandaloneModeContextManager.java
+++ b/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/StandaloneModeContextManager.java
@@ -139,7 +139,7 @@ public final class StandaloneModeContextManager implements ModeContextManager, C
     private void removeSchemaMetaData(final ShardingSphereDatabase database, final String schemaName) {
         ShardingSphereSchema schema = new ShardingSphereSchema(database.getSchema(schemaName).getTables(), database.getSchema(schemaName).getViews());
         database.removeSchema(schemaName);
-        removeDataNode(database.getRuleMetaData().findRules(MutableDataNodeRule.class), Collections.singletonList(schemaName), schema.getAllTableNames());
+        removeDataNode(database.getRuleMetaData().findRules(MutableDataNodeRule.class), Collections.singleton(schemaName), schema.getAllTableNames());
     }
     
     private void removeDataNode(final Collection<MutableDataNodeRule> rules, final Collection<String> schemaNames, final Collection<String> tobeRemovedTables) {

--- a/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQLLoader.java
+++ b/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQLLoader.java
@@ -70,7 +70,7 @@ public final class JDBCRepositorySQLLoader {
         while (resources.hasMoreElements()) {
             URL resource = resources.nextElement();
             result = JAR_URL_PROTOCOLS.contains(resource.getProtocol()) ? loadFromJar(resource, type) : loadFromDirectory(resource, type);
-            if (null != result && Objects.equals(result.isDefault(), false)) {
+            if (null != result && !result.isDefault()) {
                 break;
             }
         }
@@ -85,8 +85,7 @@ public final class JDBCRepositorySQLLoader {
             @Override
             public FileVisitResult visitFile(final Path file, final BasicFileAttributes attributes) throws IOException {
                 if (file.toString().endsWith(FILE_EXTENSION)) {
-                    JDBCRepositorySQL provider = (JDBCRepositorySQL) JAXBContext.newInstance(JDBCRepositorySQL.class).createUnmarshaller()
-                            .unmarshal(Files.newInputStream(file.toFile().toPath()));
+                    JDBCRepositorySQL provider = (JDBCRepositorySQL) JAXBContext.newInstance(JDBCRepositorySQL.class).createUnmarshaller().unmarshal(Files.newInputStream(file.toFile().toPath()));
                     if (provider.isDefault()) {
                         result[0] = provider;
                     }

--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
@@ -513,7 +513,7 @@ collationName
     ;
 
 indexName
-    : (schemaName DOT_)? identifier
+    : (owner DOT_)? name
     ;
 
 indexPartitionName

--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
@@ -513,6 +513,10 @@ collationName
     ;
 
 indexName
+    : (schemaName DOT_)? identifier
+    ;
+
+indexPartitionName
     : identifier
     ;
 

--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
@@ -361,6 +361,7 @@ partitionCmd
 
 alterIndexDefinitionClause
     : renameIndexSpecification | alterIndexDependsOnExtension | alterIndexSetTableSpace | alterTableCmds | indexPartitionCmd
+    | alterIndexMovePartition
     ;
 
 indexPartitionCmd
@@ -377,6 +378,10 @@ alterIndexDependsOnExtension
 
 alterIndexSetTableSpace
     : (OWNED BY ignoredIdentifiers)? SET TABLESPACE name (NOWAIT)?
+    ;
+
+alterIndexMovePartition
+    : MOVE PARTITION indexPartitionName TABLESPACE name
     ;
 
 tableNamesClause

--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
@@ -361,7 +361,7 @@ partitionCmd
 
 alterIndexDefinitionClause
     : renameIndexSpecification | alterIndexDependsOnExtension | alterIndexSetTableSpace | alterTableCmds | indexPartitionCmd
-    | alterIndexMovePartition
+    | alterIndexMovePartition | alterIndexRenamePartition
     ;
 
 indexPartitionCmd
@@ -382,6 +382,10 @@ alterIndexSetTableSpace
 
 alterIndexMovePartition
     : MOVE PARTITION indexPartitionName TABLESPACE name
+    ;
+
+alterIndexRenamePartition
+    : RENAME PARTITION indexPartitionName TO indexPartitionName
     ;
 
 tableNamesClause

--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
@@ -89,7 +89,7 @@ accessMethod
 
 createIndex
     : CREATE createIndexSpecification INDEX concurrentlyClause (ifNotExists? indexName)? ON onlyClause tableName
-      accessMethodClause? LP_ indexParams RP_ include? (WITH reloptions)? tableSpace? whereClause?
+      accessMethodClause? LP_ indexParams RP_ include? createIndexPartitionClause? (WITH reloptions)? tableSpace? whereClause?
     ;
 
 include
@@ -314,6 +314,19 @@ partStrategy
 
 createIndexSpecification
     : UNIQUE?
+    ;
+
+createIndexPartitionClause
+    : LOCAL (LP_ indexPartitionElemList RP_)?
+    | GLOBAL
+    ;
+
+indexPartitionElemList
+    : indexPartitionElem (COMMA_ indexPartitionElem)*
+    ;
+
+indexPartitionElem
+    : PARTITION indexPartitionName tableSpace?
     ;
 
 concurrentlyClause

--- a/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/OpenGaussStatementVisitor.java
+++ b/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/OpenGaussStatementVisitor.java
@@ -260,8 +260,13 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementBaseVi
     
     @Override
     public final ASTNode visitIndexName(final IndexNameContext ctx) {
-        IndexNameSegment indexName = new IndexNameSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), (IdentifierValue) visit(ctx.identifier()));
-        return new IndexSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), indexName);
+        IndexNameSegment indexName = new IndexNameSegment(ctx.name().getStart().getStartIndex(), ctx.name().getStop().getStopIndex(), (IdentifierValue) visit(ctx.name()));
+        IndexSegment result = new IndexSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), indexName);
+        OwnerContext owner = ctx.owner();
+        if (null != owner) {
+            result.setOwner(new OwnerSegment(owner.getStart().getStartIndex(), owner.getStop().getStopIndex(), (IdentifierValue) visit(owner.identifier())));
+        }
+        return result;
     }
     
     @Override

--- a/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/OpenGaussStatementVisitor.java
+++ b/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/OpenGaussStatementVisitor.java
@@ -207,6 +207,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segm
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.IndexPartitionTypeEnum;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.IndexPartitionsSegment;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.MovePartitionSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.RenamePartitionSegment;
 
 /**
  * Statement visitor for openGauss.
@@ -1463,5 +1464,12 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementBaseVi
                 (IdentifierValue) visit(ctx.indexPartitionName().identifier()));
         TablespaceSegment tablespace = new TablespaceSegment(ctx.name().getStart().getStartIndex(), ctx.name().getStop().getStopIndex(), (IdentifierValue) visit(ctx.name().identifier()));
         return new MovePartitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), partitionName, tablespace);
+    }
+
+    @Override
+    public ASTNode visitAlterIndexRenamePartition(final OpenGaussStatementParser.AlterIndexRenamePartitionContext ctx) {
+        PartitionNameSegment oldPartition = new PartitionNameSegment(ctx.indexPartitionName(0).getStart().getStartIndex(), ctx.indexPartitionName(0).getStop().getStopIndex(), (IdentifierValue) visit(ctx.indexPartitionName(0).identifier()));
+        PartitionNameSegment newPartition = new PartitionNameSegment(ctx.indexPartitionName(1).getStart().getStartIndex(), ctx.indexPartitionName(1).getStop().getStopIndex(), (IdentifierValue) visit(ctx.indexPartitionName(1).identifier()));
+        return new RenamePartitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), oldPartition, newPartition);
     }
 }

--- a/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/OpenGaussStatementVisitor.java
+++ b/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/OpenGaussStatementVisitor.java
@@ -1465,11 +1465,13 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementBaseVi
         TablespaceSegment tablespace = new TablespaceSegment(ctx.name().getStart().getStartIndex(), ctx.name().getStop().getStopIndex(), (IdentifierValue) visit(ctx.name().identifier()));
         return new MovePartitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), partitionName, tablespace);
     }
-
+    
     @Override
     public ASTNode visitAlterIndexRenamePartition(final OpenGaussStatementParser.AlterIndexRenamePartitionContext ctx) {
-        PartitionNameSegment oldPartition = new PartitionNameSegment(ctx.indexPartitionName(0).getStart().getStartIndex(), ctx.indexPartitionName(0).getStop().getStopIndex(), (IdentifierValue) visit(ctx.indexPartitionName(0).identifier()));
-        PartitionNameSegment newPartition = new PartitionNameSegment(ctx.indexPartitionName(1).getStart().getStartIndex(), ctx.indexPartitionName(1).getStop().getStopIndex(), (IdentifierValue) visit(ctx.indexPartitionName(1).identifier()));
+        PartitionNameSegment oldPartition = new PartitionNameSegment(ctx.indexPartitionName(0).getStart().getStartIndex(),
+                ctx.indexPartitionName(0).getStop().getStopIndex(), (IdentifierValue) visit(ctx.indexPartitionName(0).identifier()));
+        PartitionNameSegment newPartition = new PartitionNameSegment(ctx.indexPartitionName(1).getStart().getStartIndex(),
+                ctx.indexPartitionName(1).getStop().getStopIndex(), (IdentifierValue) visit(ctx.indexPartitionName(1).identifier()));
         return new RenamePartitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), oldPartition, newPartition);
     }
 }

--- a/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/type/OpenGaussDDLStatementVisitor.java
+++ b/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/type/OpenGaussDDLStatementVisitor.java
@@ -157,6 +157,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.cursor.Direct
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.index.IndexNameSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.index.IndexSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.table.RenameTableDefinitionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.tablespace.TablespaceSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.FunctionSegment;
@@ -253,6 +254,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.IndexPartitionsSegment;
 
 /**
  * DDL statement visitor for openGauss.
@@ -523,6 +525,12 @@ public final class OpenGaussDDLStatementVisitor extends OpenGaussStatementVisito
             result.setGeneratedIndexStartIndex(ctx.ON().getSymbol().getStartIndex() - 1);
         } else {
             result.setIndex((IndexSegment) visit(ctx.indexName()));
+        }
+        if (null != ctx.createIndexPartitionClause()) {
+            result.setIndexPartitionsSegment((IndexPartitionsSegment) visit(ctx.createIndexPartitionClause()));
+        }
+        if (null != ctx.tableSpace()) {
+            result.setTablespace((TablespaceSegment) visit(ctx.tableSpace()));
         }
         return result;
     }

--- a/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/type/OpenGaussDDLStatementVisitor.java
+++ b/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/type/OpenGaussDDLStatementVisitor.java
@@ -256,6 +256,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.IndexPartitionsSegment;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.MovePartitionSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.RenamePartitionSegment;
 
 /**
  * DDL statement visitor for openGauss.
@@ -582,6 +583,9 @@ public final class OpenGaussDDLStatementVisitor extends OpenGaussStatementVisito
         }
         if (null != ctx.alterIndexDefinitionClause().alterIndexMovePartition()) {
             result.setMovePartition((MovePartitionSegment) visit(ctx.alterIndexDefinitionClause().alterIndexMovePartition()));
+        }
+        if (null != ctx.alterIndexDefinitionClause().alterIndexRenamePartition()) {
+            result.setRenamePartition((RenamePartitionSegment) visit(ctx.alterIndexDefinitionClause().alterIndexRenamePartition()));
         }
         return result;
     }

--- a/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/type/OpenGaussDDLStatementVisitor.java
+++ b/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/type/OpenGaussDDLStatementVisitor.java
@@ -430,7 +430,7 @@ public final class OpenGaussDDLStatementVisitor extends OpenGaussStatementVisito
         ColumnDefinitionContext columnDefinition = ctx.columnDefinition();
         if (null != columnDefinition) {
             AddColumnDefinitionSegment addColumnDefinition = new AddColumnDefinitionSegment(
-                    ctx.columnDefinition().getStart().getStartIndex(), columnDefinition.getStop().getStopIndex(), Collections.singletonList((ColumnDefinitionSegment) visit(columnDefinition)));
+                    ctx.columnDefinition().getStart().getStartIndex(), columnDefinition.getStop().getStopIndex(), Collections.singleton((ColumnDefinitionSegment) visit(columnDefinition)));
             result.getValue().add(addColumnDefinition);
         }
         return result;
@@ -490,7 +490,7 @@ public final class OpenGaussDDLStatementVisitor extends OpenGaussStatementVisito
     
     @Override
     public ASTNode visitDropColumnSpecification(final DropColumnSpecificationContext ctx) {
-        return new DropColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), Collections.singletonList((ColumnSegment) visit(ctx.columnName())));
+        return new DropColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), Collections.singleton((ColumnSegment) visit(ctx.columnName())));
     }
     
     @Override

--- a/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/type/OpenGaussDDLStatementVisitor.java
+++ b/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/type/OpenGaussDDLStatementVisitor.java
@@ -255,6 +255,7 @@ import java.util.LinkedList;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.IndexPartitionsSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.MovePartitionSegment;
 
 /**
  * DDL statement visitor for openGauss.
@@ -578,6 +579,9 @@ public final class OpenGaussDDLStatementVisitor extends OpenGaussStatementVisito
         result.setIndex(createIndexSegment((SimpleTableSegment) visit(ctx.qualifiedName())));
         if (null != ctx.alterIndexDefinitionClause().renameIndexSpecification()) {
             result.setRenameIndex((IndexSegment) visit(ctx.alterIndexDefinitionClause().renameIndexSpecification().indexName()));
+        }
+        if (null != ctx.alterIndexDefinitionClause().alterIndexMovePartition()) {
+            result.setMovePartition((MovePartitionSegment) visit(ctx.alterIndexDefinitionClause().alterIndexMovePartition()));
         }
         return result;
     }

--- a/parser/sql/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/type/PostgreSQLDDLStatementVisitor.java
+++ b/parser/sql/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/type/PostgreSQLDDLStatementVisitor.java
@@ -541,7 +541,7 @@ public final class PostgreSQLDDLStatementVisitor extends PostgreSQLStatementVisi
         ColumnDefinitionContext columnDefinition = ctx.columnDefinition();
         if (null != columnDefinition) {
             AddColumnDefinitionSegment addColumnDefinition = new AddColumnDefinitionSegment(
-                    ctx.columnDefinition().getStart().getStartIndex(), columnDefinition.getStop().getStopIndex(), Collections.singletonList((ColumnDefinitionSegment) visit(columnDefinition)));
+                    ctx.columnDefinition().getStart().getStartIndex(), columnDefinition.getStop().getStopIndex(), Collections.singleton((ColumnDefinitionSegment) visit(columnDefinition)));
             result.getValue().add(addColumnDefinition);
         }
         return result;
@@ -601,7 +601,7 @@ public final class PostgreSQLDDLStatementVisitor extends PostgreSQLStatementVisi
     
     @Override
     public ASTNode visitDropColumnSpecification(final DropColumnSpecificationContext ctx) {
-        return new DropColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), Collections.singletonList((ColumnSegment) visit(ctx.columnName())));
+        return new DropColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), Collections.singleton((ColumnSegment) visit(ctx.columnName())));
     }
     
     @Override

--- a/parser/sql/dialect/sql92/src/main/java/org/apache/shardingsphere/sql/parser/sql92/visitor/statement/type/SQL92DDLStatementVisitor.java
+++ b/parser/sql/dialect/sql92/src/main/java/org/apache/shardingsphere/sql/parser/sql92/visitor/statement/type/SQL92DDLStatementVisitor.java
@@ -205,8 +205,7 @@ public final class SQL92DDLStatementVisitor extends SQL92StatementVisitor implem
     
     @Override
     public ASTNode visitDropColumnSpecification(final DropColumnSpecificationContext ctx) {
-        return new DropColumnDefinitionSegment(
-                ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), Collections.singletonList((ColumnSegment) visit(ctx.columnName())));
+        return new DropColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), Collections.singleton((ColumnSegment) visit(ctx.columnName())));
     }
     
     @SuppressWarnings("unchecked")

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/ddl/partition/PartitionNameSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/ddl/partition/PartitionNameSegment.java
@@ -15,30 +15,24 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment;
+package org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.partition;
 
-import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.SQLSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.partition.PartitionNameSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.tablespace.TablespaceSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 
+/**
+ * Partition name segment.
+ */
 @RequiredArgsConstructor
 @Getter
-@Setter
-public class IndexPartitionSegment implements SQLSegment {
+public class PartitionNameSegment implements SQLSegment {
     
     private final int startIndex;
     
     private final int stopIndex;
     
-    private final PartitionNameSegment partitionName;
+    private final IdentifierValue identifier;
     
-    private TablespaceSegment tablespace;
-    
-    public Optional<TablespaceSegment> getTablespace() {
-        return Optional.ofNullable(tablespace);
-    }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/ExpressionExtractUtils.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/ExpressionExtractUtils.java
@@ -109,14 +109,14 @@ public final class ExpressionExtractUtils {
             }
             // TODO support more expression type if necessary
             if (each instanceof BinaryOperationExpression) {
-                extractParameterMarkerExpressions(result, Collections.singletonList(((BinaryOperationExpression) each).getLeft()));
-                extractParameterMarkerExpressions(result, Collections.singletonList(((BinaryOperationExpression) each).getRight()));
+                extractParameterMarkerExpressions(result, Collections.singleton(((BinaryOperationExpression) each).getLeft()));
+                extractParameterMarkerExpressions(result, Collections.singleton(((BinaryOperationExpression) each).getRight()));
             }
             if (each instanceof FunctionSegment) {
                 extractParameterMarkerExpressions(result, ((FunctionSegment) each).getParameters());
             }
             if (each instanceof TypeCastExpression) {
-                extractParameterMarkerExpressions(result, Collections.singletonList(((TypeCastExpression) each).getExpression()));
+                extractParameterMarkerExpressions(result, Collections.singleton(((TypeCastExpression) each).getExpression()));
             }
             if (each instanceof InExpression) {
                 extractParameterMarkerExpressions(result, ((InExpression) each).getExpressionList());

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateIndexStatementHandler.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateIndexStatementHandler.java
@@ -21,11 +21,13 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.table.AlgorithmTypeSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.table.LockTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.tablespace.TablespaceSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.SQLStatementHandler;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.ddl.MySQLCreateIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.OpenGaussStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussCreateIndexStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.IndexPartitionsSegment;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.PostgreSQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLCreateIndexStatement;
 
@@ -94,4 +96,31 @@ public final class CreateIndexStatementHandler implements SQLStatementHandler {
         }
         return Optional.empty();
     }
+    
+    /**
+     * Get index partitions segment.
+     *
+     * @param createIndexStatement create index statement
+     * @return index partitions segment
+     */
+    public static Optional<IndexPartitionsSegment> getIndexPartitionsSegment(final CreateIndexStatement createIndexStatement) {
+        if (createIndexStatement instanceof OpenGaussCreateIndexStatement) {
+            return ((OpenGaussCreateIndexStatement) createIndexStatement).getIndexPartitionsSegment();
+        }
+        return Optional.empty();
+    }
+    
+    /**
+     * Get tablespace segment.
+     *
+     * @param createIndexStatement create index statement
+     * @return tablespace segment
+     */
+    public static Optional<TablespaceSegment> getTablespaceSegment(final CreateIndexStatement createIndexStatement) {
+        if (createIndexStatement instanceof OpenGaussCreateIndexStatement) {
+            return ((OpenGaussCreateIndexStatement) createIndexStatement).getTablespace();
+        }
+        return Optional.empty();
+    }
+    
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussAlterIndexStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussAlterIndexStatement.java
@@ -35,7 +35,7 @@ public final class OpenGaussAlterIndexStatement extends AlterIndexStatement impl
     private IndexSegment renameIndex;
     
     private MovePartitionSegment movePartition;
-
+    
     private RenamePartitionSegment renamePartition;
     
     /**
@@ -55,7 +55,7 @@ public final class OpenGaussAlterIndexStatement extends AlterIndexStatement impl
     public Optional<MovePartitionSegment> getMovePartition() {
         return Optional.ofNullable(movePartition);
     }
-
+    
     /**
      * Get rename partition segment.
      *

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussAlterIndexStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussAlterIndexStatement.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.Open
 
 import java.util.Optional;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.MovePartitionSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.RenamePartitionSegment;
 
 /**
  * OpenGauss alter index statement.
@@ -34,6 +35,8 @@ public final class OpenGaussAlterIndexStatement extends AlterIndexStatement impl
     private IndexSegment renameIndex;
     
     private MovePartitionSegment movePartition;
+
+    private RenamePartitionSegment renamePartition;
     
     /**
      * Get rename index segment.
@@ -46,9 +49,19 @@ public final class OpenGaussAlterIndexStatement extends AlterIndexStatement impl
     
     /**
      * Get move partition segment.
+     *
      * @return move partition segment
      */
     public Optional<MovePartitionSegment> getMovePartition() {
         return Optional.ofNullable(movePartition);
+    }
+
+    /**
+     * Get rename partition segment.
+     *
+     * @return rename partition segment
+     */
+    public Optional<RenamePartitionSegment> getRenamePartition() {
+        return Optional.ofNullable(renamePartition);
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussAlterIndexStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussAlterIndexStatement.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterIndexS
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.OpenGaussStatement;
 
 import java.util.Optional;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.MovePartitionSegment;
 
 /**
  * OpenGauss alter index statement.
@@ -32,6 +33,8 @@ public final class OpenGaussAlterIndexStatement extends AlterIndexStatement impl
     
     private IndexSegment renameIndex;
     
+    private MovePartitionSegment movePartition;
+    
     /**
      * Get rename index segment.
      *
@@ -39,5 +42,13 @@ public final class OpenGaussAlterIndexStatement extends AlterIndexStatement impl
      */
     public Optional<IndexSegment> getRenameIndex() {
         return Optional.ofNullable(renameIndex);
+    }
+    
+    /**
+     * Get move partition segment.
+     * @return move partition segment
+     */
+    public Optional<MovePartitionSegment> getMovePartition() {
+        return Optional.ofNullable(movePartition);
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussCreateIndexStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussCreateIndexStatement.java
@@ -20,10 +20,12 @@ package org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.tablespace.TablespaceSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.OpenGaussStatement;
 
 import java.util.Optional;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.IndexPartitionsSegment;
 
 /**
  * OpenGauss create index statement.
@@ -37,6 +39,10 @@ public final class OpenGaussCreateIndexStatement extends CreateIndexStatement im
     
     private Integer generatedIndexStartIndex;
     
+    private IndexPartitionsSegment indexPartitionsSegment;
+    
+    private TablespaceSegment tablespace;
+    
     /**
      * Get generated index start index.
      *
@@ -44,5 +50,22 @@ public final class OpenGaussCreateIndexStatement extends CreateIndexStatement im
      */
     public Optional<Integer> getGeneratedIndexStartIndex() {
         return Optional.ofNullable(generatedIndexStartIndex);
+    }
+    
+    /**
+     * Get index partitions segment.
+     *
+     * @return index partitions segment
+     */
+    public Optional<IndexPartitionsSegment> getIndexPartitionsSegment() {
+        return Optional.ofNullable(indexPartitionsSegment);
+    }
+    
+    /**
+     * Get tablespace.
+     * @return tablespace
+     */
+    public Optional<TablespaceSegment> getTablespace() {
+        return Optional.ofNullable(tablespace);
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/segment/IndexPartitionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/segment/IndexPartitionSegment.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment;
+
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.SQLSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.tablespace.TablespaceSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
+
+@RequiredArgsConstructor
+@Getter
+@Setter
+public class IndexPartitionSegment implements SQLSegment {
+    
+    private final int startIndex;
+    
+    private final int stopIndex;
+    
+    private final IdentifierValue indexPartitionName;
+    
+    private TablespaceSegment tablespace;
+    
+    public Optional<TablespaceSegment> getTablespace() {
+        return Optional.ofNullable(tablespace);
+    }
+}

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/segment/IndexPartitionTypeEnum.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/segment/IndexPartitionTypeEnum.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment;
+
+public enum IndexPartitionTypeEnum {
+    GLOBAL, LOCAL
+}

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/segment/IndexPartitionsSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/segment/IndexPartitionsSegment.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.AlterDefinitionSegment;
+
+@RequiredArgsConstructor
+@Getter
+public class IndexPartitionsSegment implements AlterDefinitionSegment {
+    
+    private final int startIndex;
+    
+    private final int stopIndex;
+    
+    private final IndexPartitionTypeEnum partitionType;
+    
+    private final Collection<IndexPartitionSegment> indexPartitionSegment = new LinkedList<>();
+}

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/segment/MovePartitionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/segment/MovePartitionSegment.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment;
 
-import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -28,7 +27,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.tablespace.Ta
 @RequiredArgsConstructor
 @Getter
 @Setter
-public class IndexPartitionSegment implements SQLSegment {
+public class MovePartitionSegment implements SQLSegment {
     
     private final int startIndex;
     
@@ -36,9 +35,5 @@ public class IndexPartitionSegment implements SQLSegment {
     
     private final PartitionNameSegment partitionName;
     
-    private TablespaceSegment tablespace;
-    
-    public Optional<TablespaceSegment> getTablespace() {
-        return Optional.ofNullable(tablespace);
-    }
+    private final TablespaceSegment tablespace;
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/segment/RenamePartitionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/segment/RenamePartitionSegment.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment;
 
 import lombok.Getter;
@@ -10,12 +27,12 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.partition.Par
 @Getter
 @Setter
 public class RenamePartitionSegment implements SQLSegment {
-
+    
     private final int startIndex;
-
+    
     private final int stopIndex;
-
+    
     private final PartitionNameSegment oldPartition;
-
+    
     private final PartitionNameSegment newPartition;
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/segment/RenamePartitionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/segment/RenamePartitionSegment.java
@@ -1,0 +1,21 @@
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.SQLSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.partition.PartitionNameSegment;
+
+@RequiredArgsConstructor
+@Getter
+@Setter
+public class RenamePartitionSegment implements SQLSegment {
+
+    private final int startIndex;
+
+    private final int stopIndex;
+
+    private final PartitionNameSegment oldPartition;
+
+    private final PartitionNameSegment newPartition;
+}

--- a/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/ColumnExtractorTest.java
+++ b/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/ColumnExtractorTest.java
@@ -51,6 +51,6 @@ class ColumnExtractorTest {
                 new ColumnSegment(10, 13, new IdentifierValue("name")), new LiteralExpressionSegment(18, 22, "LiLei"), "=", "name = 'LiLei'");
         BinaryOperationExpression rightExpression = new BinaryOperationExpression(30, 44,
                 new ColumnSegment(30, 32, new IdentifierValue("pwd")), new LiteralExpressionSegment(40, 45, "123456"), "=", "pwd = '123456'");
-        return Collections.singletonList(new WhereSegment(0, 0, new BinaryOperationExpression(0, 0, leftExpression, rightExpression, "AND", "name = 'LiLei' AND pwd = '123456'")));
+        return Collections.singleton(new WhereSegment(0, 0, new BinaryOperationExpression(0, 0, leftExpression, rightExpression, "AND", "name = 'LiLei' AND pwd = '123456'")));
     }
 }

--- a/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/ExpressionExtractUtilsTest.java
+++ b/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/ExpressionExtractUtilsTest.java
@@ -121,14 +121,14 @@ class ExpressionExtractUtilsTest {
         functionSegment.getParameters().add(param1);
         functionSegment.getParameters().add(param2);
         functionSegment.getParameters().add(param3);
-        List<ParameterMarkerExpressionSegment> result = ExpressionExtractUtils.getParameterMarkerExpressions(Collections.singletonList(functionSegment));
+        List<ParameterMarkerExpressionSegment> result = ExpressionExtractUtils.getParameterMarkerExpressions(Collections.singleton(functionSegment));
         assertThat(result.size(), is(1));
     }
     
     @Test
     void assertGetParameterMarkerExpressionsFromTypeCastExpression() {
         ParameterMarkerExpressionSegment expected = new ParameterMarkerExpressionSegment(0, 0, 1, ParameterMarkerType.DOLLAR);
-        List<ExpressionSegment> input = Collections.singletonList(new TypeCastExpression(0, 0, "$2::varchar", expected, "varchar"));
+        Collection<ExpressionSegment> input = Collections.singleton(new TypeCastExpression(0, 0, "$2::varchar", expected, "varchar"));
         List<ParameterMarkerExpressionSegment> actual = ExpressionExtractUtils.getParameterMarkerExpressions(input);
         assertThat(actual.size(), is(1));
         assertThat(actual.get(0), is(expected));
@@ -139,7 +139,7 @@ class ExpressionExtractUtilsTest {
         ListExpression listExpression = new ListExpression(0, 0);
         listExpression.getItems().add(new ParameterMarkerExpressionSegment(0, 0, 1, ParameterMarkerType.QUESTION));
         listExpression.getItems().add(new ParameterMarkerExpressionSegment(0, 0, 2, ParameterMarkerType.QUESTION));
-        List<ExpressionSegment> inExpressions = Collections.singletonList(new InExpression(0, 0, new ColumnSegment(0, 0, new IdentifierValue("order_id")), listExpression, false));
+        Collection<ExpressionSegment> inExpressions = Collections.singleton(new InExpression(0, 0, new ColumnSegment(0, 0, new IdentifierValue("order_id")), listExpression, false));
         List<ParameterMarkerExpressionSegment> actual = ExpressionExtractUtils.getParameterMarkerExpressions(inExpressions);
         assertThat(actual.size(), is(2));
     }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/RefreshTableMetaDataUpdater.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/RefreshTableMetaDataUpdater.java
@@ -65,7 +65,7 @@ public final class RefreshTableMetaDataUpdater implements ConnectionSessionRequi
         if (sqlStatement.getStorageUnitName().isPresent()) {
             String storageUnitName = sqlStatement.getStorageUnitName().get();
             ShardingSpherePreconditions.checkState(
-                    storageUnits.containsKey(storageUnitName), () -> new MissingRequiredStorageUnitsException(databaseName, Collections.singletonList(storageUnitName)));
+                    storageUnits.containsKey(storageUnitName), () -> new MissingRequiredStorageUnitsException(databaseName, Collections.singleton(storageUnitName)));
         }
     }
     

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/util/DatabaseVersionParser.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/util/DatabaseVersionParser.java
@@ -17,9 +17,9 @@
 
 package org.apache.shardingsphere.test.e2e.env.container.atomic.util;
 
+import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Database version parser.
@@ -34,6 +34,6 @@ public final class DatabaseVersionParser {
      * @return major version
      */
     public static String parseMajorVersion(final String storageContainerImage) {
-        return StringUtils.isBlank(storageContainerImage) ? "" : storageContainerImage.substring(storageContainerImage.indexOf(':') + 1, storageContainerImage.indexOf('.'));
+        return Strings.isNullOrEmpty(storageContainerImage) ? "" : storageContainerImage.substring(storageContainerImage.indexOf(':') + 1, storageContainerImage.indexOf('.'));
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserIT.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserIT.java
@@ -80,8 +80,7 @@ public abstract class InternalSQLParserIT {
                     result.add(Arguments.arguments(each.getSqlCaseId(), each.getSqlCaseType(), each.getDatabaseType()));
                 }
             }
-//            return result;
-            return result.stream().filter(e -> "alter_index_rename_partition02".equals(e.get()[0])).collect(Collectors.toList());
+            return result;
         }
         
         private boolean isPlaceholderWithoutParameter(final InternalSQLParserTestParameter testParam) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserIT.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserIT.java
@@ -80,6 +80,7 @@ public abstract class InternalSQLParserIT {
                     result.add(Arguments.arguments(each.getSqlCaseId(), each.getSqlCaseType(), each.getDatabaseType()));
                 }
             }
+//            return result;
             return result.stream().filter(e -> "alter_index_rename_partition02".equals(e.get()[0])).collect(Collectors.toList());
         }
         

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserIT.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserIT.java
@@ -80,7 +80,7 @@ public abstract class InternalSQLParserIT {
                     result.add(Arguments.arguments(each.getSqlCaseId(), each.getSqlCaseType(), each.getDatabaseType()));
                 }
             }
-            return result;
+            return result.stream().filter(e -> "alter_index_rename_partition02".equals(e.get()[0])).collect(Collectors.toList());
         }
         
         private boolean isPlaceholderWithoutParameter(final InternalSQLParserTestParameter testParam) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserIT.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserIT.java
@@ -80,7 +80,7 @@ public abstract class InternalSQLParserIT {
                     result.add(Arguments.arguments(each.getSqlCaseId(), each.getSqlCaseType(), each.getDatabaseType()));
                 }
             }
-            return result;
+            return result.stream().filter(r -> "create_index_with_owner01".equals(r.get()[0])).collect(Collectors.toList());
         }
         
         private boolean isPlaceholderWithoutParameter(final InternalSQLParserTestParameter testParam) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserIT.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserIT.java
@@ -80,7 +80,7 @@ public abstract class InternalSQLParserIT {
                     result.add(Arguments.arguments(each.getSqlCaseId(), each.getSqlCaseType(), each.getDatabaseType()));
                 }
             }
-            return result.stream().filter(r -> "create_index_with_owner01".equals(r.get()[0])).collect(Collectors.toList());
+            return result;
         }
         
         private boolean isPlaceholderWithoutParameter(final InternalSQLParserTestParameter testParam) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/index/IndexPartitionsAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/index/IndexPartitionsAssert.java
@@ -58,7 +58,7 @@ public class IndexPartitionsAssert {
     private static void assertIs(final SQLCaseAssertContext assertContext, final IndexPartitionSegment actual, final ExpectedIndexPartition expected) {
         assertNotNull(expected, assertContext.getText("Index partition should exist."));
         assertNotNull(actual, assertContext.getText("Index partition should exist."));
-        IdentifierValueAssert.assertIs(assertContext, actual.getIndexPartitionName(), expected, "Index Partition");
+        IdentifierValueAssert.assertIs(assertContext, actual.getPartitionName().getIdentifier(), expected, "Index Partition");
         if (null == expected.getTablespace()) {
             assertFalse(actual.getTablespace().isPresent(), assertContext.getText("Actual tablespace should not exist."));
         } else {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/index/IndexPartitionsAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/index/IndexPartitionsAssert.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.index;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.IndexPartitionSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.IndexPartitionsSegment;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.identifier.IdentifierValueAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.tablespace.TablespaceAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index.ExpectedIndexPartition;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index.ExpectedIndexPartitions;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IndexPartitionsAssert {
+    
+    /**
+     * Assert actual index partitions segment is correct with expected index.
+     *
+     * @param assertContext assert context
+     * @param actual actual index segment
+     * @param expected expected index
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final IndexPartitionsSegment actual, final ExpectedIndexPartitions expected) {
+        assertNotNull(expected, assertContext.getText("Index partitions should exist."));
+        assertThat(assertContext.getText("Index partitions type assertion error: "), actual.getPartitionType().name(), is(expected.getType()));
+        assertThat(assertContext.getText("Index partitions size assertion error: "), actual.getIndexPartitionSegment().size(), is(expected.getPartitions().size()));
+        int i = 0;
+        for (IndexPartitionSegment actualIndexPartitionSegment : actual.getIndexPartitionSegment()) {
+            assertIs(assertContext, actualIndexPartitionSegment, expected.getPartitions().get(i++));
+        }
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+    }
+    
+    private static void assertIs(final SQLCaseAssertContext assertContext, final IndexPartitionSegment actual, final ExpectedIndexPartition expected) {
+        assertNotNull(expected, assertContext.getText("Index partition should exist."));
+        assertNotNull(actual, assertContext.getText("Index partition should exist."));
+        IdentifierValueAssert.assertIs(assertContext, actual.getIndexPartitionName(), expected, "Index Partition");
+        if (null == expected.getTablespace()) {
+            assertFalse(actual.getTablespace().isPresent(), assertContext.getText("Actual tablespace should not exist."));
+        } else {
+            assertTrue(actual.getTablespace().isPresent(), assertContext.getText("Actual tablespace should exist."));
+            TablespaceAssert.assertIs(assertContext, actual.getTablespace().get(), expected.getTablespace());
+        }
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/tablespace/TablespaceAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/tablespace/TablespaceAssert.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.tablespace;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.tablespace.TablespaceSegment;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.identifier.IdentifierValueAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.tablespace.ExpectedTablespace;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TablespaceAssert {
+    
+    /**
+     * Assert actual tablespace segment is correct with expected tablespace.
+     *
+     * @param assertContext assert context
+     * @param actual actual tablespace segment
+     * @param expected expected tablespace
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final TablespaceSegment actual, final ExpectedTablespace expected) {
+        assertNotNull(expected, assertContext.getText("Tablespace should exist."));
+        IdentifierValueAssert.assertIs(assertContext, actual.getIdentifier(), expected, "Tablespace");
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/AlterIndexStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/AlterIndexStatementAssert.java
@@ -24,14 +24,12 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.tablespace.Ta
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.AlterIndexStatementHandler;
-import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.CreateIndexStatementHandler;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussAlterIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.MovePartitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleAlterIndexStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.index.IndexAssert;
-import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.index.IndexPartitionsAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.table.TableAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.tablespace.TablespaceAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index.ExpectedPartition;

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/AlterIndexStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/AlterIndexStatementAssert.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterIndexS
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.AlterIndexStatementHandler;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussAlterIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.MovePartitionSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.segment.RenamePartitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleAlterIndexStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
@@ -62,6 +63,7 @@ public final class AlterIndexStatementAssert {
         assertTable(assertContext, actual, expected);
         assertIndex(assertContext, actual, expected);
         assertMovePartition(assertContext, actual, expected);
+        assertRenamePartition(assertContext, actual, expected);
     }
     
     private static void assertTable(final SQLCaseAssertContext assertContext, final AlterIndexStatement actual, final AlterIndexStatementTestCase expected) {
@@ -114,6 +116,21 @@ public final class AlterIndexStatementAssert {
         } else {
             assertNotNull(actual, assertContext.getText("Actual tablespace segments should exist."));
             TablespaceAssert.assertIs(assertContext, actual, expected);
+        }
+    }
+
+    private static void assertRenamePartition(final SQLCaseAssertContext assertContext, final AlterIndexStatement actual, final AlterIndexStatementTestCase expected) {
+        if (actual instanceof OpenGaussAlterIndexStatement) {
+            OpenGaussAlterIndexStatement ogActual = (OpenGaussAlterIndexStatement) actual;
+            if (null == expected.getRenamePartition()) {
+                assertFalse(ogActual.getRenamePartition().isPresent(), assertContext.getText("Actual rename partition should not exist."));
+            } else {
+                assertTrue(ogActual.getRenamePartition().isPresent(), assertContext.getText("Actual rename partition should exist."));
+                RenamePartitionSegment renamePartition = ogActual.getRenamePartition().get();
+                assertPartition(assertContext, renamePartition.getOldPartition(), expected.getRenamePartition().getOldPartition());
+                assertPartition(assertContext, renamePartition.getNewPartition(), expected.getRenamePartition().getNewPartition());
+                SQLSegmentAssert.assertIs(assertContext, renamePartition, expected.getRenamePartition());
+            }
         }
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/AlterIndexStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/AlterIndexStatementAssert.java
@@ -118,7 +118,7 @@ public final class AlterIndexStatementAssert {
             TablespaceAssert.assertIs(assertContext, actual, expected);
         }
     }
-
+    
     private static void assertRenamePartition(final SQLCaseAssertContext assertContext, final AlterIndexStatement actual, final AlterIndexStatementTestCase expected) {
         if (actual instanceof OpenGaussAlterIndexStatement) {
             OpenGaussAlterIndexStatement ogActual = (OpenGaussAlterIndexStatement) actual;

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/CreateIndexStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/CreateIndexStatementAssert.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.tablespace.TablespaceSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.CreateIndexStatementHandler;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussCreateIndexStatement;
@@ -30,6 +31,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.col
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.index.IndexAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.index.IndexPartitionsAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.table.TableAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.tablespace.TablespaceAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.CreateIndexStatementTestCase;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -107,13 +109,17 @@ public final class CreateIndexStatementAssert {
     }
     
     private static void assertTablespace(final SQLCaseAssertContext assertContext, final CreateIndexStatement actual, final CreateIndexStatementTestCase expected) {
-        if (null == expected.getTablespace()) {
-            assertFalse(CreateIndexStatementHandler.getTablespaceSegment(actual).isPresent(), assertContext.getText("Actual tablespace segments should not exist."));
-        } else {
-            assertTrue(CreateIndexStatementHandler.getTablespaceSegment(actual).isPresent(), assertContext.getText("Actual tablespace segments should exist."));
-            assertThat(assertContext.getText(String.format("`%s`'s tablespace assertion error: ", actual.getClass().getSimpleName())),
-                    CreateIndexStatementHandler.getTablespaceSegment(actual).get().getIdentifier().getValue(), is(expected.getTablespace().getName()));
+        // TODO should assert tablespace for all databases(postgreSQL do not support tablespace right now)
+        if (actual instanceof OpenGaussCreateIndexStatement) {
+            if (null == expected.getTablespace()) {
+                assertFalse(CreateIndexStatementHandler.getTablespaceSegment(actual).isPresent(), assertContext.getText("Actual tablespace segments should not exist."));
+            } else {
+                assertTrue(CreateIndexStatementHandler.getTablespaceSegment(actual).isPresent(), assertContext.getText("Actual tablespace segments should exist."));
+                TablespaceSegment tablespaceSegment = CreateIndexStatementHandler.getTablespaceSegment(actual).get();
+                TablespaceAssert.assertIs(assertContext, tablespaceSegment, expected.getTablespace());
+            }
         }
+
     }
     
     private static void assertIndexPartitions(final SQLCaseAssertContext assertContext, final CreateIndexStatement actual, final CreateIndexStatementTestCase expected) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/CreateIndexStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/CreateIndexStatementAssert.java
@@ -119,7 +119,7 @@ public final class CreateIndexStatementAssert {
                 TablespaceAssert.assertIs(assertContext, tablespaceSegment, expected.getTablespace());
             }
         }
-
+        
     }
     
     private static void assertIndexPartitions(final SQLCaseAssertContext assertContext, final CreateIndexStatement actual, final CreateIndexStatementTestCase expected) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/CreateIndexStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/CreateIndexStatementAssert.java
@@ -75,10 +75,6 @@ public final class CreateIndexStatementAssert {
         // TODO should assert index for all databases(mysql and sqlserver do not parse index right now)
         if (actual instanceof OracleCreateIndexStatement) {
             IndexAssert.assertIs(assertContext, actual.getIndex(), expected.getIndex());
-        } else if (actual instanceof OpenGaussCreateIndexStatement) {
-            if (null != expected.getIndex()) {
-                IndexAssert.assertIs(assertContext, actual.getIndex(), expected.getIndex());
-            }
         }
     }
     

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/CreateIndexStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/CreateIndexStatementAssert.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.CreateIndexStatementHandler;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussCreateIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleCreateIndexStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.column.ColumnAssert;
@@ -68,6 +69,8 @@ public final class CreateIndexStatementAssert {
     private static void assertIndex(final SQLCaseAssertContext assertContext, final CreateIndexStatement actual, final CreateIndexStatementTestCase expected) {
         // TODO should assert index for all databases(mysql and sqlserver do not parse index right now)
         if (actual instanceof OracleCreateIndexStatement) {
+            IndexAssert.assertIs(assertContext, actual.getIndex(), expected.getIndex());
+        } else if (actual instanceof OpenGaussCreateIndexStatement) {
             IndexAssert.assertIs(assertContext, actual.getIndex(), expected.getIndex());
         }
     }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/index/ExpectedIndexPartition.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/index/ExpectedIndexPartition.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index;
+
+import javax.xml.bind.annotation.XmlElement;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.AbstractExpectedIdentifierSQLSegment;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.tablespace.ExpectedTablespace;
+
+@Getter
+@Setter
+public class ExpectedIndexPartition extends AbstractExpectedIdentifierSQLSegment {
+    
+    @XmlElement
+    private ExpectedTablespace tablespace;
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/index/ExpectedIndexPartitions.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/index/ExpectedIndexPartitions.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index;
+
+import java.util.LinkedList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.AbstractExpectedSQLSegment;
+
+@Getter
+@Setter
+public class ExpectedIndexPartitions extends AbstractExpectedSQLSegment {
+    
+    @XmlAttribute
+    private String type;
+    
+    @XmlElement(name = "index-partition")
+    private final List<ExpectedIndexPartition> partitions = new LinkedList<>();
+    
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/index/ExpectedMovePartition.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/index/ExpectedMovePartition.java
@@ -15,30 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl;
-
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index.ExpectedIndex;
-import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index.ExpectedMovePartition;
-import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedSimpleTable;
-import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index;
 
 import javax.xml.bind.annotation.XmlElement;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.AbstractExpectedSQLSegment;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.tablespace.ExpectedTablespace;
 
-/**
- * Alter index statement test case.
- */
 @Getter
 @Setter
-public final class AlterIndexStatementTestCase extends SQLParserTestCase {
+public class ExpectedMovePartition extends AbstractExpectedSQLSegment {
     
     @XmlElement
-    private ExpectedIndex index;
+    private ExpectedPartition partition;
     
     @XmlElement
-    private ExpectedSimpleTable table;
-    
-    @XmlElement(name = "move-partition")
-    private ExpectedMovePartition movePartition;
+    private ExpectedTablespace tablespace;
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/index/ExpectedRenamePartition.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/index/ExpectedRenamePartition.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -8,10 +25,10 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 @Getter
 @Setter
 public class ExpectedRenamePartition extends AbstractExpectedSQLSegment {
-
+    
     @XmlElement(name = "old-partition")
     private ExpectedPartition oldPartition;
-
+    
     @XmlElement(name = "new-partition")
     private ExpectedPartition newPartition;
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/index/ExpectedRenamePartition.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/index/ExpectedRenamePartition.java
@@ -1,0 +1,17 @@
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index;
+
+import javax.xml.bind.annotation.XmlElement;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.AbstractExpectedSQLSegment;
+
+@Getter
+@Setter
+public class ExpectedRenamePartition extends AbstractExpectedSQLSegment {
+
+    @XmlElement(name = "old-partition")
+    private ExpectedPartition oldPartition;
+
+    @XmlElement(name = "new-partition")
+    private ExpectedPartition newPartition;
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/AlterIndexStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/AlterIndexStatementTestCase.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index.ExpectedIndex;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index.ExpectedMovePartition;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index.ExpectedRenamePartition;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedSimpleTable;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
 
@@ -41,4 +42,7 @@ public final class AlterIndexStatementTestCase extends SQLParserTestCase {
     
     @XmlElement(name = "move-partition")
     private ExpectedMovePartition movePartition;
+
+    @XmlElement(name = "rename-partition")
+    private ExpectedRenamePartition renamePartition;
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/AlterIndexStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/AlterIndexStatementTestCase.java
@@ -42,7 +42,7 @@ public final class AlterIndexStatementTestCase extends SQLParserTestCase {
     
     @XmlElement(name = "move-partition")
     private ExpectedMovePartition movePartition;
-
+    
     @XmlElement(name = "rename-partition")
     private ExpectedRenamePartition renamePartition;
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/CreateIndexStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/CreateIndexStatementTestCase.java
@@ -22,6 +22,7 @@ import lombok.Setter;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.algorithm.ExpectedAlgorithmClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.column.ExpectedColumn;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index.ExpectedIndex;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.index.ExpectedIndexPartitions;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.lock.ExpectedLockTypeClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedTable;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
@@ -29,6 +30,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.S
 import javax.xml.bind.annotation.XmlElement;
 import java.util.LinkedList;
 import java.util.List;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.tablespace.ExpectedTablespace;
 
 /**
  * Create index statement test case.
@@ -48,6 +50,12 @@ public final class CreateIndexStatementTestCase extends SQLParserTestCase {
     
     @XmlElement(name = "lock-option")
     private ExpectedLockTypeClause lockOption;
+    
+    @XmlElement(name = "index-partitions")
+    private ExpectedIndexPartitions indexPartitions;
+    
+    @XmlElement(name = "tablespace")
+    private ExpectedTablespace tablespace;
     
     @XmlElement(name = "column")
     private final List<ExpectedColumn> columns = new LinkedList<>();

--- a/test/it/parser/src/main/resources/case/ddl/alter-index.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-index.xml
@@ -154,4 +154,13 @@
             <tablespace name="tablespace1" start-index="95" stop-index="105" />
         </move-partition>
     </alter-index>
+    <alter-index sql-case-id="alter_index_rename_partition02">
+        <index name="ds_customer_address_p1_index2" start-index="12" stop-index="46" >
+            <owner name="tpcds" start-index="12" stop-index="16" />
+        </index>
+        <rename-partition start-index="48" stop-index="108">
+            <old-partition name="CA_ADDRESS_SK_index1" start-index="65" stop-index="84" />
+            <new-partition name="CA_ADDRESS_SK_index4" start-index="89" stop-index="108" />
+        </rename-partition>
+    </alter-index>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/ddl/alter-index.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-index.xml
@@ -145,4 +145,13 @@
     <alter-index sql-case-id="alter_index_alter_column" />
     <alter-index sql-case-id="alter_index_with_schema" />
     <alter-index sql-case-id="alter_index_set_tablespace" />
+    <alter-index sql-case-id="alter_index_move_partition">
+        <index name="ds_customer_address_p1_index2" start-index="12" stop-index="46" >
+            <owner name="tpcds" start-index="12" stop-index="16" />
+        </index>
+        <move-partition start-index="48" stop-index="105">
+            <partition name="CA_ADDRESS_SK_index2" start-index="63" stop-index="82" />
+            <tablespace name="tablespace1" start-index="95" stop-index="105" />
+        </move-partition>
+    </alter-index>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/ddl/create-index.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-index.xml
@@ -216,6 +216,7 @@
             <simple-table name="t_order" start-index="25" stop-index="31" />
         </table>
         <column start-index="34" stop-index="37" name="code" />
+        <tablespace name="indexspace" start-index="40" stop-index="60" />
     </create-index>
 
     <create-index sql-case-id="create_index_using_gist">

--- a/test/it/parser/src/main/resources/case/ddl/create-index.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-index.xml
@@ -263,4 +263,14 @@
         <column start-index="72" stop-index="84" name="CA_ADDRESS_ID" />
         <index name="ds_customer_address_p1_index3" start-index="13" stop-index="41" />
     </create-index>
+
+    <create-index sql-case-id="create_index_with_owner01">
+        <table>
+            <simple-table name="customer_address_p1" start-index="52" stop-index="70" />
+        </table>
+        <column name="CA_ADDRESS_ID" start-index="72" stop-index="84"/>
+        <index name="ds_customer_address_p1_index3" start-index="13" stop-index="47">
+            <owner name="tpcds" start-index="13" stop-index="17" />
+        </index>
+    </create-index>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/ddl/create-index.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-index.xml
@@ -216,6 +216,7 @@
             <simple-table name="t_order" start-index="25" stop-index="31" />
         </table>
         <column start-index="34" stop-index="37" name="code" />
+        <tablespace name="indexspace" start-index="40" stop-index="60" />
     </create-index>
 
     <create-index sql-case-id="create_index_using_gist">
@@ -262,6 +263,7 @@
         </table>
         <column start-index="72" stop-index="84" name="CA_ADDRESS_ID" />
         <index name="ds_customer_address_p1_index3" start-index="13" stop-index="41" />
+        <index-partitions type="GLOBAL" start-index="87" stop-index="92" />
     </create-index>
 
     <create-index sql-case-id="create_index_with_owner01">
@@ -272,5 +274,22 @@
         <index name="ds_customer_address_p1_index3" start-index="13" stop-index="47">
             <owner name="tpcds" start-index="13" stop-index="17" />
         </index>
+    </create-index>
+    <create-index sql-case-id="create_index_with_local_partition_and_tablespace">
+        <table>
+            <simple-table name="customer_address_p1" start-index="51" stop-index="69" />
+        </table>
+        <column name="CA_ADDRESS_SK" start-index="71" stop-index="83"/>
+        <index name="ds_customer_address_p1_index2" start-index="18" stop-index="46"/>
+        <index-partitions type="LOCAL" start-index="86" stop-index="250">
+            <index-partition name="CA_ADDRESS_SK_index1" start-index="97" stop-index="126" />
+            <index-partition name="CA_ADDRESS_SK_index2" start-index="133" stop-index="185">
+                <tablespace name="tablespace1" start-index="164" stop-index="185" />
+            </index-partition>
+            <index-partition name="CA_ADDRESS_SK_index3" start-index="192" stop-index="244">
+                <tablespace name="tablespace2" start-index="223" stop-index="244" />
+            </index-partition>
+        </index-partitions>
+        <tablespace name="tablespace3" start-index="256" stop-index="277"/>
     </create-index>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/ddl/create-index.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-index.xml
@@ -253,4 +253,14 @@
         </table>
         <column start-index="60" stop-index="67" name="order_id" />
     </create-index>
+
+    <create-index sql-case-id="create_index_with_global">
+        <table start-index="46" stop-index="70">
+            <simple-table name="customer_address_p1" start-index="46" stop-index="70">
+                <owner name="tpcds" start-index="46" stop-index="50" />
+            </simple-table>
+        </table>
+        <column start-index="72" stop-index="84" name="CA_ADDRESS_ID" />
+        <index name="ds_customer_address_p1_index3" start-index="13" stop-index="41" />
+    </create-index>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/ddl/create-index.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-index.xml
@@ -216,7 +216,6 @@
             <simple-table name="t_order" start-index="25" stop-index="31" />
         </table>
         <column start-index="34" stop-index="37" name="code" />
-        <tablespace name="indexspace" start-index="40" stop-index="60" />
     </create-index>
 
     <create-index sql-case-id="create_index_using_gist">

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-index.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-index.xml
@@ -53,4 +53,5 @@
     <sql-case id="alter_index_set_tablespace" value="ALTER INDEX distributors SET TABLESPACE fasttablespace" db-types="PostgreSQL,openGauss" />
     <sql-case id="alter_index_alter_column" value="ALTER INDEX t_order_idx ALTER COLUMN 3 SET STATISTICS 1000" db-types="PostgreSQL,openGauss" />
     <sql-case id="alter_index_with_schema" value="ALTER INDEX public.t_order_idx ALTER COLUMN 3 SET STATISTICS 1000" db-types="PostgreSQL,openGauss" />
+    <sql-case id="alter_index_move_partition" value="ALTER INDEX tpcds.ds_customer_address_p1_index2 MOVE PARTITION CA_ADDRESS_SK_index2 TABLESPACE tablespace1;" db-types="openGauss" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-index.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-index.xml
@@ -54,4 +54,5 @@
     <sql-case id="alter_index_alter_column" value="ALTER INDEX t_order_idx ALTER COLUMN 3 SET STATISTICS 1000" db-types="PostgreSQL,openGauss" />
     <sql-case id="alter_index_with_schema" value="ALTER INDEX public.t_order_idx ALTER COLUMN 3 SET STATISTICS 1000" db-types="PostgreSQL,openGauss" />
     <sql-case id="alter_index_move_partition" value="ALTER INDEX tpcds.ds_customer_address_p1_index2 MOVE PARTITION CA_ADDRESS_SK_index2 TABLESPACE tablespace1;" db-types="openGauss" />
+    <sql-case id="alter_index_rename_partition02" value="ALTER INDEX tpcds.ds_customer_address_p1_index2 RENAME PARTITION CA_ADDRESS_SK_index1 TO CA_ADDRESS_SK_index4;" db-types="openGauss" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-index.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-index.xml
@@ -54,10 +54,11 @@
         WITH (FILLFACTOR = 80, PAD_INDEX = ON, DROP_EXISTING = ON);" db-types="SQLServer" />
     <sql-case id="create_index_with_global" value="CREATE INDEX ds_customer_address_p1_index3 ON tpcds.customer_address_p1(CA_ADDRESS_ID) GLOBAL;" db-types="openGauss" />
     <sql-case id="create_index_with_owner01" value="CREATE INDEX tpcds.ds_customer_address_p1_index3 ON customer_address_p1(CA_ADDRESS_ID);" db-types="openGauss" />
-<!--    <sql-case id="create_index_with_local_partition_and_tablespace" value=" CREATE INDEX ds_customer_address_p1_index2 ON tpcds.customer_address_p1(CA_ADDRESS_SK) LOCAL-->
-<!--    PARTITION CA_ADDRESS_SK_index1,-->
-<!--    PARTITION CA_ADDRESS_SK_index2 TABLESPACE example3,-->
-<!--    PARTITION CA_ADDRESS_SK_index3 TABLESPACE example4-->
-<!--    )-->
-<!--    TABLESPACE example2;" db-types="openGauss" />-->
+    <sql-case id="create_index_with_local_partition_and_tablespace" value="
+    CREATE INDEX ds_customer_address_p1_index2 ON customer_address_p1(CA_ADDRESS_SK) LOCAL
+    (PARTITION CA_ADDRESS_SK_index1,
+    PARTITION CA_ADDRESS_SK_index2 TABLESPACE tablespace1,
+    PARTITION CA_ADDRESS_SK_index3 TABLESPACE tablespace2
+    )
+    TABLESPACE tablespace3;" db-types="openGauss" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-index.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-index.xml
@@ -53,6 +53,7 @@
     <sql-case id="create_index_using_drop_existing" value="CREATE NONCLUSTERED INDEX IX_WorkOrder_ProductID ON t_order(order_id)
         WITH (FILLFACTOR = 80, PAD_INDEX = ON, DROP_EXISTING = ON);" db-types="SQLServer" />
     <sql-case id="create_index_with_global" value="CREATE INDEX ds_customer_address_p1_index3 ON tpcds.customer_address_p1(CA_ADDRESS_ID) GLOBAL;" db-types="openGauss" />
+    <sql-case id="create_index_with_owner01" value="CREATE INDEX tpcds.ds_customer_address_p1_index3 ON customer_address_p1(CA_ADDRESS_ID);" db-types="openGauss" />
 <!--    <sql-case id="create_index_with_local_partition_and_tablespace" value=" CREATE INDEX ds_customer_address_p1_index2 ON tpcds.customer_address_p1(CA_ADDRESS_SK) LOCAL-->
 <!--    PARTITION CA_ADDRESS_SK_index1,-->
 <!--    PARTITION CA_ADDRESS_SK_index2 TABLESPACE example3,-->

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-index.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-index.xml
@@ -52,4 +52,11 @@
     <sql-case id="create_index_using_ignore_dup_key" value="CREATE UNIQUE INDEX AK_Index ON t_order (order_id) WITH (IGNORE_DUP_KEY = ON)" db-types="SQLServer" />
     <sql-case id="create_index_using_drop_existing" value="CREATE NONCLUSTERED INDEX IX_WorkOrder_ProductID ON t_order(order_id)
         WITH (FILLFACTOR = 80, PAD_INDEX = ON, DROP_EXISTING = ON);" db-types="SQLServer" />
+    <sql-case id="create_index_with_global" value="CREATE INDEX ds_customer_address_p1_index3 ON tpcds.customer_address_p1(CA_ADDRESS_ID) GLOBAL;" db-types="openGauss" />
+<!--    <sql-case id="create_index_with_local_partition_and_tablespace" value=" CREATE INDEX ds_customer_address_p1_index2 ON tpcds.customer_address_p1(CA_ADDRESS_SK) LOCAL-->
+<!--    PARTITION CA_ADDRESS_SK_index1,-->
+<!--    PARTITION CA_ADDRESS_SK_index2 TABLESPACE example3,-->
+<!--    PARTITION CA_ADDRESS_SK_index3 TABLESPACE example4-->
+<!--    )-->
+<!--    TABLESPACE example2;" db-types="openGauss" />-->
 </sql-cases>

--- a/test/util/src/main/java/org/apache/shardingsphere/test/loader/strategy/impl/GitHubTestParameterLoadStrategy.java
+++ b/test/util/src/main/java/org/apache/shardingsphere/test/loader/strategy/impl/GitHubTestParameterLoadStrategy.java
@@ -17,10 +17,10 @@
 
 package org.apache.shardingsphere.test.loader.strategy.impl;
 
+import com.google.common.base.Strings;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.shardingsphere.test.loader.strategy.TestParameterLoadStrategy;
 import org.apache.shardingsphere.test.loader.summary.FileSummary;
 
@@ -82,7 +82,7 @@ public final class GitHubTestParameterLoadStrategy implements TestParameterLoadS
     private String loadContent(final URI casesURI) {
         try {
             URLConnection urlConnection = casesURI.toURL().openConnection();
-            if (StringUtils.isNotBlank(GitHubEnvironment.getInstance().getGithubToken())) {
+            if (!Strings.isNullOrEmpty(GitHubEnvironment.getInstance().getGithubToken())) {
                 urlConnection.setRequestProperty("Authorization", "Bearer " + GitHubEnvironment.getInstance().getGithubToken());
             }
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()))) {


### PR DESCRIPTION
Fixes #27862 

Changes proposed in this pull request:
  - Support parse openGauss create index with partition and tablespace sql
  - Support parse openGauss alter index move partition sql
  - Support parse openGauss alter index rename partition sql

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
