### PR TITLE
Fixed the problem of broadcast table execution error when readwrite_splitting rule exist

### DIFF
--- a/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/route/BroadcastSQLRouter.java
+++ b/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/route/BroadcastSQLRouter.java
@@ -143,7 +143,7 @@ public final class BroadcastSQLRouter implements SQLRouter<BroadcastRule> {
     
     private void routeToAllDatabaseInstance(final RouteContext routeContext, final ShardingSphereDatabase database, final BroadcastRule broadcastRule) {
         routeContext.getRouteUnits().clear();
-        for (String each : broadcastRule.getAvailableDataSourceNames()) {
+        for (String each : broadcastRule.getDataSourceNames()) {
             if (database.getResourceMetaData().getAllInstanceDataSourceNames().contains(each)) {
                 routeContext.getRouteUnits().add(new RouteUnit(new RouteMapper(each, each), Collections.emptyList()));
             }
@@ -152,7 +152,7 @@ public final class BroadcastSQLRouter implements SQLRouter<BroadcastRule> {
     
     private void routeToAllDatabase(final RouteContext routeContext, final BroadcastRule broadcastRule) {
         routeContext.getRouteUnits().clear();
-        for (String each : broadcastRule.getAvailableDataSourceNames()) {
+        for (String each : broadcastRule.getDataSourceNames()) {
             routeContext.getRouteUnits().add(new RouteUnit(new RouteMapper(each, each), Collections.emptyList()));
         }
     }

--- a/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/route/engine/type/broadcast/BroadcastDatabaseBroadcastRoutingEngine.java
+++ b/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/route/engine/type/broadcast/BroadcastDatabaseBroadcastRoutingEngine.java
@@ -32,7 +32,7 @@ public final class BroadcastDatabaseBroadcastRoutingEngine implements BroadcastR
     
     @Override
     public RouteContext route(final RouteContext routeContext, final BroadcastRule broadcastRule) {
-        for (String each : broadcastRule.getAvailableDataSourceNames()) {
+        for (String each : broadcastRule.getDataSourceNames()) {
             routeContext.getRouteUnits().add(new RouteUnit(new RouteMapper(each, each), Collections.emptyList()));
         }
         return routeContext;

--- a/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/route/engine/type/broadcast/BroadcastInstanceBroadcastRoutingEngine.java
+++ b/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/route/engine/type/broadcast/BroadcastInstanceBroadcastRoutingEngine.java
@@ -38,7 +38,7 @@ public class BroadcastInstanceBroadcastRoutingEngine implements BroadcastRouteEn
     @Override
     public RouteContext route(final RouteContext routeContext, final BroadcastRule broadcastRule) {
         RouteContext result = new RouteContext();
-        for (String each : broadcastRule.getAvailableDataSourceNames()) {
+        for (String each : broadcastRule.getDataSourceNames()) {
             if (resourceMetaData.getAllInstanceDataSourceNames().contains(each)) {
                 result.getRouteUnits().add(new RouteUnit(new RouteMapper(each, each), Collections.emptyList()));
             }

--- a/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/route/engine/type/broadcast/BroadcastTableBroadcastRoutingEngine.java
+++ b/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/route/engine/type/broadcast/BroadcastTableBroadcastRoutingEngine.java
@@ -49,7 +49,7 @@ public final class BroadcastTableBroadcastRoutingEngine implements BroadcastRout
     
     private RouteContext getRouteContext(final BroadcastRule broadcastRule) {
         RouteContext result = new RouteContext();
-        for (String each : broadcastRule.getAvailableDataSourceNames()) {
+        for (String each : broadcastRule.getDataSourceNames()) {
             result.getRouteUnits().add(new RouteUnit(new RouteMapper(each, each), Collections.singletonList(new RouteMapper("", ""))));
         }
         return result;
@@ -58,7 +58,7 @@ public final class BroadcastTableBroadcastRoutingEngine implements BroadcastRout
     private RouteContext getRouteContext(final BroadcastRule broadcastRule, final Collection<String> logicTableNames) {
         RouteContext result = new RouteContext();
         Collection<RouteMapper> tableRouteMappers = getTableRouteMappers(logicTableNames);
-        for (String each : broadcastRule.getAvailableDataSourceNames()) {
+        for (String each : broadcastRule.getDataSourceNames()) {
             RouteMapper dataSourceMapper = new RouteMapper(each, each);
             result.getRouteUnits().add(new RouteUnit(dataSourceMapper, tableRouteMappers));
         }

--- a/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/route/engine/type/unicast/BroadcastUnicastRoutingEngine.java
+++ b/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/route/engine/type/unicast/BroadcastUnicastRoutingEngine.java
@@ -50,7 +50,7 @@ public final class BroadcastUnicastRoutingEngine implements BroadcastRouteEngine
     
     @Override
     public RouteContext route(final RouteContext routeContext, final BroadcastRule broadcastRule) {
-        RouteMapper dataSourceMapper = getDataSourceRouteMapper(broadcastRule.getAvailableDataSourceNames());
+        RouteMapper dataSourceMapper = getDataSourceRouteMapper(broadcastRule.getDataSourceNames());
         routeContext.getRouteUnits().add(new RouteUnit(dataSourceMapper, createTableRouteMappers()));
         return routeContext;
     }

--- a/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/rule/BroadcastRule.java
+++ b/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/rule/BroadcastRule.java
@@ -65,29 +65,29 @@ public final class BroadcastRule implements DatabaseRule, DataNodeContainedRule,
         tableDataNodes = createShardingTableDataNodes(dataSourceNames, tables);
     }
     
-    private Collection<String> getAggregatedDataSourceNames(final Map<String, DataSource> dataSourceMap, final Collection<ShardingSphereRule> builtRules) {
-        Collection<String> result = new LinkedList<>();
+    private Collection<String> getAggregatedDataSourceNames(final Map<String, DataSource> dataSources, final Collection<ShardingSphereRule> builtRules) {
+        Collection<String> result = new LinkedList<>(dataSources.keySet());
         for (ShardingSphereRule each : builtRules) {
             if (each instanceof DataSourceContainedRule) {
-                result = getAggregatedDataSourceNames(dataSourceMap, (DataSourceContainedRule) each);
+                result = getAggregatedDataSourceNames(result, (DataSourceContainedRule) each);
             }
         }
         return result;
     }
     
-    private Collection<String> getAggregatedDataSourceNames(final Map<String, DataSource> dataSourceMap, final DataSourceContainedRule builtRule) {
+    private Collection<String> getAggregatedDataSourceNames(final Collection<String> dataSourceNames, final DataSourceContainedRule builtRule) {
         Collection<String> result = new LinkedList<>();
         for (Entry<String, Collection<String>> entry : builtRule.getDataSourceMapper().entrySet()) {
             for (String each : entry.getValue()) {
-                if (dataSourceMap.containsKey(each)) {
-                    dataSourceMap.remove(each);
+                if (dataSourceNames.contains(each)) {
+                    dataSourceNames.remove(each);
                     if (!result.contains(entry.getKey())) {
                         result.add(entry.getKey());
                     }
                 }
             }
         }
-        result.addAll(dataSourceMap.keySet());
+        result.addAll(dataSourceNames);
         return result;
     }
     

--- a/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/rule/builder/BroadcastRuleBuilder.java
+++ b/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/rule/builder/BroadcastRuleBuilder.java
@@ -37,7 +37,7 @@ public final class BroadcastRuleBuilder implements DatabaseRuleBuilder<Broadcast
     @Override
     public BroadcastRule build(final BroadcastRuleConfiguration config, final String databaseName, final DatabaseType protocolType,
                                final Map<String, DataSource> dataSources, final Collection<ShardingSphereRule> builtRules, final InstanceContext instanceContext) {
-        return new BroadcastRule(config, databaseName, dataSources);
+        return new BroadcastRule(config, databaseName, dataSources, builtRules);
     }
     
     @Override

--- a/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/route/engine/type/broadcast/BroadcastDatabaseBroadcastRoutingEngineTest.java
+++ b/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/route/engine/type/broadcast/BroadcastDatabaseBroadcastRoutingEngineTest.java
@@ -35,7 +35,7 @@ class BroadcastDatabaseBroadcastRoutingEngineTest {
     @Test
     void assertRoute() {
         BroadcastRule broadcastRule = mock(BroadcastRule.class);
-        when(broadcastRule.getAvailableDataSourceNames()).thenReturn(Arrays.asList("ds_0", "ds_1"));
+        when(broadcastRule.getDataSourceNames()).thenReturn(Arrays.asList("ds_0", "ds_1"));
         BroadcastDatabaseBroadcastRoutingEngine engine = new BroadcastDatabaseBroadcastRoutingEngine();
         RouteContext routeContext = engine.route(new RouteContext(), broadcastRule);
         assertThat(routeContext.getRouteUnits().size(), is(2));

--- a/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/route/engine/type/broadcast/BroadcastInstanceBroadcastRoutingEngineTest.java
+++ b/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/route/engine/type/broadcast/BroadcastInstanceBroadcastRoutingEngineTest.java
@@ -39,7 +39,7 @@ class BroadcastInstanceBroadcastRoutingEngineTest {
         when(resourceMetaData.getAllInstanceDataSourceNames()).thenReturn(Collections.singleton("ds_0"));
         BroadcastInstanceBroadcastRoutingEngine engine = new BroadcastInstanceBroadcastRoutingEngine(resourceMetaData);
         BroadcastRule broadcastRule = mock(BroadcastRule.class);
-        when(broadcastRule.getAvailableDataSourceNames()).thenReturn(Arrays.asList("ds_0", "ds_1"));
+        when(broadcastRule.getDataSourceNames()).thenReturn(Arrays.asList("ds_0", "ds_1"));
         RouteContext routeContext = engine.route(new RouteContext(), broadcastRule);
         assertThat(routeContext.getRouteUnits().size(), is(1));
         assertDataSourceRouteMapper(routeContext.getRouteUnits().iterator().next(), "ds_0");

--- a/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/route/engine/type/broadcast/BroadcastTableBroadcastRoutingEngineTest.java
+++ b/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/route/engine/type/broadcast/BroadcastTableBroadcastRoutingEngineTest.java
@@ -41,7 +41,7 @@ class BroadcastTableBroadcastRoutingEngineTest {
         Collection<String> broadcastRuleTableNames = Collections.singleton("t_address");
         BroadcastTableBroadcastRoutingEngine engine = new BroadcastTableBroadcastRoutingEngine(broadcastRuleTableNames);
         BroadcastRule broadcastRule = mock(BroadcastRule.class);
-        when(broadcastRule.getAvailableDataSourceNames()).thenReturn(Arrays.asList("ds_0", "ds_1"));
+        when(broadcastRule.getDataSourceNames()).thenReturn(Arrays.asList("ds_0", "ds_1"));
         when(broadcastRule.getBroadcastRuleTableNames(any())).thenReturn(Collections.singleton("t_address"));
         RouteContext routeContext = engine.route(new RouteContext(), broadcastRule);
         assertThat(routeContext.getRouteUnits().size(), is(2));
@@ -55,7 +55,7 @@ class BroadcastTableBroadcastRoutingEngineTest {
         Collection<String> broadcastRuleTableNames = Collections.singleton("t_address");
         BroadcastTableBroadcastRoutingEngine engine = new BroadcastTableBroadcastRoutingEngine(broadcastRuleTableNames);
         BroadcastRule broadcastRule = mock(BroadcastRule.class);
-        when(broadcastRule.getAvailableDataSourceNames()).thenReturn(Arrays.asList("ds_0", "ds_1"));
+        when(broadcastRule.getDataSourceNames()).thenReturn(Arrays.asList("ds_0", "ds_1"));
         when(broadcastRule.getBroadcastRuleTableNames(any())).thenReturn(Collections.emptyList());
         RouteContext routeContext = engine.route(new RouteContext(), broadcastRule);
         assertThat(routeContext.getRouteUnits().size(), is(2));

--- a/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/route/engine/type/unicast/BroadcastUnicastRoutingEngineTest.java
+++ b/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/route/engine/type/unicast/BroadcastUnicastRoutingEngineTest.java
@@ -42,7 +42,7 @@ class BroadcastUnicastRoutingEngineTest {
     @BeforeEach
     void setUp() {
         broadcastRule = mock(BroadcastRule.class);
-        when(broadcastRule.getAvailableDataSourceNames()).thenReturn(Arrays.asList("ds_0", "ds_1"));
+        when(broadcastRule.getDataSourceNames()).thenReturn(Arrays.asList("ds_0", "ds_1"));
     }
     
     @Test

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/util/YamlDatabaseConfigurationImportExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/util/YamlDatabaseConfigurationImportExecutor.java
@@ -286,7 +286,8 @@ public final class YamlDatabaseConfigurationImportExecutor {
         allRuleConfigs.add(broadcastRuleConfig);
         database.getRuleMetaData().getRules().add(new BroadcastRule(broadcastRuleConfig, database.getName(),
                 database.getResourceMetaData().getStorageUnits().entrySet().stream()
-                        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().getDataSource(), (oldValue, currentValue) -> oldValue, LinkedHashMap::new))));
+                        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().getDataSource(), (oldValue, currentValue) -> oldValue, LinkedHashMap::new)),
+                database.getRuleMetaData().getRules()));
     }
     
     private void addSingleRuleConfiguration(final SingleRuleConfiguration singleRuleConfig, final Collection<RuleConfiguration> allRuleConfigs, final ShardingSphereDatabase database) {


### PR DESCRIPTION
Fixes #28928.

Changes proposed in this pull request:
  - Fixed the problem of broadcast table execution error when readwrite_splitting rule exist

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
