### PR TITLE
Document : unify the mvn usage with ./mvnw in document

### DIFF
--- a/docs/community/content/involved/conduct/code.cn.md
+++ b/docs/community/content/involved/conduct/code.cn.md
@@ -22,7 +22,7 @@ chapter = true
  - 确保构建流程中的各个步骤都成功完成，包括：Apache 协议文件头检查、Checkstyle 检查、编译、单元测试等。构建流程启动命令：`./mvnw clean install -B -T1C -Pcheck`。
  - 确保覆盖率不低于 master 分支。
  - 应尽量将设计精细化拆分；做到小幅度修改，多次数提交，但应保证提交的完整性。
- - 通过 Spotless 统一代码风格，执行 `mvn spotless:apply -Pcheck` 格式化代码。
+ - 通过 Spotless 统一代码风格，执行 `./mvnw spotless:apply -Pcheck` 格式化代码。
  - 如果您使用 IDEA，可导入推荐的 `src/resources/code-style-idea.xml`。
  
 ## 编码规范

--- a/docs/community/content/involved/conduct/code.en.md
+++ b/docs/community/content/involved/conduct/code.en.md
@@ -19,7 +19,7 @@ The following code of conduct is based on full compliance with [ASF CODE OF COND
  - Make sure Maven build process success. Run `./mvnw clean install -B -T1C -Pcheck` command in shell to start Maven build process.
  - Make sure the test coverage rate is not lower than the master branch.
  - Careful consideration for each `pull request`; Small and frequent `pull request` with complete unit function is welcomed.
- - Through the uniform code style of spotless, execute the `mvn spotless:apply -Pcheck` formatted code.
+ - Through the uniform code style of spotless, execute the `./mvnw spotless:apply -Pcheck` formatted code.
  - If using IDEA, you can import the recommended `src/resources/code-style-idea.xml`.
 
 ## Contributor Covenant Code of Conduct

--- a/docs/community/content/involved/contribute/contributor.cn.md
+++ b/docs/community/content/involved/contribute/contributor.cn.md
@@ -40,7 +40,7 @@ git remote -v
 
 ```shell
 cd shardingsphere
-mvn clean install -DskipITs -DskipTests -Prelease
+./mvnw clean install -DskipITs -DskipTests -Prelease
 ```
 
 当你以后从 ShardingSphere 拉取最新代码并新建分支，可能会遇到类似的解析器编译错误，可以重新运行这个命令来解决问题。

--- a/docs/community/content/involved/contribute/contributor.en.md
+++ b/docs/community/content/involved/contribute/contributor.en.md
@@ -40,7 +40,7 @@ Build and install all modules, it'll install modules into Maven local repository
 
 ```shell
 cd shardingsphere
-mvn clean install -DskipITs -DskipTests -Prelease
+./mvnw clean install -DskipITs -DskipTests -Prelease
 ```
 
 When you pull the latest code from ShardingSphere and create new branch later, you might get similar compile error of parser again, then you could run this command again.

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/docker.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/docker.cn.md
@@ -25,9 +25,9 @@ docker pull apache/shardingsphere-proxy
 * 方式三：自行构建镜像
 ```bash
 git clone https://github.com/apache/shardingsphere
-mvn clean install
+./mvnw clean install
 cd shardingsphere-distribution/shardingsphere-proxy-distribution
-mvn clean package -Prelease,docker
+./mvnw clean package -Prelease,docker
 ```
 
 如果遇到以下问题，请确保 Docker daemon 进程已经运行。

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/docker.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/docker.en.md
@@ -25,9 +25,9 @@ docker pull apache/shardingsphere-proxy
 * Method 3: Build your own image
 ```bash
 git clone https://github.com/apache/shardingsphere
-mvn clean install
+./mvnw clean install
 cd shardingsphere-distribution/shardingsphere-proxy-distribution
-mvn clean package -Prelease,docker
+./mvnw clean package -Prelease,docker
 ```
 
 If the following problems emerge, please make sure Docker daemon Process is running.

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ git clone https://github.com/apache/shardingsphere.git
 
 ## compile source code
 cd shardingsphere
-mvn clean install -Prelease
+./mvnw clean install -Prelease
 ```
 
 ## Module design


### PR DESCRIPTION
Changes proposed in this pull request:
  - unify the mvn usage with ./mvnw in document

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
