### PR TITLE
Move key generate rewrite logic to infra module for reuse

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/parameter/ShardingParameterRewriterBuilder.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/parameter/ShardingParameterRewriterBuilder.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.infra.rewrite.parameter.rewriter.ParameterRewri
 import org.apache.shardingsphere.infra.rewrite.sql.token.generator.aware.RouteContextAware;
 import org.apache.shardingsphere.infra.rewrite.sql.token.generator.aware.SchemaMetaDataAware;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
-import org.apache.shardingsphere.sharding.rewrite.parameter.impl.ShardingGeneratedKeyInsertValueParameterRewriter;
+import org.apache.shardingsphere.infra.rewrite.parameter.rewriter.keygen.GeneratedKeyInsertValueParameterRewriter;
 import org.apache.shardingsphere.sharding.rewrite.parameter.impl.ShardingPaginationParameterRewriter;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sharding.rule.aware.ShardingRuleAware;
@@ -51,7 +51,7 @@ public final class ShardingParameterRewriterBuilder implements ParameterRewriter
     @Override
     public Collection<ParameterRewriter> getParameterRewriters() {
         Collection<ParameterRewriter> result = new LinkedList<>();
-        addParameterRewriter(result, new ShardingGeneratedKeyInsertValueParameterRewriter());
+        addParameterRewriter(result, new GeneratedKeyInsertValueParameterRewriter());
         addParameterRewriter(result, new ShardingPaginationParameterRewriter());
         return result;
     }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/ShardingTokenGenerateBuilder.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/ShardingTokenGenerateBuilder.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.pojo;
+package org.apache.shardingsphere.sharding.rewrite.token;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/ShardingTokenGenerateBuilder.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/ShardingTokenGenerateBuilder.java
@@ -37,10 +37,10 @@ import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.RowCountT
 import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.ShardingInsertValuesTokenGenerator;
 import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.ShardingRemoveTokenGenerator;
 import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.TableTokenGenerator;
-import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen.GeneratedKeyAssignmentTokenGenerator;
-import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen.GeneratedKeyForUseDefaultInsertColumnsTokenGenerator;
-import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen.GeneratedKeyInsertColumnTokenGenerator;
-import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen.GeneratedKeyInsertValuesTokenGenerator;
+import org.apache.shardingsphere.infra.rewrite.token.generator.keygen.GeneratedKeyAssignmentTokenGenerator;
+import org.apache.shardingsphere.infra.rewrite.token.generator.keygen.GeneratedKeyForUseDefaultInsertColumnsTokenGenerator;
+import org.apache.shardingsphere.infra.rewrite.token.generator.keygen.GeneratedKeyInsertColumnTokenGenerator;
+import org.apache.shardingsphere.infra.rewrite.token.generator.keygen.GeneratedKeyInsertValuesTokenGenerator;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sharding.rule.aware.ShardingRuleAware;
 

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/ShardingTokenGenerateBuilderTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/ShardingTokenGenerateBuilderTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.pojo;
+package org.apache.shardingsphere.sharding.rewrite.token;
 
 import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.generator.SQLTokenGenerator;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/AggregationDistinctTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/AggregationDistinctTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.sharding.rewrite.token.generator;
 
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.AggregationDistinctProjection;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/ConstraintTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/ConstraintTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.sharding.rewrite.token.generator;
 
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.AlterTableStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.CreateDatabaseStatementContext;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/CursorTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/CursorTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.sharding.rewrite.token.generator;
 
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.CloseStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.CursorStatementContext;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/DistinctProjectionPrefixTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/DistinctProjectionPrefixTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.sharding.rewrite.token.generator;
 
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.AggregationDistinctProjection;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.CreateDatabaseStatementContext;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/IndexTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/IndexTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.sharding.rewrite.token.generator;
 
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.AlterIndexStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.CreateDatabaseStatementContext;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/OffsetTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/OffsetTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.sharding.rewrite.token.generator;
 
 import org.apache.shardingsphere.infra.binder.context.segment.select.pagination.PaginationContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/OrderByTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/OrderByTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.sharding.rewrite.token.generator;
 
 import org.apache.shardingsphere.infra.binder.context.segment.select.orderby.OrderByItem;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/ProjectionsTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/ProjectionsTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.sharding.rewrite.token.generator;
 
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.AggregationDistinctProjection;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/RowCountTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/RowCountTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.sharding.rewrite.token.generator;
 
 import org.apache.shardingsphere.infra.binder.context.segment.select.pagination.PaginationContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/ShardingInsertValuesTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/ShardingInsertValuesTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.sharding.rewrite.token.generator;
 
 import org.apache.shardingsphere.infra.binder.context.segment.insert.values.InsertValueContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/ShardingRemoveTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/ShardingRemoveTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.sharding.rewrite.token.generator;
 
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/TableTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/TableTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.sharding.rewrite.token.generator;
 
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.CreateDatabaseStatementContext;

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/parameter/rewriter/keygen/GeneratedKeyInsertValueParameterRewriter.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/parameter/rewriter/keygen/GeneratedKeyInsertValueParameterRewriter.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.parameter.impl;
+package org.apache.shardingsphere.infra.rewrite.parameter.rewriter.keygen;
 
 import lombok.Setter;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
