### PR TITLE
Expand unit tests for ShardingSphereDatabase class

### DIFF
--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
@@ -17,12 +17,24 @@
 
 package org.apache.shardingsphere.infra.metadata.database;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
 import org.apache.shardingsphere.infra.config.database.impl.DataSourceProvidedDatabaseConfiguration;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.instance.InstanceContext;
 import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.DataSourceContainedRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.MutableDataNodeRule;
@@ -31,51 +43,117 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.fixture.jdbc.MockedDataSource;
 import org.apache.shardingsphere.test.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.mock.StaticMockSettings;
+import org.apache.shardingsphere.infra.config.database.DatabaseConfiguration;
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
+import org.apache.shardingsphere.infra.metadata.database.resource.StorageResource;
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Properties;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
+import java.util.HashMap;
+import java.util.Map;
 
 @ExtendWith(AutoMockExtension.class)
 @StaticMockSettings(ShardingSphereDatabase.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ShardingSphereDatabaseTest {
-    
+
+    @Test
+    void assertContainsSchema() {
+        DatabaseType databaseType = mock(DatabaseType.class);
+        RuleMetaData ruleMetaData = mock(RuleMetaData.class);
+        Map<String, ShardingSphereSchema> schemas = new HashMap<>();
+        ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
+        schemas.put("schema1", schema);
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), ruleMetaData, schemas);
+        assertTrue(database.containsSchema("schema1"));
+        assertFalse(database.containsSchema("non_existent_schema"));
+    }
+
+    @Test
+    void assertGetSchema() {
+        DatabaseType databaseType = mock(DatabaseType.class);
+        RuleMetaData ruleMetaData = mock(RuleMetaData.class);
+        Map<String, ShardingSphereSchema> schemas = new HashMap<>();
+        ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
+        schemas.put("schema1", schema);
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), ruleMetaData, schemas);
+        assertEquals(schema, database.getSchema("schema1"));
+        assertNull(database.getSchema("non_existent_schema"));
+    }
+
+    @Test
+    void assertAddSchema() {
+        DatabaseType databaseType = mock(DatabaseType.class);
+        RuleMetaData ruleMetaData = mock(RuleMetaData.class);
+        Map<String, ShardingSphereSchema> schemas = new HashMap<>();
+        ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), ruleMetaData, schemas);
+        assertFalse(database.containsSchema("new_schema"));
+        database.addSchema("new_schema", schema);
+        assertTrue(database.containsSchema("new_schema"));
+        assertEquals(schema, database.getSchema("new_schema"));
+    }
+
+    @Test
+    void assertDropSchema() {
+        DatabaseType databaseType = mock(DatabaseType.class);
+        RuleMetaData ruleMetaData = mock(RuleMetaData.class);
+        Map<String, ShardingSphereSchema> schemas = new HashMap<>();
+        ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
+        schemas.put("schema1", schema);
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), ruleMetaData, schemas);
+        assertTrue(database.containsSchema("schema1"));
+        database.dropSchema("schema1");
+        assertFalse(database.containsSchema("schema1"));
+    }
+
     @Test
     void assertIsComplete() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource()));
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(mock(ShardingSphereRule.class)));
         assertTrue(new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, Collections.emptyMap()).isComplete());
     }
-    
+
     @Test
     void assertIsNotCompleteWithoutRule() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource()));
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.emptyList());
         assertFalse(new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, Collections.emptyMap()).isComplete());
     }
-    
+
     @Test
     void assertIsNotCompleteWithoutDataSource() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.emptyMap());
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(mock(ShardingSphereRule.class)));
         assertFalse(new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, Collections.emptyMap()).isComplete());
     }
-    
+
+    @Test
+    void assertNotContainsDataSource() {
+        ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.emptyMap());
+        RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(mock(ShardingSphereRule.class)));
+        assertFalse(new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, Collections.emptyMap()).containsDataSource());
+    }
+
+    @Test
+    void assertContainsDataSource() {
+        ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource()));
+        RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(mock(ShardingSphereRule.class)));
+        assertTrue(new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, Collections.emptyMap()).containsDataSource());
+    }
+
     @Test
     void assertReloadRules() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource()));
@@ -88,7 +166,7 @@ class ShardingSphereDatabaseTest {
         database.reloadRules(MutableDataNodeRule.class);
         assertThat(database.getRuleMetaData().getRules().size(), is(3));
     }
-    
+
     @Test
     void assertGetPostgreSQLDefaultSchema() throws SQLException {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "PostgreSQL");
@@ -96,7 +174,7 @@ class ShardingSphereDatabaseTest {
                 mock(DataSourceProvidedDatabaseConfiguration.class), new ConfigurationProperties(new Properties()), mock(InstanceContext.class));
         assertNotNull(actual.getSchema("public"));
     }
-    
+
     @Test
     void assertGetMySQLDefaultSchema() throws SQLException {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
@@ -32,19 +32,12 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.fixture.jdbc.MockedDataSource;
 import org.apache.shardingsphere.test.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.mock.StaticMockSettings;
-import org.apache.shardingsphere.infra.config.database.DatabaseConfiguration;
-import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
-import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
-import org.apache.shardingsphere.infra.metadata.database.resource.StorageResource;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
@@ -56,11 +49,9 @@ import java.util.Properties;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
@@ -17,17 +17,6 @@
 
 package org.apache.shardingsphere.infra.metadata.database;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
-
 import org.apache.shardingsphere.infra.config.database.impl.DataSourceProvidedDatabaseConfiguration;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
@@ -60,9 +49,20 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
-import java.util.Properties;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(AutoMockExtension.class)
 @StaticMockSettings(ShardingSphereDatabase.class)
@@ -89,7 +89,7 @@ class ShardingSphereDatabaseTest {
         ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
         schemas.put("schema1", schema);
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), ruleMetaData, schemas);
-        assertEquals(schema, database.getSchema("schema1"));
+        assertThat(database.getSchema("schema1"), is(schema));
         assertNull(database.getSchema("non_existent_schema"));
     }
 
@@ -101,9 +101,10 @@ class ShardingSphereDatabaseTest {
         ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), ruleMetaData, schemas);
         assertFalse(database.containsSchema("new_schema"));
+
         database.addSchema("new_schema", schema);
         assertTrue(database.containsSchema("new_schema"));
-        assertEquals(schema, database.getSchema("new_schema"));
+        assertThat(database.getSchema("new_schema"), is(schema));
     }
 
     @Test

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
@@ -68,7 +68,7 @@ import static org.mockito.Mockito.mock;
 @StaticMockSettings(ShardingSphereDatabase.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ShardingSphereDatabaseTest {
-
+    
     @Test
     void assertContainsSchema() {
         DatabaseType databaseType = mock(DatabaseType.class);
@@ -80,7 +80,7 @@ class ShardingSphereDatabaseTest {
         assertTrue(database.containsSchema("schema1"));
         assertFalse(database.containsSchema("non_existent_schema"));
     }
-
+    
     @Test
     void assertGetSchema() {
         DatabaseType databaseType = mock(DatabaseType.class);
@@ -92,7 +92,7 @@ class ShardingSphereDatabaseTest {
         assertThat(database.getSchema("schema1"), is(schema));
         assertNull(database.getSchema("non_existent_schema"));
     }
-
+    
     @Test
     void assertAddSchema() {
         DatabaseType databaseType = mock(DatabaseType.class);
@@ -101,12 +101,12 @@ class ShardingSphereDatabaseTest {
         ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), ruleMetaData, schemas);
         assertFalse(database.containsSchema("new_schema"));
-
+        
         database.addSchema("new_schema", schema);
         assertTrue(database.containsSchema("new_schema"));
         assertThat(database.getSchema("new_schema"), is(schema));
     }
-
+    
     @Test
     void assertDropSchema() {
         DatabaseType databaseType = mock(DatabaseType.class);
@@ -119,42 +119,42 @@ class ShardingSphereDatabaseTest {
         database.dropSchema("schema1");
         assertFalse(database.containsSchema("schema1"));
     }
-
+    
     @Test
     void assertIsComplete() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource()));
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(mock(ShardingSphereRule.class)));
         assertTrue(new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, Collections.emptyMap()).isComplete());
     }
-
+    
     @Test
     void assertIsNotCompleteWithoutRule() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource()));
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.emptyList());
         assertFalse(new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, Collections.emptyMap()).isComplete());
     }
-
+    
     @Test
     void assertIsNotCompleteWithoutDataSource() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.emptyMap());
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(mock(ShardingSphereRule.class)));
         assertFalse(new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, Collections.emptyMap()).isComplete());
     }
