### PR TITLE
Add check the storage unit is not empty when create broadcast table rule

### DIFF
--- a/features/broadcast/distsql/handler/src/main/java/org/apache/shardingsphere/broadcast/distsql/handler/update/CreateBroadcastTableRuleStatementUpdater.java
+++ b/features/broadcast/distsql/handler/src/main/java/org/apache/shardingsphere/broadcast/distsql/handler/update/CreateBroadcastTableRuleStatementUpdater.java
@@ -20,9 +20,10 @@ package org.apache.shardingsphere.broadcast.distsql.handler.update;
 import org.apache.shardingsphere.broadcast.api.config.BroadcastRuleConfiguration;
 import org.apache.shardingsphere.broadcast.distsql.statement.CreateBroadcastTableRuleStatement;
 import org.apache.shardingsphere.distsql.handler.exception.rule.DuplicateRuleException;
+import org.apache.shardingsphere.distsql.handler.exception.storageunit.EmptyStorageUnitException;
 import org.apache.shardingsphere.distsql.handler.update.RuleDefinitionCreateUpdater;
-import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -34,6 +35,7 @@ public final class CreateBroadcastTableRuleStatementUpdater implements RuleDefin
     
     @Override
     public void checkSQLStatement(final ShardingSphereDatabase database, final CreateBroadcastTableRuleStatement sqlStatement, final BroadcastRuleConfiguration currentRuleConfig) {
+        ShardingSpherePreconditions.checkState(!database.getResourceMetaData().getStorageUnits().isEmpty(), () -> new EmptyStorageUnitException(database.getName()));
         if (!sqlStatement.isIfNotExists()) {
             checkDuplicate(sqlStatement, currentRuleConfig);
         }

--- a/features/broadcast/distsql/handler/src/test/java/org/apache/shardingsphere/broadcast/distsql/handler/update/CreateBroadcastTableRuleStatementUpdaterTest.java
+++ b/features/broadcast/distsql/handler/src/test/java/org/apache/shardingsphere/broadcast/distsql/handler/update/CreateBroadcastTableRuleStatementUpdaterTest.java
@@ -20,7 +20,9 @@ package org.apache.shardingsphere.broadcast.distsql.handler.update;
 import org.apache.shardingsphere.broadcast.api.config.BroadcastRuleConfiguration;
 import org.apache.shardingsphere.broadcast.distsql.statement.CreateBroadcastTableRuleStatement;
 import org.apache.shardingsphere.distsql.handler.exception.rule.DuplicateRuleException;
+import org.apache.shardingsphere.distsql.handler.exception.storageunit.EmptyStorageUnitException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -29,6 +31,7 @@ import java.util.LinkedList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,18 +44,34 @@ class CreateBroadcastTableRuleStatementUpdaterTest {
         BroadcastRuleConfiguration currentConfig = mock(BroadcastRuleConfiguration.class);
         when(currentConfig.getTables()).thenReturn(Collections.singleton("t_address"));
         CreateBroadcastTableRuleStatement statement = new CreateBroadcastTableRuleStatement(false, Collections.singleton("t_address"));
-        assertThrows(DuplicateRuleException.class, () -> updater.checkSQLStatement(mock(ShardingSphereDatabase.class), statement, currentConfig));
+        assertThrows(DuplicateRuleException.class, () -> updater.checkSQLStatement(mockShardingSphereDatabase(), statement, currentConfig));
     }
     
     @Test
     void assertBuildToBeCreatedRuleConfiguration() {
         BroadcastRuleConfiguration currentConfig = new BroadcastRuleConfiguration(new LinkedList<>());
         CreateBroadcastTableRuleStatement statement = new CreateBroadcastTableRuleStatement(false, Collections.singleton("t_address"));
-        updater.checkSQLStatement(mock(ShardingSphereDatabase.class), statement, currentConfig);
+        updater.checkSQLStatement(mockShardingSphereDatabase(), statement, currentConfig);
         BroadcastRuleConfiguration toBeCreatedRuleConfig = updater.buildToBeCreatedRuleConfiguration(currentConfig, statement);
         updater.updateCurrentRuleConfiguration(currentConfig, toBeCreatedRuleConfig);
         assertThat(currentConfig.getTables().size(), is(1));
         assertThat(currentConfig.getTables().iterator().next(), is("t_address"));
         updater.updateCurrentRuleConfiguration(currentConfig, toBeCreatedRuleConfig);
+    }
+    
+    private ShardingSphereDatabase mockShardingSphereDatabase() {
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        when(database.getResourceMetaData().getStorageUnits()).thenReturn(Collections.singletonMap("ds_0", mock(StorageUnit.class)));
+        return database;
+    }
+    
+    @Test
+    void assertCreatedRuleConfigurationWithNoStorageUnits() {
+        BroadcastRuleConfiguration currentConfig = mock(BroadcastRuleConfiguration.class);
+        when(currentConfig.getTables()).thenReturn(Collections.singleton("t_address"));
+        CreateBroadcastTableRuleStatement statement = new CreateBroadcastTableRuleStatement(false, Collections.singleton("t_address"));
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        when(database.getResourceMetaData().getStorageUnits()).thenReturn(Collections.emptyMap());
+        assertThrows(EmptyStorageUnitException.class, () -> updater.checkSQLStatement(database, statement, currentConfig));
     }
 }

