### PR TITLE
Update mysql connector java maven dependency

### DIFF
--- a/.github/workflows/e2e-sql.yml
+++ b/.github/workflows/e2e-sql.yml
@@ -116,7 +116,7 @@ jobs:
           - adapter: proxy
             database: MySQL
             scenario: passthrough
-            additional-options: '-Dmysql-connector-java.version=8.0.30'
+            additional-options: '-Dmysql-connector-java.version=8.0.31'
         exclude:
           - adapter: jdbc
             scenario: passthrough

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -307,8 +307,8 @@
             <version>${postgresql.version}</version>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <version>${mysql-connector-java.version}</version>
         </dependency>
         <dependency>

--- a/jdbc/core/pom.xml
+++ b/jdbc/core/pom.xml
@@ -183,8 +183,8 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>

--- a/kernel/data-pipeline/scenario/cdc/client/pom.xml
+++ b/kernel/data-pipeline/scenario/cdc/client/pom.xml
@@ -51,8 +51,8 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/kernel/transaction/type/xa/core/pom.xml
+++ b/kernel/transaction/type/xa/core/pom.xml
@@ -50,8 +50,8 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>

--- a/mode/type/standalone/repository/provider/jdbc/pom.xml
+++ b/mode/type/standalone/repository/provider/jdbc/pom.xml
@@ -69,8 +69,8 @@
         </dependency>
         
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -437,8 +437,8 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
                 <version>${mysql-connector-java.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/proxy/bootstrap/pom.xml
+++ b/proxy/bootstrap/pom.xml
@@ -123,8 +123,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/test/e2e/agent/jdbc-project/pom.xml
+++ b/test/e2e/agent/jdbc-project/pom.xml
@@ -34,8 +34,8 @@
         </dependency>
         
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/test/e2e/driver/pom.xml
+++ b/test/e2e/driver/pom.xml
@@ -38,8 +38,8 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>

--- a/test/e2e/fixture/pom.xml
+++ b/test/e2e/fixture/pom.xml
@@ -54,8 +54,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/test/e2e/operation/pipeline/pom.xml
+++ b/test/e2e/operation/pipeline/pom.xml
@@ -79,6 +79,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <!-- TODO Remove version definition and use the same 8.x version after proxy support pipeline E2E operations -->
             <version>5.1.49</version>
         </dependency>
         

--- a/test/e2e/operation/pipeline/pom.xml
+++ b/test/e2e/operation/pipeline/pom.xml
@@ -79,6 +79,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.49</version>
         </dependency>
         
         <dependency>

--- a/test/e2e/operation/showprocesslist/pom.xml
+++ b/test/e2e/operation/showprocesslist/pom.xml
@@ -41,8 +41,8 @@
         </dependency>
         
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         
         <dependency>

--- a/test/e2e/operation/transaction/pom.xml
+++ b/test/e2e/operation/transaction/pom.xml
@@ -66,8 +66,8 @@
         </dependency>
         
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/test/e2e/sql/pom.xml
+++ b/test/e2e/sql/pom.xml
@@ -39,8 +39,8 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>


### PR DESCRIPTION

Changes proposed in this pull request:
  - Use mysql:mysql-connector-java:5.1.49 for pipeline E2E. To avoid `todo` failure. Related to #28837
  - Replace maven dependency from mysql:mysql-connector-java to com.mysql:mysql-connector-j. Related to #28254

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
