### PR TITLE
Updates ElasticJob to 3.0.4 to block CVEs for SnakeYAML delivery

### DIFF
--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/yaml/AgentYamlConstructor.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/yaml/AgentYamlConstructor.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.agent.core.yaml;
 
 import org.apache.shardingsphere.agent.core.util.AgentPreconditions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.Constructor;
 
 /**
@@ -27,8 +28,8 @@ public final class AgentYamlConstructor extends Constructor {
     
     private final Class<?> rootClass;
     
-    public AgentYamlConstructor(final Class<?> rootClass) {
-        super(rootClass);
+    public AgentYamlConstructor(final Class<?> rootClass, final LoaderOptions loadingConfig) {
+        super(rootClass, loadingConfig);
         this.rootClass = rootClass;
     }
     

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/yaml/AgentYamlEngine.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/yaml/AgentYamlEngine.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.agent.core.advisor.config.yaml.entity.YamlAdvisorsConfiguration;
 import org.apache.shardingsphere.agent.core.plugin.config.yaml.entity.YamlAgentConfiguration;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.InputStream;
@@ -38,7 +39,7 @@ public final class AgentYamlEngine {
      * @return YAML agent configuration
      */
     public static YamlAgentConfiguration unmarshalYamlAgentConfiguration(final InputStream inputStream) {
-        return new Yaml(new AgentYamlConstructor(YamlAgentConfiguration.class)).loadAs(inputStream, YamlAgentConfiguration.class);
+        return new Yaml(new AgentYamlConstructor(YamlAgentConfiguration.class, createLoaderOptions())).loadAs(inputStream, YamlAgentConfiguration.class);
     }
     
     /**
@@ -48,6 +49,12 @@ public final class AgentYamlEngine {
      * @return YAML advisors configuration
      */
     public static YamlAdvisorsConfiguration unmarshalYamlAdvisorsConfiguration(final InputStream inputStream) {
-        return new Yaml(new AgentYamlConstructor(YamlAdvisorsConfiguration.class)).loadAs(inputStream, YamlAdvisorsConfiguration.class);
+        return new Yaml(new AgentYamlConstructor(YamlAdvisorsConfiguration.class, createLoaderOptions())).loadAs(inputStream, YamlAdvisorsConfiguration.class);
+    }
+    
+    private static LoaderOptions createLoaderOptions() {
+        LoaderOptions result = new LoaderOptions();
+        result.setCodePointLimit(Integer.MAX_VALUE);
+        return result;
     }
 }

--- a/distribution/proxy-native/src/main/release-docs/LICENSE
+++ b/distribution/proxy-native/src/main/release-docs/LICENSE
@@ -298,7 +298,7 @@ The text of each license is the standard Apache 2.0 license.
     proj4j 1.2.2: https://github.com/locationtech/proj4j, Apache 2.0
     quartz 2.3.2: https://github.com/quartz-scheduler/quartz, Apache 2.0
     sketches-core 0.9.0, Apache 2.0
-    snakeyaml 1.33: https://bitbucket.org/snakeyaml/snakeyaml, Apache 2.0
+    snakeyaml 2.2: https://bitbucket.org/snakeyaml/snakeyaml, Apache 2.0
     transmittable-thread-local 2.14.2: https://github.com/alibaba/transmittable-thread-local, Apache 2.0
     uzaygezen-core 0.2: https://code.google.com/p/uzaygezen, Apache 2.0
     zookeeper 3.9.0: https://github.com/apache/zookeeper, Apache 2.0

--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -298,7 +298,7 @@ The text of each license is the standard Apache 2.0 license.
     proj4j 1.2.2: https://github.com/locationtech/proj4j, Apache 2.0
     quartz 2.3.2: https://github.com/quartz-scheduler/quartz, Apache 2.0
     sketches-core 0.9.0, Apache 2.0
