### PR TITLE
Fixed spelling for "Confiugration"

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/_index.en.md
@@ -52,11 +52,11 @@ props:
   key_2: value_2
 ```
 
-Please refer to [Mode Confiugration](/en/user-manual/shardingsphere-jdbc/yaml-config/mode) for more mode details.
+Please refer to [Mode Configuration](/en/user-manual/shardingsphere-jdbc/yaml-config/mode) for more mode details.
 
-Please refer to [Data Source Confiugration](/en/user-manual/shardingsphere-jdbc/yaml-config/data-source) for more data source details.
+Please refer to [Data Source Configuration](/en/user-manual/shardingsphere-jdbc/yaml-config/data-source) for more data source details.
 
-Please refer to [Rules Confiugration](/en/user-manual/shardingsphere-jdbc/yaml-config/rules) for more rule details.
+Please refer to [Rules Configuration](/en/user-manual/shardingsphere-jdbc/yaml-config/rules) for more rule details.
 
 ### Create Data Source
 


### PR DESCRIPTION
Fixed spelling in three lines.
Changed "Confiugration" to "Configuration".

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
