### PR TITLE
Add replication slot cleanup when drop CDC tasks

### DIFF
--- a/kernel/data-pipeline/scenario/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/CDCClient.java
+++ b/kernel/data-pipeline/scenario/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/CDCClient.java
@@ -41,6 +41,7 @@ import org.apache.shardingsphere.data.pipeline.cdc.client.util.RequestIdUtils;
 import org.apache.shardingsphere.data.pipeline.cdc.client.util.ResponseFuture;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest.Type;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.DropStreamingRequestBody;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequestBody;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequestBody.BasicBody;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequestBody.LoginType;
@@ -204,6 +205,24 @@ public final class CDCClient implements AutoCloseable {
         responseFuture.waitResponseResult(config.getTimeoutMills(), connectionContext);
         connectionContext.getStreamingIds().remove(streamingId);
         log.info("Stop streaming success, streaming id: {}", streamingId);
+    }
+    
+    /**
+     * Drop streaming.
+     *
+     * @param streamingId streaming id
+     */
+    public void dropStreaming(final String streamingId) {
+        String requestId = RequestIdUtils.generateRequestId();
+        DropStreamingRequestBody body = DropStreamingRequestBody.newBuilder().setStreamingId(streamingId).build();
+        CDCRequest request = CDCRequest.newBuilder().setRequestId(requestId).setType(Type.DROP_STREAMING).setDropStreamingRequestBody(body).build();
+        ResponseFuture responseFuture = new ResponseFuture(requestId, Type.DROP_STREAMING);
+        ClientConnectionContext connectionContext = channel.attr(ClientConnectionContext.CONTEXT_KEY).get();
+        connectionContext.getResponseFutureMap().put(requestId, responseFuture);
+        channel.writeAndFlush(request);
+        responseFuture.waitResponseResult(config.getTimeoutMills(), connectionContext);
+        connectionContext.getStreamingIds().remove(streamingId);
+        log.info("Drop streaming success, streaming id: {}", streamingId);
     }
     
     @Override

--- a/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/api/impl/CDCJobAPI.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/api/impl/CDCJobAPI.java
@@ -359,6 +359,17 @@ public final class CDCJobAPI extends AbstractInventoryIncrementalJobAPIImpl {
             stop(jobId);
         }
         dropJob(jobId);
+        cleanup(jobConfig);
+    }
+    
+    private void cleanup(final CDCJobConfiguration jobConfig) {
+        for (Entry<String, Map<String, Object>> entry : jobConfig.getDataSourceConfig().getRootConfig().getDataSources().entrySet()) {
+            try {
+                PipelineJobPreparerUtils.destroyPosition(jobConfig.getJobId(), new StandardPipelineDataSourceConfiguration(entry.getValue()));
+            } catch (final SQLException ex) {
+                log.warn("job destroying failed, jobId={}, dataSourceName={}", jobConfig.getJobId(), entry.getKey(), ex);
+            }
+        }
     }
     
     @Override


### PR DESCRIPTION

Changes proposed in this pull request:
  - Add replication slot cleanup when drop CDC tasks
  - Add dropStreaming method of CDCClient.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