-    snakeyaml 1.33: https://bitbucket.org/snakeyaml/snakeyaml, Apache 2.0
+    snakeyaml 2.2: https://bitbucket.org/snakeyaml/snakeyaml, Apache 2.0
     transmittable-thread-local 2.14.2: https://github.com/alibaba/transmittable-thread-local, Apache 2.0
     uzaygezen-core 0.2: https://code.google.com/p/uzaygezen, Apache 2.0
     zookeeper 3.9.0: https://github.com/apache/zookeeper, Apache 2.0

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.cn.md
@@ -40,42 +40,13 @@ spring.datasource.url=jdbc:shardingsphere:classpath:xxx.yaml
 Spring Boot OSS 3 对 Jakarta EE 和 Java 17 进行了 “大爆炸” 升级，涉及大量复杂情况。
 
 对于正在使用 Java EE 8 API 及其实现的 ShardingSphere JDBC 而言，如果用户希望在 Spring Boot OSS 3 等基于 Jakarta EE 9+ API 的 Web 
-Framework 上使用 ShardingSphere JDBC，则需要引入 Java EE 8 的 JAXB 的实现，并指定一个特定的 SnakeYAML 版本。
+Framework 上使用 ShardingSphere JDBC，则需要引入 Java EE 8 的 JAXB 的实现。
 
 这在 Maven 的 `pom.xml` 体现为如下内容。你也可以使用其他的 JAXB API 的实现。此配置同样适用于其他基于 Jakarta EE 的 Web Framework，如 
 Quarkus 3，Micronaut Framework 4 和 Helidon 3。
 
 ```xml
 <project>
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-jdbc-core</artifactId>
-            <version>${shardingsphere.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.8</version>
-        </dependency>
-    </dependencies>
-</project>
-```
-
-如果用户是通过 https://start.spring.io/ 创建了 Spring Boot 项目，或者在 `dependencyManagement` 的 XML 标签导入了 
-`org.springframework.boot:spring-boot-dependencies` 的 POM 文件，则可通过如下内容来简化配置。
-
-```xml
-<project>
-    <properties>
-        <snakeyaml.version>1.33</snakeyaml.version>
-    </properties>
-    
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
@@ -95,7 +66,7 @@ Quarkus 3，Micronaut Framework 4 和 Helidon 3。
 
 ## 针对低版本的 Spring Boot OSS 2 的特殊处理
 
-ShardingSphere 的所有特性均可在 Spring Boot OSS 2 上使用，但低版本的 Spring Boot OSS 可能需要手动指定 SnakeYAML 的版本为 1.33 。 
+ShardingSphere 的所有特性均可在 Spring Boot OSS 2 上使用，但低版本的 Spring Boot OSS 可能需要手动指定 SnakeYAML 的版本为 2.2 。 
 这在 Maven 的 `pom.xml` 体现为如下内容。
 
 ```xml
