### PR TITLE
Improve PostgreSQL TestDecodingPlugin encoding

### DIFF
--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/common/ingest/channel/memory/SimpleMemoryPipelineChannelTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/common/ingest/channel/memory/SimpleMemoryPipelineChannelTest.java
@@ -31,11 +31,11 @@ class SimpleMemoryPipelineChannelTest {
         SimpleMemoryPipelineChannel simpleMemoryPipelineChannel = new SimpleMemoryPipelineChannel(10, new EmptyAckCallback());
         long startMills = System.currentTimeMillis();
         simpleMemoryPipelineChannel.fetchRecords(1, 1, TimeUnit.MILLISECONDS);
-        long endMills = System.currentTimeMillis();
-        assertTrue(endMills - startMills >= 1 && endMills - startMills < 50);
+        long delta = System.currentTimeMillis() - startMills;
+        assertTrue(delta >= 1 && delta < 50, "Delta is not in [1,50) : " + delta);
         startMills = System.currentTimeMillis();
         simpleMemoryPipelineChannel.fetchRecords(1, 500, TimeUnit.MILLISECONDS);
-        endMills = System.currentTimeMillis();
-        assertTrue(endMills - startMills >= 500 && endMills - startMills < 600);
+        delta = System.currentTimeMillis() - startMills;
+        assertTrue(delta >= 500 && delta < 650, "Delta is not in [500,650) : " + delta);
     }
 }

