### PR TITLE
Updates Calcite to 1.36.0 to further support the `WITH RECURSIVE` keyword

### DIFF
--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -222,8 +222,8 @@ The text of each license is the standard Apache 2.0 license.
     avatica-core 1.23.0: https://calcite.apache.org/avatica, Apache 2.0
     avatica-metrics 1.23.0: https://calcite.apache.org/avatica, Apache 2.0
     caffeine 2.9.3: https://github.com/ben-manes/caffeine, Apache 2.0
-    calcite-core 1.35.0: https://calcite.apache.org, Apache 2.0
-    calcite-linq4j 1.35.0: https://calcite.apache.org, Apache 2.0
+    calcite-core 1.36.0: https://calcite.apache.org, Apache 2.0
+    calcite-linq4j 1.36.0: https://calcite.apache.org, Apache 2.0
     commons-codec 1.16.0: https://github.com/apache/commons-codec, Apache 2.0
     commons-dbcp2 2.6.0: https://commons.apache.org/proper/commons-dbcp, Apache 2.0
     commons-exec 1.3: https://github.com/apache/commons-exec, Apache 2.0

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/CaseWhenExpressionConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/CaseWhenExpressionConverter.java
@@ -30,6 +30,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.CaseWhen
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sqlfederation.optimizer.converter.segment.expression.ExpressionConverter;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -53,7 +54,7 @@ public final class CaseWhenExpressionConverter {
         segment.getThenExprs().forEach(each -> ExpressionConverter.convert(each).ifPresent(thenExprs::add));
         Optional<SqlNode> elseExpr = ExpressionConverter.convert(segment.getElseExpr());
         return Optional.of(new SqlCase(SqlParserPos.ZERO, null, new SqlNodeList(whenExprs, SqlParserPos.ZERO), new SqlNodeList(thenExprs, SqlParserPos.ZERO),
-                elseExpr.orElseGet(() -> SqlLiteral.createCharString("NULL", SqlParserPos.ZERO))));
+                elseExpr.orElseGet(() -> SqlLiteral.createCharString("NULL", StandardCharsets.UTF_8.name(), SqlParserPos.ZERO))));
     }
     
     private static Collection<SqlNode> convertWhenExprs(final ExpressionSegment caseExpr, final Collection<ExpressionSegment> whenExprs) {

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/LiteralExpressionConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/LiteralExpressionConverter.java
@@ -28,6 +28,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.LiteralExpressionSegment;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
@@ -75,7 +76,7 @@ public final class LiteralExpressionConverter {
             return Optional.of(SqlLiteral.createExactNumeric(literalValue, SqlParserPos.ZERO));
         }
         if (segment.getLiterals() instanceof String) {
-            return Optional.of(SqlLiteral.createCharString(literalValue, SqlParserPos.ZERO));
+            return Optional.of(SqlLiteral.createCharString(literalValue, StandardCharsets.UTF_8.name(), SqlParserPos.ZERO));
         }
         return Optional.empty();
     }

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/MatchExpressionConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/MatchExpressionConverter.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OwnerSegm
 import org.apache.shardingsphere.sqlfederation.optimizer.converter.operator.common.SQLExtensionOperatorTable;
 import org.apache.shardingsphere.sqlfederation.optimizer.converter.segment.expression.ExpressionConverter;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -55,7 +56,7 @@ public final class MatchExpressionConverter {
         names.add(segment.getColumnName().getIdentifier().getValue());
         sqlNodes.add(new SqlIdentifier(names, SqlParserPos.ZERO));
         ExpressionConverter.convert(segment.getExpr()).ifPresent(sqlNodes::add);
-        SqlNode searchModifier = SqlLiteral.createCharString(segment.getSearchModifier(), SqlParserPos.ZERO);
+        SqlNode searchModifier = SqlLiteral.createCharString(segment.getSearchModifier(), StandardCharsets.UTF_8.name(), SqlParserPos.ZERO);
         sqlNodes.add(searchModifier);
         return Optional.of(new SqlBasicCall(SQLExtensionOperatorTable.MATCH_AGAINST, sqlNodes, SqlParserPos.ZERO));
     }

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/TrimFunctionConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/TrimFunctionConverter.java
@@ -33,6 +33,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.Expressi
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.FunctionSegment;
 import org.apache.shardingsphere.sqlfederation.optimizer.converter.segment.expression.ExpressionConverter;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -61,7 +62,7 @@ public final class TrimFunctionConverter {
         List<SqlNode> result = new LinkedList<>();
         if (1 == sqlSegments.size()) {
             result.add(Flag.BOTH.symbol(SqlParserPos.ZERO));
-            result.add(SqlLiteral.createCharString(" ", SqlParserPos.ZERO));
+            result.add(SqlLiteral.createCharString(" ", StandardCharsets.UTF_8.name(), SqlParserPos.ZERO));
         }
         if (2 == sqlSegments.size()) {
             result.add(Flag.BOTH.symbol(SqlParserPos.ZERO));

--- a/kernel/sql-federation/optimizer/src/test/resources/cases/federation-query-sql-cases.xml
+++ b/kernel/sql-federation/optimizer/src/test/resources/cases/federation-query-sql-cases.xml
@@ -58,7 +58,7 @@
     </test-case>
     
     <test-case sql="SELECT order_id, user_id FROM t_order_federate UNION SELECT 1, user_id FROM t_user_info WHERE information = 'before'">
-        <assertion expected-result="EnumerableUnion(all=[false])   EnumerableScan(table=[[federate_jdbc, t_order_federate]], sql=[SELECT `order_id`, `user_id` FROM `federate_jdbc`.`t_order_federate`], dynamicParameters=[null])   EnumerableScan(table=[[federate_jdbc, t_user_info]], sql=[SELECT '1', `user_id` FROM `federate_jdbc`.`t_user_info` WHERE `information` = 'before'], dynamicParameters=[null]) " />
+        <assertion expected-result="EnumerableUnion(all=[false])   EnumerableScan(table=[[federate_jdbc, t_order_federate]], sql=[SELECT `order_id`, `user_id` FROM `federate_jdbc`.`t_order_federate`], dynamicParameters=[null])   EnumerableScan(table=[[federate_jdbc, t_user_info]], sql=[SELECT _UTF-8'1', `user_id` FROM `federate_jdbc`.`t_user_info` WHERE `information` = _UTF-8'before'], dynamicParameters=[null]) " />
     </test-case>
     
     <test-case sql="SELECT order_id, user_id FROM t_order_federate LIMIT 1">
@@ -74,7 +74,7 @@
     </test-case>
     
     <test-case sql="select t_order_federate.*, t_order_item_federate_sharding.* from t_order_federate, t_order_item_federate_sharding where t_order_federate.order_id = t_order_item_federate_sharding.item_id AND t_order_item_federate_sharding.remarks = 't_order_item_federate_sharding' ">
-        <assertion expected-result="EnumerableCalc(expr#0..9=[{inputs}], proj#0..2=[{exprs}], item_id=[$t4], order_id1=[$t5], user_id0=[$t6], status0=[$t7], remarks=[$t8])   EnumerableHashJoin(condition=[=($3, $9)], joinType=[inner])     EnumerableCalc(expr#0..2=[{inputs}], expr#3=[CAST($t0):INTEGER], proj#0..3=[{exprs}])       EnumerableScan(table=[[federate_jdbc, t_order_federate]], sql=[SELECT * FROM `federate_jdbc`.`t_order_federate`], dynamicParameters=[null])     EnumerableCalc(expr#0..4=[{inputs}], expr#5=[CAST($t0):INTEGER], proj#0..5=[{exprs}])       EnumerableScan(table=[[federate_jdbc, t_order_item_federate_sharding]], sql=[SELECT * FROM `federate_jdbc`.`t_order_item_federate_sharding` WHERE `remarks` = 't_order_item_federate_sharding'], dynamicParameters=[null]) " />
+        <assertion expected-result="EnumerableCalc(expr#0..9=[{inputs}], proj#0..2=[{exprs}], item_id=[$t4], order_id1=[$t5], user_id0=[$t6], status0=[$t7], remarks=[$t8])   EnumerableHashJoin(condition=[=($3, $9)], joinType=[inner])     EnumerableCalc(expr#0..2=[{inputs}], expr#3=[CAST($t0):INTEGER], proj#0..3=[{exprs}])       EnumerableScan(table=[[federate_jdbc, t_order_federate]], sql=[SELECT * FROM `federate_jdbc`.`t_order_federate`], dynamicParameters=[null])     EnumerableCalc(expr#0..4=[{inputs}], expr#5=[CAST($t0):INTEGER], proj#0..5=[{exprs}])       EnumerableScan(table=[[federate_jdbc, t_order_item_federate_sharding]], sql=[SELECT * FROM `federate_jdbc`.`t_order_item_federate_sharding` WHERE `remarks` = _UTF-8't_order_item_federate_sharding'], dynamicParameters=[null]) " />
     </test-case>
     
     <test-case sql="select o.*, i.* from t_order_federate o, t_order_item_federate_sharding i where o.order_id = i.item_id">
@@ -190,7 +190,7 @@
     </test-case>
     
     <test-case sql="select t_order_federate.*, t_order_item_federate_sharding.* from t_order_federate, t_order_item_federate_sharding where t_order_federate.order_id = t_order_item_federate_sharding.item_id AND t_order_item_federate_sharding.remarks = 't_order_item_federate_sharding' ">
-        <assertion expected-result="EnumerableCalc(expr#0..9=[{inputs}], proj#0..2=[{exprs}], item_id=[$t4], order_id1=[$t5], user_id0=[$t6], status0=[$t7], remarks=[$t8])   EnumerableHashJoin(condition=[=($3, $9)], joinType=[inner])     EnumerableCalc(expr#0..2=[{inputs}], expr#3=[CAST($t0):INTEGER], proj#0..3=[{exprs}])       EnumerableScan(table=[[federate_jdbc, t_order_federate]], sql=[SELECT * FROM `federate_jdbc`.`t_order_federate`], dynamicParameters=[null])     EnumerableCalc(expr#0..4=[{inputs}], expr#5=[CAST($t0):INTEGER], proj#0..5=[{exprs}])       EnumerableScan(table=[[federate_jdbc, t_order_item_federate_sharding]], sql=[SELECT * FROM `federate_jdbc`.`t_order_item_federate_sharding` WHERE `remarks` = 't_order_item_federate_sharding'], dynamicParameters=[null]) " />
+        <assertion expected-result="EnumerableCalc(expr#0..9=[{inputs}], proj#0..2=[{exprs}], item_id=[$t4], order_id1=[$t5], user_id0=[$t6], status0=[$t7], remarks=[$t8])   EnumerableHashJoin(condition=[=($3, $9)], joinType=[inner])     EnumerableCalc(expr#0..2=[{inputs}], expr#3=[CAST($t0):INTEGER], proj#0..3=[{exprs}])       EnumerableScan(table=[[federate_jdbc, t_order_federate]], sql=[SELECT * FROM `federate_jdbc`.`t_order_federate`], dynamicParameters=[null])     EnumerableCalc(expr#0..4=[{inputs}], expr#5=[CAST($t0):INTEGER], proj#0..5=[{exprs}])       EnumerableScan(table=[[federate_jdbc, t_order_item_federate_sharding]], sql=[SELECT * FROM `federate_jdbc`.`t_order_item_federate_sharding` WHERE `remarks` = _UTF-8't_order_item_federate_sharding'], dynamicParameters=[null]) " />
     </test-case>
     
     <test-case sql="select o.*, i.* from t_order_federate o, t_order_item_federate_sharding i where o.order_id = i.item_id">
@@ -426,15 +426,15 @@
     </test-case>
     
     <test-case sql="SELECT * FROM multi_types_first first JOIN multi_types_second second ON first.id = second.id WHERE second.char_column = '1'">
-        <assertion expected-result="EnumerableHashJoin(condition=[=($0, $22)], joinType=[inner])   EnumerableScan(table=[[federate_jdbc, multi_types_first]], sql=[SELECT * FROM `federate_jdbc`.`multi_types_first`], dynamicParameters=[null])   EnumerableScan(table=[[federate_jdbc, multi_types_second]], sql=[SELECT * FROM `federate_jdbc`.`multi_types_second` WHERE `char_column` = '1'], dynamicParameters=[null]) " />
+        <assertion expected-result="EnumerableHashJoin(condition=[=($0, $22)], joinType=[inner])   EnumerableScan(table=[[federate_jdbc, multi_types_first]], sql=[SELECT * FROM `federate_jdbc`.`multi_types_first`], dynamicParameters=[null])   EnumerableScan(table=[[federate_jdbc, multi_types_second]], sql=[SELECT * FROM `federate_jdbc`.`multi_types_second` WHERE `char_column` = _UTF-8'1'], dynamicParameters=[null]) " />
     </test-case>
     
     <test-case sql="SELECT * FROM multi_types_first first JOIN multi_types_second second ON first.id = second.id WHERE second.varchar_column = '1'">
-        <assertion expected-result="EnumerableHashJoin(condition=[=($0, $22)], joinType=[inner])   EnumerableScan(table=[[federate_jdbc, multi_types_first]], sql=[SELECT * FROM `federate_jdbc`.`multi_types_first`], dynamicParameters=[null])   EnumerableScan(table=[[federate_jdbc, multi_types_second]], sql=[SELECT * FROM `federate_jdbc`.`multi_types_second` WHERE `varchar_column` = '1'], dynamicParameters=[null]) " />
+        <assertion expected-result="EnumerableHashJoin(condition=[=($0, $22)], joinType=[inner])   EnumerableScan(table=[[federate_jdbc, multi_types_first]], sql=[SELECT * FROM `federate_jdbc`.`multi_types_first`], dynamicParameters=[null])   EnumerableScan(table=[[federate_jdbc, multi_types_second]], sql=[SELECT * FROM `federate_jdbc`.`multi_types_second` WHERE `varchar_column` = _UTF-8'1'], dynamicParameters=[null]) " />
     </test-case>
     
     <test-case sql="SELECT * FROM multi_types_first first JOIN multi_types_second second ON first.id = second.id WHERE second.long_varchar_column = '1'">
-        <assertion expected-result="EnumerableHashJoin(condition=[=($0, $22)], joinType=[inner])   EnumerableScan(table=[[federate_jdbc, multi_types_first]], sql=[SELECT * FROM `federate_jdbc`.`multi_types_first`], dynamicParameters=[null])   EnumerableScan(table=[[federate_jdbc, multi_types_second]], sql=[SELECT * FROM `federate_jdbc`.`multi_types_second` WHERE `long_varchar_column` = '1'], dynamicParameters=[null]) " />
+        <assertion expected-result="EnumerableHashJoin(condition=[=($0, $22)], joinType=[inner])   EnumerableScan(table=[[federate_jdbc, multi_types_first]], sql=[SELECT * FROM `federate_jdbc`.`multi_types_first`], dynamicParameters=[null])   EnumerableScan(table=[[federate_jdbc, multi_types_second]], sql=[SELECT * FROM `federate_jdbc`.`multi_types_second` WHERE `long_varchar_column` = _UTF-8'1'], dynamicParameters=[null]) " />
     </test-case>
     
     <test-case sql="WITH cte AS (SELECT 1 AS col1, 2 AS col2 UNION ALL SELECT 3, 4) SELECT col1, col2 FROM cte">

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <json-path.version>2.9.0</json-path.version>
         <json-smart.version>2.4.10</json-smart.version>
         <accessors-smart.version>2.4.9</accessors-smart.version>
-        <asm.version>9.3</asm.version>
+        <asm.version>9.6</asm.version>
         <groovy.version>4.0.10</groovy.version>
         <freemarker.version>2.3.31</freemarker.version>
         <bytebuddy.version>1.14.8</bytebuddy.version>
@@ -90,8 +90,8 @@
         <jakarta.jakartaee-bom.version>8.0.0</jakarta.jakartaee-bom.version>
         <glassfish-jaxb.version>2.3.9</glassfish-jaxb.version>
         
-        <calcite.version>1.35.0</calcite.version>
-        <immutables.version>2.9.3</immutables.version>
+        <calcite.version>1.36.0</calcite.version>
+        <immutables.version>2.10.0</immutables.version>
         
         <atomikos.version>6.0.0</atomikos.version>
         <narayana.version>5.12.4.Final</narayana.version>


### PR DESCRIPTION
For #28474.

Changes proposed in this pull request:
  - Updates Calcite to 1.36.0 to further support the `WITH RECURSIVE` keyword. Refer to https://issues.apache.org/jira/browse/CALCITE-129 .
  - This PR is used to activate testing of E2E. Due to the changes in https://github.com/apache/calcite/pull/3429, Calcite will bring charset to String after parsing SQL. However, ShardingSphere currently does not involve the logic of `org.apache.calcite.util.NlsString`, and the related charset cannot be obtained.
  - ~~This PR may also be partially influenced by https://gitlab.ow2.org/asm/asm/-/issues/318008 . There is a reported bug in asm.~~ The issue on the asm side seems to be from a bug on JDK8u.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
