### PR TITLE
Add unit test for GovernanceRepositoryAPIImpl

### DIFF
--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
@@ -160,11 +160,11 @@ class GovernanceRepositoryAPIImplTest {
     @Test
     void testGovernanceRepositoryAPIImplMethods() {
         String parentJobId = "testParentJob";
-        String checkJobId = "testCheckJob";
-        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId, checkJobId);
-        Optional<String> retrievedCheckJobId = governanceRepositoryAPI.getLatestCheckJobId(parentJobId);
-        assertTrue(retrievedCheckJobId.isPresent(), "Expected a checkJobId to be present");
-        assertEquals(checkJobId, retrievedCheckJobId.get(), "The retrieved checkJobId does not match the expected one");
+        String expectedCheckJobId = "testCheckJob";
+        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId, expectedCheckJobId);
+        Optional<String> actualCheckJobIdOpt = governanceRepositoryAPI.getLatestCheckJobId(parentJobId);
+        assertTrue(actualCheckJobIdOpt.isPresent(), "Expected a checkJobId to be present");
+        assertEquals(expectedCheckJobId, actualCheckJobIdOpt.get(), "The retrieved checkJobId does not match the expected one");
         governanceRepositoryAPI.deleteLatestCheckJobId(parentJobId);
         assertFalse(governanceRepositoryAPI.getLatestCheckJobId(parentJobId).isPresent(), "Expected no checkJobId to be present after deletion");
     }

--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
@@ -156,7 +156,7 @@ class GovernanceRepositoryAPIImplTest {
         assertTrue(actual.isPresent());
         assertThat(actual.get(), is("testValue"));
     }
-
+    
     @Test
     void assertLatestCheckJobIdPersistenceDeletion() {
         String parentJobId = "testParentJob";
@@ -168,7 +168,7 @@ class GovernanceRepositoryAPIImplTest {
         governanceRepositoryAPI.deleteLatestCheckJobId(parentJobId);
         assertFalse(governanceRepositoryAPI.getLatestCheckJobId(parentJobId).isPresent(), "Expected no checkJobId to be present after deletion");
     }
-
+    
     private MigrationJobItemContext mockJobItemContext() {
         MigrationJobItemContext result = PipelineContextUtils.mockMigrationJobItemContext(JobConfigurationBuilder.createJobConfiguration());
         MigrationTaskConfiguration taskConfig = result.getTaskConfig();

--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
@@ -48,9 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 class GovernanceRepositoryAPIImplTest {
@@ -155,7 +153,39 @@ class GovernanceRepositoryAPIImplTest {
         assertTrue(actual.isPresent());
         assertThat(actual.get(), is("testValue"));
     }
-    
+
+    @Test
+    void assertPersistLatestCheckJobId() {
+        String parentJobId = "parentJob123";
+        String checkJobId = "checkJob456";
+        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId, checkJobId);
+        Optional<String> retrievedCheckJobId = governanceRepositoryAPI.getLatestCheckJobId(parentJobId);
+        assertTrue(retrievedCheckJobId.isPresent(), "Expected a checkJobId to be present");
+        assertEquals(retrievedCheckJobId.get(), checkJobId, "The retrieved checkJobId does not match the persisted one");
+    }
+
+    @Test
+    void assertGetLatestCheckJobId() {
+        String parentJobId = "parentJob789";
+        String checkJobId = "checkJob012";
+        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId, checkJobId);
+        Optional<String> retrievedCheckJobId = governanceRepositoryAPI.getLatestCheckJobId(parentJobId);
+        assertTrue(retrievedCheckJobId.isPresent(), "Expected a checkJobId to be present");
+        assertEquals(checkJobId, retrievedCheckJobId.get(), "The retrieved checkJobId does not match the expected one");
+        governanceRepositoryAPI.deleteLatestCheckJobId(parentJobId);
+        assertFalse(governanceRepositoryAPI.getLatestCheckJobId(parentJobId).isPresent(), "Expected no checkJobId to be present after deletion");
+    }
+
+    @Test
+    void assertDeleteLatestCheckJobId() {
+        String parentJobId = "parentJob123";
+        String checkJobId = "checkJob456";
+        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId, checkJobId);
+        assertTrue(governanceRepositoryAPI.getLatestCheckJobId(parentJobId).isPresent(), "Expected checkJobId to be present before deletion");
+        governanceRepositoryAPI.deleteLatestCheckJobId(parentJobId);
+        assertFalse(governanceRepositoryAPI.getLatestCheckJobId(parentJobId).isPresent(), "Expected no checkJobId to be present after deletion");
+    }
+
     private MigrationJobItemContext mockJobItemContext() {
         MigrationJobItemContext result = PipelineContextUtils.mockMigrationJobItemContext(JobConfigurationBuilder.createJobConfiguration());
         MigrationTaskConfiguration taskConfig = result.getTaskConfig();

--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
@@ -159,22 +159,15 @@ class GovernanceRepositoryAPIImplTest {
 
     @Test
     void testGovernanceRepositoryAPIImplMethods() {
-        String parentJobId1 = "parentJob123";
-        String checkJobId1 = "checkJob456";
-        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId1, checkJobId1);
-        Optional<String> retrievedCheckJobId1 = governanceRepositoryAPI.getLatestCheckJobId(parentJobId1);
-        assertTrue(retrievedCheckJobId1.isPresent(), "Expected a checkJobId to be present");
-        assertEquals(retrievedCheckJobId1.get(), checkJobId1, "The retrieved checkJobId does not match the persisted one");
-        String parentJobId2 = "parentJob789";
-        String checkJobId2 = "checkJob012";
-        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId2, checkJobId2);
-        Optional<String> retrievedCheckJobId2 = governanceRepositoryAPI.getLatestCheckJobId(parentJobId2);
-        assertTrue(retrievedCheckJobId2.isPresent(), "Expected a checkJobId to be present");
-        assertEquals(checkJobId2, retrievedCheckJobId2.get(), "The retrieved checkJobId does not match the expected one");
-        governanceRepositoryAPI.deleteLatestCheckJobId(parentJobId2);
-        assertFalse(governanceRepositoryAPI.getLatestCheckJobId(parentJobId2).isPresent(), "Expected no checkJobId to be present after deletion");
+        String parentJobId = "testParentJob";
+        String checkJobId = "testCheckJob";
+        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId, checkJobId);
+        Optional<String> retrievedCheckJobId = governanceRepositoryAPI.getLatestCheckJobId(parentJobId);
+        assertTrue(retrievedCheckJobId.isPresent(), "Expected a checkJobId to be present");
+        assertEquals(checkJobId, retrievedCheckJobId.get(), "The retrieved checkJobId does not match the expected one");
+        governanceRepositoryAPI.deleteLatestCheckJobId(parentJobId);
+        assertFalse(governanceRepositoryAPI.getLatestCheckJobId(parentJobId).isPresent(), "Expected no checkJobId to be present after deletion");
     }
