### PR TITLE
Remove duplicate rule definitions in Oracle BaseRule.g4

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -2098,23 +2098,3 @@ keyForBlob
 sourceText
     : identifier
     ;
-
-primaryName
-    : identifier
-    ;
-
-directoryObjectName
-    : identifier
-    ;
-
-serverFileName
-    : identifier
-    ;
-
-keyForBlob
-    : identifier
-    ;
-
-sourceText
-    : identifier
-    ;


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove duplicate rule definitions in Oracle BaseRule.g4

---

Before committing this PR, I'm sure that I have checked the following options:
- [  ✓] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [  ✓] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [  ✓] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [  ✓] I have added corresponding unit tests for my changes.