@@ -109,12 +80,26 @@ ShardingSphere 的所有特性均可在 Spring Boot OSS 2 上使用，但低版�
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.2</version>
         </dependency>
     </dependencies>
 </project>
 ```
 
-如果用户是通过 https://start.spring.io/ 创建了 Spring Boot 项目，或者在 `dependencyManagement` 的 XML 标签导入了
-`org.springframework.boot:spring-boot-dependencies`的 POM 文件，同样可以选择通过配置 `snakeyaml.version` 的 `properties` 
-来简化内容。
+如果用户是通过 https://start.spring.io/ 创建了 Spring Boot 项目，则可通过如下内容来简化配置。
+
+```xml
+<project>
+    <properties>
+        <snakeyaml.version>2.2</snakeyaml.version>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-jdbc-core</artifactId>
+            <version>${shardingsphere.version}</version>
+        </dependency>
+    </dependencies>
+</project>
+```

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.en.md
@@ -41,43 +41,13 @@ Spring Boot OSS 3 has made a "big bang" upgrade to Jakarta EE and Java 17, with 
 
 For ShardingSphere JDBC that is using the Java EE 8 API and its implementation, if you want to use ShardingSphere JDBC 
 on a Jakarta EE 9+ API-based web framework such as Spring Boot OSS 3, you need to introduce a JAXB implementation of 
-Java EE 8 and specify a specific version of SnakeYAML.
+Java EE 8.
 
 This is reflected in Maven's `pom.xml` as follows. You can also use other JAXB API implementations. This configuration 
 also applies to other Jakarta EE-based Web Frameworks, such as Quarkus 3, Micronaut Framework 4 and Helidon 3.
 
 ```xml
 <project>
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-jdbc-core</artifactId>
-            <version>${shardingsphere.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.8</version>
-        </dependency>
-    </dependencies>
-</project>
-```
-
-If the user created the Spring Boot project from https://start.spring.io/, or the `dependencyManagement` XML tag was 
-imported POM file for `org.springframework.boot:spring-boot-dependencies`, users can simplify configuration by 
-following things.
-
-```xml
-<project>
-    <properties>
-        <snakeyaml.version>1.33</snakeyaml.version>
-    </properties>
-    
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
@@ -98,7 +68,7 @@ In addition, ShardingSphere's XA distributed transactions are not yet ready on S
 ## Special handling for earlier versions of Spring Boot OSS 2
 
 All features of ShardingSphere are available on Spring Boot OSS 2, but earlier versions of Spring Boot OSS may require 
-manually specifying version 1.33 for SnakeYAML.
+manually specifying version 2.2 for SnakeYAML.
 This is reflected in Maven's `pom.xml` as follows.
 
 ```xml
@@ -112,11 +82,27 @@ This is reflected in Maven's `pom.xml` as follows.
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.2</version>
         </dependency>
     </dependencies>
 </project>
 ```
-If the user created the Spring Boot project from https://start.spring.io/, or the `dependencyManagement` XML tag was
-imported POM file for `org.springframework.boot:spring-boot-dependencies`, users can also choose to simplify the content
-by configuring `properties` for `snakeyaml.version`.
+
+If the user created the Spring Boot project from https://start.spring.io/, users can simplify configuration by
+following things.
+
+```xml
+<project>
+    <properties>
+        <snakeyaml.version>2.2</snakeyaml.version>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-jdbc-core</artifactId>
+            <version>${shardingsphere.version}</version>
+        </dependency>
+    </dependencies>
+</project>
+```

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlEngine.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlEngine.java
@@ -107,8 +107,8 @@ public final class YamlEngine {
         DumperOptions dumperOptions = new DumperOptions();
         dumperOptions.setLineBreak(DumperOptions.LineBreak.getPlatformLineBreak());
         if (value instanceof Collection) {
-            return new Yaml(new ShardingSphereYamlRepresenter(), dumperOptions).dumpAs(value, null, DumperOptions.FlowStyle.BLOCK);
+            return new Yaml(new ShardingSphereYamlRepresenter(dumperOptions)).dumpAs(value, null, DumperOptions.FlowStyle.BLOCK);
         }
-        return new Yaml(new ShardingSphereYamlRepresenter(), dumperOptions).dumpAsMap(value);
+        return new Yaml(new ShardingSphereYamlRepresenter(dumperOptions)).dumpAsMap(value);
     }
 }

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/representer/ShardingSphereYamlRepresenter.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/representer/ShardingSphereYamlRepresenter.java
@@ -39,7 +39,8 @@ import java.util.Map.Entry;
  */
 public final class ShardingSphereYamlRepresenter extends Representer {
     
-    public ShardingSphereYamlRepresenter() {
+    public ShardingSphereYamlRepresenter(final DumperOptions dumperOptions) {
+        super(dumperOptions);
         Map<String, Class<?>> yamlShortcuts = new HashMap<>();
         ShardingSphereServiceLoader.getServiceInstances(ShardingSphereYamlShortcuts.class).stream().map(ShardingSphereYamlShortcuts::getYamlShortcuts).forEach(yamlShortcuts::putAll);
         yamlShortcuts.forEach((key, value) -> addClassTag(value, new Tag(key)));

--- a/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/YamlEngineTest.java
+++ b/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/YamlEngineTest.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.infra.util.yaml;
 
 import org.apache.shardingsphere.infra.util.yaml.fixture.shortcuts.YamlShortcutsConfigurationFixture;
 import org.junit.jupiter.api.Test;
-import org.yaml.snakeyaml.constructor.ConstructorException;
+import org.yaml.snakeyaml.composer.ComposerException;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -101,7 +101,7 @@ class YamlEngineTest {
                 yamlContent.append(line).append(System.lineSeparator());
             }
         }
-        assertThrows(ConstructorException.class, () -> YamlEngine.unmarshal(yamlContent.toString(), Object.class));
+        assertThrows(ComposerException.class, () -> YamlEngine.unmarshal(yamlContent.toString(), Object.class));
     }
     
     @Test

--- a/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/constructor/ShardingSphereYamlConstructorTest.java
+++ b/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/constructor/ShardingSphereYamlConstructorTest.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.infra.util.yaml.constructor;
 import org.apache.shardingsphere.infra.util.yaml.fixture.pojo.YamlConfigurationFixture;
 import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.ConstructorException;
+import org.yaml.snakeyaml.composer.ComposerException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -53,7 +53,7 @@ class ShardingSphereYamlConstructorTest {
     @Test
     void assertToObjectWithNotAcceptClass() throws IOException {
         try (InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("yaml/accepted-class.yaml")) {
-            assertThrows(ConstructorException.class, () -> new Yaml(new ShardingSphereYamlConstructor(Object.class)).loadAs(inputStream, Object.class));
+            assertThrows(ComposerException.class, () -> new Yaml(new ShardingSphereYamlConstructor(Object.class)).loadAs(inputStream, Object.class));
         }
     }
 }

--- a/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/representer/ShardingSphereYamlRepresenterTest.java
+++ b/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/representer/ShardingSphereYamlRepresenterTest.java
@@ -37,7 +37,7 @@ class ShardingSphereYamlRepresenterTest {
     @Test
     void assertToYamlWithoutContent() {
         YamlConfigurationFixture actual = new YamlConfigurationFixture();
-        assertThat(new Yaml(new ShardingSphereYamlRepresenter(), new DumperOptions()).dumpAsMap(actual), is("{}\n"));
+        assertThat(new Yaml(new ShardingSphereYamlRepresenter(new DumperOptions())).dumpAsMap(actual), is("{}\n"));
     }
     
     @Test
@@ -53,7 +53,7 @@ class ShardingSphereYamlRepresenterTest {
         actual.getEmbeddedMap().put("embedded_map_1", new LinkedHashMap<>());
         actual.getEmbeddedMap().put("embedded_map_2", Collections.singletonMap("embedded_map_foo", "embedded_map_foo_value"));
         actual.setCustomizedTag("customized_tag");
-        String expected = new Yaml(new ShardingSphereYamlRepresenter(), new DumperOptions()).dumpAsMap(actual);
+        String expected = new Yaml(new ShardingSphereYamlRepresenter(new DumperOptions())).dumpAsMap(actual);
         assertThat(expected, containsString("collection:\n- value1\n- value2\n"));
         assertThat(expected, containsString("map:\n  key1: value1\n  key2: value2\n"));
         assertThat(expected, not(containsString("embedded_map_1")));

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         
         <antlr4.version>4.10.1</antlr4.version>
         <bytebuddy.version>1.14.8</bytebuddy.version>
-        <snakeyaml.version>1.33</snakeyaml.version>
+        <snakeyaml.version>2.2</snakeyaml.version>
         <gson.version>2.10.1</gson.version>
         <jackson.version>2.14.0</jackson.version>
         <json-path.version>2.8.0</json-path.version>
@@ -97,7 +97,7 @@
         <jetcd.version>0.7.6</jetcd.version>
         <grpc.version>1.58.0</grpc.version>
         
-        <elasticjob.version>3.0.3</elasticjob.version>
+        <elasticjob.version>3.0.4</elasticjob.version>
         
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.12</logback.version>


### PR DESCRIPTION
Fixes #24636.

Changes proposed in this pull request:
  - Updates ElasticJob to 3.0.4 to block CVEs for SnakeYAML delivery. Refer to https://github.com/apache/shardingsphere-elasticjob/releases/tag/3.0.4 .
  - Also fixes #28233.
  - Also fixes #28067.
  - Also fixes #27370.
  - Also fixes #25291.
  - Since the CI of the Exmaple module is broken on JDK21, I am not handling the changes to the Example module in this PR. Refer to https://github.com/apache/shardingsphere/actions/runs/6563502380 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
