### PR TITLE
Improve alter tablespace syntax rules

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -439,6 +439,10 @@ tablespaceName
     : identifier
     ;
 
+newTablespaceName
+    : identifier
+    ;
+
 subprogramName
     : identifier
     ;
@@ -1724,6 +1728,10 @@ nationalCharset
     ;
 
 filenamePattern
+    : STRING_
+    ;
+
+replacementFilenamePattern
     : STRING_
     ;
 

--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -3957,8 +3957,8 @@ permanentTablespaceClause
     ;
 
 alterTablespace
-	: ALTER TABLESPACE tablespaceName
-	( defaultTablespaceParams
+    : ALTER TABLESPACE tablespaceName
+    ( defaultTablespaceParams
     | MINIMUM EXTENT sizeClause
     | RESIZE sizeClause
     | COALESCE
@@ -3974,20 +3974,20 @@ alterTablespace
     | tablespaceRetentionClause
     | alterTablespaceEncryption
     | lostWriteProtection
-	)
-	;
+    )
+    ;
 
 defaultTablespaceParams
-	: DEFAULT defaultTableCompression? defaultIndexCompression? inmemoryClause? ilmClause? storageClause?
-	;
+    : DEFAULT defaultTableCompression? defaultIndexCompression? inmemoryClause? ilmClause? storageClause?
+    ;
 
 defaultTableCompression
-	: TABLE (COMPRESS FOR OLTP | COMPRESS FOR QUERY (LOW | HIGH) | COMPRESS FOR ARCHIVE (LOW | HIGH) | NOCOMPRESS)
-	;
+    : TABLE (COMPRESS FOR OLTP | COMPRESS FOR QUERY (LOW | HIGH) | COMPRESS FOR ARCHIVE (LOW | HIGH) | NOCOMPRESS)
+    ;
 
 defaultIndexCompression
-	: INDEX (COMPRESS ADVANCED (LOW | HIGH) | NOCOMPRESS)
-	;
+    : INDEX (COMPRESS ADVANCED (LOW | HIGH) | NOCOMPRESS)
+    ;
 
 datafileTempfileClauses
     : ADD (DATAFILE | TEMPFILE) (fileSpecification (COMMA_ fileSpecification)*)?

--- a/test/it/parser/src/main/resources/case/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-table.xml
@@ -1727,6 +1727,10 @@
         <table name="t1" start-index="12" stop-index="13" />
     </alter-table>
     
+    <alter-table sql-case-id="alter_table_modify_lob_storage_maxsize_cache">
+        <table name="xml_lob_tab" start-index="12" stop-index="22" />
+    </alter-table>
+    
     <alter-table sql-case-id="alter_table_move_compress_for_oltp">
         <table name="table_name" start-index="12" stop-index="21" />
     </alter-table>

--- a/test/it/parser/src/main/resources/case/ddl/alter-tablespace.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-tablespace.xml
@@ -137,4 +137,16 @@
     <alter-tablespace sql-case-id="alter_tablespace_autoextend_on_next_g">
         <tablespace start-index="17" stop-index="22" name="bigtbs" />
     </alter-tablespace>
+    
+    <alter-tablespace sql-case-id="alter_tablespace_add_datafile_size_m">
+        <tablespace start-index="17" stop-index="22" name="lmtbsb" />
+    </alter-tablespace>
+    
+    <alter-tablespace sql-case-id="alter_tablespace_nologging">
+        <tablespace start-index="17" stop-index="22" name="tbs_03" />
+    </alter-tablespace>
+    
+    <alter-tablespace sql-case-id="alter_tablespace_add_tempfile_size_m_reuse">
+        <tablespace start-index="17" stop-index="22" name="lmtemp" />
+    </alter-tablespace>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
@@ -235,6 +235,7 @@
     <sql-case id="alter_table_modify_lob_deduplicate" value="ALTER TABLE t1 MODIFY LOB(a) (DEDUPLICATE)" db-types="Oracle" />
     <sql-case id="alter_table_modify_lob_nocompress" value="ALTER TABLE t1 MODIFY LOB(a) (NOCOMPRESS)" db-types="Oracle" />
     <sql-case id="alter_table_modify_lob_encrypt_using" value="ALTER TABLE t1 MODIFY LOB(a) (ENCRYPT USING '3DES168')" db-types="Oracle" />
+    <sql-case id="alter_table_modify_lob_storage_maxsize_cache" value="ALTER TABLE xml_lob_tab MODIFY LOB (XMLDATA) (STORAGE (MAXSIZE 2G) CACHE)" db-types="Oracle" />
     <sql-case id="alter_table_move_compress_for_oltp" value="ALTER TABLE table_name MOVE COMPRESS FOR OLTP" db-types="Oracle" />
     <sql-case id="alter_table_modify_encrypt_identified_by_password" value="ALTER TABLE t1 MODIFY ( a CLOB ENCRYPT IDENTIFIED BY foo)" db-types="Oracle" />
     <sql-case id="alter_table_move_nocompress_parallel" value="ALTER TABLE table_name MOVE NOCOMPRESS PARALLEL" db-types="Oracle" />

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-tablespace.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-tablespace.xml
@@ -59,4 +59,7 @@
                  TO '/u02/oracle/rbdb1/users01.dbf',
                     '/u02/oracle/rbdb1/users02.dbf'" db-types="Oracle" />
     <sql-case id="alter_tablespace_autoextend_on_next_g" value="ALTER TABLESPACE bigtbs AUTOEXTEND ON NEXT 20G" db-types="Oracle" />
+    <sql-case id="alter_tablespace_add_datafile_size_m" value="ALTER TABLESPACE lmtbsb ADD DATAFILE '/u02/oracle/data/lmtbsb02.dbf' SIZE 1M" db-types="Oracle" />
+    <sql-case id="alter_tablespace_nologging" value="ALTER TABLESPACE tbs_03 NOLOGGING" db-types="Oracle" />
+    <sql-case id="alter_tablespace_add_tempfile_size_m_reuse" value="ALTER TABLESPACE lmtemp ADD TEMPFILE '/u02/oracle/data/lmtemp02.dbf' SIZE 18M REUSE" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Fixes #26995.

Changes proposed in this pull request:
  - Improve alter tablespace syntax rules
  - Format alter tablespace rules
  - Add create tablespace and alter tablespace defaultTablespaceParams rule
  - Change incorrect parsing rules in alter tablespace
  - Reference issues: 26996 ~ 27003
  - Ref: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/ALTER-TABLESPACE.html#GUID-CA074861-55D3-4768-8995-43D4DA26365D

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ✓] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ✓] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ✓] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ✓] I have added corresponding unit tests for my changes.
