### PR TITLE
Remove `serverTimezone=UTC` parameter at MySQLConnectionPropertiesParser and E2E

### DIFF
--- a/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/connector/MySQLConnectionPropertiesParser.java
+++ b/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/connector/MySQLConnectionPropertiesParser.java
@@ -54,7 +54,6 @@ public final class MySQLConnectionPropertiesParser implements ConnectionProperti
         result.setProperty("netTimeoutForStreamingResults", "0");
         result.setProperty("tinyInt1isBit", Boolean.FALSE.toString());
         result.setProperty("useSSL", Boolean.FALSE.toString());
-        result.setProperty("serverTimezone", "UTC");
         result.setProperty("zeroDateTimeBehavior", "round");
         return result;
     }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/runtime/DataSourceEnvironment.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/runtime/DataSourceEnvironment.java
@@ -88,7 +88,7 @@ public final class DataSourceEnvironment {
             case "MySQL":
                 return String.format(
                         "jdbc:mysql://%s:%s/%s?useSSL=true&requireSSL=true&enabledTLSProtocols=TLSv1.2,TLSv1.3&verifyServerCertificate=false"
-                                + "&useServerPrepStmts=true&serverTimezone=UTC&useLocalSessionState=true&characterEncoding=utf-8&allowPublicKeyRetrieval=true",
+                                + "&useServerPrepStmts=true&useLocalSessionState=true&characterEncoding=utf-8&allowPublicKeyRetrieval=true",
                         host, port, dataSourceName);
             case "PostgreSQL":
                 return String.format("jdbc:postgresql://%s:%s/%s?ssl=on&sslmode=prefer", host, port, dataSourceName);


### PR DESCRIPTION
Because of upgrade to `MySQL Connector/J 8.x`, Configuring `serverTimezone` alone is effective, however, the default time zone in the program is used when`serverTimezone` is configured individually in `MySQL Connector/J 5.1.x`

So, it's better add the parameter manually if needed

refer 
1. https://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html
2. https://dev.mysql.com/doc/connectors/en/connector-j-time-instants.html
3. https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-23.html

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
