### PR TITLE
Configure read/write separation according to the example, the error indicates that the table cannot be found

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/readwrite-splitting.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/readwrite-splitting.cn.md
@@ -51,6 +51,10 @@ rules:
   loadBalancers:
     random:
       type: RANDOM
+# 需要配置单表规则，不然会读不到表
+- !SINGLE
+  tables:
+    - "*.*"
 ```
 
 ## 相关参考


### PR DESCRIPTION
Configure read/write separation according to the example, the error indicates that the table cannot be found

Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
