### PR TITLE
Migrate JAXB Runtime from `com.sun.xml.bind:jaxb-impl` to `org.glassfish.jaxb:jaxb-runtime`

### DIFF
--- a/distribution/proxy-native/src/main/release-docs/LICENSE
+++ b/distribution/proxy-native/src/main/release-docs/LICENSE
@@ -345,9 +345,8 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
 
     javax.activation-api 1.2.0: https://github.com/javaee/javax.annotation, CDDL
     jta 1.1: http://jta-spec.java.net, CDDL
-    jaxb-api 2.3.0: http://www.oracle.com, CDDL
-    jaxb-core 2.3.0: http://www.oracle.com, CDDL
-    jaxb-impl 2.3.0 http://www.oracle.com, CDDL
+    jaxb-api 2.3.1: http://www.oracle.com, CDDL
+    jaxb-runtime 2.3.1 https://javaee.github.io/jaxb-v2/, CDDL
 
 ========================================================================
 EPL licenses

--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -345,9 +345,8 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
 
     javax.activation-api 1.2.0: https://github.com/javaee/javax.annotation, CDDL
     jta 1.1: http://jta-spec.java.net, CDDL
-    jaxb-api 2.3.0: http://www.oracle.com, CDDL
-    jaxb-core 2.3.0: http://www.oracle.com, CDDL
-    jaxb-impl 2.3.0 http://www.oracle.com, CDDL
+    jaxb-api 2.3.1: http://www.oracle.com, CDDL
+    jaxb-runtime 2.3.1 https://javaee.github.io/jaxb-v2/, CDDL
 
 ========================================================================
 EPL licenses

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.cn.md
@@ -56,7 +56,7 @@ Quarkus 3，Micronaut Framework 4 和 Helidon 3。
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.8</version>
+            <version>2.3.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.en.md
@@ -57,7 +57,7 @@ also applies to other Jakarta EE-based Web Frameworks, such as Quarkus 3, Micron
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.8</version>
+            <version>2.3.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/kernel/sql-federation/core/pom.xml
+++ b/kernel/sql-federation/core/pom.xml
@@ -60,13 +60,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kernel/sql-federation/executor/pom.xml
+++ b/kernel/sql-federation/executor/pom.xml
@@ -80,13 +80,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kernel/sql-federation/optimizer/pom.xml
+++ b/kernel/sql-federation/optimizer/pom.xml
@@ -100,13 +100,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kernel/transaction/type/xa/provider/narayana/pom.xml
+++ b/kernel/transaction/type/xa/provider/narayana/pom.xml
@@ -63,12 +63,8 @@
             <artifactId>jaxb-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>

--- a/mode/type/standalone/repository/provider/jdbc/pom.xml
+++ b/mode/type/standalone/repository/provider/jdbc/pom.xml
@@ -45,12 +45,8 @@
             <artifactId>jaxb-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>

--- a/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQLLoader.java
+++ b/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQLLoader.java
@@ -82,7 +82,7 @@ public final class JDBCRepositorySQLLoader {
     }
     
     /**
-     * Under the GraalVM Native Image corresponding to GraalVM CE 21.0.1, although there is
+     * Under the GraalVM Native Image corresponding to GraalVM CE 23.0.2 For JDK 17.0.9, although there is
      * `com.oracle.svm.core.jdk.resources.NativeImageResourceFileSystemProvider`, the corresponding
      * `com.oracle.svm.core.jdk.resources.NativeImageResourceFileSystem` does not autoload. This is mainly to align the
      * behavior of `ZipFileSystemProvider`, so ShardingSphere need to manually open and close the FileSystem
@@ -101,12 +101,12 @@ public final class JDBCRepositorySQLLoader {
      * @see sun.nio.fs.UnixFileSystemProvider
      */
     private static JDBCRepositorySQL loadFromDirectory(final URL url, final String type) throws URISyntaxException, IOException {
-        if (null != System.getProperty("org.graalvm.nativeimage.imagecode")) {
-            try (FileSystem ignored = FileSystems.newFileSystem(URI.create("resource:/"), Collections.singletonMap("create", "true"))) {
+        if (null == System.getProperty("org.graalvm.nativeimage.imagecode") || !"runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))) {
+            return loadFromDirectoryLegacy(url, type);
+        } else {
+            try (FileSystem ignored = FileSystems.newFileSystem(URI.create("resource:/"), Collections.emptyMap())) {
                 return loadFromDirectoryLegacy(url, type);
             }
-        } else {
-            return loadFromDirectoryLegacy(url, type);
         }
     }
     

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,8 @@
         <freemarker.version>2.3.31</freemarker.version>
         <bytebuddy.version>1.14.8</bytebuddy.version>
         
-        <jaxb.version>2.3.0</jaxb.version>
+        <jaxb-api.version>2.3.1</jaxb-api.version>
+        <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
         <annotation-api.version>1.3.2</annotation-api.version>
         <activation-api.version>1.2.0</activation-api.version>
         
@@ -298,17 +299,12 @@
             <dependency>
                 <groupId>javax.xml.bind</groupId>
                 <artifactId>jaxb-api</artifactId>
-                <version>${jaxb.version}</version>
+                <version>${jaxb-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-core</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${jaxb.version}</version>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb-runtime.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.annotation</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -56,12 +56,8 @@
             <artifactId>jaxb-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>


### PR DESCRIPTION
Fixes #29012.

Changes proposed in this pull request:
  - Migrate JAXB Runtime from `com.sun.xml.bind:jaxb-impl` to `org.glassfish.jaxb:jaxb-runtime`. Refer to https://bugs.openjdk.org/browse/JDK-8193033 . 

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
