### PR TITLE
Support OpenGauss elem_contained_by_range function parse

### DIFF
--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
@@ -445,6 +445,8 @@ unreservedWord
     | INT4
     | INT16
     | FLOAT4
+    | ELEM_CONTAINED_BY_RANGE
+
     ;
 
 typeFuncNameKeyword
@@ -1096,6 +1098,7 @@ functionExprCommonSubexpr
     | XMLSERIALIZE LP_ documentOrContent aExpr AS simpleTypeName RP_
     | PREDICT BY modelName LP_ FEATURES name (COMMA_ name)* RP_
     | TS_REWRITE LP_ aExpr (TYPE_CAST_ TSQUERY)? (COMMA_ aExpr (TYPE_CAST_ TSQUERY)?)* RP_
+    | ELEM_CONTAINED_BY_RANGE LP_ aExpr COMMA_ dataType RP_
     ;
 
 typeName

--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/OpenGaussKeyword.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/OpenGaussKeyword.g4
@@ -1416,3 +1416,7 @@ INT16
 INT1
     : I N T [1]
     ;
+
+ELEM_CONTAINED_BY_RANGE
+    : E L E M UL_ C O N T A I N E D UL_ B Y UL_ R A N G E
+    ;

--- a/test/it/parser/src/main/resources/case/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-expression.xml
@@ -2985,4 +2985,12 @@
             </expression-projection>
         </projections>
     </select>
+    
+    <select sql-case-id="select_elem_contained_by_range_function">
+        <projections start-index="7" stop-index="53">
+            <expression-projection start-index="7" stop-index="53" text="elem_contained_by_range('2', numrange(1.1,2.2))">
+                <function start-index="7" stop-index="53" function-name="elem_contained_by_range" text="elem_contained_by_range('2', numrange(1.1,2.2))" />
+            </expression-projection>
+        </projections>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-expression.xml
@@ -127,4 +127,5 @@
     <sql-case id="select_inet_function_with_inet_operator" value="SELECT inet '192.168.1.5' &lt;&lt;= inet '192.168.1.5' AS RESULT;" db-types="openGauss" />
     <sql-case id="select_ts_rewrite_function" value="SELECT ts_rewrite('a &amp; b'::tsquery, 'a'::tsquery, 'c'::tsquery);" db-types="openGauss" />
     <sql-case id="select_int_2_function" value="select int2(25.3);" db-types="openGauss" />
+    <sql-case id="select_elem_contained_by_range_function" value="SELECT elem_contained_by_range('2', numrange(1.1,2.2));" db-types="openGauss" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/unsupported/unsupported.xml
+++ b/test/it/parser/src/main/resources/sql/unsupported/unsupported.xml
@@ -242,8 +242,6 @@
     <sql-case id="unsupported_select_case_for_opengauss_247" value="select int4range(10,10) &lt;&gt; '(10,11)'::int4range as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_248" value="select int8range(15,25) &lt;&gt; int8range(15,25) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_249" value="select tsrange('[2021-01-01,2021-03-01)') &lt;&gt; ('[2021-01-01,2021-03-01)') as result;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_250" value="select elem_contained_by_range('abc', int8range(15,25)) as result;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_251" value="select elem_contained_by_range(2, numrange(1.1,2.2)) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_252" value="select int4range(1,5) &gt;= '[1,4]'::int4range as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_253" value="select int8range(15,26) &gt;= int8range(15,26) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_254" value="select numrange(8.1,10.2,'[]') &gt;= numrange(5.1,6.7,'()') as result;" db-types="openGauss" />
@@ -299,11 +297,6 @@
     <sql-case id="unsupported_select_case_for_opengauss_304" value="select int4range(10,16) &amp;&lt; '(10,11)'::int4range as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_305" value="select int4range(1,3) - int8range(25,35) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_306" value="select tsrange('[2021-01-01,2021-03-01)') - '[3,4]'::int4range  as result;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_307" value="select elem_contained_by_range('2', numrange(1.1,2.2));" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_308" value="select elem_contained_by_range('10', int4range(10,80)) as result;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_309" value="select elem_contained_by_range('20', int8range(15,25)) as result;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_310" value="select elem_contained_by_range('2021-02-05', tsrange('[2021-01-01,2021-03-01)')) as result;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_311" value="select elem_contained_by_range('2025-12-11 pst', tsrange('[2013-12-11 pst,2021-03-01 pst)')) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_312" value="select lower(int4range(10,80)) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_313" value="select lower(int8range(15,25)) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_314" value="select lower(numrange(1.1,2.2)) as result;" db-types="openGauss" />


### PR DESCRIPTION
Fixes #27779.

Changes proposed in this pull request:
  - Support OpenGauss elem_contained_by_range function parse
  ref: https://docs.opengauss.org/en/docs/3.1.0/docs/Developerguide/range-functions-and-operators.html

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
