### PR TITLE
Fix oracle select union sql parse

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
@@ -136,7 +136,7 @@ select
     ;
 
 selectSubquery
-    : (queryBlock | selectCombineClause | parenthesisSelectSubquery) pivotClause? orderByClause? rowLimitingClause
+    : (selectCombineClause | queryBlock | parenthesisSelectSubquery) pivotClause? orderByClause? rowLimitingClause
     ;
 
 selectCombineClause

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
@@ -670,20 +670,17 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
     }
     
     private void setSelectCombineClause(final SelectCombineClauseContext ctx, final OracleSelectStatement result, final OracleSelectStatement left) {
-        for (int i = 0; i < ctx.selectSubquery().size(); i++) {
-            CombineType combineType;
-            if (null != ctx.UNION(i) && null != ctx.ALL(i)) {
-                combineType = CombineType.UNION_ALL;
-            } else if (null != ctx.UNION(i)) {
-                combineType = CombineType.UNION;
-            } else if (null != ctx.INTERSECT(i)) {
-                combineType = CombineType.INTERSECT;
-            } else {
-                combineType = CombineType.MINUS;
-            }
-            result.setCombine(new CombineSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), left,
-                    combineType, (OracleSelectStatement) visit(ctx.selectSubquery(i))));
+        CombineType combineType;
+        if (null != ctx.UNION(0) && null != ctx.ALL(0)) {
+            combineType = CombineType.UNION_ALL;
+        } else if (null != ctx.UNION(0)) {
+            combineType = CombineType.UNION;
+        } else if (null != ctx.INTERSECT(0)) {
+            combineType = CombineType.INTERSECT;
+        } else {
+            combineType = CombineType.MINUS;
         }
+        result.setCombine(new CombineSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), left, combineType, (OracleSelectStatement) visit(ctx.selectSubquery(0))));
     }
     
     @Override

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
@@ -656,7 +656,7 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
         if (null != ctx.selectSubquery()) {
             result.setProjections(left.getProjections());
             result.setFrom(left.getFrom());
-            visitSelectCombineClause(ctx, result, left);
+            setSelectCombineClause(ctx, result, left);
         }
         if (null != ctx.orderByClause()) {
             result.setOrderBy((OrderBySegment) visit(ctx.orderByClause()));
@@ -669,8 +669,8 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
         return visit(ctx.selectSubquery());
     }
     
