### PR TITLE
Fix Object 'DUAL' not found exception when execute select 1 from dual with sql federation

### DIFF
--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/SQLNodeConverterEngine.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/SQLNodeConverterEngine.java
@@ -23,7 +23,6 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DALStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.ExplainStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DDLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.DMLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.DeleteStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.InsertStatement;
@@ -57,8 +56,6 @@ public final class SQLNodeConverterEngine {
         Optional<SqlNode> result = Optional.empty();
         if (sqlStatement instanceof DMLStatement) {
             result = convert((DMLStatement) sqlStatement);
-        } else if (sqlStatement instanceof DDLStatement) {
-            result = convert((DDLStatement) sqlStatement);
         } else if (sqlStatement instanceof DALStatement) {
             result = convert((DALStatement) sqlStatement);
         }
@@ -72,10 +69,6 @@ public final class SQLNodeConverterEngine {
         if (sqlStatement instanceof DeleteStatement) {
             return Optional.of(new DeleteStatementConverter().convert((DeleteStatement) sqlStatement));
         }
-        return Optional.empty();
-    }
-    
-    private static Optional<SqlNode> convert(final DDLStatement sqlStatement) {
         if (sqlStatement instanceof UpdateStatement) {
             return Optional.of(new UpdateStatementConverter().convert((UpdateStatement) sqlStatement));
         }

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/from/impl/SimpleTableConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/from/impl/SimpleTableConverter.java
@@ -46,6 +46,9 @@ public final class SimpleTableConverter {
      * @return sql node
      */
     public static Optional<SqlNode> convert(final SimpleTableSegment segment) {
+        if ("DUAL".equalsIgnoreCase(segment.getTableName().getIdentifier().getValue())) {
+            return Optional.empty();
+        }
         TableNameSegment tableName = segment.getTableName();
         List<String> names = new ArrayList<>();
         if (segment.getOwner().isPresent()) {

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/projection/ProjectionsConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/projection/ProjectionsConverter.java
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.AggregationProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ColumnProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ExpressionProjectionSegment;
@@ -29,6 +30,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.Projecti
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionsSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ShorthandProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.SubqueryProjectionSegment;
+import org.apache.shardingsphere.sqlfederation.optimizer.converter.segment.expression.impl.ParameterMarkerExpressionConverter;
 import org.apache.shardingsphere.sqlfederation.optimizer.converter.segment.projection.impl.AggregationProjectionConverter;
 import org.apache.shardingsphere.sqlfederation.optimizer.converter.segment.projection.impl.ColumnProjectionConverter;
 import org.apache.shardingsphere.sqlfederation.optimizer.converter.segment.projection.impl.ExpressionProjectionConverter;
@@ -74,6 +76,9 @@ public final class ProjectionsConverter {
         }
         if (segment instanceof AggregationProjectionSegment) {
             return AggregationProjectionConverter.convert((AggregationProjectionSegment) segment);
+        }
+        if (segment instanceof ParameterMarkerExpressionSegment) {
+            return ParameterMarkerExpressionConverter.convert((ParameterMarkerExpressionSegment) segment);
         }
         // TODO process other projection
         return Optional.empty();

--- a/test/it/optimizer/src/test/resources/converter/select.xml
+++ b/test/it/optimizer/src/test/resources/converter/select.xml
@@ -17,7 +17,7 @@
   -->
 
 <sql-node-converter-test-cases>
-    <test-cases sql-case-id="select_string_constant_type_cast" expected-sql="SELECT CAST('1' AS INTEGER), CAST('2' AS DECIMAL)" dbtypes="openGauss,PostgreSQL" />
+    <test-cases sql-case-id="select_string_constant_type_cast" expected-sql="SELECT CAST('1' AS INTEGER), CAST('2' AS DECIMAL)" db-types="openGauss,PostgreSQL" />
     <test-cases sql-case-id="select_with_database_name_and_schema_name_in_table" expected-sql="SELECT &quot;order_id&quot; FROM &quot;sharding_db&quot;.&quot;public&quot;.&quot;t_order&quot; WHERE &quot;user_id&quot; = ? AND &quot;order_id&quot; = ?" db-types="PostgreSQL,openGauss" sql-case-types="PLACEHOLDER" />
     <test-cases sql-case-id="select_with_database_name_and_schema_name_in_table" expected-sql="SELECT &quot;order_id&quot; FROM &quot;sharding_db&quot;.&quot;public&quot;.&quot;t_order&quot; WHERE &quot;user_id&quot; = 1 AND &quot;order_id&quot; = 1" db-types="PostgreSQL,openGauss" sql-case-types="LITERAL" />
     <test-cases sql-case-id="select_with_spatial_function" expected-sql="SELECT * FROM `t_order` WHERE `ST_DISTANCE_SPHERE`(`POINT`(113.358772, 23.1273723), `POINT`(`user_id`, `order_id`)) &lt;&gt; 0" db-types="MySQL" />
@@ -33,4 +33,6 @@
     <test-cases sql-case-id="select_with_assignment_operator" expected-sql="SELECT `rn` := 1, `now_code` := '' FROM `t_order`" db-types="MySQL" />
     <test-cases sql-case-id="select_with_assignment_operator_and_keyword" expected-sql="SELECT `KEY` := '', `num` := 123 FROM `t_order`" db-types="MySQL" />
     <test-cases sql-case-id="select_with_json_value_return_type" expected-sql="SELECT * FROM `t_order` WHERE JSON_VALUE(`items`, '''$.name''' 'RETURNING' VARCHAR(100)) = 'jack'" db-types="MySQL" />
+    <test-cases sql-case-id="select_projection_with_parameter" expected-sql="SELECT 1 &quot;id&quot;, ?, &quot;SYSDATE&quot; &quot;create_time&quot;, &quot;TRUNC&quot;(&quot;SYSDATE&quot;) &quot;create_date&quot;" db-types="Oracle" sql-case-types="PLACEHOLDER" />
+    <test-cases sql-case-id="select_projection_with_parameter" expected-sql="SELECT 1 &quot;id&quot;, 'OK' &quot;status&quot;, &quot;SYSDATE&quot; &quot;create_time&quot;, &quot;TRUNC&quot;(&quot;SYSDATE&quot;) &quot;create_date&quot;" db-types="Oracle" sql-case-types="LITERAL" />
 </sql-node-converter-test-cases>


### PR DESCRIPTION
Fixes #28800.

Changes proposed in this pull request:
  - fix Object 'DUAL' not found exception when execute select 1 from dual with sql federation
  - add sql statement convert unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
