### PR TITLE
Update Consul Client to expose deprecated Consul API

### DIFF
--- a/mode/type/cluster/repository/provider/consul/pom.xml
+++ b/mode/type/cluster/repository/provider/consul/pom.xml
@@ -32,6 +32,12 @@
                 <groupId>com.ecwid.consul</groupId>
                 <artifactId>consul-api</artifactId>
                 <version>${consul.api.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>

--- a/mode/type/cluster/repository/provider/consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ShardingSphereQueryParams.java
+++ b/mode/type/cluster/repository/provider/consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ShardingSphereQueryParams.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.mode.repository.cluster.consul;
 
 import com.ecwid.consul.UrlParameters;
-import com.ecwid.consul.Utils;
 import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
@@ -42,7 +41,7 @@ public final class ShardingSphereQueryParams implements UrlParameters {
             result.add(String.format("wait=%dms", TimeUnit.MILLISECONDS.toMillis(waitMillis)));
         }
         if (-1 != index) {
-            result.add(String.format("index=%s", Utils.toUnsignedString(index)));
+            result.add(String.format("index=%s", Long.toUnsignedString(index)));
         }
         return result;
     }

--- a/mode/type/cluster/repository/provider/consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/lock/ConsulDistributedLock.java
+++ b/mode/type/cluster/repository/provider/consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/lock/ConsulDistributedLock.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.mode.repository.cluster.consul.lock;
 
 import com.ecwid.consul.ConsulException;
-import com.ecwid.consul.transport.RawResponse;
+import com.ecwid.consul.transport.HttpResponse;
 import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.OperationException;
 import com.ecwid.consul.v1.QueryParams;
@@ -133,7 +133,7 @@ public final class ConsulDistributedLock implements DistributedLock {
         }
     }
     
-    private Response<GetValue> getResponse(final RawResponse rawResponse) {
+    private Response<GetValue> getResponse(final HttpResponse rawResponse) {
         if (200 == rawResponse.getStatusCode()) {
             List<GetValue> value = JsonUtils.fromJsonString(rawResponse.getContent(), new TypeReference<List<GetValue>>() {
             });

--- a/pom.xml
+++ b/pom.xml
@@ -106,11 +106,11 @@
         <zookeeper.version>3.9.0</zookeeper.version>
         <audience-annotations.version>0.12.0</audience-annotations.version>
         <jetcd.version>0.7.6</jetcd.version>
-        <consul.api.version>1.4.1</consul.api.version>
+        <consul.api.version>1.4.5</consul.api.version>
         
         <grpc.version>1.58.0</grpc.version>
         <protobuf.version>3.21.12</protobuf.version>
-        <httpclient.version>4.5.13</httpclient.version>
+        <httpclient.version>4.5.14</httpclient.version>
         <okhttp.version>4.12.0</okhttp.version>
         
         <elasticjob.version>3.0.4</elasticjob.version>


### PR DESCRIPTION
For #22354.

Changes proposed in this pull request:
  - Update Consul Client to expose deprecated Consul 1.17 API. Refer to https://github.com/Ecwid/consul-api/issues/246 .
  - `com.ecwid.consul.transport.RawResponse` has been renamed at https://github.com/Ecwid/consul-api/commit/fcee76283a2e122212943d58b7d9173f67f8412c .
  - `com.ecwid.consul.Utils#toUnsignedString` has been removed at https://github.com/Ecwid/consul-api/commit/ffd9e29df1ab203e2777e012d12b4f6028df1251.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
