### PR TITLE
Improve oracle create index syntax parse

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -2122,3 +2122,7 @@ credentialName
 agentDblink
     : STRING_
     ;
+
+xPathsList
+    : STRING_
+    ;

--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -390,11 +390,12 @@ clusterIndexClause
     ;
 
 indexAttributes
-    : (ONLINE | (SORT|NOSORT) | REVERSE | (VISIBLE | INVISIBLE))
+    : (physicalAttributesClause | loggingClause | ONLINE | TABLESPACE (tablespaceName | DEFAULT) | indexCompression
+    | (SORT | NOSORT) | REVERSE | (VISIBLE | INVISIBLE) | partialIndexClause | parallelClause)+
     ;
 
 tableIndexClause
-    : tableName alias? indexExpressions
+    : tableName alias? indexExpressions indexProperties?
     ;
 
 indexExpressions
@@ -403,6 +404,149 @@ indexExpressions
 
 indexExpression
     : (columnName | expr) (ASC | DESC)?
+    ;
+
+indexProperties
+    : (((globalPartitionedIndex | localPartitionedIndex) | indexAttributes)+ | INDEXTYPE IS (domainIndexClause | xmlIndexClause))?
+    ;
+
+globalPartitionedIndex
+    : GLOBAL PARTITION BY (RANGE LP_ columnOrColumnList RP_ LP_ indexPartitioningClause RP_ | HASH LP_ columnOrColumnList RP_ (individualHashPartitions | hashPartitionsByQuantity))
+    ;
+
+indexPartitioningClause
+    : PARTITION partitionName? VALUES LESS THAN LP_ literals (COMMA_ literals) RP_ segmentAttributesClause?
+    ;
+
+localPartitionedIndex
+    : LOCAL (onRangePartitionedTable | onListPartitionedTable | onHashPartitionedTable | onCompPartitionedTable)?
+    ;
+
+onRangePartitionedTable
+    : LP_ PARTITION partitionName? (segmentAttributesClause | indexCompression)* (USABLE | UNUSABLE)? (COMMA_ PARTITION partitionName? (segmentAttributesClause | indexCompression)* (USABLE | UNUSABLE)?) RP_
+    ;
+
+onListPartitionedTable
+    : LP_ PARTITION partitionName? (segmentAttributesClause | indexCompression)* (USABLE | UNUSABLE)? (COMMA_ PARTITION partitionName? (segmentAttributesClause | indexCompression)* (USABLE | UNUSABLE)?) RP_
+    ;
+
+onHashPartitionedTable
+    : (STORE IN LP_ tablespaceName (COMMA_ tablespaceName) RP_ | LP_ PARTITION partitionName? (TABLESPACE tablespaceName)? indexCompression? (USABLE | UNUSABLE)? RP_)
+    ;
+
+onCompPartitionedTable
+    : (STORE IN LP_ tablespaceName (COMMA_ tablespaceName) RP_)? LP_ PARTITION partitionName? (segmentAttributesClause | indexCompression)* (USABLE | UNUSABLE)? indexSubpartitionClause RP_
+    ;
+
+domainIndexClause
+    : indexTypeName localDomainIndexClause? parallelClause? (PARAMETERS LP_ SQ_ odciParameters SQ_ RP_)?
+    ;
+
+localDomainIndexClause
+    : LOCAL (LP_ PARTITION partitionName? (PARAMETERS LP_ SQ_  SQ_ odciParameters RP_)? (COMMA_ PARTITION partitionName? (PARAMETERS LP_ SQ_  SQ_ odciParameters RP_)?)* RP_)?
+    ;
+
+xmlIndexClause
+    : (XDB COMMA_)? XMLINDEX localXmlIndexClause? parallelClause? xmlIndexParametersClause?
+    ;
+
+localXmlIndexClause
+    : LOCAL (LP_ PARTITION partitionName xmlIndexParametersClause? (COMMA_ PARTITION partitionName xmlIndexParametersClause?)* RP_)?
+    ;
+
+xmlIndexParametersClause
+    : PARAMETERS LP_ SQ_ (xmlIndexParameters | PARAM identifier) SQ_ RP_
+    ;
+
+xmlIndexParameters
+    : (xmlIndexParameterClause)* (TABLESPACE identifier)?
+    ;
+
+xmlIndexParameterClause
+    : unstructuredClause | structuredClause | asyncClause
+    ;
+
+unstructuredClause
+    : (PATHS (createIndexPathsClause | alterIndexPathsClause) | (pathTableClause | pikeyClause | pathIdClause | orderKeyClause | valueClause | dropPathTableClause) parallelClause?)
+    ;
+
+createIndexPathsClause
+    : LP_ (INCLUDE LP_ xPathsList RP_ | EXCLUDE LP_ xPathsList RP_) namespaceMappingClause RP_
+    ;
+
+alterIndexPathsClause
+    : LP_ (INDEX_ALL_PATHS | (INCLUDE | EXCLUDE) (ADD | REMOVE) LP_ xPathsList RP_ namespaceMappingClause?) RP_
+    ;
+
+namespaceMappingClause
+    : NAMESPACE MAPPING LP_ namespace+ RP_
+    ;
+
+pathTableClause
+    : PATH TABLE identifier? (LP_ segmentAttributesClause tableProperties RP_)?
+    ;
+
+pikeyClause
+    : PIKEY (INDEX identifier? (LP_ indexAttributes RP_)?)?
+    ;
+
+pathIdClause
+    : PATH ID (INDEX identifier? LP_ indexAttributes RP_)?
+    ;
+
+orderKeyClause
+    : ORDER KEY (INDEX identifier? LP_ indexAttributes RP_)?
+    ;
+
+valueClause
+    : VALUE (INDEX identifier? LP_ indexAttributes RP_)?
+    ;
+
+dropPathTableClause
+    : DROP PATH TABLE
+    ;
+
+structuredClause
+    : groupsClause | alterIndexGroupClause
+    ;
+
+asyncClause
+    : ASYNC LP_ SYNC (ALWAYS | MANUAL | EVERY repeatInterval=STRING_ | ON COMMIT) (STALE LP_ (FALSE | TRUE) RP_)? RP_
+    ;
+
+groupsClause
+    : ((GROUP identifier)? xmlIndexXmltableClause)+
+    ;
+
+xmlIndexXmltableClause
+    : XMLTABLE identifier (LP_ segmentAttributesClause tableCompression? inmemoryTableClause? tableProperties RP_)?
+    ( xmlNamespacesClause COMMA_)? xQueryString=STRING_ (PASSING identifier)? COLUMNS columnClause (COMMA_ columnClause)*
+    ;
+
+columnClause
+    : columnName (FOR ORDINALITY | dataType PATH STRING_ VIRTUAL?)
+    ;
+
+alterIndexGroupClause
+    : (NONBLOCKING? ADD_GROUP groupsClause | DROP_GROUP (GROUP identifier (COMMA_ identifier))?
+    | NONBLOCKING? ADD_COLUMN addColumnOptions | DROP_COLUMN dropColumnOptions
+    | NONBLOCKING ABORT | NONBLOCKING COMPLETE | MODIFY_COLUMN_TYPE modifyColumnTypeOptions)
+    ;
+
+addColumnOptions
+    : (GROUP identifier)? XMLTABLE identifier (xmlNamespacesClause COMMA_)? COLUMNS columnClause (COMMA_ columnClause)*
+    ;
+
+dropColumnOptions
+    : (GROUP identifier)? XMLTABLE identifier COLUMNS identifier (COMMA_ identifier)
+    ;
+
+modifyColumnTypeOptions
+    : (GROUP identifier)? XMLTABLE identifier COLUMNS identifier identifier (COMMA_ identifier identifier)
+    ;
+
+xmlNamespacesClause
+    : XMLNAMESPACES LP_ (STRING_ AS identifier | DEFAULT STRING_) (COMMA_ (STRING_ AS identifier | DEFAULT STRING_))* RP_
     ;
 
 bitmapJoinIndexClause

