### PR TITLE
SQL E2E compatible with com.mysql:mysql-connector-j:8.0

### DIFF
--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/RALE2EIT.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/RALE2EIT.java
@@ -124,7 +124,8 @@ class RALE2EIT {
     }
     
     private void assertResultSet(final SingleE2EContainerComposer containerComposer, final Statement statement, final String sql) throws SQLException {
-        try (ResultSet resultSet = statement.executeQuery(sql)) {
+        statement.execute(sql);
+        try (ResultSet resultSet = statement.getResultSet()) {
             assertResultSet(containerComposer, resultSet);
         }
     }

--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/RQLE2EIT.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/RQLE2EIT.java
@@ -59,10 +59,11 @@ class RQLE2EIT {
     }
     
     private void assertExecute(final SingleE2EContainerComposer containerComposer) throws SQLException {
-        try (Connection connection = containerComposer.getTargetDataSource().getConnection()) {
-            try (
-                    Statement statement = connection.createStatement();
-                    ResultSet resultSet = statement.executeQuery(containerComposer.getSQL())) {
+        try (
+                Connection connection = containerComposer.getTargetDataSource().getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute(containerComposer.getSQL());
+            try (ResultSet resultSet = statement.getResultSet()) {
                 assertResultSet(containerComposer, resultSet);
             }
         }


### PR DESCRIPTION

Changes proposed in this pull request:
  - SQL E2E compatible with com.mysql:mysql-connector-j:8.0

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
