### PR TITLE
Add PipelineJobAlreadyExistsException

### DIFF
--- a/docs/document/content/user-manual/error-code/sql-error-code.cn.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.cn.md
@@ -139,6 +139,7 @@ SQL 错误码以标准的 SQL State，Vendor Code 和详细错误信息提供，
 | HY000     | 18093       | Can not poll event because of binlog sync channel already closed.                  |
 | HY000     | 18095       | Can not find consistency check job of \`%s\`.                                      |
 | HY000     | 18096       | Uncompleted consistency check job \`%s\` exists.                                   |
+| HY000     | 18097       | Job \`%s\` already exists.                                                         |
 | HY000     | 18200       | Not find stream data source table.                                                 |
 | HY000     | 18201       | CDC server exception, reason is: %s.                                               |
 | HY000     | 18202       | CDC login failed, reason is: %s                                                    |

--- a/docs/document/content/user-manual/error-code/sql-error-code.en.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.en.md
@@ -139,6 +139,7 @@ SQL error codes provide by standard `SQL State`, `Vendor Code` and `Reason`, whi
 | HY000     | 18093       | Can not poll event because of binlog sync channel already closed.                  |
 | HY000     | 18095       | Can not find consistency check job of \`%s\`.                                      |
 | HY000     | 18096       | Uncompleted consistency check job \`%s\` exists.                                   |
+| HY000     | 18097       | Job \`%s\` already exists.                                                                 |
 | HY000     | 18200       | Not find stream data source table.                                                 |
 | HY000     | 18201       | CDC server exception, reason is: %s.                                               |
 | HY000     | 18202       | CDC login failed, reason is: %s                                                    |

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PipelineJobAlreadyExistsException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PipelineJobAlreadyExistsException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.exception.job;
+
+import org.apache.shardingsphere.infra.exception.core.external.sql.sqlstate.XOpenSQLState;
+import org.apache.shardingsphere.infra.exception.core.external.sql.type.kernel.category.PipelineSQLException;
+
+/**
+ * Pipeline job already exists exception.
+ */
+public final class PipelineJobAlreadyExistsException extends PipelineSQLException {
+    
+    private static final long serialVersionUID = 2854259384634892428L;
+    
+    public PipelineJobAlreadyExistsException(final String jobId) {
+        super(XOpenSQLState.GENERAL_ERROR, 97, String.format("Job `%s` already exists.", jobId));
+    }
+}

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/service/impl/AbstractPipelineJobAPIImpl.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/service/impl/AbstractPipelineJobAPIImpl.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.data.pipeline.common.pojo.PipelineJobInfo;
 import org.apache.shardingsphere.data.pipeline.common.pojo.PipelineJobMetaData;
 import org.apache.shardingsphere.data.pipeline.common.registrycenter.repository.GovernanceRepositoryAPI;
 import org.apache.shardingsphere.data.pipeline.common.util.PipelineDistributedBarrier;
+import org.apache.shardingsphere.data.pipeline.core.exception.job.PipelineJobAlreadyExistsException;
 import org.apache.shardingsphere.data.pipeline.core.exception.job.PipelineJobCreationWithInvalidShardingCountException;
 import org.apache.shardingsphere.data.pipeline.core.exception.job.PipelineJobHasAlreadyStartedException;
 import org.apache.shardingsphere.data.pipeline.core.exception.job.PipelineJobNotFoundException;
@@ -89,8 +90,8 @@ public abstract class AbstractPipelineJobAPIImpl implements PipelineJobAPI {
         GovernanceRepositoryAPI repositoryAPI = PipelineAPIFactory.getGovernanceRepositoryAPI(PipelineJobIdUtils.parseContextKey(jobId));
         String jobConfigKey = PipelineMetaDataNode.getJobConfigPath(jobId);
         if (repositoryAPI.isExisted(jobConfigKey)) {
-            log.warn("jobId already exists in registry center, ignore, jobConfigKey={}", jobConfigKey);
-            return Optional.of(jobId);
+            log.error("jobId already exists in registry center, jobConfigKey={}", jobConfigKey);
+            throw new PipelineJobAlreadyExistsException(jobId);
         }
         repositoryAPI.persist(PipelineMetaDataNode.getJobRootPath(jobId), getJobClassName());
         repositoryAPI.persist(jobConfigKey, YamlEngine.marshal(convertJobConfiguration(jobConfig)));


### PR DESCRIPTION
When job id exists, a better way to handle this might be to throw the exception.

Changes proposed in this pull request:
  - Add PipelineJobAlreadyExistsException

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
