### PR TITLE
Verify inventory finished before starting consistency check

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/common/execute/ExecuteEngine.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/common/execute/ExecuteEngine.java
@@ -43,6 +43,8 @@ public final class ExecuteEngine {
     
     private static final String THREAD_SUFFIX = "-%d";
     
+    private static final ExecutorService CALLBACK_EXECUTOR = Executors.newSingleThreadScheduledExecutor(ExecutorThreadFactoryBuilder.build(THREAD_PREFIX + "callback" + THREAD_SUFFIX));
+    
     private final ExecutorService executorService;
     
     /**
@@ -118,14 +120,14 @@ public final class ExecuteEngine {
     public static void trigger(final Collection<CompletableFuture<?>> futures, final ExecuteCallback executeCallback) {
         BlockingQueue<CompletableFuture<?>> futureQueue = new LinkedBlockingQueue<>();
         for (CompletableFuture<?> each : futures) {
-            each.whenComplete(new BiConsumer<Object, Throwable>() {
+            each.whenCompleteAsync(new BiConsumer<Object, Throwable>() {
                 
                 @SneakyThrows(InterruptedException.class)
                 @Override
                 public void accept(final Object unused, final Throwable throwable) {
                     futureQueue.put(each);
                 }
-            });
+            }, CALLBACK_EXECUTOR);
         }
         for (int i = 1, count = futures.size(); i <= count; i++) {
             CompletableFuture<?> future = futureQueue.take();

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/AbstractSingleTableInventoryCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/AbstractSingleTableInventoryCalculator.java
@@ -49,7 +49,6 @@ public abstract class AbstractSingleTableInventoryCalculator implements SingleTa
             log.info("cancel, statement is null or closed");
             return;
         }
-        long startTimeMillis = System.currentTimeMillis();
         try {
             statement.cancel();
         } catch (final SQLFeatureNotSupportedException ex) {
@@ -59,7 +58,6 @@ public abstract class AbstractSingleTableInventoryCalculator implements SingleTa
             // CHECKSTYLE:ON
             log.info("cancel failed: {}", ex.getMessage());
         }
-        log.info("cancel cost {} ms", System.currentTimeMillis() - startTimeMillis);
     }
     
     /**

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/PipelineJobProgressDetector.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/PipelineJobProgressDetector.java
@@ -21,9 +21,11 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.common.ingest.position.FinishedPosition;
+import org.apache.shardingsphere.data.pipeline.common.job.progress.InventoryIncrementalJobItemProgress;
 import org.apache.shardingsphere.data.pipeline.core.task.PipelineTask;
 
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * Pipeline job progress detector.
@@ -33,15 +35,34 @@ import java.util.Collection;
 public final class PipelineJobProgressDetector {
     
     /**
-     * All inventory tasks is finished.
+     * Whether all inventory tasks is finished.
      *
      * @param inventoryTasks to check inventory tasks
-     * @return is finished
+     * @return finished or not
      */
-    public static boolean allInventoryTasksFinished(final Collection<PipelineTask> inventoryTasks) {
+    public static boolean isAllInventoryTasksFinished(final Collection<PipelineTask> inventoryTasks) {
         if (inventoryTasks.isEmpty()) {
             log.warn("inventoryTasks is empty");
         }
         return inventoryTasks.stream().allMatch(each -> each.getTaskProgress().getPosition() instanceof FinishedPosition);
+    }
+    
+    /**
+     * Whether inventory is finished or not.
+     *
+     * @param jobShardingCount job sharding count
+     * @param jobItemProgresses job item progresses
+     * @return finished or not
+     */
+    public static boolean isInventoryFinished(final int jobShardingCount, final Collection<InventoryIncrementalJobItemProgress> jobItemProgresses) {
+        return isAllProgressesFilled(jobShardingCount, jobItemProgresses) && isAllInventoryTasksCompleted(jobItemProgresses);
+    }
+    
+    private static boolean isAllProgressesFilled(final int jobShardingCount, final Collection<InventoryIncrementalJobItemProgress> jobItemProgresses) {
+        return jobShardingCount == jobItemProgresses.size() && jobItemProgresses.stream().allMatch(Objects::nonNull);
+    }
+    
+    private static boolean isAllInventoryTasksCompleted(final Collection<InventoryIncrementalJobItemProgress> jobItemProgresses) {
+        return jobItemProgresses.stream().flatMap(each -> each.getInventory().getProgresses().values().stream()).allMatch(each -> each.getPosition() instanceof FinishedPosition);
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/runner/InventoryIncrementalTasksRunner.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/runner/InventoryIncrementalTasksRunner.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.data.pipeline.common.execute.ExecuteCallback;
 import org.apache.shardingsphere.data.pipeline.common.execute.ExecuteEngine;
 import org.apache.shardingsphere.data.pipeline.common.ingest.position.FinishedPosition;
 import org.apache.shardingsphere.data.pipeline.common.job.JobStatus;
+import org.apache.shardingsphere.data.pipeline.core.job.progress.persist.PipelineJobProgressPersistService;
 import org.apache.shardingsphere.infra.util.close.QuietlyCloser;
 import org.apache.shardingsphere.data.pipeline.core.job.PipelineJobIdUtils;
 import org.apache.shardingsphere.data.pipeline.core.job.progress.PipelineJobProgressDetector;
@@ -126,6 +127,7 @@ public class InventoryIncrementalTasksRunner implements PipelineTasksRunner {
     protected void inventorySuccessCallback() {
         if (PipelineJobProgressDetector.isAllInventoryTasksFinished(inventoryTasks)) {
             log.info("onSuccess, all inventory tasks finished.");
+            PipelineJobProgressPersistService.persistNow(jobItemContext.getJobId(), jobItemContext.getShardingItem());
             executeIncrementalTask();
         } else {
             log.info("onSuccess, inventory tasks not finished");

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/runner/InventoryIncrementalTasksRunner.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/runner/InventoryIncrementalTasksRunner.java
@@ -78,7 +78,7 @@ public class InventoryIncrementalTasksRunner implements PipelineTasksRunner {
             return;
         }
         TypedSPILoader.getService(PipelineJobAPI.class, PipelineJobIdUtils.parseJobType(jobItemContext.getJobId()).getType()).persistJobItemProgress(jobItemContext);
-        if (PipelineJobProgressDetector.allInventoryTasksFinished(inventoryTasks)) {
+        if (PipelineJobProgressDetector.isAllInventoryTasksFinished(inventoryTasks)) {
             log.info("All inventory tasks finished.");
             executeIncrementalTask();
         } else {
@@ -124,7 +124,7 @@ public class InventoryIncrementalTasksRunner implements PipelineTasksRunner {
     }
     
     protected void inventorySuccessCallback() {
-        if (PipelineJobProgressDetector.allInventoryTasksFinished(inventoryTasks)) {
+        if (PipelineJobProgressDetector.isAllInventoryTasksFinished(inventoryTasks)) {
             log.info("onSuccess, all inventory tasks finished.");
             executeIncrementalTask();
         } else {

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/PipelineContainerComposer.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/PipelineContainerComposer.java
@@ -393,7 +393,9 @@ public final class PipelineContainerComposer implements AutoCloseable {
             Set<String> statusSet = jobStatus.stream().map(each -> String.valueOf(each.get("status"))).collect(Collectors.toSet());
             if (statusSet.contains(JobStatus.PREPARING.name()) || statusSet.contains(JobStatus.RUNNING.name())) {
                 Awaitility.await().pollDelay(2L, TimeUnit.SECONDS).until(() -> true);
+                continue;
             }
+            break;
         }
     }
     

--- a/test/e2e/operation/pipeline/src/test/resources/env/common/migration-command.xml
+++ b/test/e2e/operation/pipeline/src/test/resources/env/common/migration-command.xml
@@ -37,7 +37,8 @@
         REGISTER MIGRATION SOURCE STORAGE UNIT ds_0 (
         URL="${ds0}",
         USER="${user}",
-        PASSWORD="${password}"
+        PASSWORD="${password}",
+        PROPERTIES("maximumPoolSize"="50","idleTimeout"="30000")
         );
     </register-migration-source-storage-unit-template>
     
@@ -45,15 +46,18 @@
         REGISTER STORAGE UNIT ds_2 (
         URL="${ds2}",
         USER="${user}",
-        PASSWORD="${password}"
+        PASSWORD="${password}",
+        PROPERTIES("maximumPoolSize"="50","idleTimeout"="30000")
         ),ds_3 (
         URL="${ds3}",
         USER="${user}",
-        PASSWORD="${password}"
+        PASSWORD="${password}",
+        PROPERTIES("maximumPoolSize"="50","idleTimeout"="30000")
         ),ds_4 (
         URL="${ds4}",
         USER="${user}",
-        PASSWORD="${password}"
+        PASSWORD="${password}",
+        PROPERTIES("maximumPoolSize"="50","idleTimeout"="30000")
         )
     </register-migration-target-storage-unit-template>
     


### PR DESCRIPTION
If consistency check is started before inventory stage done, then consistency check should fail, it's not necessary to do it, so forbid it to avoid starting it by mistake.

Changes proposed in this pull request:
  - Verify inventory finished before starting consistency check
  - Persist inventory progress after inventory done. Make sure when user find job status reaches EXECUTE_INCREMENTAL_TASK, consistency check could be started

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
