### PR TITLE
Support OpenGauss Network Address Functions parse

### DIFF
--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/BaseRule.g4
@@ -1104,6 +1104,10 @@ functionExprCommonSubexpr
     | TS_REWRITE LP_ aExpr (TYPE_CAST_ TSQUERY)? (COMMA_ aExpr (TYPE_CAST_ TSQUERY)?)* RP_
     | ELEM_CONTAINED_BY_RANGE LP_ aExpr COMMA_ dataType RP_
     | (LOWER_INF | UPPER_INF) LP_ aExpr TYPE_CAST_ identifier RP_
+    | ABBREV LP_ (INET | CIDR) STRING_ RP_
+    | SET_MASKLEN LP_ STRING_ (TYPE_CAST_ CIDR)? COMMA_ numberLiterals RP_
+    | TEXT LP_ INET STRING_ RP_
+    | TRUNC LP_ MACADDR STRING_ RP_
     ;
 
 typeName

--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/OpenGaussKeyword.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/OpenGaussKeyword.g4
@@ -1428,3 +1428,15 @@ LOWER_INF
 UPPER_INF
     : U P P E R UL_ I N F
     ;
+
+ABBREV
+    : A B B R E V
+    ;
+
+SET_MASKLEN
+    : S E T UL_ M A S K L E N
+    ;
+
+TRUNC
+    : T R U N C
+    ;

--- a/test/it/parser/src/main/resources/case/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-expression.xml
@@ -3093,4 +3093,36 @@
             </expression-projection>
         </projections>
     </select>
+    
+    <select sql-case-id="select_abbrev_function">
+        <projections start-index="7" stop-index="42">
+            <expression-projection start-index="7" stop-index="42" text="abbrev(cidr '10.1.0.0/16')" alias="RESULT">
+                <function start-index="7" stop-index="42" function-name="abbrev" text="abbrev(cidr '10.1.0.0/16')" alias="RESULT" />
+            </expression-projection>
+        </projections>
+    </select>
+    
+    <select sql-case-id="select_set_masklen_function">
+        <projections start-index="7" stop-index="55">
+            <expression-projection start-index="7" stop-index="55" text="set_masklen('192.168.1.0/24'::cidr, 16)" alias="RESULT">
+                <function start-index="7" stop-index="55" function-name="set_masklen" text="set_masklen('192.168.1.0/24'::cidr, 16)" alias="RESULT" />
+            </expression-projection>
+        </projections>
+    </select>
+    
+    <select sql-case-id="select_text_inet_function">
+        <projections start-index="7" stop-index="40">
+            <expression-projection start-index="7" stop-index="40" text="text(inet '192.168.1.5')" alias="RESULT">
+                <function start-index="7" stop-index="40" function-name="text" text="text(inet '192.168.1.5')" alias="RESULT" />
+            </expression-projection>
+        </projections>
+    </select>
+    
+    <select sql-case-id="select_trunc_function">
+        <projections start-index="7" stop-index="50">
+            <expression-projection start-index="7" stop-index="50" text="trunc(macaddr '12:34:56:78:90:ab')" alias="RESULT">
+                <function start-index="7" stop-index="50" function-name="trunc" text="trunc(macaddr '12:34:56:78:90:ab')" alias="RESULT" />
+            </expression-projection>
+        </projections>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-expression.xml
@@ -132,4 +132,8 @@
     <sql-case id="select_int4range" value="SELECT int4range(2,4) &lt;@ int4range(1,7) AS RESULT;" db-types="openGauss" />
     <sql-case id="select_lower_inf_function" value="SELECT lower_inf('(,)'::daterange) AS RESULT;" db-types="openGauss" />
     <sql-case id="select_tsquery" value="SELECT 'super:*'::tsquery;" db-types="openGauss" />
+    <sql-case id="select_abbrev_function" value="SELECT abbrev(cidr '10.1.0.0/16') AS RESULT;" db-types="openGauss" />
+    <sql-case id="select_set_masklen_function" value="SELECT set_masklen('192.168.1.0/24'::cidr, 16) AS RESULT;" db-types="openGauss" />
+    <sql-case id="select_text_inet_function" value="SELECT text(inet '192.168.1.5') AS RESULT;" db-types="openGauss" />
+    <sql-case id="select_trunc_function" value="SELECT trunc(macaddr '12:34:56:78:90:ab') AS RESULT;" db-types="openGauss" />
 </sql-cases>


### PR DESCRIPTION
Fixes #27664.

Changes proposed in this pull request:
  - Support OpenGauss abbrev(inet) Function parse
  - Support OpenGauss abbrev(cidr) Function parse
  - Support OpenGauss set_masklen(cidr, int) Function parse
  - Support OpenGauss text(inet) Function parse
  - Support OpenGauss trunc(macaddr) Function parse
ref: https://docs.opengauss.org/en/docs/latest/docs/SQLReference/network-address-functions-and-operators.html

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