-    private void visitSelectCombineClause(final SelectCombineClauseContext ctx, final OracleSelectStatement result, final OracleSelectStatement left) {
-        for (int i = 0 ; i < ctx.selectSubquery().size(); i++) {
+    private void setSelectCombineClause(final SelectCombineClauseContext ctx, final OracleSelectStatement result, final OracleSelectStatement left) {
+        for (int i = 0; i < ctx.selectSubquery().size(); i++) {
             CombineType combineType;
             if (null != ctx.UNION(i) && null != ctx.ALL(i)) {
                 combineType = CombineType.UNION_ALL;

--- a/test/it/parser/src/main/resources/case/dml/select-combine.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-combine.xml
@@ -893,4 +893,129 @@
             </right>
         </combine>
     </select>
+    
+    <select sql-case-id="select_union_all_where">
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
+        </projections>
+        <from>
+            <simple-table name="TEST_TABLE_1" start-index="14" stop-index="25" />
+        </from>
+        <combine combine-type="UNION_ALL" start-index="0" stop-index="88">
+            <left>
+                <projections start-index="7" stop-index="7">
+                    <shorthand-projection start-index="7" stop-index="7" />
+                </projections>
+                <from>
+                    <simple-table name="TEST_TABLE_1" start-index="14" stop-index="25" />
+                </from>
+                <where start-index="27" stop-index="38">
+                    <expr>
+                        <binary-operation-expression start-index="33" stop-index="38">
+                            <left>
+                                <column name="ID" start-index="33" stop-index="34" />
+                            </left>
+                            <right>
+                                <literal-expression value="1" start-index="38" stop-index="38" />
+                            </right>
+                            <operator>=</operator>
+                        </binary-operation-expression>
+                    </expr>
+                </where>
+            </left>
+            <right>
+                <projections start-index="57" stop-index="57">
+                    <shorthand-projection start-index="57" stop-index="57" />
+                </projections>
+                <from>
+                    <simple-table name="TEST_TABLE_2" start-index="64" stop-index="75" />
+                </from>
+                <where start-index="77" stop-index="88">
+                    <expr>
+                        <binary-operation-expression start-index="83" stop-index="88">
+                            <left>
+                                <column name="ID" start-index="83" stop-index="84" />
+                            </left>
+                            <right>
+                                <literal-expression value="2" start-index="88" stop-index="88" />
+                            </right>
+                            <operator>=</operator>
+                        </binary-operation-expression>
+                    </expr>
+                </where>
+            </right>
+        </combine>
+    </select>
+    
+    <select sql-case-id="select_union_all_minus">
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
+        </projections>
+        <from>
+            <simple-table name="TEST_TABLE_1" start-index="14" stop-index="25" />
+        </from>
+        <combine combine-type="UNION_ALL" start-index="0" stop-index="95">
+            <left>
+                <projections start-index="7" stop-index="7">
+                    <shorthand-projection start-index="7" stop-index="7" />
+                </projections>
+                <from>
+                    <simple-table name="TEST_TABLE_1" start-index="14" stop-index="25" />
+                </from>
+            </left>
+            <right>
+                <projections start-index="44" stop-index="44">
+                    <shorthand-projection start-index="44" stop-index="44" />
+                </projections>
+                <from>
+                    <simple-table name="TEST_TABLE_2" start-index="51" stop-index="62" />
+                </from>
+                <combine combine-type="MINUS" start-index="37" stop-index="95">
+                    <left>
+                        <projections start-index="44" stop-index="44">
+                            <shorthand-projection start-index="44" stop-index="44" />
+                        </projections>
+                        <from>
+                            <simple-table name="TEST_TABLE_2" start-index="51" stop-index="62" />
+                        </from>
+                    </left>
+                    <right>
+                        <projections start-index="77" stop-index="77">
+                            <shorthand-projection start-index="77" stop-index="77" />
+                        </projections>
+                        <from>
+                            <simple-table name="TEST_TABLE_3" start-index="84" stop-index="95" />
+                        </from>
+                    </right>
+                </combine>
+            </right>
+        </combine>
+    </select>
+    
+    <select sql-case-id="select_union_subquery">
+        <projections start-index="8" stop-index="14">
+            <column-projection name="TEST_ID" start-index="8" stop-index="14" />
+        </projections>
+        <from>
+            <simple-table name="TEST_TABLE" start-index="22" stop-index="31" />
+        </from>
+        <combine combine-type="UNION" start-index="0" stop-index="71">
+            <left>
+                <projections start-index="8" stop-index="14">
+                    <column-projection name="TEST_ID" start-index="8" stop-index="14" />
+                </projections>
+                <from>
+                    <simple-table name="TEST_TABLE" start-index="22" stop-index="31" />
+                </from>
+            </left>
+            <right>
+                <projections start-index="48" stop-index="54">
+                    <column-projection name="TEST_ID" start-index="48" stop-index="54" />
+                </projections>
+                <from>
+                    <simple-table name="TEST_TABLE" start-index="61" stop-index="70" />
+                </from>
+            </right>
+        </combine>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-combine.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-combine.xml
@@ -38,4 +38,7 @@
     <sql-case id="select_except_intersect" value="SELECT * FROM table1 EXCEPT SELECT * FROM table2 INTERSECT SELECT * FROM table3" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_except_intersect_union" value="SELECT * FROM table1 EXCEPT SELECT * FROM table2 INTERSECT SELECT * FROM table3 UNION SELECT * FROM table4" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_sub_union" value="SELECT * FROM table1 UNION (SELECT * FROM table2 UNION SELECT * FROM table3)" db-types="MySQL,PostgreSQL,openGauss" />
+    <sql-case id="select_union_all_where" value="SELECT * FROM TEST_TABLE_1 WHERE ID = 1 UNION ALL SELECT * FROM TEST_TABLE_2 WHERE ID = 2" db-types="Oracle" />
+    <sql-case id="select_union_all_minus" value="SELECT * FROM TEST_TABLE_1 UNION ALL SELECT * FROM TEST_TABLE_2 MINUS SELECT * FROM TEST_TABLE_3" db-types="Oracle" />
+    <sql-case id="select_union_subquery" value="(SELECT TEST_ID FROM  TEST_TABLE) UNION (SELECT TEST_ID FROM TEST_TABLE)" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - The Oracle select SQL statement union was not parsed
  - Fix oracle select union sql parse
  - Add test sql

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ✓] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ✓] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ✓] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ✓] I have added corresponding unit tests for my changes.