--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
@@ -7771,3 +7771,23 @@ DEFINITION
 COLLATE
     : C O L L A T E
     ;
+
+XDB
+    : X D B
+    ;
+
+XMLINDEX
+    : X M L I N D E X
+    ;
+
+INDEX_ALL_PATHS
+    : I N D E X UL_ A L L UL_ P A T H S
+    ;
+
+NONBLOCKING
+    : N O N B L O C K I N G
+    ;
+
+MODIFY_COLUMN_TYPE
+    : M O D I F Y UL_ C O L U M N UL_ T Y P E
+    ;

--- a/test/it/parser/src/main/resources/case/ddl/create-index.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-index.xml
@@ -253,4 +253,20 @@
         </table>
         <column start-index="60" stop-index="67" name="order_id" />
     </create-index>
+
+    <create-index sql-case-id="create_index_on_local_parallel_nologging">
+        <index name="from_number_ix" start-index="13" stop-index="26" />
+        <table>
+            <simple-table name="call_detail_records" start-index="31" stop-index="49" />
+        </table>
+        <column start-index="51" stop-index="61" name="from_number" />
+    </create-index>
+
+    <create-index sql-case-id="create_bitmap_index_on_local_parallel_nologging">
+        <index name="is_active_bix" start-index="20" stop-index="32" />
+        <table>
+            <simple-table name="credit_card_accounts" start-index="37" stop-index="56" />
+        </table>
+        <column start-index="58" stop-index="66" name="is_active" />
+    </create-index>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-index.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-index.xml
@@ -52,4 +52,6 @@
     <sql-case id="create_index_using_ignore_dup_key" value="CREATE UNIQUE INDEX AK_Index ON t_order (order_id) WITH (IGNORE_DUP_KEY = ON)" db-types="SQLServer" />
     <sql-case id="create_index_using_drop_existing" value="CREATE NONCLUSTERED INDEX IX_WorkOrder_ProductID ON t_order(order_id)
         WITH (FILLFACTOR = 80, PAD_INDEX = ON, DROP_EXISTING = ON);" db-types="SQLServer" />
+    <sql-case id="create_index_on_local_parallel_nologging" value="CREATE INDEX from_number_ix ON call_detail_records(from_number) LOCAL PARALLEL NOLOGGING" db-types="Oracle" />
+    <sql-case id="create_bitmap_index_on_local_parallel_nologging" value="CREATE BITMAP INDEX is_active_bix ON credit_card_accounts(is_active) LOCAL PARALLEL NOLOGGING" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Fixes #27084.

Changes proposed in this pull request:
  - Improve oracle create index syntax parse
  - Related reference documents:
  - https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/CREATE-INDEX.html#GUID-1F89BBC0-825F-4215-AF71-7588E31D8BFE
  - https://docs.oracle.com/en/database/oracle/oracle-database/19/adxdb/indexes-for-XMLType-data.html#GUID-BCC7D521-E6B9-4636-98E1-25628BA0FEFC
  - https://docs.oracle.com/en/database/oracle/oracle-database/19/adxdb/xquery-and-XML-DB.html#GUID-39CDBF4D-258D-4CFE-AEBF-06ECD660C08D
  - https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_SCHEDULER.html#GUID-73622B78-EFF4-4D06-92F5-E358AB2D58F3

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
