### PR TITLE
Add Date Masking Buitlin Algorithm | Keep Year Only

### DIFF
--- a/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/DateKeepYearOnlyAlgorithm.java
+++ b/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/DateKeepYearOnlyAlgorithm.java
@@ -1,0 +1,28 @@
+package org.apache.shardingsphere.mask.algorithm.replace;
+
+import org.apache.commons.lang3.time.DateUtils;
+import org.apache.shardingsphere.mask.spi.MaskAlgorithm;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+public class DateKeepYearOnlyAlgorithm implements MaskAlgorithm<Object, Date> {
+    @Override
+    public Date mask(Object plainValue) {
+        java.sql.Date result = null == plainValue ? null : (java.sql.Date)plainValue;
+        if(null == plainValue){
+            return result;
+        }
+        Calendar cal = new GregorianCalendar();
+        cal.setTime(result);
+        cal.set(Calendar.DAY_OF_YEAR,1); // Remove Month and Day information from the Value.
+        return new java.sql.Date(cal.getTime().getTime());
+    }
+    @Override
+    public String getType() {
+        return "DATE_KEEP_YEAR_ONLY";
+    }
+}

--- a/features/mask/core/src/main/resources/META-INF/services/org.apache.shardingsphere.mask.spi.MaskAlgorithm
+++ b/features/mask/core/src/main/resources/META-INF/services/org.apache.shardingsphere.mask.spi.MaskAlgorithm
@@ -23,3 +23,4 @@ org.apache.shardingsphere.mask.algorithm.cover.MaskBeforeSpecialCharsAlgorithm
 org.apache.shardingsphere.mask.algorithm.cover.MaskFirstNLastMMaskAlgorithm
 org.apache.shardingsphere.mask.algorithm.cover.MaskFromXToYMaskAlgorithm
 org.apache.shardingsphere.mask.algorithm.replace.GenericTableRandomReplaceAlgorithm
+org.apache.shardingsphere.mask.algorithm.cover.DateKeepYearOnlyAlgorithm


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Add a builtin algorithm for masking dates. This Algo keeps the original year info and replace the rest of the date information with the first day of the year.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
