### PR TITLE
Add unit test for PipelineJobCenter

### DIFF
--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/PipelineJobCenterTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/PipelineJobCenterTest.java
@@ -1,0 +1,132 @@
+package org.apache.shardingsphere.data.pipeline.core.job;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.shardingsphere.data.pipeline.common.context.PipelineJobItemContext;
+import org.apache.shardingsphere.data.pipeline.common.job.PipelineJob;
+import org.apache.shardingsphere.data.pipeline.core.task.runner.PipelineTasksRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PipelineJobCenterTest {
+
+    @Test
+    void addJob(){
+        PipelineJob pipelineJob=new PipelineJob() {
+            @Override
+            public Optional<PipelineTasksRunner> getTasksRunner(int shardingItem) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Collection<Integer> getShardingItems() {
+                return null;
+            }
+
+            @Override
+            public void stop() {
+
+            }
+        };
+        PipelineJobCenter.addJob("12",pipelineJob);
+        Assertions.assertEquals(pipelineJob,PipelineJobCenter.getJob("12"));
+        Assertions.assertTrue(PipelineJobCenter.isJobExisting("12"));
+    }
+
+    @Test
+    void isJobExisting() {
+        PipelineJob pipelineJob=new PipelineJob() {
+            @Override
+            public Optional<PipelineTasksRunner> getTasksRunner(int shardingItem) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Collection<Integer> getShardingItems() {
+                return null;
+            }
+
+            @Override
+            public void stop() {
+
+            }
+        };
+        PipelineJobCenter.addJob("12",pipelineJob);
+        Assertions.assertTrue(PipelineJobCenter.isJobExisting("12"));
+
+    }
+
+    @Test
+    void getJob() {
+        PipelineJob pipelineJob=new PipelineJob() {
+            @Override
+            public Optional<PipelineTasksRunner> getTasksRunner(int shardingItem) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Collection<Integer> getShardingItems() {
+                return null;
+            }
+
+            @Override
+            public void stop() {
+
+            }
+        };
+        PipelineJobCenter.addJob("13",pipelineJob);
+        Assertions.assertEquals(pipelineJob,PipelineJobCenter.getJob("13"));
+    }
+
+    @Test
+    void getJobItemContext() {
+        PipelineJob pipelineJob=mock(PipelineJob.class);
+        PipelineTasksRunner pipelineTasksRunner=mock(PipelineTasksRunner.class);
+        PipelineJobItemContext pipelineJobItemContext=mock(PipelineJobItemContext.class);
+        when(pipelineJob.getTasksRunner(anyInt())).thenReturn(Optional.of(pipelineTasksRunner));
+        when(pipelineTasksRunner.getJobItemContext()).thenReturn(pipelineJobItemContext);
+        PipelineJobCenter.addJob("111",pipelineJob);
+        Optional<PipelineJobItemContext> result=PipelineJobCenter.getJobItemContext("111",1);
+        assertTrue(result.isPresent());
+        assertEquals(pipelineJobItemContext,result);
+    }
+
+    @Test
+    void getShardingItems() {
+        PipelineJob pipelineJob=new PipelineJob() {
+            @Override
+            public Optional<PipelineTasksRunner> getTasksRunner(int shardingItem) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Collection<Integer> getShardingItems() {
+                Collection<Integer> collection=new ArrayList<>();
+                collection.add(2);
+                collection.add(3);
+                return collection;
+            }
+
+            @Override
+            public void stop() {
+
+            }
+        };
+        PipelineJobCenter.addJob("11",pipelineJob);
+        Collection<Integer> testCollection=new ArrayList<>();
+        testCollection.add(2);
+        testCollection.add(3);
+        Assertions.assertFalse(pipelineJob.getShardingItems().isEmpty());
+        Assertions.assertEquals(testCollection,PipelineJobCenter.getShardingItems("11"));
+    }
+}

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/PipelineJobCenterTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/PipelineJobCenterTest.java
@@ -1,17 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.shardingsphere.data.pipeline.core.job;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import org.apache.shardingsphere.data.pipeline.common.context.PipelineJobItemContext;
 import org.apache.shardingsphere.data.pipeline.common.job.PipelineJob;
 import org.apache.shardingsphere.data.pipeline.core.task.runner.PipelineTasksRunner;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.util.Assert;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -19,70 +41,53 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class PipelineJobCenterTest {
-
+    
     @Test
-    void addJob(){
-        PipelineJob pipelineJob=mock(PipelineJob.class);
-        PipelineJobCenter.addJob("12",pipelineJob);
-        Assertions.assertEquals(pipelineJob,PipelineJobCenter.getJob("12"));
-        Assertions.assertTrue(PipelineJobCenter.isJobExisting("12"));
+    void testPipelineJobCenter() {
+        PipelineJob pipelineJob = mock(PipelineJob.class);
+        PipelineJobCenter.addJob("Job1", pipelineJob);
+        
+        assertTrue(PipelineJobCenter.isJobExisting("Job1"));
+        assertFalse(PipelineJobCenter.isJobExisting("Job2"));
+        assertNotNull(PipelineJobCenter.getJob("Job1"));
+        assertEquals(pipelineJob, PipelineJobCenter.getJob("Job1"));
+        assertNull(PipelineJobCenter.getJob("Job2"));
+        
+        PipelineJob pipelineJob1 = mock(PipelineJob.class);
+        PipelineJobCenter.addJob("Job3", pipelineJob1);
+        assertNotNull(PipelineJobCenter.getJob("Job3"));
+        assertEquals(pipelineJob1, PipelineJobCenter.getJob("Job3"));
+        PipelineJobCenter.stop("Job3");
     }
-
-    @Test
-    void isJobExisting() {
-        PipelineJob pipelineJob=mock(PipelineJob.class);
-        PipelineJobCenter.addJob("12",pipelineJob);
-        Assertions.assertTrue(PipelineJobCenter.isJobExisting("12"));
-        assertNotNull(PipelineJobCenter.getJob("12"));
-    }
-
-    @Test
-    void getJob() {
-        PipelineJob pipelineJob=mock(PipelineJob.class);
-        PipelineJobCenter.addJob("13",pipelineJob);
-        assertTrue(PipelineJobCenter.isJobExisting("13"));
-        Assertions.assertEquals(pipelineJob,PipelineJobCenter.getJob("13"));
-    }
-
+    
     @Test
     void getJobItemContext() {
-        PipelineJob pipelineJob=mock(PipelineJob.class);
-        PipelineTasksRunner pipelineTasksRunner=mock(PipelineTasksRunner.class);
-        PipelineJobItemContext pipelineJobItemContext=mock(PipelineJobItemContext.class);
+        PipelineJob pipelineJob = mock(PipelineJob.class);
+        PipelineTasksRunner pipelineTasksRunner = mock(PipelineTasksRunner.class);
+        PipelineJobItemContext pipelineJobItemContext = mock(PipelineJobItemContext.class);
+        Optional<PipelineJobItemContext> pipelineJobItemContext1 = Optional.ofNullable(pipelineJobItemContext);
         when(pipelineJob.getTasksRunner(anyInt())).thenReturn(Optional.of(pipelineTasksRunner));
         when(pipelineTasksRunner.getJobItemContext()).thenReturn(pipelineJobItemContext);
-        PipelineJobCenter.addJob("111",pipelineJob);
-        Optional<PipelineJobItemContext> result=PipelineJobCenter.getJobItemContext("111",1);
+        PipelineJobCenter.addJob("Job1", pipelineJob);
+        Optional<PipelineJobItemContext> result = PipelineJobCenter.getJobItemContext("Job1", 1);
+        Optional<PipelineJobItemContext> result1 = PipelineJobCenter.getJobItemContext("Job2", 1);
         assertTrue(result.isPresent());
-        assertEquals(pipelineJobItemContext,result);
+        assertEquals(pipelineJobItemContext1, result);
+        assertFalse(result1.isPresent());
+        assertNotNull(result1);
+        PipelineJobCenter.stop("Job1");
     }
-
+    
     @Test
     void getShardingItems() {
-        PipelineJob pipelineJob=new PipelineJob() {
-            @Override
-            public Optional<PipelineTasksRunner> getTasksRunner(int shardingItem) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Collection<Integer> getShardingItems() {
-                Collection<Integer> collection=new ArrayList<>();
-                collection.add(2);
-                collection.add(3);
-                return collection;
-            }
-
-            @Override
-            public void stop() {
-
-            }
-        };
-        PipelineJobCenter.addJob("11",pipelineJob);
-        Collection<Integer> testCollection=new ArrayList<>();
-        testCollection.add(2);
-        testCollection.add(3);
-        Assertions.assertFalse(pipelineJob.getShardingItems().isEmpty());
-        Assertions.assertEquals(testCollection,PipelineJobCenter.getShardingItems("11"));
+        PipelineJob pipelineJob = mock(PipelineJob.class);
+        PipelineJobCenter.addJob("Job1", pipelineJob);
+        when(pipelineJob.getShardingItems()).thenReturn(Arrays.asList(1, 2, 3));
+        Collection<Integer> shardingItems = pipelineJob.getShardingItems();
+        
+        Assertions.assertFalse(shardingItems.isEmpty());
+        Assertions.assertEquals(Arrays.asList(1, 2, 3), PipelineJobCenter.getShardingItems("Job1"));
+        assertEquals(Collections.EMPTY_LIST, PipelineJobCenter.getShardingItems("Job2"));
+        PipelineJobCenter.stop("Job1");
     }
 }

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/PipelineJobCenterTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/PipelineJobCenterTest.java
@@ -17,25 +17,20 @@
 
 package org.apache.shardingsphere.data.pipeline.core.job;
 
-import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-
 import org.apache.shardingsphere.data.pipeline.common.context.PipelineJobItemContext;
 import org.apache.shardingsphere.data.pipeline.common.job.PipelineJob;
 import org.apache.shardingsphere.data.pipeline.core.task.runner.PipelineTasksRunner;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.util.Assert;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -59,11 +54,11 @@ class PipelineJobCenterTest {
         PipelineJob pipelineJob = mock(PipelineJob.class);
         PipelineTasksRunner pipelineTasksRunner = mock(PipelineTasksRunner.class);
         PipelineJobItemContext pipelineJobItemContext = mock(PipelineJobItemContext.class);
-        Optional<PipelineJobItemContext> optionalPipelineJobItemContext = Optional.ofNullable(pipelineJobItemContext);
         when(pipelineJob.getTasksRunner(anyInt())).thenReturn(Optional.of(pipelineTasksRunner));
         when(pipelineTasksRunner.getJobItemContext()).thenReturn(pipelineJobItemContext);
         PipelineJobCenter.addJob("Job1", pipelineJob);
         Optional<PipelineJobItemContext> result = PipelineJobCenter.getJobItemContext("Job1", 1);
+        Optional<PipelineJobItemContext> optionalPipelineJobItemContext = Optional.ofNullable(pipelineJobItemContext);
         assertTrue(result.isPresent());
         assertEquals(Optional.empty(), PipelineJobCenter.getJobItemContext("Job2", 1));
         assertEquals(optionalPipelineJobItemContext, result);

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/PipelineJobCenterTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/PipelineJobCenterTest.java
@@ -22,22 +22,7 @@ class PipelineJobCenterTest {
 
     @Test
     void addJob(){
-        PipelineJob pipelineJob=new PipelineJob() {
-            @Override
-            public Optional<PipelineTasksRunner> getTasksRunner(int shardingItem) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Collection<Integer> getShardingItems() {
-                return null;
-            }
-
-            @Override
-            public void stop() {
-
-            }
-        };
+        PipelineJob pipelineJob=mock(PipelineJob.class);
         PipelineJobCenter.addJob("12",pipelineJob);
         Assertions.assertEquals(pipelineJob,PipelineJobCenter.getJob("12"));
         Assertions.assertTrue(PipelineJobCenter.isJobExisting("12"));
@@ -45,46 +30,17 @@ class PipelineJobCenterTest {
 
     @Test
     void isJobExisting() {
-        PipelineJob pipelineJob=new PipelineJob() {
-            @Override
-            public Optional<PipelineTasksRunner> getTasksRunner(int shardingItem) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Collection<Integer> getShardingItems() {
-                return null;
-            }
-
-            @Override
-            public void stop() {
-
-            }
-        };
+        PipelineJob pipelineJob=mock(PipelineJob.class);
         PipelineJobCenter.addJob("12",pipelineJob);
         Assertions.assertTrue(PipelineJobCenter.isJobExisting("12"));
-
+        assertNotNull(PipelineJobCenter.getJob("12"));
     }
 
     @Test
     void getJob() {
-        PipelineJob pipelineJob=new PipelineJob() {
-            @Override
-            public Optional<PipelineTasksRunner> getTasksRunner(int shardingItem) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Collection<Integer> getShardingItems() {
-                return null;
-            }
-
-            @Override
-            public void stop() {
-
-            }
-        };
+        PipelineJob pipelineJob=mock(PipelineJob.class);
         PipelineJobCenter.addJob("13",pipelineJob);
+        assertTrue(PipelineJobCenter.isJobExisting("13"));
         Assertions.assertEquals(pipelineJob,PipelineJobCenter.getJob("13"));
     }
 

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/PipelineJobCenterTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/PipelineJobCenterTest.java
@@ -46,18 +46,12 @@ class PipelineJobCenterTest {
     void testPipelineJobCenter() {
         PipelineJob pipelineJob = mock(PipelineJob.class);
         PipelineJobCenter.addJob("Job1", pipelineJob);
-        
         assertTrue(PipelineJobCenter.isJobExisting("Job1"));
         assertFalse(PipelineJobCenter.isJobExisting("Job2"));
         assertNotNull(PipelineJobCenter.getJob("Job1"));
         assertEquals(pipelineJob, PipelineJobCenter.getJob("Job1"));
         assertNull(PipelineJobCenter.getJob("Job2"));
-        
-        PipelineJob pipelineJob1 = mock(PipelineJob.class);
-        PipelineJobCenter.addJob("Job3", pipelineJob1);
-        assertNotNull(PipelineJobCenter.getJob("Job3"));
-        assertEquals(pipelineJob1, PipelineJobCenter.getJob("Job3"));
-        PipelineJobCenter.stop("Job3");
+        PipelineJobCenter.stop("Job1");
     }
     
     @Test
@@ -65,16 +59,14 @@ class PipelineJobCenterTest {
         PipelineJob pipelineJob = mock(PipelineJob.class);
         PipelineTasksRunner pipelineTasksRunner = mock(PipelineTasksRunner.class);
         PipelineJobItemContext pipelineJobItemContext = mock(PipelineJobItemContext.class);
-        Optional<PipelineJobItemContext> pipelineJobItemContext1 = Optional.ofNullable(pipelineJobItemContext);
+        Optional<PipelineJobItemContext> optionalPipelineJobItemContext = Optional.ofNullable(pipelineJobItemContext);
         when(pipelineJob.getTasksRunner(anyInt())).thenReturn(Optional.of(pipelineTasksRunner));
         when(pipelineTasksRunner.getJobItemContext()).thenReturn(pipelineJobItemContext);
         PipelineJobCenter.addJob("Job1", pipelineJob);
         Optional<PipelineJobItemContext> result = PipelineJobCenter.getJobItemContext("Job1", 1);
-        Optional<PipelineJobItemContext> result1 = PipelineJobCenter.getJobItemContext("Job2", 1);
         assertTrue(result.isPresent());
-        assertEquals(pipelineJobItemContext1, result);
-        assertFalse(result1.isPresent());
-        assertNotNull(result1);
+        assertEquals(Optional.empty(), PipelineJobCenter.getJobItemContext("Job2", 1));
+        assertEquals(optionalPipelineJobItemContext, result);
         PipelineJobCenter.stop("Job1");
     }
     
@@ -84,7 +76,6 @@ class PipelineJobCenterTest {
         PipelineJobCenter.addJob("Job1", pipelineJob);
         when(pipelineJob.getShardingItems()).thenReturn(Arrays.asList(1, 2, 3));
         Collection<Integer> shardingItems = pipelineJob.getShardingItems();
-        
         Assertions.assertFalse(shardingItems.isEmpty());
         Assertions.assertEquals(Arrays.asList(1, 2, 3), PipelineJobCenter.getShardingItems("Job1"));
         assertEquals(Collections.EMPTY_LIST, PipelineJobCenter.getShardingItems("Job2"));

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/PipelineJobCenterTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/PipelineJobCenterTest.java
@@ -17,15 +17,17 @@
 
 package org.apache.shardingsphere.data.pipeline.core.job;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
 import org.apache.shardingsphere.data.pipeline.common.context.PipelineJobItemContext;
 import org.apache.shardingsphere.data.pipeline.common.job.PipelineJob;
 import org.apache.shardingsphere.data.pipeline.core.task.runner.PipelineTasksRunner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -38,7 +40,7 @@ import static org.mockito.Mockito.when;
 class PipelineJobCenterTest {
     
     @Test
-    void testPipelineJobCenter() {
+    void assertPipelineJobCenter() {
         PipelineJob pipelineJob = mock(PipelineJob.class);
         PipelineJobCenter.addJob("Job1", pipelineJob);
         assertTrue(PipelineJobCenter.isJobExisting("Job1"));
@@ -50,7 +52,7 @@ class PipelineJobCenterTest {
     }
     
     @Test
-    void getJobItemContext() {
+    void assertGetJobItemContext() {
         PipelineJob pipelineJob = mock(PipelineJob.class);
         PipelineTasksRunner pipelineTasksRunner = mock(PipelineTasksRunner.class);
         PipelineJobItemContext pipelineJobItemContext = mock(PipelineJobItemContext.class);
@@ -66,7 +68,7 @@ class PipelineJobCenterTest {
     }
     
     @Test
-    void getShardingItems() {
+    void assertGetShardingItems() {
         PipelineJob pipelineJob = mock(PipelineJob.class);
         PipelineJobCenter.addJob("Job1", pipelineJob);
         when(pipelineJob.getShardingItems()).thenReturn(Arrays.asList(1, 2, 3));


### PR DESCRIPTION
Fixes #28542 .

Changes proposed in this pull request:
  -
Added unit tests for PipelineJobCenter to test its public functions to improve unit test coverage. Methods: addJob, isJobExisting, getJob, getJobItemContext, getShardingItems.
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
