### PR TITLE
Added unit tests for EncryptColumnNameReviser revive method

### DIFF
--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/metadata/reviser/column/EncryptColumnNameReviserTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/metadata/reviser/column/EncryptColumnNameReviserTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.metadata.reviser.column;
+
+import org.apache.shardingsphere.encrypt.rule.EncryptTable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EncryptColumnNameReviserTest {
+    
+    @Test
+    void assertRevise() {
+        EncryptTable encryptTable = mock(EncryptTable.class);
+        EncryptColumnNameReviser encryptColumnNameReviser = new EncryptColumnNameReviser(encryptTable);
+        when(encryptTable.isCipherColumn("Cipher")).thenReturn(true);
+        when(encryptTable.getLogicColumnByCipherColumn("Cipher")).thenReturn("Logic");
+        Assertions.assertEquals("Logic", encryptColumnNameReviser.revise("Cipher"));
+        Assertions.assertEquals("NonCipher", encryptColumnNameReviser.revise("NonCipher"));
+    }
+}


### PR DESCRIPTION
Fixes #28549 .

Changes proposed in this pull request:
  -
Added unit tests for EncryptColumnNameReviser to test its public functions to improve unit test coverage.Method:revise()
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
