### PR TITLE
Add unit test for YamlTableDataConsistencyCheckResultSwapper

### DIFF
--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/result/yaml/YamlTableDataConsistencyCheckResultSwapperTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/result/yaml/YamlTableDataConsistencyCheckResultSwapperTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.yaml;
+
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableDataConsistencyCheckIgnoredType;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableDataConsistencyCheckResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class YamlTableDataConsistencyCheckResultSwapperTest {
+    
+    private YamlTableDataConsistencyCheckResultSwapper yamlTableDataConsistencyCheckResultSwapper;
+    
+    @BeforeEach
+    void setUp() {
+        yamlTableDataConsistencyCheckResultSwapper = new YamlTableDataConsistencyCheckResultSwapper();
+    }
+    
+    @Test
+    void assertSwapToYamlConfigurationWithTableDataConsistencyCheckIgnoredType() {
+        TableDataConsistencyCheckResult data = new TableDataConsistencyCheckResult(TableDataConsistencyCheckIgnoredType.NO_UNIQUE_KEY);
+        YamlTableDataConsistencyCheckResult result = yamlTableDataConsistencyCheckResultSwapper.swapToYamlConfiguration(data);
+        assertThat(result.getIgnoredType(), is("NO_UNIQUE_KEY"));
+        assertFalse(result.isMatched());
+    }
+    
+    @Test
+    void assertSwapToYamlConfigurationWithTableDataConsistencyCheckResultMatched() {
+        TableDataConsistencyCheckResult data = new TableDataConsistencyCheckResult(true);
+        YamlTableDataConsistencyCheckResult result = yamlTableDataConsistencyCheckResultSwapper.swapToYamlConfiguration(data);
+        assertNull(result.getIgnoredType());
+        assertTrue(result.isMatched());
+    }
+    
+    @Test
+    void assertSwapToObjectWithYamlTableDataConsistencyCheckResultIgnoredType() {
+        YamlTableDataConsistencyCheckResult yamlConfig = new YamlTableDataConsistencyCheckResult();
+        yamlConfig.setIgnoredType("NO_UNIQUE_KEY");
+        TableDataConsistencyCheckResult result = yamlTableDataConsistencyCheckResultSwapper.swapToObject(yamlConfig);
+        assertThat(result.getIgnoredType(), is(TableDataConsistencyCheckIgnoredType.NO_UNIQUE_KEY));
+        assertFalse(result.isMatched());
+    }
+    
+    @Test
+    void assertSwapToObjectWithYamlTableDataConsistencyCheckResultMatched() {
+        YamlTableDataConsistencyCheckResult yamlConfig = new YamlTableDataConsistencyCheckResult(true);
+        TableDataConsistencyCheckResult result = yamlTableDataConsistencyCheckResultSwapper.swapToObject(yamlConfig);
+        assertNull(result.getIgnoredType());
+        assertTrue(result.isMatched());
+    }
+    
+    @Test
+    void assertSwapToObjectWithNullYamlTableDataConsistencyCheckResult() {
+        assertNull(yamlTableDataConsistencyCheckResultSwapper.swapToObject((YamlTableDataConsistencyCheckResult) null));
+    }
+    
+    @Test
+    void assertSwapToObjectWithNullYamlTableDataConsistencyCheckResultIgnoredType() {
+        YamlTableDataConsistencyCheckResult yamlConfig = new YamlTableDataConsistencyCheckResult();
+        yamlConfig.setIgnoredType(null);
+        TableDataConsistencyCheckResult result = yamlTableDataConsistencyCheckResultSwapper.swapToObject(yamlConfig);
+        assertNull(result.getIgnoredType());
+        assertFalse(result.isMatched());
+    }
+    
+    @Test
+    void assertSwapToObjectWithEmptyYamlTableDataConsistencyCheckResultMatched() {
+        YamlTableDataConsistencyCheckResult yamlConfig = new YamlTableDataConsistencyCheckResult();
+        yamlConfig.setIgnoredType("");
+        TableDataConsistencyCheckResult result = yamlTableDataConsistencyCheckResultSwapper.swapToObject(yamlConfig);
+        assertNull(result.getIgnoredType());
+        assertFalse(result.isMatched());
+    }
+    
+    @Test
+    void assertSwapToObjectWithString() {
+        TableDataConsistencyCheckResult result = yamlTableDataConsistencyCheckResultSwapper.swapToObject("ignoredType: NO_UNIQUE_KEY");
+        assertThat(result.getIgnoredType(), is(TableDataConsistencyCheckIgnoredType.NO_UNIQUE_KEY));
+        assertFalse(result.isMatched());
+    }
+    
+    @Test
+    void assertSwapToObjectWithEmptyString() {
+        assertNull(yamlTableDataConsistencyCheckResultSwapper.swapToObject(""));
+    }
+    
+    @Test
+    void assertSwapToObjectWithBlankString() {
+        assertNull(yamlTableDataConsistencyCheckResultSwapper.swapToObject(" "));
+    }
+}


### PR DESCRIPTION
Fixes #28540 .

Changes proposed in this pull request:
  - Added unit test for YamlTableDataConsistencyCheckResultSwapper with 100% coverage

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
