### PR TITLE
Add support for GRANT, REVOKE openGauss

### DIFF
--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
@@ -1934,6 +1934,7 @@ onObjectClause
     | ALL PROCEDURES IN SCHEMA nameList
     | ALL ROUTINES IN SCHEMA nameList
     | CLIENT_MASTER_KEY nameList
+    | COLUMN_ENCRYPTION_KEY nameList
     ;
     
 numericOnlyList

--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/OpenGaussKeyword.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/OpenGaussKeyword.g4
@@ -1444,3 +1444,7 @@ TRUNC
 CLIENT_MASTER_KEY
     : C L I E N T UL_ M A S T E R UL_ K E Y
     ;
+
+COLUMN_ENCRYPTION_KEY
+    : C O L U M N UL_ E N C R Y P T I O N UL_ K E Y
+    ;

--- a/test/it/parser/src/main/resources/case/dcl/grant.xml
+++ b/test/it/parser/src/main/resources/case/dcl/grant.xml
@@ -275,4 +275,5 @@
     <grant sql-case-id="grant_view_definition_on_type" />
     <grant sql-case-id="grant_execute_on_xml_schema_collection" />
     <grant sql-case-id="grant_usage_on_client_master_key" />
+    <grant sql-case-id="grant_usage_on_column_encryption_key" />
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dcl/revoke.xml
+++ b/test/it/parser/src/main/resources/case/dcl/revoke.xml
@@ -228,4 +228,6 @@
     <revoke sql-case-id="revoke_execute_on_system_object" />
     <revoke sql-case-id="revoke_view_definition_on_type" />
     <revoke sql-case-id="revoke_execute_on_xml_schema_collection" />
+    <revoke sql-case-id="revoke_usage_on_column_encryption_key" />
+    <revoke sql-case-id="revoke_usage_on_client_master_key" />
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dcl/grant-user.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dcl/grant-user.xml
@@ -151,4 +151,5 @@
     <sql-case id="grant_view_definition_on_type" value="GRANT VIEW DEFINITION ON TYPE::schema1.type1 TO user1 WITH GRANT OPTION" db-types="SQLServer" />
     <sql-case id="grant_execute_on_xml_schema_collection" value="GRANT EXECUTE ON XML SCHEMA COLLECTION::schema1.collection1 TO user1" db-types="SQLServer" />
     <sql-case id="grant_usage_on_client_master_key" value="GRANT USAGE ON CLIENT_MASTER_KEY MyCMK1 to user1" db-types="openGauss" />
+    <sql-case id="grant_usage_on_column_encryption_key" value="GRANT USAGE ON COLUMN_ENCRYPTION_KEY MyCEK1 to user1" db-types="openGauss" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dcl/revoke-user.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dcl/revoke-user.xml
@@ -125,4 +125,6 @@
     <sql-case id="revoke_execute_on_system_object" value="REVOKE EXECUTE ON sys.sp_addlinkedserver FROM public" db-types="SQLServer" />
     <sql-case id="revoke_view_definition_on_type" value="REVOKE VIEW DEFINITION ON TYPE::schema1.type1 FROM user1 CASCADE" db-types="SQLServer" />
     <sql-case id="revoke_execute_on_xml_schema_collection" value="REVOKE EXECUTE ON XML SCHEMA COLLECTION::schema1.xmlschemacollection1 FROM user1" db-types="SQLServer" />
+    <sql-case id="revoke_usage_on_column_encryption_key" value="REVOKE USAGE ON COLUMN_ENCRYPTION_KEY MyCEK1 FROM user1" db-types="openGauss" />
+    <sql-case id="revoke_usage_on_client_master_key" value="REVOKE USAGE ON CLIENT_MASTER_KEY MyCMK1 FROM user1" db-types="openGauss" />
 </sql-cases>


### PR DESCRIPTION
Refs #27639.

Changes proposed in this pull request:
  - Add openGauss SQL support for `GRANT` and `REVOKE` for `COLUMN_ENCRYPTION_KEY`
  - Add openGauss SQL support for `REVOKE` for `CLIENT_MASTER_KEY`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
