### PR TITLE
Remove java stream api and build sql when execute addAssignment method

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/insert/EncryptInsertOnUpdateTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/insert/EncryptInsertOnUpdateTokenGenerator.java
@@ -161,7 +161,7 @@ public final class EncryptInsertOnUpdateTokenGenerator implements CollectionSQLT
         } else if (likeQueryColumn.isPresent() != valueLikeQueryColumn.isPresent()) {
             throw new UnsupportedEncryptSQLException(String.format("%s=VALUES(%s)", column, valueColumn));
         }
-        if (result.getAssignment().isEmpty()) {
+        if (result.isAssignmentsEmpty()) {
             throw new UnsupportedEncryptSQLException(String.format("%s=VALUES(%s)", column, valueColumn));
         }
         return result;

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/pojo/EncryptFunctionAssignmentToken.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/pojo/EncryptFunctionAssignmentToken.java
@@ -21,12 +21,13 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.stream.Collectors;
 
 /**
  * Function assignment token for encrypt.
  */
 public final class EncryptFunctionAssignmentToken extends EncryptAssignmentToken {
+    
+    private final StringBuilder builder = new StringBuilder();
     
     private final Collection<FunctionAssignment> assignments = new LinkedList<>();
     
@@ -41,20 +42,23 @@ public final class EncryptFunctionAssignmentToken extends EncryptAssignmentToken
      * @param value assignment value
      */
     public void addAssignment(final String columnName, final Object value) {
-        assignments.add(new FunctionAssignment(columnName, value));
+        FunctionAssignment functionAssignment = new FunctionAssignment(columnName, value);
+        assignments.add(functionAssignment);
+        builder.append(functionAssignment).append(", ");
     }
     
     /**
-     * Get assignments.
-     * @return FunctionAssignment collection
+     * Judge whether assignments is empty or not.
+     * 
+     * @return whether assignments is empty or not
      */
-    public Collection<FunctionAssignment> getAssignment() {
-        return assignments;
+    public boolean isAssignmentsEmpty() {
+        return assignments.isEmpty();
     }
     
     @Override
     public String toString() {
-        return assignments.stream().map(FunctionAssignment::toString).collect(Collectors.joining(", "));
+        return builder.substring(0, builder.length() - 2);
     }
     
     @RequiredArgsConstructor


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove java stream api and build sql when execute addAssignment method

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
