### PR TITLE
Adding Unit test for NewGlobalNode#getGlobalRuleVersionNode

### DIFF
--- a/kernel/metadata/core/src/test/java/org/apache/shardingsphere/metadata/persist/node/NewGlobalNodeTest.java
+++ b/kernel/metadata/core/src/test/java/org/apache/shardingsphere/metadata/persist/node/NewGlobalNodeTest.java
@@ -49,4 +49,9 @@ class NewGlobalNodeTest {
     void assertGetGlobalRuleVersionsNode() {
         assertThat(NewGlobalNode.getGlobalRuleVersionsNode("transaction"), is("/rules/transaction/versions"));
     }
+
+    @Test
+    void assertGetGlobalRuleVersionNode() {
+        assertThat(NewGlobalNode.getGlobalRuleVersionNode("transaction", "0"), is("/rules/transaction/versions/0"));
+    }
 }

--- a/kernel/metadata/core/src/test/java/org/apache/shardingsphere/metadata/persist/node/NewGlobalNodeTest.java
+++ b/kernel/metadata/core/src/test/java/org/apache/shardingsphere/metadata/persist/node/NewGlobalNodeTest.java
@@ -49,7 +49,7 @@ class NewGlobalNodeTest {
     void assertGetGlobalRuleVersionsNode() {
         assertThat(NewGlobalNode.getGlobalRuleVersionsNode("transaction"), is("/rules/transaction/versions"));
     }
-
+    
     @Test
     void assertGetGlobalRuleVersionNode() {
         assertThat(NewGlobalNode.getGlobalRuleVersionNode("transaction", "0"), is("/rules/transaction/versions/0"));


### PR DESCRIPTION
Fixes #28493.

Changes proposed in this pull request:
  - Added unit test for NewGlobalNode#getGlobalRuleVersionNode, asserts expected result

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
