### PR TITLE
Support OpenGauss lower_inf upper_inf function parse

### DIFF
--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
@@ -449,6 +449,7 @@ unreservedWord
     | INT8RANGE
     | INT4RANGE
     | NUMRANGE
+    | DATERANGE
     ;
 
 typeFuncNameKeyword
@@ -1101,6 +1102,7 @@ functionExprCommonSubexpr
     | PREDICT BY modelName LP_ FEATURES name (COMMA_ name)* RP_
     | TS_REWRITE LP_ aExpr (TYPE_CAST_ TSQUERY)? (COMMA_ aExpr (TYPE_CAST_ TSQUERY)?)* RP_
     | ELEM_CONTAINED_BY_RANGE LP_ aExpr COMMA_ dataType RP_
+    | (LOWER_INF | UPPER_INF) LP_ aExpr TYPE_CAST_ identifier RP_
     ;
 
 typeName

--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/OpenGaussKeyword.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/OpenGaussKeyword.g4
@@ -1420,3 +1420,11 @@ INT1
 ELEM_CONTAINED_BY_RANGE
     : E L E M UL_ C O N T A I N E D UL_ B Y UL_ R A N G E
     ;
+
+LOWER_INF
+    : L O W E R UL_ I N F
+    ;
+
+UPPER_INF
+    : U P P E R UL_ I N F
+    ;

--- a/test/it/parser/src/main/resources/case/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-expression.xml
@@ -3069,4 +3069,12 @@
             </expression-projection>
         </projections>
     </select>
+    
+    <select sql-case-id="select_lower_inf_function">
+        <projections start-index="7" stop-index="43">
+            <expression-projection start-index="7" stop-index="43" text="lower_inf('(,)'::daterange)" alias="RESULT">
+                <function start-index="7" stop-index="35" function-name="lower_inf" text="lower_inf('(,)'::daterange)" />
+            </expression-projection>
+        </projections>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-expression.xml
@@ -130,4 +130,5 @@
     <sql-case id="select_elem_contained_by_range_function" value="SELECT elem_contained_by_range('2', numrange(1.1,2.2));" db-types="openGauss" />
     <sql-case id="select_int8range" value="SELECT int8range(5,15) * int8range(10,20) AS RESULT;" db-types="openGauss" />
     <sql-case id="select_int4range" value="SELECT int4range(2,4) &lt;@ int4range(1,7) AS RESULT;" db-types="openGauss" />
+    <sql-case id="select_lower_inf_function" value="SELECT lower_inf('(,)'::daterange) AS RESULT;" db-types="openGauss" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/unsupported/unsupported.xml
+++ b/test/it/parser/src/main/resources/sql/unsupported/unsupported.xml
@@ -141,32 +141,6 @@
     <sql-case id="unsupported_select_case_for_opengauss_139" value="select array_lower([1,2,3], 1) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_140" value="select array_lower(array[1,2,3], @) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_141" value="select array_lower(array[1,2,3], ) as result;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_145" value="select daterange('2000-05-06','2000-08-08','(]');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_146" value="select daterange('2000-05-06 00:01:09','2000-08-08 19:59:00','(]');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_147" value="select daterange('2000-05-06 12:01:09','2000-08-08 19:59:00','(]');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_148" value="select daterange('2000-05-06 00:01:09','2000-08-08 09:59:00','(]');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_149" value="select daterange('2000-05-06 17:01:09','2000-08-08 09:59:00','(]');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_150" value="select daterange('2000-05-06','2000-08-08','()');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_151" value="select daterange('2000-05-06 00:01:09','2000-08-08 19:59:00','()');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_152" value="select daterange('2000-05-06 12:01:09','2000-08-08 19:59:00','()');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_153" value="select daterange('2000-05-06 00:01:09','2000-08-08 09:59:00','()');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_154" value="select daterange('2000-05-06 17:01:09','2000-08-08 09:59:00','()');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_155" value="select daterange('2000-05-06','2000-08-08','abc');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_156" value="select daterange('2001-05-06','2000-08-08');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_157" value="select daterange('2001-05-06','2001-05-06');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_158" value="select daterange('2000-05-06','2000-08-08','[)');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_159" value="select daterange('2000-05-06 00:01:09','2000-08-08 19:59:00','[)');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_160" value="select daterange('2000-05-06 12:01:09','2000-08-08 19:59:00','[)');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_161" value="select daterange('2000-05-06 00:01:09','2000-08-08 09:59:00','[)');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_162" value="select daterange('2000-05-06 17:01:09','2000-08-08 09:59:00','[)');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_163" value="select daterange('2000-05-06','2000-08-08','[]');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_164" value="select daterange('2000-05-06 00:01:09','2000-08-08 19:59:00','[]');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_165" value="select daterange('2000-05-06 12:01:09','2000-08-08 19:59:00','[]');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_166" value="select daterange('2000-05-06 00:01:09','2000-08-08 09:59:00','[]');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_167" value="select daterange('2000-05-06 17:01:09','2000-08-08 09:59:00','[]');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_169" value="select daterange('2001-02-16 20:38:40','2001-02-16 20:38:41');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_170" value="select daterange('2018-05-14 14:09:04.127444+08','2018-05-16 14:09:04.127444+08');" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_171" value="select daterange('2000-05-06','2000-08-08');" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_174" value="select bitand(6,) as result from sys_dummy;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_175" value="select bitand(,6) as result from sys_dummy;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_176" value="select first(s_name) as name, first(s_id nulls first ) from first06;" db-types="openGauss" />
@@ -234,7 +208,6 @@
     <sql-case id="unsupported_select_case_for_opengauss_325" value="select '2026-09-09'::timestamp &lt;@ tsrange('[2021-01-01,2028-03-01)') as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_330" value="select tsrange('[2021-01-01,2021-03-01)') &amp;&amp; ('[2021-01-01,2021-03-01)') as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_331" value="select tsrange('[2013-12-11 pst,2021-03-01 pst)') &amp;&amp; ('[2013-12-11 pst,2021-05-01 pst)') as result;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_334" value="select upper_inf('(,)'::daterange) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_338" value="select upper_inf(tsrange('(2021-01-01,]')) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_339" value="select upper_inf(tsrange('[,2021-03-01 pst]')) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_347" value="select tsrange('[2021-01-01,2021-03-01)') -('[2021-03-01,2021-10-01)') as result;" db-types="openGauss" />
@@ -255,7 +228,6 @@
     <sql-case id="unsupported_select_case_for_opengauss_371" value="select upper(bugstatus (create, closed)) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_375" value="select isempty(tsrange('[2021-01-01,2021-03-01)')) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_376" value="select isempty(tsrange('[2013-12-11 pst,2021-03-01 pst)')) as result;" db-types="openGauss" />
-    <sql-case id="unsupported_select_case_for_opengauss_377" value="select lower_inf('(,)'::daterange) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_381" value="select lower_inf(tsrange('(2021-01-01,2021-03-01]')) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_382" value="select lower_inf(tsrange('[,2021-03-01 pst]')) as result;" db-types="openGauss" />
     <sql-case id="unsupported_select_case_for_opengauss_383" value="select hll_hash_boolean(@,10);" db-types="openGauss" />


### PR DESCRIPTION
Fixes #27778.

Changes proposed in this pull request:
  - Support OpenGauss lower_inf upper_inf function parse
  ref: https://docs.opengauss.org/en/docs/3.1.0/docs/Developerguide/range-functions-and-operators.html

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