-
 
     private MigrationJobItemContext mockJobItemContext() {
         MigrationJobItemContext result = PipelineContextUtils.mockMigrationJobItemContext(JobConfigurationBuilder.createJobConfiguration());

--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
@@ -158,7 +158,7 @@ class GovernanceRepositoryAPIImplTest {
     }
 
     @Test
-    void testGovernanceRepositoryAPIImplMethods() {
+    void assertLatestCheckJobIdPersistenceDeletion() {
         String parentJobId = "testParentJob";
         String expectedCheckJobId = "testCheckJob";
         governanceRepositoryAPI.persistLatestCheckJobId(parentJobId, expectedCheckJobId);

--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
@@ -48,7 +48,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 class GovernanceRepositoryAPIImplTest {
@@ -155,36 +158,23 @@ class GovernanceRepositoryAPIImplTest {
     }
 
     @Test
-    void assertPersistLatestCheckJobId() {
-        String parentJobId = "parentJob123";
-        String checkJobId = "checkJob456";
-        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId, checkJobId);
-        Optional<String> retrievedCheckJobId = governanceRepositoryAPI.getLatestCheckJobId(parentJobId);
-        assertTrue(retrievedCheckJobId.isPresent(), "Expected a checkJobId to be present");
-        assertEquals(retrievedCheckJobId.get(), checkJobId, "The retrieved checkJobId does not match the persisted one");
+    void testGovernanceRepositoryAPIImplMethods() {
+        String parentJobId1 = "parentJob123";
+        String checkJobId1 = "checkJob456";
+        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId1, checkJobId1);
+        Optional<String> retrievedCheckJobId1 = governanceRepositoryAPI.getLatestCheckJobId(parentJobId1);
+        assertTrue(retrievedCheckJobId1.isPresent(), "Expected a checkJobId to be present");
+        assertEquals(retrievedCheckJobId1.get(), checkJobId1, "The retrieved checkJobId does not match the persisted one");
+        String parentJobId2 = "parentJob789";
+        String checkJobId2 = "checkJob012";
+        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId2, checkJobId2);
+        Optional<String> retrievedCheckJobId2 = governanceRepositoryAPI.getLatestCheckJobId(parentJobId2);
+        assertTrue(retrievedCheckJobId2.isPresent(), "Expected a checkJobId to be present");
+        assertEquals(checkJobId2, retrievedCheckJobId2.get(), "The retrieved checkJobId does not match the expected one");
+        governanceRepositoryAPI.deleteLatestCheckJobId(parentJobId2);
+        assertFalse(governanceRepositoryAPI.getLatestCheckJobId(parentJobId2).isPresent(), "Expected no checkJobId to be present after deletion");
     }
 
-    @Test
-    void assertGetLatestCheckJobId() {
-        String parentJobId = "parentJob789";
-        String checkJobId = "checkJob012";
-        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId, checkJobId);
-        Optional<String> retrievedCheckJobId = governanceRepositoryAPI.getLatestCheckJobId(parentJobId);
-        assertTrue(retrievedCheckJobId.isPresent(), "Expected a checkJobId to be present");
-        assertEquals(checkJobId, retrievedCheckJobId.get(), "The retrieved checkJobId does not match the expected one");
-        governanceRepositoryAPI.deleteLatestCheckJobId(parentJobId);
-        assertFalse(governanceRepositoryAPI.getLatestCheckJobId(parentJobId).isPresent(), "Expected no checkJobId to be present after deletion");
-    }
-
-    @Test
-    void assertDeleteLatestCheckJobId() {
-        String parentJobId = "parentJob123";
-        String checkJobId = "checkJob456";
-        governanceRepositoryAPI.persistLatestCheckJobId(parentJobId, checkJobId);
-        assertTrue(governanceRepositoryAPI.getLatestCheckJobId(parentJobId).isPresent(), "Expected checkJobId to be present before deletion");
-        governanceRepositoryAPI.deleteLatestCheckJobId(parentJobId);
-        assertFalse(governanceRepositoryAPI.getLatestCheckJobId(parentJobId).isPresent(), "Expected no checkJobId to be present after deletion");
-    }
 
     private MigrationJobItemContext mockJobItemContext() {
         MigrationJobItemContext result = PipelineContextUtils.mockMigrationJobItemContext(JobConfigurationBuilder.createJobConfiguration());


### PR DESCRIPTION
Fixes #28545.

Changes proposed in this pull request:

-  Added unit tests for persistLatestCheckJobId
-  Added unit tests for getLatestCheckJobId
-  Added unit tests for deleteLatestCheckJobId

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
