### PR TITLE
Declare in the document that ReadWriteSplitting Config is parsed by GroovyShell by default and adds corresponding unit tests

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/readwrite-splitting.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/readwrite-splitting.cn.md
@@ -15,9 +15,9 @@ weight = 3
 rules:
 - !READWRITE_SPLITTING
   dataSources:
-    <data_source_name> (+): # 读写分离逻辑数据源名称
-       write_data_source_name: # 写库数据源名称
-       read_data_source_names: # 读库数据源名称，多个从数据源用逗号分隔
+    <data_source_name> (+): # 读写分离逻辑数据源名称，默认使用 Groovy 的行表达式 SPI 实现来解析
+       write_data_source_name: # 写库数据源名称，默认使用 Groovy 的行表达式 SPI 实现来解析
+       read_data_source_names: # 读库数据源名称，多个从数据源用逗号分隔，默认使用 Groovy 的行表达式 SPI 实现来解析
        transactionalReadQueryStrategy (?): # 事务内读请求的路由策略，可选值：PRIMARY（路由至主库）、FIXED（同一事务内路由至固定数据源）、DYNAMIC（同一事务内路由至非固定数据源）。默认值：DYNAMIC
        loadBalancerName: # 负载均衡算法名称
   

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/readwrite-splitting.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/readwrite-splitting.en.md
@@ -14,9 +14,9 @@ Read/write splitting YAML configuration is highly readable. The YAML format enab
 rules:
 - !READWRITE_SPLITTING
   dataSources:
-    <data_source_name> (+): # Logic data source name of readwrite-splitting
-      write_data_source_name: # Write data source name
-      read_data_source_names: # Read data source names, multiple data source names separated with comma
+    <data_source_name> (+): # Logic data source name of readwrite-splitting, which uses Groovy's Row Value Expressions SPI implementation to parse by default
+      write_data_source_name: # Write data source name, which uses Groovy's Row Value Expressions SPI implementation to parse by default
+      read_data_source_names: # Read data source names, multiple data source names separated with comma, which uses Groovy's Row Value Expressions SPI implementation to parse by default
       transactionalReadQueryStrategy (?): # Routing strategy for read query within a transaction, values include: PRIMARY (to primary), FIXED (to fixed data source), DYNAMIC (to any data source), default value: DYNAMIC
       loadBalancerName: # Load balance algorithm name
   


### PR DESCRIPTION
For #29000.

Changes proposed in this pull request:
  - Declare in the document that ReadWriteSplitting Config is parsed by GroovyShell by default and adds corresponding unit tests.
  - Also for #21347 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
