### PR TITLE
Update maven-shade-plugin from 3.4.1 to 3.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
         <maven-release-plugin.version>3.0.0</maven-release-plugin.version>
         <maven-assembly-plugin.version>3.5.0</maven-assembly-plugin.version>
-        <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
+        <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
         
         <!-- Check plugin versions -->
         <apache-rat-plugin.version>0.15</apache-rat-plugin.version>


### PR DESCRIPTION
Fix the shade plugin does not work with JDK 20 (https://github.com/apache/maven-shade-plugin/releases)