### PR TITLE
Use deepEquals instead of equals at MySQLIncrementalDumper

### DIFF
--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLIncrementalDumper.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLIncrementalDumper.java
@@ -179,7 +179,7 @@ public final class MySQLIncrementalDumper extends AbstractPipelineLifecycleRunna
             for (int j = 0; j < beforeValues.length; j++) {
                 Serializable oldValue = beforeValues[j];
                 Serializable newValue = afterValues[j];
-                boolean updated = !Objects.equals(newValue, oldValue);
+                boolean updated = !Objects.deepEquals(newValue, oldValue);
                 PipelineColumnMetaData columnMetaData = tableMetaData.getColumnMetaData(j + 1);
                 dataRecord.addColumn(new Column(columnMetaData.getName(),
                         handleValue(columnMetaData, oldValue),

--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
@@ -87,6 +87,8 @@ class GovernanceRepositoryAPIImplTest {
         assertFalse(governanceRepositoryAPI.isJobConfigurationExisted("foo_job"));
         getClusterPersistRepository().persist("/pipeline/jobs/foo_job/config", "foo");
         assertTrue(governanceRepositoryAPI.isJobConfigurationExisted("foo_job"));
+        getClusterPersistRepository().delete("/pipeline/jobs/foo_job/config");
+        assertFalse(governanceRepositoryAPI.isJobConfigurationExisted("foo_job"));
     }
     
     @Test

--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/job/service/GovernanceRepositoryAPIImplTest.java
@@ -31,6 +31,8 @@ import org.apache.shardingsphere.data.pipeline.core.task.InventoryTask;
 import org.apache.shardingsphere.data.pipeline.core.task.PipelineTaskUtils;
 import org.apache.shardingsphere.data.pipeline.scenario.migration.config.MigrationTaskConfiguration;
 import org.apache.shardingsphere.data.pipeline.scenario.migration.context.MigrationJobItemContext;
+import org.apache.shardingsphere.elasticjob.infra.pojo.JobConfigurationPOJO;
+import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
 import org.apache.shardingsphere.mode.event.DataChangedEvent;
 import org.apache.shardingsphere.mode.event.DataChangedEvent.Type;
 import org.apache.shardingsphere.mode.manager.ContextManager;
@@ -85,10 +87,11 @@ class GovernanceRepositoryAPIImplTest {
     @Test
     void assertIsJobConfigurationExisted() {
         assertFalse(governanceRepositoryAPI.isJobConfigurationExisted("foo_job"));
-        getClusterPersistRepository().persist("/pipeline/jobs/foo_job/config", "foo");
+        JobConfigurationPOJO value = new JobConfigurationPOJO();
+        value.setJobName("foo_job");
+        value.setShardingTotalCount(1);
+        getClusterPersistRepository().persist("/pipeline/jobs/foo_job/config", YamlEngine.marshal(value));
         assertTrue(governanceRepositoryAPI.isJobConfigurationExisted("foo_job"));
-        getClusterPersistRepository().delete("/pipeline/jobs/foo_job/config");
-        assertFalse(governanceRepositoryAPI.isJobConfigurationExisted("foo_job"));
     }
     
     @Test


### PR DESCRIPTION

Changes proposed in this pull request:
  - Use deepEquals instead of equals, because it's support binary data such as `byte[]`, `Byte` 
  - Clean invalid job config, avoid affecting other cases

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
