### PR TITLE
add unit tests for EncryptColumnExistedReviser.java

### DIFF
--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/metadata/reviser/column/EncryptColumnExistedReviserTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/metadata/reviser/column/EncryptColumnExistedReviserTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.metadata.reviser.column;
+
+import org.apache.shardingsphere.encrypt.rule.EncryptTable;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class EncryptColumnExistedReviserTest {
+    
+    @Test
+    public void assertIsExistedWithCipherColumn() {
+        EncryptTable encryptTable = mock(EncryptTable.class);
+        when(encryptTable.isCipherColumn("cipher_column")).thenReturn(true);
+        EncryptColumnExistedReviser reviser = new EncryptColumnExistedReviser(encryptTable);
+        assertTrue(reviser.isExisted("cipher_column"));
+    }
+    
+    @Test
+    public void assertIsExistedWithAssistedQueryColumn() {
+        EncryptTable encryptTable = mock(EncryptTable.class);
+        when(encryptTable.isAssistedQueryColumn("assisted_query_column")).thenReturn(true);
+        EncryptColumnExistedReviser reviser = new EncryptColumnExistedReviser(encryptTable);
+        assertFalse(reviser.isExisted("assisted_query_column"));
+    }
+    
+    @Test
+    public void assertIsExistedWithLikeQueryColumn() {
+        EncryptTable encryptTable = mock(EncryptTable.class);
+        when(encryptTable.isLikeQueryColumn("like_query_column")).thenReturn(true);
+        EncryptColumnExistedReviser reviser = new EncryptColumnExistedReviser(encryptTable);
+        assertFalse(reviser.isExisted("like_query_column"));
+    }
+    
+    @Test
+    public void assertIsExistedWithNormalColumn() {
+        EncryptTable encryptTable = mock(EncryptTable.class);
+        EncryptColumnExistedReviser reviser = new EncryptColumnExistedReviser(encryptTable);
+        assertTrue(reviser.isExisted("normal_column"));
+    }
+}

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/metadata/reviser/column/EncryptColumnExistedReviserTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/metadata/reviser/column/EncryptColumnExistedReviserTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class EncryptColumnExistedReviserTest {
+class EncryptColumnExistedReviserTest {
     
     @Test
     public void assertIsExistedWithCipherColumn() {


### PR DESCRIPTION
Fixes #28548 

Changes proposed in this pull request:
  -
Added unit tests for EncryptColumnExistedReviser.java

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
