### PR TITLE
Support parsing SQL Server INSERT INTO sql #29152

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -48,6 +48,8 @@ intervalUnit
 
 stringLiterals
     : STRING_
+    | NCHAR_TEXT
+    | UCHAR_TEXT
     ;
 
 numberLiterals

--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/Literals.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/Literals.g4
@@ -28,7 +28,7 @@ IDENTIFIER_
     ;
 
 STRING_
-    : (N | U)? SINGLE_QUOTED_TEXT
+    : SINGLE_QUOTED_TEXT
     ;
 
 SINGLE_QUOTED_TEXT
@@ -53,6 +53,14 @@ HEX_DIGIT_
 
 BIT_NUM_
     : '0b' ('0' | '1')+ | B SQ_ ('0' | '1')+ SQ_
+    ;
+
+NCHAR_TEXT
+    : N STRING_
+    ;
+
+UCHAR_TEXT
+    : U STRING_
     ;
 
 fragment INT_

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
@@ -238,7 +238,11 @@ public abstract class OracleStatementVisitor extends OracleStatementBaseVisitor<
     
     @Override
     public final ASTNode visitStringLiterals(final StringLiteralsContext ctx) {
-        return new StringLiteralValue(ctx.getText());
+        if (null != ctx.STRING_()) {
+            return new StringLiteralValue(ctx.getText());
+        } else {
+            return new StringLiteralValue(ctx.getText().substring(1));
+        }
     }
     
     @Override

--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
@@ -35,6 +35,7 @@ literals
 
 stringLiterals
     : STRING_
+    | NCHAR_TEXT
     ;
 
 numberLiterals
@@ -151,7 +152,7 @@ sequenceName
     ;
 
 tableName
-    : (owner DOT_)? name
+    : ((databaseName DOT_)? owner DOT_)? name
     ;
 
 queueName
@@ -167,7 +168,11 @@ serviceName
     ;
 
 columnName
-    : (owner DOT_)? name
+    : (owner DOT_)? (name | scriptVariableName)
+    ;
+
+scriptVariableName
+    : DOLLAR_ LP_ name RP_
     ;
 
 owner

--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
@@ -152,7 +152,7 @@ sequenceName
     ;
 
 tableName
-    : ((databaseName DOT_)? owner DOT_)? name
+    : (databaseName DOT_ (owner DOT_) ? | (owner DOT_) ?) name
     ;
 
 queueName

--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/Symbol.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/Symbol.g4
@@ -57,3 +57,4 @@ BQ_:                 '`';
 QUESTION_:           '?';
 AT_:                 '@';
 SEMI_:               ';';
+DOLLAR_:             '$';

--- a/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
+++ b/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
@@ -316,7 +316,7 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
     }
     
     @Override
-    public ASTNode visitScriptVariableName(SQLServerStatementParser.ScriptVariableNameContext ctx) {
+    public ASTNode visitScriptVariableName(final SQLServerStatementParser.ScriptVariableNameContext ctx) {
         return new IdentifierValue(ctx.getText());
     }
     

--- a/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
+++ b/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
@@ -300,7 +300,7 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
                 ownerSegment.setOwner(new OwnerSegment(dbName.getStart().getStartIndex(), dbName.getStop().getStopIndex(), (IdentifierValue) visit(dbName.identifier())));
             }
             result.setOwner(ownerSegment);
-        } else if (null != ctx.databaseName()){
+        } else if (null != ctx.databaseName()) {
             SQLServerStatementParser.DatabaseNameContext dbName = ctx.databaseName();
             result.setOwner(new OwnerSegment(dbName.getStart().getStartIndex(), dbName.getStop().getStopIndex(), (IdentifierValue) visit(dbName.identifier())));
         }

--- a/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
+++ b/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
@@ -229,7 +229,11 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
     
     @Override
     public final ASTNode visitStringLiterals(final StringLiteralsContext ctx) {
-        return new StringLiteralValue(ctx.getText());
+        if (null != ctx.STRING_()) {
+            return new StringLiteralValue(ctx.getText());
+        } else {
+            return new StringLiteralValue(ctx.getText().substring(1));
+        }
     }
     
     @Override
@@ -296,6 +300,9 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
                 ownerSegment.setOwner(new OwnerSegment(dbName.getStart().getStartIndex(), dbName.getStop().getStopIndex(), (IdentifierValue) visit(dbName.identifier())));
             }
             result.setOwner(ownerSegment);
+        } else if (null != ctx.databaseName()){
+            SQLServerStatementParser.DatabaseNameContext dbName = ctx.databaseName();
+            result.setOwner(new OwnerSegment(dbName.getStart().getStartIndex(), dbName.getStop().getStopIndex(), (IdentifierValue) visit(dbName.identifier())));
         }
         return result;
     }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/value/literal/impl/StringLiteralValue.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/value/literal/impl/StringLiteralValue.java
