### PR TITLE
Support OpenGauss number numeric operators parse

### DIFF
--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
@@ -584,6 +584,11 @@ aExpr
     | aExpr MOD_ aExpr
     | aExpr CARET_ aExpr
     | aExpr AMPERSAND_ aExpr
+    | DN_ aExpr
+    | aExpr NOT_
+    | aExpr POUND_ aExpr
+    | TILDE_ aExpr
+    | CUBE_ROOT_ aExpr
     | aExpr VERTICAL_BAR_ aExpr
     | aExpr qualOp aExpr
     | qualOp aExpr

--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/Symbol.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/Symbol.g4
@@ -90,3 +90,5 @@ GEOMETRIC_PERPENDICULAR_:       '?-|';
 GEOMETRIC_SAME_AS_:             '~=';
 SIGNED_LEFT_SHIFT_E_:           '<<=';
 SIGNED_RIGHT_SHIFT_E_:          '>>=';
+DN_:                            '!!';
+CUBE_ROOT_:                     '||/';

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -6951,4 +6951,10 @@
             </expr>
         </where>
     </select>
+    
+    <select sql-case-id="select_numeric_operator">
+        <projections start-index="7" stop-index="18">
+            <expression-projection start-index="7" stop-index="18" text="5!" alias="RESULT" />
+        </projections>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -210,4 +210,5 @@
     <sql-case id="select_with_to_date_function" value="SELECT TO_DATE('Febuary 15, 2016, 11:00 A.M.' DEFAULT 'January 01, 2016 12:00 A.M.' ON CONVERSION ERROR, 'Month dd, YYYY, HH:MI A.M.') FROM DUAL;" db-types="Oracle" />
     <sql-case id="select_with_expressions_in_projection" value="SELECT ((a.enddate - term + term2 + 1) / (last_day(term) - term + 1)) cnt, a.empid FROM employee aWHERE nvl(disabled, 0) = 1  AND enddate BETWEEN term AND last_day(term)  AND EXISTS (SELECT 1 FROM post d WHERE a.orgid = d.orgid   AND a.postid = d.postid   AND d.title != 'TEST'   AND nvl(d.postid, 0) != 0)" db-types="Oracle" />
     <sql-case id="select_with_custom_table_function" value="SELECT COUNT(empid) FROM EMPLOYEE b, custom_function(b.orgid) a WHERE a.postid = b.postid" db-types="Oracle" />
+    <sql-case id="select_numeric_operator" value="SELECT 5! AS RESULT;" db-types="openGauss" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/unsupported/unsupported.xml
+++ b/test/it/parser/src/main/resources/sql/unsupported/unsupported.xml
@@ -394,29 +394,16 @@
     <sql-case id="unsupported_select_case_for_opengauss_399" value="select trim(leading'2' from );" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_400" value="select trim(trailing '2' from );" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_401" value="select substring(from 4 for 4) as text1;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_403" value="select ||/ clo1 from data_01;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_404" value="select  clo1! from data_01;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_405" value="select  clo2! from data_01;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_406" value="select @clo1, @clo2 from data_01;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_407" value="select @ clo1, @clo2 from data_01;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_408" value="select ||/ clo2 from data_01;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_410" value="select @ clo1, @ clo2 from data_01;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_411" value="select  ||/clo1 from data_01;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_412" value="select  ||/clo2 from data_01;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_415" value="select ||/clo1,||/clo2 from data_01;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_416" value="select @clo1 from data_01;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_417" value="select cos(2*pi(),2*pi()));" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_418" value="select ||/ clo1,||/clo2 from data_01;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_420" value="select |/clo1 from data_01;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_423" value="select |/clo2 from data_01;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_424" value="select |/clo1,|/clo2 from data_01;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_425" value="select  |/clo1 from data_01;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_426" value="select  |/clo2 from data_01;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_427" value="select  !!clo1 from data_01;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_428" value="select  !!clo2 from data_01;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_430" value="select ~ clo1 , ~ clo2 from data_01;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_431" value="select ~ (clo1+clo2) from data_01;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_432" value="select ~clo1, ~clo2 from data_01;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_433" value="select atan2(,) from sys_dummy;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_434" value="select atan2('11+11',) from sys_dummy;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_435" value="select atan2(11 11) from sys_dummy;" db-types="openGauss" />


### PR DESCRIPTION
Fixes #27738.

Changes proposed in this pull request:
  - Support OpenGauss number numeric operators parse
  ref: https://docs.opengauss.org/zh/docs/3.1.1-lite/docs/Developerguide/%E6%95%B0%E5%AD%97%E6%93%8D%E4%BD%9C%E5%87%BD%E6%95%B0%E5%92%8C%E6%93%8D%E4%BD%9C%E7%AC%A6.html

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
