### PR TITLE
Use CaseInsensitiveMap to avoid npe when databaseName is upper

### DIFF
--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/XAShardingSphereTransactionManager.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/XAShardingSphereTransactionManager.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.transaction.xa;
 
 import lombok.SneakyThrows;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
@@ -41,7 +42,6 @@ import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -52,7 +52,7 @@ import java.util.Properties;
  */
 public final class XAShardingSphereTransactionManager implements ShardingSphereTransactionManager {
     
-    private final Map<String, XATransactionDataSource> cachedDataSources = new HashMap<>();
+    private final Map<String, XATransactionDataSource> cachedDataSources = new CaseInsensitiveMap<>();
     
     private XATransactionManagerProvider xaTransactionManagerProvider;
     


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Use CaseInsensitiveMap to avoid npe when databaseName is upper

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
