### PR TITLE
Merge XmlNameSpacesClause to avoid antlr compile exception on local machine

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -520,7 +520,7 @@ groupsClause
 
 xmlIndexXmltableClause
     : XMLTABLE identifier (LP_ segmentAttributesClause tableCompression? inmemoryTableClause? tableProperties RP_)?
-    ( xmlNamespacesClause COMMA_)? xQueryString=STRING_ (PASSING identifier)? COLUMNS columnClause (COMMA_ columnClause)*
+    ( xmlNameSpacesClause COMMA_)? xQueryString=STRING_ (PASSING identifier)? COLUMNS columnClause (COMMA_ columnClause)*
     ;
 
 columnClause
@@ -534,7 +534,7 @@ alterIndexGroupClause
     ;
 
 addColumnOptions
-    : (GROUP identifier)? XMLTABLE identifier (xmlNamespacesClause COMMA_)? COLUMNS columnClause (COMMA_ columnClause)*
+    : (GROUP identifier)? XMLTABLE identifier (xmlNameSpacesClause COMMA_)? COLUMNS columnClause (COMMA_ columnClause)*
     ;
 
 dropColumnOptions
@@ -543,10 +543,6 @@ dropColumnOptions
 
 modifyColumnTypeOptions
     : (GROUP identifier)? XMLTABLE identifier COLUMNS identifier identifier (COMMA_ identifier identifier)
-    ;
-
-xmlNamespacesClause
-    : XMLNAMESPACES LP_ (STRING_ AS identifier | DEFAULT STRING_) (COMMA_ (STRING_ AS identifier | DEFAULT STRING_))* RP_
     ;
 
 bitmapJoinIndexClause


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Merge XmlNameSpacesClause to avoid antlr compile exception on local machine

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