--- a/kernel/data-pipeline/dialect/postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/decode/TestDecodingPlugin.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/decode/TestDecodingPlugin.java
@@ -32,6 +32,7 @@ import org.apache.shardingsphere.data.pipeline.postgresql.ingest.wal.event.Write
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.util.LinkedList;
@@ -252,7 +253,7 @@ public final class TestDecodingPlugin implements DecodingPlugin {
         for (int i = 0; i < offset; i++) {
             result[i] = data.get(startPosition + i);
         }
-        return new String(result);
+        return new String(result, StandardCharsets.UTF_8);
     }
     
     private String readNextString(final ByteBuffer data) {

--- a/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/decode/TestDecodingPluginTest.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/decode/TestDecodingPluginTest.java
@@ -28,6 +28,7 @@ import org.postgresql.jdbc.TimestampUtils;
 import org.postgresql.replication.LogSequenceNumber;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -47,7 +48,7 @@ class TestDecodingPluginTest {
     @Test
     void assertDecodeWriteRowEvent() {
         ByteBuffer data = ByteBuffer.wrap(("table public.test: INSERT: data[character varying]:' 1 2 3'' 😊中' t_json_empty[json]:'{}' t_json[json]:'{\"test\":\"中中{中中}' 中\"}'"
-                + " t_jsonb[jsonb]:'{\"test\":\"😊Emoji中\"}'").getBytes());
+                + " t_jsonb[jsonb]:'{\"test\":\"😊Emoji中\"}'").getBytes(StandardCharsets.UTF_8));
         WriteRowEvent actual = (WriteRowEvent) new TestDecodingPlugin(null).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
@@ -59,7 +60,8 @@ class TestDecodingPluginTest {
     
     @Test
     void assertDecodeUpdateRowEvent() {
-        ByteBuffer data = ByteBuffer.wrap("table public.test: UPDATE: unicode[character varying]:' 1 2 3'' 😊中 ' t_json_empty[json]:'{}' t_json[json]:'{\"test\":\"中中{中中}' 中\"}'".getBytes());
+        ByteBuffer data = ByteBuffer.wrap("table public.test: UPDATE: unicode[character varying]:' 1 2 3'' 😊中 ' t_json_empty[json]:'{}' t_json[json]:'{\"test\":\"中中{中中}' 中\"}'"
+                .getBytes(StandardCharsets.UTF_8));
         UpdateRowEvent actual = (UpdateRowEvent) new TestDecodingPlugin(null).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
@@ -70,7 +72,7 @@ class TestDecodingPluginTest {
     
     @Test
     void assertDecodeDeleteRowEvent() {
-        ByteBuffer data = ByteBuffer.wrap("table public.test: DELETE: data[integer]:1".getBytes());
+        ByteBuffer data = ByteBuffer.wrap("table public.test: DELETE: data[integer]:1".getBytes(StandardCharsets.UTF_8));
         DeleteRowEvent actual = (DeleteRowEvent) new TestDecodingPlugin(null).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
@@ -79,7 +81,7 @@ class TestDecodingPluginTest {
     
     @Test
     void assertDecodeWriteRowEventWithByteA() {
-        ByteBuffer data = ByteBuffer.wrap("table public.test: INSERT: data[bytea]:'\\xff00ab'".getBytes());
+        ByteBuffer data = ByteBuffer.wrap("table public.test: INSERT: data[bytea]:'\\xff00ab'".getBytes(StandardCharsets.UTF_8));
         WriteRowEvent actual = (WriteRowEvent) new TestDecodingPlugin(null).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
@@ -88,13 +90,13 @@ class TestDecodingPluginTest {
     
     @Test
     void assertDecodeUnknownTableType() {
-        ByteBuffer data = ByteBuffer.wrap("unknown".getBytes());
+        ByteBuffer data = ByteBuffer.wrap("unknown".getBytes(StandardCharsets.UTF_8));
         assertThat(new TestDecodingPlugin(null).decode(data, logSequenceNumber), instanceOf(PlaceholderEvent.class));
     }
     
     @Test
     void assertDecodeUnknownRowEventType() {
-        ByteBuffer data = ByteBuffer.wrap("table public.test: UNKNOWN: data[character varying]:'1 2 3'''".getBytes());
+        ByteBuffer data = ByteBuffer.wrap("table public.test: UNKNOWN: data[character varying]:'1 2 3'''".getBytes(StandardCharsets.UTF_8));
         assertThrows(IngestException.class, () -> new TestDecodingPlugin(null).decode(data, logSequenceNumber));
     }
     
@@ -102,13 +104,14 @@ class TestDecodingPluginTest {
     void assertDecodeTime() throws SQLException {
         TimestampUtils timestampUtils = mock(TimestampUtils.class);
         when(timestampUtils.toTime(null, "1 2 3'")).thenThrow(new SQLException(""));
-        ByteBuffer data = ByteBuffer.wrap("table public.test: INSERT: data[time without time zone]:'1 2 3'''".getBytes());
+        ByteBuffer data = ByteBuffer.wrap("table public.test: INSERT: data[time without time zone]:'1 2 3'''".getBytes(StandardCharsets.UTF_8));
         assertThrows(DecodingException.class, () -> new TestDecodingPlugin(new PostgreSQLTimestampUtils(timestampUtils)).decode(data, logSequenceNumber));
     }
     
     @Test
     void assertDecodeInsertWithNullValue() {
-        ByteBuffer data = ByteBuffer.wrap("table public.test: INSERT: id[integer]:123 col0[integer]:null col1[character varying]:null col2[character varying]:'nonnull'".getBytes());
+        ByteBuffer data = ByteBuffer.wrap("table public.test: INSERT: id[integer]:123 col0[integer]:null col1[character varying]:null col2[character varying]:'nonnull'"
+                .getBytes(StandardCharsets.UTF_8));
         AbstractWALEvent actual = new TestDecodingPlugin(null).decode(data, logSequenceNumber);
         assertThat(actual, instanceOf(WriteRowEvent.class));
         WriteRowEvent actualWriteRowEvent = (WriteRowEvent) actual;
@@ -120,7 +123,7 @@ class TestDecodingPluginTest {
     
     @Test
     void assertDecodeJsonValue() {
-        ByteBuffer data = ByteBuffer.wrap("table public.test: INSERT: id[integer]:123 ".getBytes());
+        ByteBuffer data = ByteBuffer.wrap("table public.test: INSERT: id[integer]:123 ".getBytes(StandardCharsets.UTF_8));
         AbstractWALEvent actual = new TestDecodingPlugin(null).decode(data, logSequenceNumber);
         assertThat(actual, instanceOf(WriteRowEvent.class));
     }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Improve SimpleMemoryPipelineChannelTest
  - Use UTF-8 for PostgreSQL TestDecodingPlugin

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
