### PR TITLE
Restore the slf4j version from 2.0.9 to 1.7.36 before Spring Boot 2 ends the OSS life cycle

### DIFF
--- a/agent/core/src/test/java/org/apache/shardingsphere/fixture/log/LogbackConfigurationFixture.java
+++ b/agent/core/src/test/java/org/apache/shardingsphere/fixture/log/LogbackConfigurationFixture.java
@@ -39,7 +39,7 @@ public final class LogbackConfigurationFixture extends BasicConfigurator {
     public static final String SHARDINGSPHERE_LOGGER_NAME = "org.apache.shardingsphere.agent";
     
     @Override
-    public ExecutionStatus configure(final LoggerContext loggerContext) {
+    public void configure(final LoggerContext loggerContext) {
         Appender<ILoggingEvent> appender = createFileAppender(loggerContext);
         Logger rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
         rootLogger.setLevel(Level.INFO);
@@ -48,7 +48,6 @@ public final class LogbackConfigurationFixture extends BasicConfigurator {
         logger.setLevel(Level.INFO);
         logger.setAdditive(false);
         logger.addAppender(appender);
-        return ExecutionStatus.NEUTRAL;
     }
     
     private FileAppender<ILoggingEvent> createFileAppender(final LoggerContext loggerContext) {

--- a/distribution/proxy-native/src/main/release-docs/LICENSE
+++ b/distribution/proxy-native/src/main/release-docs/LICENSE
@@ -263,7 +263,7 @@ The text of each license is the standard Apache 2.0 license.
     jackson-databind 2.14.0: http://github.com/FasterXML/jackson, Apache 2.0
     jackson-dataformat-yaml 2.14.0: http://github.com/FasterXML/jackson, Apache 2.0
     jackson-datatype-jsr310 2.14.0: http://github.com/FasterXML/jackson, Apache 2.0
-    jcl-over-slf4j 2.0.9: https://github.com/qos-ch/slf4j, Apache 2.0
+    jcl-over-slf4j 1.7.36: https://github.com/qos-ch/slf4j, Apache 2.0
     jetcd-api 0.7.6: https://github.com/etcd-io/jetcd, Apache 2.0
     jetcd-common 0.7.6: https://github.com/etcd-io/jetcd, Apache 2.0
     jetcd-core 0.7.6: https://github.com/etcd-io/jetcd, Apache 2.0
@@ -356,8 +356,8 @@ EPL licenses
 The following components are provided under the EPL License. See project link for details.
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
-    logback-classic 1.3.11: https://github.com/qos-ch/logback, EPL 1.0
-    logback-core 1.3.11: https://github.com/qos-ch/logback, EPL 1.0
+    logback-classic 1.2.12: https://github.com/qos-ch/logback, EPL 1.0
+    logback-core 1.2.12: https://github.com/qos-ch/logback, EPL 1.0
     mchange-commons-java 0.2.15: https://github.com/swaldman/mchange-commons-java, EPL 1.0
     h2 2.2.224: https://github.com/h2database/h2database, EPL 1.0
 
@@ -373,5 +373,5 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     bctls-jdk15on 1.70: https://www.bouncycastle.org, MIT
     bcutil-jdk15on 1.70: https://www.bouncycastle.org, MIT
     checker-qual 3.39.0: https://github.com/typetools/checker-framework/blob/master/checker-qual, MIT
-    jul-to-slf4j 2.0.9: https://www.slf4j.org, MIT
-    slf4j-api 2.0.9: https://www.slf4j.org, MIT
+    jul-to-slf4j 1.7.36: https://www.slf4j.org, MIT
+    slf4j-api 1.7.36: https://www.slf4j.org, MIT

--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -263,7 +263,7 @@ The text of each license is the standard Apache 2.0 license.
     jackson-databind 2.14.0: http://github.com/FasterXML/jackson, Apache 2.0
     jackson-dataformat-yaml 2.14.0: http://github.com/FasterXML/jackson, Apache 2.0
     jackson-datatype-jsr310 2.14.0: http://github.com/FasterXML/jackson, Apache 2.0
-    jcl-over-slf4j 2.0.9: https://github.com/qos-ch/slf4j, Apache 2.0
+    jcl-over-slf4j 1.7.36: https://github.com/qos-ch/slf4j, Apache 2.0
     jetcd-api 0.7.6: https://github.com/etcd-io/jetcd, Apache 2.0
     jetcd-common 0.7.6: https://github.com/etcd-io/jetcd, Apache 2.0
     jetcd-core 0.7.6: https://github.com/etcd-io/jetcd, Apache 2.0
@@ -356,8 +356,8 @@ EPL licenses
 The following components are provided under the EPL License. See project link for details.
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
-    logback-classic 1.3.11: https://github.com/qos-ch/logback, EPL 1.0
-    logback-core 1.3.11: https://github.com/qos-ch/logback, EPL 1.0
+    logback-classic 1.2.12: https://github.com/qos-ch/logback, EPL 1.0
+    logback-core 1.2.12: https://github.com/qos-ch/logback, EPL 1.0
     mchange-commons-java 0.2.15: https://github.com/swaldman/mchange-commons-java, EPL 1.0
     h2 2.2.224: https://github.com/h2database/h2database, EPL 1.0
 
@@ -373,5 +373,5 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     bctls-jdk15on 1.70: https://www.bouncycastle.org, MIT
     bcutil-jdk15on 1.70: https://www.bouncycastle.org, MIT
     checker-qual 3.39.0: https://github.com/typetools/checker-framework/blob/master/checker-qual, MIT
-    jul-to-slf4j 2.0.9: https://www.slf4j.org, MIT
-    slf4j-api 2.0.9: https://www.slf4j.org, MIT
+    jul-to-slf4j 1.7.36: https://www.slf4j.org, MIT
+    slf4j-api 1.7.36: https://www.slf4j.org, MIT

--- a/pom.xml
+++ b/pom.xml
@@ -117,8 +117,8 @@
         
         <elasticjob.version>3.0.4</elasticjob.version>
         
-        <slf4j.version>2.0.9</slf4j.version>
-        <logback.version>1.3.11</logback.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <logback.version>1.2.12</logback.version>
         <commons-logging.version>1.2</commons-logging.version>
         
         <lombok.version>1.18.30</lombok.version>
@@ -441,10 +441,18 @@
             
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-bom</artifactId>
+                <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>${slf4j.version}</version>
             </dependency>
             
             <dependency>

--- a/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/config/LogbackConfiguration.java
+++ b/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/config/LogbackConfiguration.java
@@ -39,13 +39,12 @@ public class LogbackConfiguration extends BasicConfigurator {
     public static final String NETTY_LOGGER_NAME = "io.netty";
     
     @Override
-    public ExecutionStatus configure(final LoggerContext loggerContext) {
+    public void configure(final LoggerContext loggerContext) {
         ConsoleAppender<ILoggingEvent> consoleAppender = createConsoleAppender(loggerContext);
         Logger rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
         rootLogger.setLevel(Level.INFO);
         rootLogger.addAppender(consoleAppender);
         initBasicLogger(loggerContext);
-        return ExecutionStatus.NEUTRAL;
     }
     
     private ConsoleAppender<ILoggingEvent> createConsoleAppender(final LoggerContext loggerContext) {


### PR DESCRIPTION
For #28826.

Changes proposed in this pull request:
  - Restore the slf4j version from 2.0.9 to 1.7.36 before Spring Boot 2 ends the OSS life cycle.
  - #28826 Increasing the slf4j version to 2.0.9 caused all downstreams running ShardingSphere JDBC on Spring Boot 2.x to receive an Error. 
  - The Spring Boot side is restricted by the underlying design. The 2.x branch of Spring Boot will use slf4j 1.x until the end of the OSS life cycle. Due to changes in the API of the corresponding logback implementation, it is impossible to use logback 1.3.x on Spring Boot 2.x. Reference https://github.com/spring-projects/spring-boot/issues/34708.
  - I believe the current PR will not affect Spring Boot 3 downstream, because slf4j 2.0 is designed to be compatible with slf4j 1.x. The real issue involved here is binary incompatibility between logback 1.2 and 1.3. I believe we have to wait for Spring Boot 2 to end its OSS life cycle before we start talking about slf4j 2.0.
  - This PR also touches on the problem of bom not existing in slf4j 1.x.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