@@ -30,7 +30,11 @@ public final class StringLiteralValue implements LiteralValue<String> {
     private final String value;
     
     public StringLiteralValue(final String value) {
-        this.value = value.substring(1, value.length() - 1);
+        if (value.startsWith("N")) {
+            this.value = value.substring(2, value.length() - 1);
+        } else {
+            this.value = value.substring(1, value.length() - 1);
+        }
     }
     
     /**

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/value/literal/impl/StringLiteralValue.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/value/literal/impl/StringLiteralValue.java
@@ -30,11 +30,7 @@ public final class StringLiteralValue implements LiteralValue<String> {
     private final String value;
     
     public StringLiteralValue(final String value) {
-        if (value.startsWith("N")) {
-            this.value = value.substring(2, value.length() - 1);
-        } else {
-            this.value = value.substring(1, value.length() - 1);
-        }
+        this.value = value.substring(1, value.length() - 1);
     }
     
     /**

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema-postgresql.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema-postgresql.xml
@@ -305,7 +305,7 @@
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM pg_catalog.pg_stat_all_tables limit 1" db-types="PostgreSQL" scenario-types="tbl" adapters="proxy">
+    <test-case sql="SELECT * FROM pg_catalog.pg_stat_all_tables where relname != 'pg_range' limit 1" db-types="PostgreSQL" scenario-types="tbl" adapters="proxy">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 

--- a/test/it/parser/src/main/resources/case/dml/insert.xml
+++ b/test/it/parser/src/main/resources/case/dml/insert.xml
@@ -2699,7 +2699,7 @@
                     </function>
                 </assignment-value>
                 <assignment-value>
-                    <literal-expression value="'500 Oracle Parkway" start-index="59" stop-index="79" literal-start-index="59" literal-stop-index="79" />
+                    <literal-expression value="500 Oracle Parkway" start-index="60" stop-index="79" literal-start-index="59" literal-stop-index="79" />
                 </assignment-value>
                 <assignment-value>
                     <column name="sysdate" start-index="81" stop-index="87" literal-start-index="81" literal-stop-index="87" />

--- a/test/it/parser/src/main/resources/case/dml/insert.xml
+++ b/test/it/parser/src/main/resources/case/dml/insert.xml
@@ -2900,4 +2900,69 @@
             </from>
         </select>
     </insert>
+    <insert sql-case-id="insert_with_nchar_1">
+        <table name="T1" start-index="12" stop-index="17">
+            <owner name="dbo" start-index="12" stop-index="14" />
+        </table>
+        <columns start-index="18" stop-index="18" />
+        <values>
+            <value>
+                <assignment-value>
+                    <literal-expression value="1" start-index="27" stop-index="27" />
+                </assignment-value>
+                <assignment-value>
+                    <literal-expression value="Natalia" start-index="30" stop-index="39" />
+                </assignment-value>
+            </value>
+        </values>
+    </insert>
+    <insert sql-case-id="insert_with_nchar_2">
+        <table name="T1" start-index="12" stop-index="17">
+            <owner name="dbo" start-index="12" stop-index="14" />
+        </table>
+        <columns start-index="18" stop-index="18" />
+        <values>
+            <value>
+                <assignment-value>
+                    <literal-expression value="2" start-index="27" stop-index="27" />
+                </assignment-value>
+                <assignment-value>
+                    <literal-expression value="Mark" start-index="30" stop-index="36" />
+                </assignment-value>
+            </value>
+        </values>
+    </insert>
+    <insert sql-case-id="insert_with_nchar_3">
+        <table name="T1" start-index="12" stop-index="17">
+            <owner name="dbo" start-index="12" stop-index="14" />
+        </table>
+        <columns start-index="18" stop-index="18" />
+        <values>
+            <value>
+                <assignment-value>
+                    <literal-expression value="3" start-index="27" stop-index="27" />
+                </assignment-value>
+                <assignment-value>
+                    <literal-expression value="Randolph" start-index="30" stop-index="40" />
+                </assignment-value>
+            </value>
+        </values>
+    </insert>
+    <insert sql-case-id="insert_with_dbName">
+        <table name="VariableTest" start-index="12" stop-index="46">
+            <owner name="dbo" start-index="31" stop-index="33">
+                <owner name="AdventureWorks2022" start-index="12" stop-index="29"/>
+            </owner>
+        </table>
+        <columns start-index="47" stop-index="52">
+            <column name="Col1" start-index="48" stop-index="51" />
+        </columns>
+        <values>
+            <value>
+                <assignment-value>
+                    <literal-expression value="$(tablename)" start-index="61" stop-index="74" />
+                </assignment-value>
+            </value>
+        </values>
+    </insert>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -7498,4 +7498,31 @@
             <column-item name="updatable" order-direction="ASC" start-index="116" stop-index="124" />
         </order-by>
     </select>
+    <select sql-case-id="select_with_script_variables">
+        <from>
+            <simple-table name="Person" alias="x" start-index="28" stop-index="42">
+                <owner name="Person" start-index="28" stop-index="33"/>
+            </simple-table>
+        </from>
+        <projections start-index="7" stop-index="21">
+            <column-projection name="$(ColumnName)" start-index="7" stop-index="21">
+                <owner name="x" start-index="7" stop-index="7" />
+            </column-projection>>
+        </projections>
+        <where start-index="44" stop-index="71">
+            <expr>
+                <binary-operation-expression start-index="50" stop-index="71">
+                    <left>
+                        <column name="BusinessEntityID" start-index="50" stop-index="67">
+                            <owner name="x" start-index="50" stop-index="50" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="5" start-index="71" stop-index="71" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -7307,19 +7307,19 @@
 
     <select sql-case-id="select_with_unicode_string">
         <projections start-index="7" stop-index="22" literal-start-index="7" literal-stop-index="22">
-            <expression-projection text="'test" start-index="7" stop-index="13" literal-start-index="7"
+            <expression-projection text="test" start-index="7" stop-index="13" literal-start-index="7"
                                    literal-stop-index="13">
-                <literalText>'test</literalText>
+                <literalText>test</literalText>
                 <expr>
-                    <literal-expression value="'test" start-index="7" stop-index="13" literal-start-index="7"
+                    <literal-expression value="test" start-index="7" stop-index="13" literal-start-index="7"
                                         literal-stop-index="13"/>
                 </expr>
             </expression-projection>
-            <expression-projection text="'test" start-index="16" stop-index="22" literal-start-index="16"
+            <expression-projection text="test" start-index="16" stop-index="22" literal-start-index="16"
                                    literal-stop-index="22">
-                <literalText>'test</literalText>
+                <literalText>test</literalText>
                 <expr>
-                    <literal-expression value="'test" start-index="16" stop-index="22" literal-start-index="16"
+                    <literal-expression value="test" start-index="16" stop-index="22" literal-start-index="16"
                                         literal-stop-index="22"/>
                 </expr>
             </expression-projection>

--- a/test/it/parser/src/main/resources/sql/supported/dml/insert.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/insert.xml
@@ -103,4 +103,8 @@
     <sql-case id="insert_with_national_character_set" value="INSERT INTO customers VALUES (1000, TO_NCHAR('John Smith'),N'500 Oracle Parkway',sysdate);" db-types="Oracle" />
     <sql-case id="insert_with_oracle_datetime_type" value="INSERT INTO t_order (create_date, create_timestamp, create_interval_year, create_interval_day) VALUES (TO_DATE('2009', 'YYYY'), TO_DATE('2009', 'YYYY'), (TO_DATE('2009', 'YYYY') - TO_DATE('2009', 'YYYY')) year to MONTH, (TO_DATE('2009', 'YYYY') - TO_DATE('2009', 'YYYY')) DAY TO SECOND);" db-types="Oracle" />
     <sql-case id="insert_all_into" value="INSERT ALL INTO T_MASK(ID,EMAIL,NAME,PHONE,ADDRESS) VALUES (1,'2','3','4','5') INTO T_MASK(ID,EMAIL,NAME,PHONE,ADDRESS) VALUES (2,'2','3','4','5') INTO T_MASK(ID,EMAIL,NAME,PHONE,ADDRESS) VALUES (3,'2','3','4','5') SELECT 1 FROM DUAL" db-types="Oracle" />
+    <sql-case id="insert_with_nchar_1" value="INSERT INTO dbo.T1 VALUES (1, N'Natalia')" db-types="SQLServer"/>
+    <sql-case id="insert_with_nchar_2" value="INSERT INTO dbo.T1 VALUES (2, N'Mark')" db-types="SQLServer"/>
+    <sql-case id="insert_with_nchar_3" value="INSERT INTO dbo.T1 VALUES (3, N'Randolph')" db-types="SQLServer"/>
+    <sql-case id="insert_with_dbName" value="INSERT INTO AdventureWorks2022.dbo.VariableTest(Col1) VALUES('$(tablename)')" db-types="SQLServer"/>
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -229,4 +229,5 @@
     <sql-case id="select_wm_concat_function3" value="SELECT REPLACE(WM_CONCAT(NAME),',','|') FROM TEST_TABLE" db-types="Oracle" />
     <sql-case id="select_wm_concat_function4" value="SELECT NAME,WM_CONCAT(DECODE(SUBSTR((TO_CHAR(NAME)),0,1),'.','0'||TO_CHAR(NAME),TO_CHAR(NAME))) WM_NAME FROM TEST_TABLE WHERE NAME ='TEST' GROUP BY NAME" db-types="Oracle" />
     <sql-case id="select_with_user_updatable_columns" value="SELECT column_name, updatable FROM user_updatable_columns WHERE table_name = 'LOCATIONS_VIEW' ORDER BY column_name, updatable" db-types="Oracle" />
+    <sql-case id="select_with_script_variables" value="SELECT x.$(ColumnName) FROM Person.Person x WHERE x.BusinessEntityID > 5" db-types="SQLServer" />
 </sql-cases>


### PR DESCRIPTION
Fixes #29152.

Changes proposed in this pull request:
- Support parsing SQL Server INSERT INTO sql
1. INSERT INTO dbo.T1 VALUES (1, N'Natalia')
2. SELECT x.$(ColumnName) FROM Person.Person x WHERE x.BusinessEntityID < 5
3. INSERT INTO AdventureWorks2022.dbo.VariableTest(Col1) VALUES('$(tablename)')

- Fix the error parser in oracle Nchar
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes
