### PR TITLE
Support OpenGauss number manipulation functions parse

### DIFF
--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
@@ -440,6 +440,11 @@ unreservedWord
     | JSON
     | POSITION
     | INET
+    | INT1
+    | INT2
+    | INT4
+    | INT16
+    | FLOAT4
     ;
 
 typeFuncNameKeyword

--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/OpenGaussKeyword.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/OpenGaussKeyword.g4
@@ -1408,3 +1408,11 @@ FEATURES
 TS_REWRITE
     : T S UL_ R E W R I T E
     ;
+
+INT16
+    : I N T [16]
+    ;
+
+INT1
+    : I N T [1]
+    ;

--- a/test/it/parser/src/main/resources/case/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-expression.xml
@@ -2977,4 +2977,12 @@
             </expression-projection>
         </projections>
     </select>
+    
+    <select sql-case-id="select_int_2_function">
+        <projections start-index="7" stop-index="16">
+            <expression-projection start-index="7" stop-index="16" text="int2(25.3)">
+                <function start-index="7" stop-index="16" text="int2(25.3);" function-name="int2" />
+            </expression-projection>
+        </projections>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-expression.xml
@@ -126,4 +126,5 @@
     <sql-case id="select_inet_function" value="SELECT inet '192.168.1.5' = inet '192.168.1.5' AS RESULT;" db-types="openGauss" />
     <sql-case id="select_inet_function_with_inet_operator" value="SELECT inet '192.168.1.5' &lt;&lt;= inet '192.168.1.5' AS RESULT;" db-types="openGauss" />
     <sql-case id="select_ts_rewrite_function" value="SELECT ts_rewrite('a &amp; b'::tsquery, 'a'::tsquery, 'c'::tsquery);" db-types="openGauss" />
+    <sql-case id="select_int_2_function" value="select int2(25.3);" db-types="openGauss" />
 </sql-cases>


### PR DESCRIPTION
Fixes #27739.

Changes proposed in this pull request:
  - Support OpenGauss number manipulation functions parse
  ref: https://docs.opengauss.org/zh/docs/3.1.1-lite/docs/Developerguide/%E6%95%B0%E5%AD%97%E6%93%8D%E4%BD%9C%E5%87%BD%E6%95%B0%E5%92%8C%E6%93%8D%E4%BD%9C%E7%AC%A6.html

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