--- a/features/broadcast/distsql/handler/src/test/java/org/apache/shardingsphere/broadcast/distsql/handler/update/CreateBroadcastTableRuleStatementUpdaterTest.java
+++ b/features/broadcast/distsql/handler/src/test/java/org/apache/shardingsphere/broadcast/distsql/handler/update/CreateBroadcastTableRuleStatementUpdaterTest.java
@@ -40,7 +40,7 @@ class CreateBroadcastTableRuleStatementUpdaterTest {
     private final CreateBroadcastTableRuleStatementUpdater updater = new CreateBroadcastTableRuleStatementUpdater();
     
     @Test
-    void assertCreatedRuleConfigurationWithNoStorageUnits() {
+    void assertCheckSQLStatementWithEmptyStorageUnit() {
         BroadcastRuleConfiguration currentConfig = mock(BroadcastRuleConfiguration.class);
         when(currentConfig.getTables()).thenReturn(Collections.singleton("t_address"));
         CreateBroadcastTableRuleStatement statement = new CreateBroadcastTableRuleStatement(false, Collections.singleton("t_address"));

--- a/features/broadcast/distsql/handler/src/test/java/org/apache/shardingsphere/broadcast/distsql/handler/update/CreateBroadcastTableRuleStatementUpdaterTest.java
+++ b/features/broadcast/distsql/handler/src/test/java/org/apache/shardingsphere/broadcast/distsql/handler/update/CreateBroadcastTableRuleStatementUpdaterTest.java
@@ -40,6 +40,16 @@ class CreateBroadcastTableRuleStatementUpdaterTest {
     private final CreateBroadcastTableRuleStatementUpdater updater = new CreateBroadcastTableRuleStatementUpdater();
     
     @Test
+    void assertCreatedRuleConfigurationWithNoStorageUnits() {
+        BroadcastRuleConfiguration currentConfig = mock(BroadcastRuleConfiguration.class);
+        when(currentConfig.getTables()).thenReturn(Collections.singleton("t_address"));
+        CreateBroadcastTableRuleStatement statement = new CreateBroadcastTableRuleStatement(false, Collections.singleton("t_address"));
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        when(database.getResourceMetaData().getStorageUnits()).thenReturn(Collections.emptyMap());
+        assertThrows(EmptyStorageUnitException.class, () -> updater.checkSQLStatement(database, statement, currentConfig));
+    }
+    
+    @Test
     void assertCheckSQLStatementWithDuplicateBroadcastRule() {
         BroadcastRuleConfiguration currentConfig = mock(BroadcastRuleConfiguration.class);
         when(currentConfig.getTables()).thenReturn(Collections.singleton("t_address"));
@@ -63,15 +73,5 @@ class CreateBroadcastTableRuleStatementUpdaterTest {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getResourceMetaData().getStorageUnits()).thenReturn(Collections.singletonMap("ds_0", mock(StorageUnit.class)));
         return database;
-    }
-    
-    @Test
-    void assertCreatedRuleConfigurationWithNoStorageUnits() {
-        BroadcastRuleConfiguration currentConfig = mock(BroadcastRuleConfiguration.class);
-        when(currentConfig.getTables()).thenReturn(Collections.singleton("t_address"));
-        CreateBroadcastTableRuleStatement statement = new CreateBroadcastTableRuleStatement(false, Collections.singleton("t_address"));
-        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
-        when(database.getResourceMetaData().getStorageUnits()).thenReturn(Collections.emptyMap());
-        assertThrows(EmptyStorageUnitException.class, () -> updater.checkSQLStatement(database, statement, currentConfig));
     }
 }


### PR DESCRIPTION
Fixes #29027.

Changes proposed in this pull request:
  - Add check the storage unit is not empty when create broadcast table rule

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
