### PR TITLE
Add unit test in GovernanceRepositoryAPIImplTest

### DIFF
--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
@@ -138,7 +138,7 @@ class GovernanceRepositoryAPIImplTest {
         assertThat(shardingItems.size(), is(1));
         assertThat(shardingItems.get(0), is(jobItemContext.getShardingItem()));
     }
-
+    
     @Test
     void assertPersistJobOffsetInfo() {
         assertFalse(governanceRepositoryAPI.getJobOffsetInfo("1").isPresent());
@@ -147,7 +147,7 @@ class GovernanceRepositoryAPIImplTest {
         assertTrue(actual.isPresent());
         assertThat(actual.get(), is("testValue"));
     }
-
+    
     private MigrationJobItemContext mockJobItemContext() {
         MigrationJobItemContext result = PipelineContextUtils.mockMigrationJobItemContext(JobConfigurationBuilder.createJobConfiguration());
         MigrationTaskConfiguration taskConfig = result.getTaskConfig();

--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
@@ -138,7 +138,16 @@ class GovernanceRepositoryAPIImplTest {
         assertThat(shardingItems.size(), is(1));
         assertThat(shardingItems.get(0), is(jobItemContext.getShardingItem()));
     }
-    
+
+    @Test
+    void assertPersistJobOffsetInfo() {
+        assertFalse(governanceRepositoryAPI.getJobOffsetInfo("1").isPresent());
+        governanceRepositoryAPI.persistJobOffsetInfo("1", "testValue");
+        Optional<String> actual = governanceRepositoryAPI.getJobOffsetInfo("1");
+        assertTrue(actual.isPresent());
+        assertThat(actual.get(), is("testValue"));
+    }
+
     private MigrationJobItemContext mockJobItemContext() {
         MigrationJobItemContext result = PipelineContextUtils.mockMigrationJobItemContext(JobConfigurationBuilder.createJobConfiguration());
         MigrationTaskConfiguration taskConfig = result.getTaskConfig();


### PR DESCRIPTION
Fixes #28544 .

Changes proposed in this pull request:
  - Adds unit test for persistJobOffsetInfo, getJobOffsetInfo methods

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
