### PR TITLE
Parse unadapted Database to SQL92 dialect and add support for JDBC URLs for commonly used testcontainers

### DIFF
--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/type/DatabaseTypeFactory.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/type/DatabaseTypeFactory.java
@@ -19,10 +19,11 @@ package org.apache.shardingsphere.infra.database.core.type;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 
 import java.util.Collection;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 /**
@@ -39,7 +40,10 @@ public final class DatabaseTypeFactory {
      */
     public static DatabaseType get(final String url) {
         Collection<DatabaseType> databaseTypes = ShardingSphereServiceLoader.getServiceInstances(DatabaseType.class).stream().filter(each -> matchURLs(url, each)).collect(Collectors.toList());
-        ShardingSpherePreconditions.checkState(!databaseTypes.isEmpty(), () -> new UnsupportedStorageTypeException(url));
+        if (databaseTypes.isEmpty()) {
+            return TypedSPILoader.findService(DatabaseType.class, null, new Properties())
+                    .orElseThrow(() -> new UnsupportedStorageTypeException(url));
+        }
         for (DatabaseType each : databaseTypes) {
             if (each.getTrunkDatabaseType().isPresent()) {
                 return each;

--- a/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/type/fixture/TrunkDatabaseTypeFixture.java
+++ b/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/type/fixture/TrunkDatabaseTypeFixture.java
@@ -33,9 +33,4 @@ public final class TrunkDatabaseTypeFixture implements DatabaseType {
     public String getType() {
         return "TRUNK";
     }
-    
-    @Override
-    public boolean isDefault() {
-        return true;
-    }
 }

--- a/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/type/MySQLDatabaseType.java
+++ b/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/type/MySQLDatabaseType.java
@@ -23,13 +23,13 @@ import java.util.Arrays;
 import java.util.Collection;
 
 /**
- * Database type of MySQL.
+ * Database type of MySQL. Includes verification of Docker Images involved in commonly used testcontainers.
  */
 public final class MySQLDatabaseType implements DatabaseType {
     
     @Override
     public Collection<String> getJdbcUrlPrefixes() {
-        return Arrays.asList("jdbc:mysql:", "jdbc:mysqlx:");
+        return Arrays.asList("jdbc:mysql:", "jdbc:mysqlx:", "jdbc:tc:mysql:");
     }
     
     @Override

--- a/infra/database/type/mysql/src/test/java/org/apache/shardingsphere/infra/database/mysql/type/MySQLDatabaseTypeTest.java
+++ b/infra/database/type/mysql/src/test/java/org/apache/shardingsphere/infra/database/mysql/type/MySQLDatabaseTypeTest.java
@@ -30,6 +30,6 @@ class MySQLDatabaseTypeTest {
     
     @Test
     void assertGetJdbcUrlPrefixes() {
-        assertThat(TypedSPILoader.getService(DatabaseType.class, "MySQL").getJdbcUrlPrefixes(), is(Arrays.asList("jdbc:mysql:", "jdbc:mysqlx:")));
+        assertThat(TypedSPILoader.getService(DatabaseType.class, "MySQL").getJdbcUrlPrefixes(), is(Arrays.asList("jdbc:mysql:", "jdbc:mysqlx:", "jdbc:tc:mysql:")));
     }
 }

--- a/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/type/OracleDatabaseType.java
+++ b/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/type/OracleDatabaseType.java
@@ -19,17 +19,17 @@ package org.apache.shardingsphere.infra.database.oracle.type;
 
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 /**
- * Database type of Oracle.
+ * Database type of Oracle. Includes verification of Docker Images involved in commonly used testcontainers.
  */
 public final class OracleDatabaseType implements DatabaseType {
     
     @Override
     public Collection<String> getJdbcUrlPrefixes() {
-        return Collections.singleton(String.format("jdbc:%s:", getType().toLowerCase()));
+        return Arrays.asList(String.format("jdbc:%s:", getType().toLowerCase()), "jdbc:tc:gvenzl/oracle-free:", "jdbc:tc:gvenzl/oracle-xe:");
     }
     
     @Override

--- a/infra/database/type/oracle/src/test/java/org/apache/shardingsphere/infra/database/oracle/type/OracleDatabaseTypeTest.java
+++ b/infra/database/type/oracle/src/test/java/org/apache/shardingsphere/infra/database/oracle/type/OracleDatabaseTypeTest.java
@@ -21,7 +21,7 @@ import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,6 +30,6 @@ class OracleDatabaseTypeTest {
     
     @Test
     void assertGetJdbcUrlPrefixes() {
-        assertThat(TypedSPILoader.getService(DatabaseType.class, "Oracle").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:oracle:")));
+        assertThat(TypedSPILoader.getService(DatabaseType.class, "Oracle").getJdbcUrlPrefixes(), is(Arrays.asList("jdbc:oracle:", "jdbc:tc:gvenzl/oracle-free:", "jdbc:tc:gvenzl/oracle-xe:")));
     }
 }

--- a/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/type/PostgreSQLDatabaseType.java
+++ b/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/type/PostgreSQLDatabaseType.java
@@ -19,17 +19,17 @@ package org.apache.shardingsphere.infra.database.postgresql.type;
 
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 /**
- * Database type of PostgreSQL.
+ * Database type of PostgreSQL. Includes verification of Docker Images involved in commonly used testcontainers.
  */
 public final class PostgreSQLDatabaseType implements DatabaseType {
     
     @Override
     public Collection<String> getJdbcUrlPrefixes() {
-        return Collections.singleton(String.format("jdbc:%s:", getType().toLowerCase()));
+        return Arrays.asList(String.format("jdbc:%s:", getType().toLowerCase()), "jdbc:tc:postgres:");
     }
     
     @Override

--- a/infra/database/type/postgresql/src/test/java/org/apache/shardingsphere/infra/database/postgresql/type/PostgreSQLDatabaseTypeTest.java
+++ b/infra/database/type/postgresql/src/test/java/org/apache/shardingsphere/infra/database/postgresql/type/PostgreSQLDatabaseTypeTest.java
@@ -21,7 +21,7 @@ import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,6 +30,6 @@ class PostgreSQLDatabaseTypeTest {
     
     @Test
     void assertGetJdbcUrlPrefixes() {
-        assertThat(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:postgresql:")));
+        assertThat(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL").getJdbcUrlPrefixes(), is(Arrays.asList("jdbc:postgresql:", "jdbc:tc:postgres:")));
     }
 }

--- a/infra/database/type/sql92/src/test/java/org/apache/shardingsphere/infra/database/sql92/type/SQL92DatabaseTypeTest.java
+++ b/infra/database/type/sql92/src/test/java/org/apache/shardingsphere/infra/database/sql92/type/SQL92DatabaseTypeTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.database.sql92.type;
 
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
 
@@ -31,5 +32,13 @@ class SQL92DatabaseTypeTest {
     @Test
     void assertGetJdbcUrlPrefixes() {
         assertThat(TypedSPILoader.getService(DatabaseType.class, "SQL92").getJdbcUrlPrefixes(), is(Collections.emptyList()));
+    }
+    
+    @Test
+    void assertGetDatabaseTypeWithUnrecognizedURL() {
+        assertThat(DatabaseTypeFactory.get("jdbc:not-existed:test").getType(), is("SQL92"));
+        assertThat(DatabaseTypeFactory.get("jdbc:vertica://VerticaHost:portNumber/databaseName").getType(), is("SQL92"));
+        assertThat(DatabaseTypeFactory.get("jdbc:ch://my-server/system").getType(), is("SQL92"));
+        assertThat(DatabaseTypeFactory.get("jdbc:clickhouse://localhost:8123/test").getType(), is("SQL92"));
     }
 }

--- a/infra/database/type/sqlserver/src/main/java/org/apache/shardingsphere/infra/database/sqlserver/type/SQLServerDatabaseType.java
+++ b/infra/database/type/sqlserver/src/main/java/org/apache/shardingsphere/infra/database/sqlserver/type/SQLServerDatabaseType.java
@@ -23,13 +23,14 @@ import java.util.Arrays;
 import java.util.Collection;
 
 /**
- * Database type of SQLServer.
+ * Database type of SQLServer. Includes verification of Docker Images involved in commonly used testcontainers.
  */
 public final class SQLServerDatabaseType implements DatabaseType {
     
     @Override
     public Collection<String> getJdbcUrlPrefixes() {
-        return Arrays.asList("jdbc:microsoft:sqlserver:", "jdbc:sqlserver:");
+        return Arrays.asList("jdbc:microsoft:sqlserver:", "jdbc:sqlserver:",
+                "jdbc:tc:mcr.microsoft.com/mssql/server:", "jdbc:tc:mcr.microsoft.com/mssql/rhel/server:");
     }
     
     @Override

--- a/infra/database/type/sqlserver/src/test/java/org/apache/shardingsphere/infra/database/sqlserver/type/SQLServerDatabaseTypeTest.java
+++ b/infra/database/type/sqlserver/src/test/java/org/apache/shardingsphere/infra/database/sqlserver/type/SQLServerDatabaseTypeTest.java
@@ -30,6 +30,7 @@ class SQLServerDatabaseTypeTest {
     
     @Test
     void assertGetJdbcUrlPrefixes() {
-        assertThat(TypedSPILoader.getService(DatabaseType.class, "SQLServer").getJdbcUrlPrefixes(), is(Arrays.asList("jdbc:microsoft:sqlserver:", "jdbc:sqlserver:")));
+        assertThat(TypedSPILoader.getService(DatabaseType.class, "SQLServer").getJdbcUrlPrefixes(),
+                is(Arrays.asList("jdbc:microsoft:sqlserver:", "jdbc:sqlserver:", "jdbc:tc:mcr.microsoft.com/mssql/server:", "jdbc:tc:mcr.microsoft.com/mssql/rhel/server:")));
     }
 }


### PR DESCRIPTION
Fixes #28892.

Changes proposed in this pull request:
  - Parse unadapted Database to SQL92 dialect. This involves a regression of changes from #27270. As of that PR, `org.apache.shardingsphere.infra.database.core.type.fixture.TrunkDatabaseTypeFixture` reimplements `isDefault()`.
  - Add support for JDBC URLs for commonly used testcontainers. For #29052.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
