### PR TITLE
Change the definition position of the create table SelectStatement class

### DIFF
--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/CreateTableStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/CreateTableStatement.java
@@ -23,9 +23,11 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.Column
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.constraint.ConstraintDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
 
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.Optional;
 
 /**
  * Create table statement.
@@ -36,7 +38,18 @@ public abstract class CreateTableStatement extends AbstractSQLStatement implemen
     
     private SimpleTableSegment table;
     
+    private SelectStatement selectStatement;
+    
     private final Collection<ColumnDefinitionSegment> columnDefinitions = new LinkedList<>();
     
     private final Collection<ConstraintDefinitionSegment> constraintDefinitions = new LinkedList<>();
+    
+    /**
+     * Get select statement.
+     *
+     * @return select statement
+     */
+    public Optional<SelectStatement> getSelectStatement() {
+        return Optional.ofNullable(selectStatement);
+    }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerCreateTableStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerCreateTableStatement.java
@@ -21,12 +21,10 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateTableStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * SQLServer create table statement.
@@ -36,15 +34,4 @@ import java.util.Optional;
 public final class SQLServerCreateTableStatement extends CreateTableStatement implements SQLServerStatement {
     
     private final List<ColumnSegment> columns = new LinkedList<>();
-    
-    private SelectStatement selectStatement;
-    
-    /**
-     * Get select statement.
-     *
-     * @return select statement
-     */
-    public Optional<SelectStatement> getSelectStatement() {
-        return Optional.ofNullable(selectStatement);
-    }
 }


### PR DESCRIPTION
Ref #28752.

Changes proposed in this pull request:
  - Change the definition position of the create table SelectStatement class
  - mysql, oracle, sqlserver, opengauss, and postgresql all have syntax definitions for sql statements in the `create table as select `format

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ✓] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ✓] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ✓] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ✓] I have added corresponding unit tests for my changes.