@@ -30,10 +30,10 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * Sharding generated key insert value parameter rewriter.
+ * Generated key insert value parameter rewriter.
  */
 @Setter
-public final class ShardingGeneratedKeyInsertValueParameterRewriter implements ParameterRewriter {
+public final class GeneratedKeyInsertValueParameterRewriter implements ParameterRewriter {
     
     @Override
     public boolean isNeedRewrite(final SQLStatementContext sqlStatementContext) {

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/BaseGeneratedKeyTokenGenerator.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/BaseGeneratedKeyTokenGenerator.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen;
+package org.apache.shardingsphere.infra.rewrite.token.generator.keygen;
 
 import org.apache.shardingsphere.infra.rewrite.sql.token.generator.OptionalSQLTokenGenerator;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyAssignmentTokenGenerator.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyAssignmentTokenGenerator.java
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen;
+package org.apache.shardingsphere.infra.rewrite.token.generator.keygen;
 
 import com.google.common.base.Preconditions;
 import lombok.Setter;
 import org.apache.shardingsphere.infra.rewrite.sql.token.generator.aware.ParametersAware;
-import org.apache.shardingsphere.sharding.rewrite.token.pojo.GeneratedKeyAssignmentToken;
-import org.apache.shardingsphere.sharding.rewrite.token.pojo.LiteralGeneratedKeyAssignmentToken;
-import org.apache.shardingsphere.sharding.rewrite.token.pojo.ParameterMarkerGeneratedKeyAssignmentToken;
+import org.apache.shardingsphere.infra.rewrite.token.pojo.keygen.GeneratedKeyAssignmentToken;
+import org.apache.shardingsphere.infra.rewrite.token.pojo.keygen.LiteralGeneratedKeyAssignmentToken;
+import org.apache.shardingsphere.infra.rewrite.token.pojo.keygen.ParameterMarkerGeneratedKeyAssignmentToken;
 import org.apache.shardingsphere.infra.binder.context.segment.insert.keygen.GeneratedKeyContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.InsertStatement;

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyForUseDefaultInsertColumnsTokenGenerator.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyForUseDefaultInsertColumnsTokenGenerator.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen;
+package org.apache.shardingsphere.infra.rewrite.token.generator.keygen;
 
 import com.google.common.base.Preconditions;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.UseDefaultInsertColumnsToken;

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyInsertColumnTokenGenerator.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyInsertColumnTokenGenerator.java
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen;
+package org.apache.shardingsphere.infra.rewrite.token.generator.keygen;
 
 import com.google.common.base.Preconditions;
-import org.apache.shardingsphere.sharding.rewrite.token.pojo.GeneratedKeyInsertColumnToken;
+import org.apache.shardingsphere.infra.rewrite.token.pojo.keygen.GeneratedKeyInsertColumnToken;
 import org.apache.shardingsphere.infra.binder.context.segment.insert.keygen.GeneratedKeyContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.InsertColumnsSegment;

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyInsertValuesTokenGenerator.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyInsertValuesTokenGenerator.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen;
+package org.apache.shardingsphere.infra.rewrite.token.generator.keygen;
 
 import com.google.common.base.Preconditions;
 import lombok.Setter;

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/pojo/keygen/GeneratedKeyAssignmentToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/pojo/keygen/GeneratedKeyAssignmentToken.java
@@ -15,19 +15,27 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.pojo;
+package org.apache.shardingsphere.infra.rewrite.token.pojo.keygen;
+
+import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.Attachable;
+import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;
 
 /**
- * Generated key assignment token for parameter marker.
+ * Generated key assignment token.
  */
-public final class ParameterMarkerGeneratedKeyAssignmentToken extends GeneratedKeyAssignmentToken {
+public abstract class GeneratedKeyAssignmentToken extends SQLToken implements Attachable {
     
-    public ParameterMarkerGeneratedKeyAssignmentToken(final int startIndex, final String columnName) {
-        super(startIndex, columnName);
+    private final String columnName;
+    
+    protected GeneratedKeyAssignmentToken(final int startIndex, final String columnName) {
+        super(startIndex);
+        this.columnName = columnName;
     }
     
     @Override
-    protected String getRightValue() {
-        return "?";
+    public final String toString() {
+        return ", " + columnName + " = " + getRightValue();
     }
+    
+    protected abstract String getRightValue();
 }

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/pojo/keygen/GeneratedKeyInsertColumnToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/pojo/keygen/GeneratedKeyInsertColumnToken.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.pojo;
+package org.apache.shardingsphere.infra.rewrite.token.pojo.keygen;
 
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.Attachable;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/pojo/keygen/LiteralGeneratedKeyAssignmentToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/pojo/keygen/LiteralGeneratedKeyAssignmentToken.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.pojo;
+package org.apache.shardingsphere.infra.rewrite.token.pojo.keygen;
 
 /**
  * Generated key assignment token for literal.

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/pojo/keygen/ParameterMarkerGeneratedKeyAssignmentToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/token/pojo/keygen/ParameterMarkerGeneratedKeyAssignmentToken.java
@@ -15,27 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.pojo;
-
-import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.Attachable;
-import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;
+package org.apache.shardingsphere.infra.rewrite.token.pojo.keygen;
 
 /**
- * Generated key assignment token.
+ * Generated key assignment token for parameter marker.
  */
-public abstract class GeneratedKeyAssignmentToken extends SQLToken implements Attachable {
+public final class ParameterMarkerGeneratedKeyAssignmentToken extends GeneratedKeyAssignmentToken {
     
-    private final String columnName;
-    
-    protected GeneratedKeyAssignmentToken(final int startIndex, final String columnName) {
-        super(startIndex);
-        this.columnName = columnName;
+    public ParameterMarkerGeneratedKeyAssignmentToken(final int startIndex, final String columnName) {
+        super(startIndex, columnName);
     }
     
     @Override
-    public final String toString() {
-        return ", " + columnName + " = " + getRightValue();
+    protected String getRightValue() {
+        return "?";
     }
-    
-    protected abstract String getRightValue();
 }

--- a/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/parameter/rewriter/keygen/GeneratedKeyInsertValueParameterRewriterTest.java
+++ b/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/parameter/rewriter/keygen/GeneratedKeyInsertValueParameterRewriterTest.java
@@ -15,14 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.parameter;
+package org.apache.shardingsphere.infra.rewrite.parameter.rewriter.keygen;
 
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.rewrite.parameter.builder.ParameterBuilder;
 import org.apache.shardingsphere.infra.rewrite.parameter.builder.impl.GroupedParameterBuilder;
 import org.apache.shardingsphere.infra.rewrite.parameter.builder.impl.StandardParameterBuilder;
-import org.apache.shardingsphere.sharding.rewrite.parameter.impl.ShardingGeneratedKeyInsertValueParameterRewriter;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
@@ -42,7 +41,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class ShardingGeneratedKeyInsertValueParameterRewriterTest {
+class GeneratedKeyInsertValueParameterRewriterTest {
     
     private static final int TEST_PARAMETER_COUNT = 3;
     
@@ -50,7 +49,7 @@ class ShardingGeneratedKeyInsertValueParameterRewriterTest {
     
     @Test
     void assertIsNeedRewrite() {
-        ShardingGeneratedKeyInsertValueParameterRewriter paramRewriter = new ShardingGeneratedKeyInsertValueParameterRewriter();
+        GeneratedKeyInsertValueParameterRewriter paramRewriter = new GeneratedKeyInsertValueParameterRewriter();
         SelectStatementContext selectStatementContext = mock(SelectStatementContext.class);
         assertFalse(paramRewriter.isNeedRewrite(selectStatementContext));
         InsertStatementContext insertStatementContext = mock(InsertStatementContext.class, RETURNS_DEEP_STUBS);
@@ -68,7 +67,7 @@ class ShardingGeneratedKeyInsertValueParameterRewriterTest {
     void assertRewrite() {
         InsertStatementContext insertStatementContext = getInsertStatementContext();
         ParameterBuilder groupedParamBuilder = getParameterBuilder();
-        ShardingGeneratedKeyInsertValueParameterRewriter paramRewriter = new ShardingGeneratedKeyInsertValueParameterRewriter();
+        GeneratedKeyInsertValueParameterRewriter paramRewriter = new GeneratedKeyInsertValueParameterRewriter();
         paramRewriter.rewrite(groupedParamBuilder, insertStatementContext, null);
         assertThat(((GroupedParameterBuilder) groupedParamBuilder).getParameterBuilders().get(0).getAddedIndexAndParameters().get(TEST_PARAMETER_COUNT), hasItem(TEST_GENERATED_VALUE));
     }

--- a/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyAssignmentTokenGeneratorTest.java
+++ b/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyAssignmentTokenGeneratorTest.java
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.infra.rewrite.token.generator.keygen;
 
 import org.apache.shardingsphere.infra.binder.context.segment.insert.keygen.GeneratedKeyContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;
-import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen.GeneratedKeyAssignmentTokenGenerator;
-import org.apache.shardingsphere.sharding.rewrite.token.pojo.LiteralGeneratedKeyAssignmentToken;
-import org.apache.shardingsphere.sharding.rewrite.token.pojo.ParameterMarkerGeneratedKeyAssignmentToken;
+import org.apache.shardingsphere.infra.rewrite.token.pojo.keygen.LiteralGeneratedKeyAssignmentToken;
+import org.apache.shardingsphere.infra.rewrite.token.pojo.keygen.ParameterMarkerGeneratedKeyAssignmentToken;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.assignment.SetAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLInsertStatement;
 import org.junit.jupiter.api.Test;

--- a/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyForUseDefaultInsertColumnsTokenGeneratorTest.java
+++ b/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyForUseDefaultInsertColumnsTokenGeneratorTest.java
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.infra.rewrite.token.generator.keygen;
 
 import org.apache.shardingsphere.infra.binder.context.segment.insert.keygen.GeneratedKeyContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;
-import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen.GeneratedKeyForUseDefaultInsertColumnsTokenGenerator;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.InsertColumnsSegment;
 import org.junit.jupiter.api.Test;
 

--- a/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyInsertColumnTokenGeneratorTest.java
+++ b/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyInsertColumnTokenGeneratorTest.java
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.infra.rewrite.token.generator.keygen;
 
 import org.apache.shardingsphere.infra.binder.context.segment.insert.keygen.GeneratedKeyContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;
-import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen.GeneratedKeyInsertColumnTokenGenerator;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.InsertColumnsSegment;
 import org.junit.jupiter.api.Test;
 

--- a/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyInsertValuesTokenGeneratorTest.java
+++ b/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/token/generator/keygen/GeneratedKeyInsertValuesTokenGeneratorTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token;
+package org.apache.shardingsphere.infra.rewrite.token.generator.keygen;
 
 import org.apache.shardingsphere.infra.binder.context.segment.insert.keygen.GeneratedKeyContext;
 import org.apache.shardingsphere.infra.binder.context.segment.insert.values.InsertValueContext;
@@ -25,7 +25,6 @@ import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatem
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.InsertValue;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.InsertValuesToken;
-import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.keygen.GeneratedKeyInsertValuesTokenGenerator;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/token/pojo/keygen/GeneratedKeyAssignmentTokenTest.java
+++ b/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/token/pojo/keygen/GeneratedKeyAssignmentTokenTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.pojo;
+package org.apache.shardingsphere.infra.rewrite.token.pojo.keygen;
 
 import org.junit.jupiter.api.Test;
 

--- a/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/token/pojo/keygen/GeneratedKeyInsertColumnTokenTest.java
+++ b/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/token/pojo/keygen/GeneratedKeyInsertColumnTokenTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.rewrite.token.pojo;
+package org.apache.shardingsphere.infra.rewrite.token.pojo.keygen;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Move key generate rewrite logic to infra module for reuse
  - Add sharding table check for ShardingSQLRewriteContextDecorator

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