-
+    
     @Test
     void assertNotContainsDataSource() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.emptyMap());
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(mock(ShardingSphereRule.class)));
         assertFalse(new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, Collections.emptyMap()).containsDataSource());
     }
-
+    
     @Test
     void assertContainsDataSource() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource()));
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(mock(ShardingSphereRule.class)));
         assertTrue(new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, Collections.emptyMap()).containsDataSource());
     }
-
+    
     @Test
     void assertReloadRules() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource()));
@@ -167,7 +167,7 @@ class ShardingSphereDatabaseTest {
         database.reloadRules(MutableDataNodeRule.class);
         assertThat(database.getRuleMetaData().getRules().size(), is(3));
     }
-
+    
     @Test
     void assertGetPostgreSQLDefaultSchema() throws SQLException {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "PostgreSQL");
@@ -175,7 +175,7 @@ class ShardingSphereDatabaseTest {
                 mock(DataSourceProvidedDatabaseConfiguration.class), new ConfigurationProperties(new Properties()), mock(InstanceContext.class));
         assertNotNull(actual.getSchema("public"));
     }
-
+    
     @Test
     void assertGetMySQLDefaultSchema() throws SQLException {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");


### PR DESCRIPTION
### Notes

This PR fixes - https://github.com/apache/shardingsphere/issues/28568

Changes proposed in this pull request contains unit tests for the following methods in `ShardingSphereDatabase` class

- `containsSchema`
- `getSchema`
- `addSchema`
- `dropSchema`
- `containsDataSource`

Unit tests for the static `create` method will be included in a follow-up PR

### Testing

```
./mvnw clean install -Prelease -T1C -DskipTests -Djacoco.skip=true -Dcheckstyle.skip=true -Drat.skip=true -Dmaven.javadoc.skip=true -B

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache ShardingSphere 5.4.1-SNAPSHOT:
[INFO] 
[INFO] Apache ShardingSphere .............................. SUCCESS [  4.895 s]
[INFO] shardingsphere-infra ............................... SUCCESS [  0.269 s]
[INFO] shardingsphere-infra-exception ..................... SUCCESS [  0.151 s]
[INFO] shardingsphere-infra-exception-core ................ SUCCESS [  2.408 s]
[INFO] shardingsphere-test ................................ SUCCESS [  0.460 s]
[INFO] shardingsphere-test-util ........................... SUCCESS [  6.001 s]
[INFO] shardingsphere-infra-spi ........................... SUCCESS [  2.159 s]
[INFO] shardingsphere-infra-util .......................... SUCCESS [  2.786 s]
[INFO] shardingsphere-infra-database ...................... SUCCESS [  0.137 s]
[INFO] shardingsphere-infra-database-core ................. SUCCESS [  3.275 s]
[INFO] shardingsphere-infra-database-type ................. SUCCESS [  0.119 s]
[INFO] shardingsphere-infra-database-mysql ................ SUCCESS [  2.053 s]
[INFO] shardingsphere-infra-database-mariadb .............. SUCCESS [  1.593 s]
[INFO] shardingsphere-infra-database-postgresql ........... SUCCESS [  2.540 s]
[INFO] shardingsphere-infra-database-opengauss ............ SUCCESS [  1.982 s]
[INFO] shardingsphere-infra-database-oracle ............... SUCCESS [  1.798 s]
[INFO] shardingsphere-infra-database-sqlserver ............ SUCCESS [  1.714 s]
[INFO] shardingsphere-infra-database-h2 ................... SUCCESS [  2.397 s]
[INFO] shardingsphere-infra-database-sql92 ................ SUCCESS [  1.311 s]
[INFO] shardingsphere-test-fixture ........................ SUCCESS [  0.185 s]
[INFO] shardingsphere-test-fixture-database ............... SUCCESS [  1.255 s]
[INFO] shardingsphere-infra-data-source-pool .............. SUCCESS [  0.179 s]
[INFO] shardingsphere-infra-data-source-pool-core ......... SUCCESS [  2.842 s]
[INFO] shardingsphere-infra-data-source-pool-type ......... SUCCESS [  0.096 s]
[INFO] shardingsphere-infra-data-source-pool-hikari ....... SUCCESS [  1.739 s]
[INFO] shardingsphere-parser .............................. SUCCESS [  0.158 s]
[INFO] shardingsphere-parser-sql .......................... SUCCESS [  0.131 s]
[INFO] shardingsphere-parser-sql-spi ...................... SUCCESS [  1.004 s]
[INFO] shardingsphere-parser-sql-statement ................ SUCCESS [ 11.030 s]
[INFO] shardingsphere-parser-sql-engine ................... SUCCESS [  1.718 s]
[INFO] shardingsphere-infra-common ........................ SUCCESS [  8.345 s]
[INFO] shardingsphere-infra-exception-dialect ............. SUCCESS [  0.094 s]
[INFO] shardingsphere-infra-exception-dialect-core ........ SUCCESS [  1.731 s]
[INFO] shardingsphere-infra-exception-dialect-type ........ SUCCESS [  0.152 s]
[INFO] shardingsphere-mysql-dialect-exception ............. SUCCESS [  2.201 s]
[INFO] shardingsphere-postgresql-dialect-exception ........ SUCCESS [  1.955 s]
[INFO] shardingsphere-parser-distsql ...................... SUCCESS [  0.194 s]
[INFO] shardingsphere-parser-distsql-statement ............ SUCCESS [  2.200 s]
[INFO] shardingsphere-parser-distsql-engine ............... SUCCESS [  5.458 s]
[INFO] shardingsphere-infra-parser ........................ SUCCESS [  1.875 s]
[INFO] shardingsphere-infra-binder ........................ SUCCESS [  7.771 s]
[INFO] shardingsphere-infra-session ....................... SUCCESS [  1.324 s]
[INFO] shardingsphere-infra-route ......................... SUCCESS [  2.336 s]
[INFO] shardingsphere-kernel .............................. SUCCESS [  0.219 s]
[INFO] shardingsphere-sql-translator ...................... SUCCESS [  0.123 s]
[INFO] shardingsphere-sql-translator-api .................. SUCCESS [  1.589 s]
[INFO] shardingsphere-mode ................................ SUCCESS [  0.214 s]
[INFO] shardingsphere-mode-api ............................ SUCCESS [  2.199 s]
[INFO] shardingsphere-sql-translator-core ................. SUCCESS [  1.627 s]
[INFO] shardingsphere-sql-translator-provider ............. SUCCESS [  0.150 s]
[INFO] shardingsphere-sql-translator-native-provider ...... SUCCESS [  0.885 s]
[INFO] shardingsphere-infra-rewrite ....................... SUCCESS [  2.542 s]
[INFO] shardingsphere-infra-executor ...................... SUCCESS [  4.363 s]
[INFO] shardingsphere-authority ........................... SUCCESS [  0.130 s]
[INFO] shardingsphere-authority-api ....................... SUCCESS [  1.307 s]
[INFO] shardingsphere-authority-core ...................... SUCCESS [  4.004 s]
[INFO] shardingsphere-single .............................. SUCCESS [  0.142 s]
[INFO] shardingsphere-single-api .......................... SUCCESS [  1.338 s]
[INFO] shardingsphere-transaction ......................... SUCCESS [  0.128 s]
[INFO] shardingsphere-transaction-api ..................... SUCCESS [  1.112 s]
[INFO] shardingsphere-transaction-core .................... SUCCESS [  3.080 s]
[INFO] shardingsphere-infra-context ....................... SUCCESS [  3.780 s]
[INFO] shardingsphere-test-fixture-infra .................. SUCCESS [  1.712 s]
[INFO] shardingsphere-infra-merge ......................... SUCCESS [  4.275 s]
[INFO] shardingsphere-infra-distsql-handler ............... SUCCESS [  1.919 s]
[INFO] shardingsphere-infra-expr .......................... SUCCESS [  0.143 s]
[INFO] shardingsphere-infra-expr-spi ...................... SUCCESS [  0.908 s]
[INFO] shardingsphere-infra-expr-type ..................... SUCCESS [  0.110 s]
[INFO] shardingsphere-infra-expr-groovy ................... SUCCESS [  2.308 s]
[INFO] shardingsphere-infra-expr-literal .................. SUCCESS [  1.238 s]
[INFO] shardingsphere-infra-expr-core ..................... SUCCESS [  1.609 s]
[INFO] shardingsphere-infra-expr-espresso ................. SUCCESS [  3.368 s]
[INFO] shardingsphere-data-pipeline ....................... SUCCESS [  0.160 s]
[INFO] shardingsphere-data-pipeline-distsql ............... SUCCESS [  0.094 s]
[INFO] shardingsphere-data-pipeline-distsql-statement ..... SUCCESS [  1.314 s]
[INFO] shardingsphere-data-pipeline-distsql-parser ........ SUCCESS [  2.898 s]
[INFO] shardingsphere-features ............................ SUCCESS [  0.211 s]
[INFO] shardingsphere-sharding ............................ SUCCESS [  0.099 s]
[INFO] shardingsphere-sharding-distsql .................... SUCCESS [  0.115 s]
[INFO] shardingsphere-sharding-distsql-statement .......... SUCCESS [  1.560 s]
[INFO] shardingsphere-sharding-distsql-parser ............. SUCCESS [  3.135 s]
[INFO] shardingsphere-broadcast ........................... SUCCESS [  0.194 s]
[INFO] shardingsphere-broadcast-distsql ................... SUCCESS [  0.088 s]
[INFO] shardingsphere-broadcast-distsql-statement ......... SUCCESS [  1.240 s]
[INFO] shardingsphere-broadcast-distsql-parser ............ SUCCESS [  1.483 s]
[INFO] shardingsphere-readwrite-splitting ................. SUCCESS [  0.156 s]
[INFO] shardingsphere-readwrite-splitting-distsql ......... SUCCESS [  0.092 s]
[INFO] shardingsphere-readwrite-splitting-distsql-statement SUCCESS [  1.110 s]
[INFO] shardingsphere-readwrite-splitting-distsql-parser .. SUCCESS [  1.723 s]
[INFO] shardingsphere-encrypt ............................. SUCCESS [  0.195 s]
[INFO] shardingsphere-encrypt-distsql ..................... SUCCESS [  0.130 s]
[INFO] shardingsphere-encrypt-distsql-statement ........... SUCCESS [  1.057 s]
[INFO] shardingsphere-encrypt-distsql-parser .............. SUCCESS [  1.867 s]
[INFO] shardingsphere-mask ................................ SUCCESS [  0.171 s]
[INFO] shardingsphere-mask-distsql ........................ SUCCESS [  0.084 s]
[INFO] shardingsphere-mask-distsql-statement .............. SUCCESS [  1.420 s]
[INFO] shardingsphere-mask-distsql-parser ................. SUCCESS [  1.924 s]
[INFO] shardingsphere-authority-distsql ................... SUCCESS [  0.124 s]
[INFO] shardingsphere-authority-distsql-statement ......... SUCCESS [  1.343 s]
[INFO] shardingsphere-authority-distsql-parser ............ SUCCESS [  1.224 s]
[INFO] shardingsphere-global-clock ........................ SUCCESS [  0.167 s]
[INFO] shardingsphere-global-clock-api .................... SUCCESS [  1.669 s]
[INFO] shardingsphere-global-clock-distsql ................ SUCCESS [  0.099 s]
[INFO] shardingsphere-global-clock-distsql-statement ...... SUCCESS [  1.213 s]
[INFO] shardingsphere-global-clock-distsql-parser ......... SUCCESS [  1.356 s]
[INFO] shardingsphere-traffic ............................. SUCCESS [  0.092 s]
[INFO] shardingsphere-traffic-distsql ..................... SUCCESS [  0.091 s]
[INFO] shardingsphere-traffic-distsql-statement ........... SUCCESS [  1.374 s]
[INFO] shardingsphere-traffic-distsql-parser .............. SUCCESS [  1.536 s]
[INFO] shardingsphere-transaction-distsql ................. SUCCESS [  0.107 s]
[INFO] shardingsphere-transaction-distsql-statement ....... SUCCESS [  1.160 s]
[INFO] shardingsphere-transaction-distsql-parser .......... SUCCESS [  1.666 s]
[INFO] shardingsphere-single-distsql ...................... SUCCESS [  0.078 s]
[INFO] shardingsphere-single-distsql-statement ............ SUCCESS [  1.108 s]
[INFO] shardingsphere-single-distsql-parser ............... SUCCESS [  1.866 s]
[INFO] shardingsphere-sql-parser .......................... SUCCESS [  0.112 s]
[INFO] shardingsphere-sql-parser-distsql .................. SUCCESS [  0.108 s]
[INFO] shardingsphere-sql-parser-distsql-statement ........ SUCCESS [  1.091 s]
[INFO] shardingsphere-sql-parser-distsql-parser ........... SUCCESS [  1.360 s]
[INFO] shardingsphere-sql-translator-distsql .............. SUCCESS [  0.094 s]
[INFO] shardingsphere-sql-translator-distsql-statement .... SUCCESS [  0.662 s]
[INFO] shardingsphere-sql-translator-distsql-parser ....... SUCCESS [  1.436 s]
[INFO] shardingsphere-shadow .............................. SUCCESS [  0.134 s]
[INFO] shardingsphere-shadow-distsql ...................... SUCCESS [  0.083 s]
[INFO] shardingsphere-shadow-distsql-statement ............ SUCCESS [  1.157 s]
[INFO] shardingsphere-shadow-distsql-parser ............... SUCCESS [  2.057 s]
[INFO] shardingsphere-it .................................. SUCCESS [  1.217 s]
[INFO] shardingsphere-it-parser ........................... SUCCESS [ 15.553 s]
[INFO] shardingsphere-parser-sql-dialect .................. SUCCESS [  0.455 s]
[INFO] shardingsphere-parser-sql-sql92 .................... SUCCESS [  5.908 s]
[INFO] shardingsphere-parser-sql-postgresql ............... SUCCESS [ 24.495 s]
[INFO] shardingsphere-parser-sql-mysql .................... SUCCESS [ 25.354 s]
[INFO] shardingsphere-parser-sql-oracle ................... SUCCESS [01:49 min]
[INFO] shardingsphere-parser-sql-sqlserver ................ SUCCESS [ 11.526 s]
[INFO] shardingsphere-parser-sql-opengauss ................ SUCCESS [ 28.102 s]
[INFO] shardingsphere-db-protocol ......................... SUCCESS [  0.263 s]
[INFO] shardingsphere-db-protocol-core .................... SUCCESS [  2.029 s]
[INFO] shardingsphere-postgresql-protocol ................. SUCCESS [  4.332 s]
[INFO] shardingsphere-mysql-protocol ...................... SUCCESS [  5.124 s]
[INFO] shardingsphere-opengauss-protocol .................. SUCCESS [  2.652 s]
[INFO] shardingsphere-metadata ............................ SUCCESS [  0.121 s]
[INFO] shardingsphere-metadata-core ....................... SUCCESS [  5.626 s]
[INFO] shardingsphere-mode-core ........................... SUCCESS [  3.430 s]
[INFO] shardingsphere-mode-type ........................... SUCCESS [  0.114 s]
[INFO] shardingsphere-standalone-mode ..................... SUCCESS [  0.190 s]
[INFO] shardingsphere-standalone-mode-repository .......... SUCCESS [  0.084 s]
[INFO] shardingsphere-standalone-mode-repository-api ...... SUCCESS [  1.153 s]
[INFO] shardingsphere-standalone-mode-core ................ SUCCESS [  2.141 s]
[INFO] shardingsphere-standalone-mode-repository-provider . SUCCESS [  0.138 s]
[INFO] shardingsphere-standalone-mode-repository-jdbc ..... SUCCESS [  2.405 s]
[INFO] shardingsphere-cluster-mode ........................ SUCCESS [  0.133 s]
[INFO] shardingsphere-cluster-mode-repository ............. SUCCESS [  0.230 s]
[INFO] shardingsphere-cluster-mode-repository-api ......... SUCCESS [  1.846 s]
[INFO] shardingsphere-sql-federation ...................... SUCCESS [  0.158 s]
[INFO] shardingsphere-sql-federation-api .................. SUCCESS [  1.712 s]
[INFO] shardingsphere-single-core ......................... SUCCESS [  3.194 s]
[INFO] shardingsphere-cluster-mode-core ................... SUCCESS [  4.282 s]
[INFO] shardingsphere-cluster-mode-repository-provider .... SUCCESS [  0.136 s]
[INFO] shardingsphere-cluster-mode-repository-zookeeper ... SUCCESS [  2.550 s]
[INFO] shardingsphere-cluster-mode-repository-etcd ........ SUCCESS [  5.779 s]
[INFO] shardingsphere-cluster-mode-repository-consul ...... SUCCESS [  2.312 s]
[INFO] shardingsphere-single-distsql-handler .............. SUCCESS [  2.140 s]
[INFO] shardingsphere-authority-distsql-handler ........... SUCCESS [  3.532 s]
[INFO] shardingsphere-transaction-type .................... SUCCESS [  0.095 s]
[INFO] shardingsphere-transaction-xa ...................... SUCCESS [  0.263 s]
[INFO] shardingsphere-transaction-xa-spi .................. SUCCESS [  2.179 s]
[INFO] shardingsphere-transaction-xa-provider ............. SUCCESS [  0.124 s]
[INFO] shardingsphere-transaction-xa-atomikos ............. SUCCESS [  3.073 s]
[INFO] shardingsphere-transaction-xa-core ................. SUCCESS [  3.007 s]
[INFO] shardingsphere-transaction-xa-narayana ............. SUCCESS [  2.580 s]
[INFO] shardingsphere-transaction-base .................... SUCCESS [  0.204 s]
[INFO] shardingsphere-transaction-base-seata-at ........... SUCCESS [  5.775 s]
[INFO] shardingsphere-transaction-distsql-handler ......... SUCCESS [  3.007 s]
[INFO] shardingsphere-time-service ........................ SUCCESS [  0.111 s]
[INFO] shardingsphere-time-service-api .................... SUCCESS [  0.928 s]
[INFO] shardingsphere-time-service-core ................... SUCCESS [  1.201 s]
[INFO] shardingsphere-time-service-type ................... SUCCESS [  0.237 s]
[INFO] shardingsphere-system-time-service ................. SUCCESS [  1.557 s]
[INFO] shardingsphere-database-time-service ............... SUCCESS [  1.907 s]
[INFO] shardingsphere-data-pipeline-api ................... SUCCESS [  2.962 s]
[INFO] shardingsphere-sql-parser-api ...................... SUCCESS [  0.904 s]
[INFO] shardingsphere-sql-parser-core ..................... SUCCESS [  1.902 s]
[INFO] shardingsphere-sharding-api ........................ SUCCESS [  1.609 s]
[INFO] shardingsphere-sql-federation-core ................. SUCCESS [  7.819 s]
[INFO] shardingsphere-it-yaml ............................. SUCCESS [  1.126 s]
[INFO] shardingsphere-sharding-core ....................... SUCCESS [ 13.201 s]
[INFO] shardingsphere-data-pipeline-core .................. SUCCESS [  7.153 s]
[INFO] shardingsphere-global-clock-core ................... SUCCESS [  2.400 s]
[INFO] shardingsphere-global-clock-type ................... SUCCESS [  0.106 s]
[INFO] shardingsphere-global-clock-tso .................... SUCCESS [  0.150 s]
[INFO] shardingsphere-global-clock-tso-spi ................ SUCCESS [  1.170 s]
[INFO] shardingsphere-global-clock-tso-provider ........... SUCCESS [  0.198 s]
[INFO] shardingsphere-global-clock-tso-provider-redis ..... SUCCESS [  1.309 s]
[INFO] shardingsphere-global-clock-tso-core ............... SUCCESS [  1.530 s]
[INFO] shardingsphere-traffic-api ......................... SUCCESS [  1.440 s]
[INFO] shardingsphere-traffic-core ........................ SUCCESS [  2.022 s]
[INFO] shardingsphere-broadcast-api ....................... SUCCESS [  0.988 s]
[INFO] shardingsphere-broadcast-core ...................... SUCCESS [  2.577 s]
[INFO] shardingsphere-readwrite-splitting-api ............. SUCCESS [  1.566 s]
[INFO] shardingsphere-readwrite-splitting-core ............ SUCCESS [  3.331 s]
[INFO] shardingsphere-encrypt-api ......................... SUCCESS [  1.389 s]
[INFO] shardingsphere-encrypt-core ........................ SUCCESS [  6.033 s]
[INFO] shardingsphere-mask-api ............................ SUCCESS [  1.355 s]
[INFO] shardingsphere-mask-core ........................... SUCCESS [  2.552 s]
[INFO] shardingsphere-shadow-api .......................... SUCCESS [  1.060 s]
[INFO] shardingsphere-shadow-core ......................... SUCCESS [  2.923 s]
[INFO] shardingsphere-logging ............................. SUCCESS [  0.150 s]
[INFO] shardingsphere-logging-api ......................... SUCCESS [  1.163 s]
[INFO] shardingsphere-logging-core ........................ SUCCESS [  1.976 s]
[INFO] shardingsphere-jdbc ................................ SUCCESS [  0.198 s]
[INFO] shardingsphere-jdbc-core ........................... SUCCESS [  6.605 s]
[INFO] shardingsphere-data-pipeline-dialect ............... SUCCESS [  0.144 s]
[INFO] shardingsphere-data-pipeline-mysql ................. SUCCESS [  4.418 s]
[INFO] shardingsphere-data-pipeline-postgresql ............ SUCCESS [  4.447 s]
[INFO] shardingsphere-data-pipeline-opengauss ............. SUCCESS [  4.739 s]
[INFO] shardingsphere-data-pipeline-h2 .................... SUCCESS [  2.386 s]
[INFO] shardingsphere-data-pipeline-scenario .............. SUCCESS [  0.110 s]
[INFO] shardingsphere-data-pipeline-scenario-consistencycheck SUCCESS [  3.305 s]
[INFO] shardingsphere-data-pipeline-scenario-migration .... SUCCESS [  3.501 s]
[INFO] shardingsphere-data-pipeline-cdc ................... SUCCESS [  0.191 s]
[INFO] shardingsphere-data-pipeline-cdc-protocol .......... SUCCESS [  6.404 s]
[INFO] shardingsphere-data-pipeline-cdc-core .............. SUCCESS [  4.170 s]
[INFO] shardingsphere-data-pipeline-distsql-handler ....... SUCCESS [  3.706 s]
[INFO] shardingsphere-data-pipeline-cdc-client ............ SUCCESS [  3.219 s]
[INFO] shardingsphere-sql-federation-distsql .............. SUCCESS [  0.087 s]
[INFO] shardingsphere-sql-federation-distsql-statement .... SUCCESS [  0.998 s]
[INFO] shardingsphere-sql-federation-distsql-parser ....... SUCCESS [  1.369 s]
[INFO] shardingsphere-sql-federation-distsql-handler ...... SUCCESS [  1.837 s]
[INFO] shardingsphere-sql-parser-distsql-handler .......... SUCCESS [  2.677 s]
[INFO] shardingsphere-sql-translator-jooq-provider ........ SUCCESS [  1.263 s]
[INFO] shardingsphere-sql-translator-distsql-handler ...... SUCCESS [  2.886 s]
[INFO] shardingsphere-traffic-distsql-handler ............. SUCCESS [  2.207 s]
[INFO] shardingsphere-global-clock-hlc .................... SUCCESS [  1.075 s]
[INFO] shardingsphere-global-clock-distsql-handler ........ SUCCESS [  2.065 s]
[INFO] shardingsphere-sharding-distsql-handler ............ SUCCESS [  5.077 s]
[INFO] shardingsphere-broadcast-distsql-handler ........... SUCCESS [  2.424 s]
[INFO] shardingsphere-readwrite-splitting-distsql-handler . SUCCESS [  2.089 s]
[INFO] shardingsphere-encrypt-distsql-handler ............. SUCCESS [  2.595 s]
[INFO] shardingsphere-shadow-distsql-handler .............. SUCCESS [  2.558 s]
[INFO] shardingsphere-mask-distsql-handler ................ SUCCESS [  2.152 s]
[INFO] shardingsphere-proxy ............................... SUCCESS [  0.150 s]
[INFO] shardingsphere-proxy-backend ....................... SUCCESS [  0.102 s]
[INFO] shardingsphere-proxy-backend-core .................. SUCCESS [  8.179 s]
[INFO] shardingsphere-proxy-frontend ...................... SUCCESS [  0.134 s]
[INFO] shardingsphere-proxy-frontend-spi .................. SUCCESS [  3.416 s]
[INFO] shardingsphere-proxy-backend-type .................. SUCCESS [  0.100 s]
[INFO] shardingsphere-proxy-backend-mysql ................. SUCCESS [  6.015 s]
[INFO] shardingsphere-proxy-backend-postgresql ............ SUCCESS [  4.957 s]
[INFO] shardingsphere-proxy-backend-opengauss ............. SUCCESS [  4.976 s]
[INFO] shardingsphere-proxy-frontend-core ................. SUCCESS [  3.309 s]
[INFO] shardingsphere-proxy-frontend-type ................. SUCCESS [  0.125 s]
[INFO] shardingsphere-proxy-frontend-mysql ................ SUCCESS [  6.451 s]
[INFO] shardingsphere-proxy-frontend-postgresql ........... SUCCESS [  6.643 s]
[INFO] shardingsphere-proxy-frontend-opengauss ............ SUCCESS [  5.680 s]
[INFO] shardingsphere-proxy-backend-hbase ................. SUCCESS [  6.399 s]
[INFO] shardingsphere-proxy-bootstrap ..................... SUCCESS [  5.241 s]
[INFO] shardingsphere-agent ............................... SUCCESS [  0.197 s]
[INFO] shardingsphere-agent-api ........................... SUCCESS [  0.949 s]
[INFO] shardingsphere-agent-core .......................... SUCCESS [  8.402 s]
[INFO] shardingsphere-agent-plugins ....................... SUCCESS [  0.100 s]
[INFO] shardingsphere-agent-plugin-core ................... SUCCESS [  2.849 s]
[INFO] shardingsphere-agent-plugin-metrics ................ SUCCESS [  0.189 s]
[INFO] shardingsphere-agent-metrics-core .................. SUCCESS [  6.450 s]
[INFO] shardingsphere-agent-metrics-type .................. SUCCESS [  0.108 s]
[INFO] shardingsphere-agent-metrics-prometheus ............ SUCCESS [  5.581 s]
[INFO] shardingsphere-agent-plugin-tracing ................ SUCCESS [  0.094 s]
[INFO] shardingsphere-agent-tracing-core .................. SUCCESS [  2.154 s]
[INFO] shardingsphere-agent-tracing-type .................. SUCCESS [  0.798 s]
[INFO] shardingsphere-agent-tracing-opentelemetry ......... SUCCESS [  7.732 s]
[INFO] shardingsphere-agent-plugin-logging ................ SUCCESS [  0.083 s]
[INFO] shardingsphere-agent-logging-type .................. SUCCESS [  0.165 s]
[INFO] shardingsphere-agent-logging-file .................. SUCCESS [  1.074 s]
[INFO] shardingsphere-it-optimizer ........................ SUCCESS [  2.534 s]
[INFO] shardingsphere-it-rewriter ......................... SUCCESS [  2.141 s]
[INFO] shardingsphere-it-pipeline ......................... SUCCESS [  4.151 s]
[INFO] shardingsphere-test-e2e ............................ SUCCESS [  0.182 s]
[INFO] shardingsphere-test-e2e-fixture .................... SUCCESS [  4.400 s]
[INFO] shardingsphere-test-e2e-env ........................ SUCCESS [  5.693 s]
[INFO] shardingsphere-test-e2e-sql ........................ SUCCESS [  7.306 s]
[INFO] shardingsphere-test-e2e-driver ..................... SUCCESS [  2.879 s]
[INFO] shardingsphere-test-e2e-agent ...................... SUCCESS [  0.160 s]
[INFO] shardingsphere-test-e2e-agent-plugins .............. SUCCESS [  0.185 s]
[INFO] shardingsphere-test-e2e-agent-plugins-common ....... SUCCESS [  1.536 s]
[INFO] shardingsphere-test-e2e-agent-plugins-metrics ...... SUCCESS [  0.258 s]
[INFO] shardingsphere-test-e2e-agent-plugins-metrics-prometheus SUCCESS [  1.589 s]
[INFO] shardingsphere-test-e2e-agent-plugins-tracing ...... SUCCESS [  0.159 s]
[INFO] shardingsphere-test-e2e-agent-plugins-jaeger ....... SUCCESS [  1.785 s]
[INFO] shardingsphere-test-e2e-agent-plugins-zipkin ....... SUCCESS [  1.536 s]
[INFO] shardingsphere-test-e2e-agent-plugins-logging ...... SUCCESS [  0.214 s]
[INFO] shardingsphere-test-e2e-agent-plugins-logging-file . SUCCESS [  1.213 s]
[INFO] shardingsphere-test-e2e-agent-jdbc-project ......... SUCCESS [  3.709 s]
[INFO] shardingsphere-test-e2e-operation .................. SUCCESS [  0.133 s]
[INFO] shardingsphere-test-e2e-pipeline ................... SUCCESS [  6.073 s]
[INFO] shardingsphere-test-e2e-transaction ................ SUCCESS [  5.445 s]
[INFO] shardingsphere-test-e2e-showprocesslist ............ SUCCESS [  4.148 s]
[INFO] shardingsphere-distribution ........................ SUCCESS [  0.149 s]
[INFO] shardingsphere-src-distribution .................... SUCCESS [ 14.301 s]
[INFO] shardingsphere-agent-distribution .................. SUCCESS [  2.971 s]
[INFO] shardingsphere-jdbc-distribution ................... SUCCESS [  5.016 s]
[INFO] shardingsphere-proxy-distribution .................. SUCCESS [ 25.068 s]
[INFO] shardingsphere-proxy-native-distribution ........... SUCCESS [  3.324 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  07:24 min (Wall Clock)
[INFO] Finished at: 2023-10-06T05:08:43Z
[INFO] ------------------------------------------------------------------------
```

```
./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache ShardingSphere 5.4.1-SNAPSHOT:
[INFO] 
[INFO] Apache ShardingSphere .............................. SUCCESS [  7.422 s]
[INFO] shardingsphere-infra ............................... SUCCESS [  0.510 s]
[INFO] shardingsphere-infra-exception ..................... SUCCESS [  0.228 s]
[INFO] shardingsphere-infra-exception-core ................ SUCCESS [ 10.653 s]
[INFO] shardingsphere-test ................................ SUCCESS [  0.886 s]
[INFO] shardingsphere-test-util ........................... SUCCESS [  9.722 s]
[INFO] shardingsphere-infra-spi ........................... SUCCESS [  9.346 s]
[INFO] shardingsphere-infra-util .......................... SUCCESS [  5.961 s]
[INFO] shardingsphere-infra-database ...................... SUCCESS [  0.333 s]
[INFO] shardingsphere-infra-database-core ................. SUCCESS [ 11.644 s]
[INFO] shardingsphere-infra-database-type ................. SUCCESS [  0.186 s]
[INFO] shardingsphere-infra-database-mysql ................ SUCCESS [  9.156 s]
[INFO] shardingsphere-infra-database-mariadb .............. SUCCESS [  3.074 s]
[INFO] shardingsphere-infra-database-postgresql ........... SUCCESS [  8.650 s]
[INFO] shardingsphere-infra-database-opengauss ............ SUCCESS [  9.264 s]
[INFO] shardingsphere-infra-database-oracle ............... SUCCESS [  8.409 s]
[INFO] shardingsphere-infra-database-sqlserver ............ SUCCESS [  8.407 s]
[INFO] shardingsphere-infra-database-h2 ................... SUCCESS [  8.375 s]
[INFO] shardingsphere-infra-database-sql92 ................ SUCCESS [  3.161 s]
[INFO] shardingsphere-test-fixture ........................ SUCCESS [  0.583 s]
[INFO] shardingsphere-test-fixture-database ............... SUCCESS [  1.136 s]
[INFO] shardingsphere-infra-data-source-pool .............. SUCCESS [  0.380 s]
[INFO] shardingsphere-infra-data-source-pool-core ......... SUCCESS [  9.658 s]
[INFO] shardingsphere-infra-data-source-pool-type ......... SUCCESS [  0.230 s]
[INFO] shardingsphere-infra-data-source-pool-hikari ....... SUCCESS [  8.515 s]
[INFO] shardingsphere-parser .............................. SUCCESS [  0.407 s]
[INFO] shardingsphere-parser-sql .......................... SUCCESS [  0.307 s]
[INFO] shardingsphere-parser-sql-spi ...................... SUCCESS [  1.170 s]
[INFO] shardingsphere-parser-sql-statement ................ SUCCESS [ 16.144 s]
[INFO] shardingsphere-parser-sql-engine ................... SUCCESS [  4.449 s]
[INFO] shardingsphere-infra-common ........................ SUCCESS [ 16.043 s]
[INFO] shardingsphere-infra-exception-dialect ............. SUCCESS [  0.347 s]
[INFO] shardingsphere-infra-exception-dialect-core ........ SUCCESS [  6.565 s]
[INFO] shardingsphere-infra-exception-dialect-type ........ SUCCESS [  0.209 s]
[INFO] shardingsphere-mysql-dialect-exception ............. SUCCESS [  7.885 s]
[INFO] shardingsphere-postgresql-dialect-exception ........ SUCCESS [  7.039 s]
[INFO] shardingsphere-parser-distsql ...................... SUCCESS [  0.377 s]
[INFO] shardingsphere-parser-distsql-statement ............ SUCCESS [  3.855 s]
[INFO] shardingsphere-parser-distsql-engine ............... SUCCESS [ 10.183 s]
[INFO] shardingsphere-infra-parser ........................ SUCCESS [  6.888 s]
[INFO] shardingsphere-infra-binder ........................ SUCCESS [ 40.881 s]
[INFO] shardingsphere-infra-session ....................... SUCCESS [  1.553 s]
[INFO] shardingsphere-infra-route ......................... SUCCESS [  8.227 s]
[INFO] shardingsphere-kernel .............................. SUCCESS [  0.440 s]
[INFO] shardingsphere-sql-translator ...................... SUCCESS [  0.320 s]
[INFO] shardingsphere-sql-translator-api .................. SUCCESS [  1.042 s]
[INFO] shardingsphere-mode ................................ SUCCESS [  0.508 s]
[INFO] shardingsphere-mode-api ............................ SUCCESS [  4.366 s]
[INFO] shardingsphere-sql-translator-core ................. SUCCESS [  3.738 s]
[INFO] shardingsphere-sql-translator-provider ............. SUCCESS [  0.217 s]
[INFO] shardingsphere-sql-translator-native-provider ...... SUCCESS [  0.888 s]
[INFO] shardingsphere-infra-rewrite ....................... SUCCESS [ 13.140 s]
[INFO] shardingsphere-infra-executor ...................... SUCCESS [ 11.608 s]
[INFO] shardingsphere-authority ........................... SUCCESS [  0.389 s]
[INFO] shardingsphere-authority-api ....................... SUCCESS [  1.001 s]
[INFO] shardingsphere-authority-core ...................... SUCCESS [  7.626 s]
[INFO] shardingsphere-single .............................. SUCCESS [  0.266 s]
[INFO] shardingsphere-single-api .......................... SUCCESS [  1.225 s]
[INFO] shardingsphere-transaction ......................... SUCCESS [  0.188 s]
[INFO] shardingsphere-transaction-api ..................... SUCCESS [  0.732 s]
[INFO] shardingsphere-transaction-core .................... SUCCESS [ 10.710 s]
[INFO] shardingsphere-infra-context ....................... SUCCESS [  9.308 s]
[INFO] shardingsphere-test-fixture-infra .................. SUCCESS [  1.026 s]
[INFO] shardingsphere-infra-merge ......................... SUCCESS [ 10.517 s]
[INFO] shardingsphere-infra-distsql-handler ............... SUCCESS [  1.466 s]
[INFO] shardingsphere-infra-expr .......................... SUCCESS [  0.451 s]
[INFO] shardingsphere-infra-expr-spi ...................... SUCCESS [  0.965 s]
[INFO] shardingsphere-infra-expr-type ..................... SUCCESS [  0.260 s]
[INFO] shardingsphere-infra-expr-groovy ................... SUCCESS [ 13.686 s]
[INFO] shardingsphere-infra-expr-literal .................. SUCCESS [  3.975 s]
[INFO] shardingsphere-infra-expr-core ..................... SUCCESS [  4.887 s]
[INFO] shardingsphere-infra-expr-espresso ................. SUCCESS [  4.866 s]
[INFO] shardingsphere-data-pipeline ....................... SUCCESS [  0.352 s]
[INFO] shardingsphere-data-pipeline-distsql ............... SUCCESS [  0.328 s]
[INFO] shardingsphere-data-pipeline-distsql-statement ..... SUCCESS [  1.409 s]
[INFO] shardingsphere-data-pipeline-distsql-parser ........ SUCCESS [  2.246 s]
[INFO] shardingsphere-features ............................ SUCCESS [  0.427 s]
[INFO] shardingsphere-sharding ............................ SUCCESS [  0.418 s]
[INFO] shardingsphere-sharding-distsql .................... SUCCESS [  0.370 s]
[INFO] shardingsphere-sharding-distsql-statement .......... SUCCESS [  1.326 s]
[INFO] shardingsphere-sharding-distsql-parser ............. SUCCESS [  3.264 s]
[INFO] shardingsphere-broadcast ........................... SUCCESS [  0.196 s]
[INFO] shardingsphere-broadcast-distsql ................... SUCCESS [  0.315 s]
[INFO] shardingsphere-broadcast-distsql-statement ......... SUCCESS [  0.983 s]
[INFO] shardingsphere-broadcast-distsql-parser ............ SUCCESS [  1.581 s]
[INFO] shardingsphere-readwrite-splitting ................. SUCCESS [  0.763 s]
[INFO] shardingsphere-readwrite-splitting-distsql ......... SUCCESS [  0.271 s]
[INFO] shardingsphere-readwrite-splitting-distsql-statement SUCCESS [  1.055 s]
[INFO] shardingsphere-readwrite-splitting-distsql-parser .. SUCCESS [  1.485 s]
[INFO] shardingsphere-encrypt ............................. SUCCESS [  0.266 s]
[INFO] shardingsphere-encrypt-distsql ..................... SUCCESS [  0.237 s]
[INFO] shardingsphere-encrypt-distsql-statement ........... SUCCESS [  1.513 s]
[INFO] shardingsphere-encrypt-distsql-parser .............. SUCCESS [  1.603 s]
[INFO] shardingsphere-mask ................................ SUCCESS [  0.454 s]
[INFO] shardingsphere-mask-distsql ........................ SUCCESS [  0.220 s]
[INFO] shardingsphere-mask-distsql-statement .............. SUCCESS [  1.110 s]
[INFO] shardingsphere-mask-distsql-parser ................. SUCCESS [  2.099 s]
[INFO] shardingsphere-authority-distsql ................... SUCCESS [  0.232 s]
[INFO] shardingsphere-authority-distsql-statement ......... SUCCESS [  1.238 s]
[INFO] shardingsphere-authority-distsql-parser ............ SUCCESS [  1.478 s]
[INFO] shardingsphere-global-clock ........................ SUCCESS [  0.383 s]
[INFO] shardingsphere-global-clock-api .................... SUCCESS [  0.879 s]
[INFO] shardingsphere-global-clock-distsql ................ SUCCESS [  0.290 s]
[INFO] shardingsphere-global-clock-distsql-statement ...... SUCCESS [  1.188 s]
[INFO] shardingsphere-global-clock-distsql-parser ......... SUCCESS [  1.419 s]
[INFO] shardingsphere-traffic ............................. SUCCESS [  0.223 s]
[INFO] shardingsphere-traffic-distsql ..................... SUCCESS [  0.321 s]
[INFO] shardingsphere-traffic-distsql-statement ........... SUCCESS [  0.962 s]
[INFO] shardingsphere-traffic-distsql-parser .............. SUCCESS [  1.442 s]
[INFO] shardingsphere-transaction-distsql ................. SUCCESS [  0.292 s]
[INFO] shardingsphere-transaction-distsql-statement ....... SUCCESS [  0.910 s]
[INFO] shardingsphere-transaction-distsql-parser .......... SUCCESS [  1.413 s]
[INFO] shardingsphere-single-distsql ...................... SUCCESS [  0.204 s]
[INFO] shardingsphere-single-distsql-statement ............ SUCCESS [  1.275 s]
[INFO] shardingsphere-single-distsql-parser ............... SUCCESS [  1.620 s]
[INFO] shardingsphere-sql-parser .......................... SUCCESS [  0.210 s]
[INFO] shardingsphere-sql-parser-distsql .................. SUCCESS [  0.312 s]
[INFO] shardingsphere-sql-parser-distsql-statement ........ SUCCESS [  1.124 s]
[INFO] shardingsphere-sql-parser-distsql-parser ........... SUCCESS [  1.072 s]
[INFO] shardingsphere-sql-translator-distsql .............. SUCCESS [  0.210 s]
[INFO] shardingsphere-sql-translator-distsql-statement .... SUCCESS [  1.053 s]
[INFO] shardingsphere-sql-translator-distsql-parser ....... SUCCESS [  1.337 s]
[INFO] shardingsphere-shadow .............................. SUCCESS [  0.157 s]
[INFO] shardingsphere-shadow-distsql ...................... SUCCESS [  0.274 s]
[INFO] shardingsphere-shadow-distsql-statement ............ SUCCESS [  1.302 s]
[INFO] shardingsphere-shadow-distsql-parser ............... SUCCESS [  1.697 s]
[INFO] shardingsphere-it .................................. SUCCESS [  1.291 s]
[INFO] shardingsphere-it-parser ........................... SUCCESS [ 55.482 s]
[INFO] shardingsphere-parser-sql-dialect .................. SUCCESS [  0.544 s]
[INFO] shardingsphere-parser-sql-sql92 .................... SUCCESS [ 42.904 s]
[INFO] shardingsphere-parser-sql-postgresql ............... SUCCESS [01:02 min]
[INFO] shardingsphere-parser-sql-mysql .................... SUCCESS [01:10 min]
[INFO] shardingsphere-parser-sql-oracle ................... SUCCESS [02:46 min]
[INFO] shardingsphere-parser-sql-sqlserver ................ SUCCESS [ 58.912 s]
[INFO] shardingsphere-parser-sql-opengauss ................ SUCCESS [01:05 min]
[INFO] shardingsphere-db-protocol ......................... SUCCESS [  0.262 s]
[INFO] shardingsphere-db-protocol-core .................... SUCCESS [  8.910 s]
[INFO] shardingsphere-postgresql-protocol ................. SUCCESS [ 13.301 s]
[INFO] shardingsphere-mysql-protocol ...................... SUCCESS [ 29.227 s]
[INFO] shardingsphere-opengauss-protocol .................. SUCCESS [ 11.429 s]
[INFO] shardingsphere-metadata ............................ SUCCESS [  0.259 s]
[INFO] shardingsphere-metadata-core ....................... SUCCESS [ 13.154 s]
[INFO] shardingsphere-mode-core ........................... SUCCESS [ 15.271 s]
[INFO] shardingsphere-mode-type ........................... SUCCESS [  0.425 s]
[INFO] shardingsphere-standalone-mode ..................... SUCCESS [  0.260 s]
[INFO] shardingsphere-standalone-mode-repository .......... SUCCESS [  0.215 s]
[INFO] shardingsphere-standalone-mode-repository-api ...... SUCCESS [  1.339 s]
[INFO] shardingsphere-standalone-mode-core ................ SUCCESS [  9.684 s]
[INFO] shardingsphere-standalone-mode-repository-provider . SUCCESS [  0.207 s]
[INFO] shardingsphere-standalone-mode-repository-jdbc ..... SUCCESS [ 11.014 s]
[INFO] shardingsphere-cluster-mode ........................ SUCCESS [  0.344 s]
[INFO] shardingsphere-cluster-mode-repository ............. SUCCESS [  0.225 s]
[INFO] shardingsphere-cluster-mode-repository-api ......... SUCCESS [  6.795 s]
[INFO] shardingsphere-sql-federation ...................... SUCCESS [  0.255 s]
[INFO] shardingsphere-sql-federation-api .................. SUCCESS [  1.378 s]
[INFO] shardingsphere-single-core ......................... SUCCESS [ 13.959 s]
[INFO] shardingsphere-cluster-mode-core ................... SUCCESS [ 36.499 s]
[INFO] shardingsphere-cluster-mode-repository-provider .... SUCCESS [  0.215 s]
[INFO] shardingsphere-cluster-mode-repository-zookeeper ... SUCCESS [ 10.676 s]
[INFO] shardingsphere-cluster-mode-repository-etcd ........ SUCCESS [ 10.955 s]
[INFO] shardingsphere-cluster-mode-repository-consul ...... SUCCESS [  9.296 s]
[INFO] shardingsphere-single-distsql-handler .............. SUCCESS [ 10.335 s]
[INFO] shardingsphere-authority-distsql-handler ........... SUCCESS [  6.503 s]
[INFO] shardingsphere-transaction-type .................... SUCCESS [  0.346 s]
[INFO] shardingsphere-transaction-xa ...................... SUCCESS [  0.179 s]
[INFO] shardingsphere-transaction-xa-spi .................. SUCCESS [  6.539 s]
[INFO] shardingsphere-transaction-xa-provider ............. SUCCESS [  0.215 s]
[INFO] shardingsphere-transaction-xa-atomikos ............. SUCCESS [  7.717 s]
[INFO] shardingsphere-transaction-xa-core ................. SUCCESS [ 14.464 s]
[INFO] shardingsphere-transaction-xa-narayana ............. SUCCESS [  8.328 s]
[INFO] shardingsphere-transaction-base .................... SUCCESS [  0.140 s]
[INFO] shardingsphere-transaction-base-seata-at ........... SUCCESS [ 13.254 s]
[INFO] shardingsphere-transaction-distsql-handler ......... SUCCESS [  8.172 s]
[INFO] shardingsphere-time-service ........................ SUCCESS [  0.290 s]
[INFO] shardingsphere-time-service-api .................... SUCCESS [  1.188 s]
[INFO] shardingsphere-time-service-core ................... SUCCESS [  1.425 s]
[INFO] shardingsphere-time-service-type ................... SUCCESS [  0.299 s]
[INFO] shardingsphere-system-time-service ................. SUCCESS [  3.570 s]
[INFO] shardingsphere-database-time-service ............... SUCCESS [  4.407 s]
[INFO] shardingsphere-data-pipeline-api ................... SUCCESS [  5.671 s]
[INFO] shardingsphere-sql-parser-api ...................... SUCCESS [  1.137 s]
[INFO] shardingsphere-sql-parser-core ..................... SUCCESS [  4.132 s]
[INFO] shardingsphere-sharding-api ........................ SUCCESS [  1.553 s]
[INFO] shardingsphere-sql-federation-core ................. SUCCESS [ 37.254 s]
[INFO] shardingsphere-it-yaml ............................. SUCCESS [  1.126 s]
[INFO] shardingsphere-sharding-core ....................... SUCCESS [01:05 min]
[INFO] shardingsphere-data-pipeline-core .................. SUCCESS [ 21.374 s]
[INFO] shardingsphere-global-clock-core ................... SUCCESS [  3.618 s]
[INFO] shardingsphere-global-clock-type ................... SUCCESS [  0.468 s]
[INFO] shardingsphere-global-clock-tso .................... SUCCESS [  0.246 s]
[INFO] shardingsphere-global-clock-tso-spi ................ SUCCESS [  2.361 s]
[INFO] shardingsphere-global-clock-tso-provider ........... SUCCESS [  0.187 s]
[INFO] shardingsphere-global-clock-tso-provider-redis ..... SUCCESS [  1.215 s]
[INFO] shardingsphere-global-clock-tso-core ............... SUCCESS [  1.260 s]
[INFO] shardingsphere-traffic-api ......................... SUCCESS [  1.277 s]
[INFO] shardingsphere-traffic-core ........................ SUCCESS [ 11.463 s]
[INFO] shardingsphere-broadcast-api ....................... SUCCESS [  1.186 s]
[INFO] shardingsphere-broadcast-core ...................... SUCCESS [  9.984 s]
[INFO] shardingsphere-readwrite-splitting-api ............. SUCCESS [  1.145 s]
[INFO] shardingsphere-readwrite-splitting-core ............ SUCCESS [ 14.188 s]
[INFO] shardingsphere-encrypt-api ......................... SUCCESS [  1.184 s]
[INFO] shardingsphere-encrypt-core ........................ SUCCESS [ 23.632 s]
[INFO] shardingsphere-mask-api ............................ SUCCESS [  1.144 s]
[INFO] shardingsphere-mask-core ........................... SUCCESS [ 11.713 s]
[INFO] shardingsphere-shadow-api .......................... SUCCESS [  1.408 s]
[INFO] shardingsphere-shadow-core ......................... SUCCESS [ 11.565 s]
[INFO] shardingsphere-logging ............................. SUCCESS [  0.314 s]
[INFO] shardingsphere-logging-api ......................... SUCCESS [  0.933 s]
[INFO] shardingsphere-logging-core ........................ SUCCESS [  4.674 s]
[INFO] shardingsphere-jdbc ................................ SUCCESS [  0.493 s]
[INFO] shardingsphere-jdbc-core ........................... SUCCESS [ 52.530 s]
[INFO] shardingsphere-data-pipeline-dialect ............... SUCCESS [  0.297 s]
[INFO] shardingsphere-data-pipeline-mysql ................. SUCCESS [ 18.311 s]
[INFO] shardingsphere-data-pipeline-postgresql ............ SUCCESS [ 16.715 s]
[INFO] shardingsphere-data-pipeline-opengauss ............. SUCCESS [ 10.659 s]
[INFO] shardingsphere-data-pipeline-h2 .................... SUCCESS [  2.208 s]
[INFO] shardingsphere-data-pipeline-scenario .............. SUCCESS [  0.266 s]
[INFO] shardingsphere-data-pipeline-scenario-consistencycheck SUCCESS [  6.064 s]
[INFO] shardingsphere-data-pipeline-scenario-migration .... SUCCESS [  6.324 s]
[INFO] shardingsphere-data-pipeline-cdc ................... SUCCESS [  0.200 s]
[INFO] shardingsphere-data-pipeline-cdc-protocol .......... SUCCESS [ 10.853 s]
[INFO] shardingsphere-data-pipeline-cdc-core .............. SUCCESS [ 10.782 s]
[INFO] shardingsphere-data-pipeline-distsql-handler ....... SUCCESS [  6.621 s]
[INFO] shardingsphere-data-pipeline-cdc-client ............ SUCCESS [  5.085 s]
[INFO] shardingsphere-sql-federation-distsql .............. SUCCESS [  0.271 s]
[INFO] shardingsphere-sql-federation-distsql-statement .... SUCCESS [  0.791 s]
[INFO] shardingsphere-sql-federation-distsql-parser ....... SUCCESS [  1.360 s]
[INFO] shardingsphere-sql-federation-distsql-handler ...... SUCCESS [  6.370 s]
[INFO] shardingsphere-sql-parser-distsql-handler .......... SUCCESS [  6.572 s]
[INFO] shardingsphere-sql-translator-jooq-provider ........ SUCCESS [  1.331 s]
[INFO] shardingsphere-sql-translator-distsql-handler ...... SUCCESS [  6.292 s]
[INFO] shardingsphere-traffic-distsql-handler ............. SUCCESS [  7.168 s]
[INFO] shardingsphere-global-clock-hlc .................... SUCCESS [  1.120 s]
[INFO] shardingsphere-global-clock-distsql-handler ........ SUCCESS [  6.611 s]
[INFO] shardingsphere-sharding-distsql-handler ............ SUCCESS [ 18.010 s]
[INFO] shardingsphere-broadcast-distsql-handler ........... SUCCESS [  8.890 s]
[INFO] shardingsphere-readwrite-splitting-distsql-handler . SUCCESS [  9.922 s]
[INFO] shardingsphere-encrypt-distsql-handler ............. SUCCESS [  7.923 s]
[INFO] shardingsphere-shadow-distsql-handler .............. SUCCESS [  9.897 s]
[INFO] shardingsphere-mask-distsql-handler ................ SUCCESS [  8.917 s]
[INFO] shardingsphere-proxy ............................... SUCCESS [  0.214 s]
[INFO] shardingsphere-proxy-backend ....................... SUCCESS [  0.298 s]
[INFO] shardingsphere-proxy-backend-core .................. SUCCESS [ 41.798 s]
[INFO] shardingsphere-proxy-frontend ...................... SUCCESS [  0.419 s]
[INFO] shardingsphere-proxy-frontend-spi .................. SUCCESS [  4.079 s]
[INFO] shardingsphere-proxy-backend-type .................. SUCCESS [  0.373 s]
[INFO] shardingsphere-proxy-backend-mysql ................. SUCCESS [ 19.750 s]
[INFO] shardingsphere-proxy-backend-postgresql ............ SUCCESS [ 14.745 s]
[INFO] shardingsphere-proxy-backend-opengauss ............. SUCCESS [  9.999 s]
[INFO] shardingsphere-proxy-frontend-core ................. SUCCESS [ 19.048 s]
[INFO] shardingsphere-proxy-frontend-type ................. SUCCESS [  0.456 s]
[INFO] shardingsphere-proxy-frontend-mysql ................ SUCCESS [ 28.589 s]
[INFO] shardingsphere-proxy-frontend-postgresql ........... SUCCESS [ 30.237 s]
[INFO] shardingsphere-proxy-frontend-opengauss ............ SUCCESS [ 19.317 s]
[INFO] shardingsphere-proxy-backend-hbase ................. SUCCESS [ 23.455 s]
[INFO] shardingsphere-proxy-bootstrap ..................... SUCCESS [  7.661 s]
[INFO] shardingsphere-agent ............................... SUCCESS [  0.788 s]
[INFO] shardingsphere-agent-api ........................... SUCCESS [  1.300 s]
[INFO] shardingsphere-agent-core .......................... SUCCESS [ 15.560 s]
[INFO] shardingsphere-agent-plugins ....................... SUCCESS [  0.186 s]
[INFO] shardingsphere-agent-plugin-core ................... SUCCESS [  4.609 s]
[INFO] shardingsphere-agent-plugin-metrics ................ SUCCESS [  0.075 s]
[INFO] shardingsphere-agent-metrics-core .................. SUCCESS [ 22.018 s]
[INFO] shardingsphere-agent-metrics-type .................. SUCCESS [  0.125 s]
[INFO] shardingsphere-agent-metrics-prometheus ............ SUCCESS [  7.796 s]
[INFO] shardingsphere-agent-plugin-tracing ................ SUCCESS [  0.050 s]
[INFO] shardingsphere-agent-tracing-core .................. SUCCESS [  1.457 s]
[INFO] shardingsphere-agent-tracing-type .................. SUCCESS [  0.818 s]
[INFO] shardingsphere-agent-tracing-opentelemetry ......... SUCCESS [ 16.600 s]
[INFO] shardingsphere-agent-plugin-logging ................ SUCCESS [  0.037 s]
[INFO] shardingsphere-agent-logging-type .................. SUCCESS [  0.089 s]
[INFO] shardingsphere-agent-logging-file .................. SUCCESS [  5.940 s]
[INFO] shardingsphere-it-optimizer ........................ SUCCESS [ 43.398 s]
[INFO] shardingsphere-it-rewriter ......................... SUCCESS [ 43.087 s]
[INFO] shardingsphere-it-pipeline ......................... SUCCESS [ 48.216 s]
[INFO] shardingsphere-test-e2e ............................ SUCCESS [  0.411 s]
[INFO] shardingsphere-test-e2e-fixture .................... SUCCESS [  6.445 s]
[INFO] shardingsphere-test-e2e-env ........................ SUCCESS [  7.293 s]
[INFO] shardingsphere-test-e2e-sql ........................ SUCCESS [ 12.377 s]
[INFO] shardingsphere-test-e2e-driver ..................... SUCCESS [ 22.509 s]
[INFO] shardingsphere-test-e2e-agent ...................... SUCCESS [  0.350 s]
[INFO] shardingsphere-test-e2e-agent-plugins .............. SUCCESS [  0.381 s]
[INFO] shardingsphere-test-e2e-agent-plugins-common ....... SUCCESS [  1.286 s]
[INFO] shardingsphere-test-e2e-agent-plugins-metrics ...... SUCCESS [  0.287 s]
[INFO] shardingsphere-test-e2e-agent-plugins-metrics-prometheus SUCCESS [  6.637 s]
[INFO] shardingsphere-test-e2e-agent-plugins-tracing ...... SUCCESS [  0.242 s]
[INFO] shardingsphere-test-e2e-agent-plugins-jaeger ....... SUCCESS [  5.917 s]
[INFO] shardingsphere-test-e2e-agent-plugins-zipkin ....... SUCCESS [  5.294 s]
[INFO] shardingsphere-test-e2e-agent-plugins-logging ...... SUCCESS [  0.194 s]
[INFO] shardingsphere-test-e2e-agent-plugins-logging-file . SUCCESS [  3.356 s]
[INFO] shardingsphere-test-e2e-agent-jdbc-project ......... SUCCESS [  2.430 s]
[INFO] shardingsphere-test-e2e-operation .................. SUCCESS [  0.448 s]
[INFO] shardingsphere-test-e2e-pipeline ................... SUCCESS [ 10.541 s]
[INFO] shardingsphere-test-e2e-transaction ................ SUCCESS [  9.638 s]
[INFO] shardingsphere-test-e2e-showprocesslist ............ SUCCESS [  7.775 s]
[INFO] shardingsphere-distribution ........................ SUCCESS [  0.340 s]
[INFO] shardingsphere-src-distribution .................... SUCCESS [  0.294 s]
[INFO] shardingsphere-agent-distribution .................. SUCCESS [  0.145 s]
[INFO] shardingsphere-jdbc-distribution ................... SUCCESS [  2.303 s]
[INFO] shardingsphere-proxy-distribution .................. SUCCESS [  2.886 s]
[INFO] shardingsphere-proxy-native-distribution ........... SUCCESS [  2.926 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  20:00 min (Wall Clock)
[INFO] Finished at: 2023-10-06T05:31:19Z
[INFO] ------------------------------------------------------------------------
```





---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
