### PR TITLE
Prevent ReadwriteSplitting rule class from parsing Groovy syntax under GraalVM Native Image

### DIFF
--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/groovy/GroovyUtils.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/groovy/GroovyUtils.java
@@ -28,6 +28,20 @@ import java.util.List;
 public class GroovyUtils {
     
     /**
+     * If the context class is in the GraalVM Native Image Runtime, this function returns `false`.
+     * This function returns `true` when the context class is in GraalVM Native Image BuildTime or under Hotspot JVM.
+     * <p/>
+     * ShardingSphere use the System Property of `org.graalvm.nativeimage.imagecode` to identify whether this class is
+     * in the GraalVM Native Image environment. The background of this property comes from
+     * <a href="https://junit.org/junit5/docs/5.10.0/api/org.junit.jupiter.api/org/junit/jupiter/api/condition/DisabledInNativeImage.html">Annotation Interface DisabledInNativeImage</a>.
+     *
+     * @return The judgment result of the environment where the context class is located
+     */
+    public static Boolean isNotRuntimeInGraalVMNativeImage() {
+        return null == System.getProperty("org.graalvm.nativeimage.imagecode") || !"runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
+    }
+    
+    /**
      * Split GroovyShell expression to a ArrayList.
      *
      * @param inlineExpression GroovySHell expression.

--- a/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQLLoader.java
+++ b/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQLLoader.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.mode.repository.standalone.jdbc.sql;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
+import org.apache.shardingsphere.infra.util.groovy.GroovyUtils;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -87,10 +88,6 @@ public final class JDBCRepositorySQLLoader {
      * `com.oracle.svm.core.jdk.resources.NativeImageResourceFileSystem` does not autoload. This is mainly to align the
      * behavior of `ZipFileSystemProvider`, so ShardingSphere need to manually open and close the FileSystem
      * corresponding to the `resource:/` scheme. For more background reference <a href="https://github.com/oracle/graal/issues/7682">oracle/graal#7682</a>.
-     * <p/>
-     * ShardingSphere use the System Property of `org.graalvm.nativeimage.imagecode` to identify whether this class is in the
-     * GraalVM Native Image environment. The background of this property comes from
-     * <a href="https://junit.org/junit5/docs/5.10.0/api/org.junit.jupiter.api/org/junit/jupiter/api/condition/DisabledInNativeImage.html">Annotation Interface DisabledInNativeImage</a>.
      *
      * @param url  url
      * @param type type of JDBC repository SQL
@@ -101,7 +98,7 @@ public final class JDBCRepositorySQLLoader {
      * @see sun.nio.fs.UnixFileSystemProvider
      */
     private static JDBCRepositorySQL loadFromDirectory(final URL url, final String type) throws URISyntaxException, IOException {
-        if (null == System.getProperty("org.graalvm.nativeimage.imagecode") || !"runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))) {
+        if (GroovyUtils.isNotRuntimeInGraalVMNativeImage()) {
             return loadFromDirectoryLegacy(url, type);
         } else {
             try (FileSystem ignored = FileSystems.newFileSystem(URI.create("resource:/"), Collections.emptyMap())) {


### PR DESCRIPTION
For #21347.

Changes proposed in this pull request:
  - Prevent ReadwriteSplitting rule class from parsing Groovy syntax under GraalVM Native Image. According to #21347, we need to block calls to GroovyShell related classes under GraalVM Native Image.
  - This PR brings out a magical hidden feature. In ReadwriteSplitting, `<data_source_name>`, `<data_source_name>.write_data_source_name` and `<data_source_name>.read_data_source_names` are allowed to be configured through Groovy Expressions. No matter in the Example module, the unit tests do not reflect this, and the documentation does not mention it. It looks like the relevant unit test was removed in a past commit.
  - Also for #29000 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
