### PR TITLE
Support for building with OpenJDK 21

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        java-version: [ 11, 17, 20 ]
+        java-version: [ 11, 17, 21-ea ]
     steps:
       - name: Support Long Paths in Windows
         if: matrix.os == 'windows-latest'

--- a/agent/core/pom.xml
+++ b/agent/core/pom.xml
@@ -52,6 +52,7 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -33,17 +33,8 @@
         <module>plugins</module>
     </modules>
     
-    <properties>
-        <bytebuddy.version>1.14.4</bytebuddy.version>
-    </properties>
-    
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>${bytebuddy.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.apache.shardingsphere</groupId>
                 <artifactId>shardingsphere-test-util</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <transmittable-thread-local.version>2.14.2</transmittable-thread-local.version>
         
         <antlr4.version>4.10.1</antlr4.version>
+        <bytebuddy.version>1.14.8</bytebuddy.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <gson.version>2.9.1</gson.version>
         <jackson.version>2.14.0</jackson.version>
@@ -102,7 +103,7 @@
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.11</logback.version>
         
-        <lombok.version>1.18.20</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
         
         <postgresql.version>42.4.1</postgresql.version>
         <opengauss.version>3.1.0-og</opengauss.version>
@@ -128,15 +129,15 @@
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
         <docker-compose-maven-plugin.version>4.0.0</docker-compose-maven-plugin.version>
         <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
-        <native-maven-plugin.version>0.9.24</native-maven-plugin.version>
+        <native-maven-plugin.version>0.9.27</native-maven-plugin.version>
         
         <!-- Compile plugin versions -->
         <maven-enforcer-plugin.version>3.2.1</maven-enforcer-plugin.version>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-        <jandex-maven-plugin.version>3.0.5</jandex-maven-plugin.version>
+        <jandex-maven-plugin.version>3.1.3</jandex-maven-plugin.version>
         <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
         <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
@@ -571,20 +572,37 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${bytebuddy.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>${bytebuddy.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>${mockito.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy-agent</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-inline</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -674,14 +692,17 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         
         <dependency>
@@ -1235,7 +1256,6 @@
                             <excludes>
                                 <exclude>org.apache.shardingsphere.agent.core.**</exclude>
                             </excludes>
-                            <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED</argLine>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
Fixes #28293 .

Changes proposed in this pull request:
  - Support for building with OpenJDK 21.
  - Due to JEP 451, JDK21's CI has thousands more lines of warnings.  Reference https://github.com/mockito/mockito/issues/3037 .
  - Since GraalVM Updater is deprecated in GraalVM CE 23.1.0 For JDK 21, the `shardingsphere-infra-expr-espresso` submodule will not be reusable, there are some temporary processing at https://github.com/apache/shardingsphere/pull/28340 .  Looking to the future, it is impossible for us to introduce the GPL LICENSE Espresso ontology into ShardingSphere. This module will be deleted or maintained by a third party in the foreseeable future.
  - The javac in GraalVM CE 23.1.0 For JDK21 may has bugs. An error occurred when the ShardingSphere Proxy Native was migrated to GraalVM CE 23.1.0 For JDK21 build. The build of ShardingSphere Proxy Native will continue using GraalVM 23.0.1 For JDK17.
```bash
========================================================================================================================
GraalVM Native Image: Generating 'apache-shardingsphere-proxy-native' (executable)...
========================================================================================================================
[1/8] Initializing...                                                                                   (12.0s @ 0.41GB)
Java version: 21+35, vendor version: GraalVM CE 21+35.1
Graal compiler: optimization level: 2, target machine: x86-64-v3
C compiler: gcc (linux, x86_64, 11.4.0)
Garbage collector: Serial GC (max heap size: 80% of RAM)
2 user-specific feature(s):
- com.oracle.svm.polyglot.groovy.GroovyIndyInterfaceFeature
- com.oracle.svm.thirdparty.gson.GsonFeature
------------------------------------------------------------------------------------------------------------------------
Build resources:
- 9.57GB of memory (75.6% of 12.67GB system memory, determined at start)
- 6 thread(s) (100.0% of 6 available processor(s), determined at start)
[2/8] Performing analysis...  []                                                                        (69.2s @ 2.78GB)
27,510 reachable types   (76.6% of   35,901 total)
45,905 reachable fields  (52.2% of   87,956 total)
140,093 reachable methods (55.7% of  251,477 total)
8,227 types,   300 fields, and 6,865 methods registered for reflection

Error: java.util.concurrent.ExecutionException: java.lang.ClassCastException: class jdk.vm.ci.meta.NullConstant cannot be cast to class org.graalvm.compiler.core.common.type.TypedConstant (jdk.vm.ci.meta.NullConstant is in module jdk.internal.vm.ci of loader 'bootstrap'; org.graalvm.compiler.core.common.type.TypedConstant is in module jdk.internal.vm.compiler of loader 'platform')
------------------------------------------------------------------------------------------------------------------------
11.9s (14.3% of total time) in 55 GCs | Peak RSS: 6.23GB | CPU load: 5.30
========================================================================================================================
Finished generating 'apache-shardingsphere-proxy-native' in 1m 21s.
com.oracle.svm.driver.NativeImage$NativeImageError
at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.showError(NativeImage.java:2336)
at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.build(NativeImage.java:1919)
at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.performBuild(NativeImage.java:1878)
at org.graalvm.nativeimage.driver/com.oracle.svm.driver.NativeImage.main(NativeImage.java:1852)
at java.base@21/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
