### PR TITLE
Fix encrypt e2e test case exception caused by EncryptRule#getLogicColumnByCipherColumn

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptTable.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptTable.java
@@ -134,7 +134,7 @@ public final class EncryptTable {
     public String getLogicColumnByCipherColumn(final String cipherColumnName) {
         for (Entry<String, EncryptColumn> entry : columns.entrySet()) {
             if (entry.getValue().getCipher().getName().equalsIgnoreCase(cipherColumnName)) {
-                return entry.getKey();
+                return entry.getValue().getName();
             }
         }
         throw new EncryptLogicColumnNotFoundException(cipherColumnName);

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rule/EncryptTableTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rule/EncryptTableTest.java
@@ -80,7 +80,7 @@ class EncryptTableTest {
     
     @Test
     void assertGetLogicColumnByCipherColumn() {
-        assertNotNull(encryptTable.getLogicColumnByCipherColumn("cipherColumn"));
+        assertThat(encryptTable.getLogicColumnByCipherColumn("cipherColumn"), is("logicColumn"));
     }
     
     @Test


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix encrypt e2e test case exception caused by EncryptRule#getLogicColumnByCipherColumn

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
