### PR TITLE
Support SimpleMemoryPipelineChannel use 0 blocking queue size

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/PipelineChannel.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/PipelineChannel.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Pipeline channel.
+ * <p>It supports multiple push threads and one fetch thread.</p>
  */
 public interface PipelineChannel extends Closeable {
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/memory/MemoryPipelineChannelCreator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/memory/MemoryPipelineChannelCreator.java
@@ -41,8 +41,8 @@ public final class MemoryPipelineChannelCreator implements PipelineChannelCreato
     
     @Override
     public PipelineChannel createPipelineChannel(final int outputConcurrency, final int averageElementSize, final AckCallback ackCallback) {
-        return 1 == outputConcurrency ? new SimpleMemoryPipelineChannel((int) Math.ceil((double) blockQueueSize / averageElementSize), ackCallback)
-                : new MultiplexMemoryPipelineChannel(outputConcurrency, blockQueueSize, ackCallback);
+        return 1 == outputConcurrency ? new SimpleMemoryPipelineChannel(blockQueueSize / averageElementSize, ackCallback)
+                : new MultiplexMemoryPipelineChannel(outputConcurrency, blockQueueSize < 1 ? 5 : blockQueueSize, ackCallback);
     }
     
     @Override

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/memory/SimpleMemoryPipelineChannel.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/memory/SimpleMemoryPipelineChannel.java
@@ -27,6 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -39,7 +40,7 @@ public final class SimpleMemoryPipelineChannel implements PipelineChannel {
     private final AckCallback ackCallback;
     
     public SimpleMemoryPipelineChannel(final int blockQueueSize, final AckCallback ackCallback) {
-        this.queue = new ArrayBlockingQueue<>(blockQueueSize);
+        this.queue = blockQueueSize < 1 ? new SynchronousQueue<>() : new ArrayBlockingQueue<>(blockQueueSize);
         this.ackCallback = ackCallback;
     }
     
@@ -50,7 +51,6 @@ public final class SimpleMemoryPipelineChannel implements PipelineChannel {
     }
     
     @SneakyThrows(InterruptedException.class)
-    // TODO thread-safe?
     @Override
     public List<Record> fetchRecords(final int batchSize, final long timeout, final TimeUnit timeUnit) {
         List<Record> result = new LinkedList<>();

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/memory/SimpleMemoryPipelineChannel.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/memory/SimpleMemoryPipelineChannel.java
@@ -40,7 +40,7 @@ public final class SimpleMemoryPipelineChannel implements PipelineChannel {
     private final AckCallback ackCallback;
     
     public SimpleMemoryPipelineChannel(final int blockQueueSize, final AckCallback ackCallback) {
-        this.queue = blockQueueSize < 1 ? new SynchronousQueue<>() : new ArrayBlockingQueue<>(blockQueueSize);
+        this.queue = blockQueueSize < 1 ? new SynchronousQueue<>(true) : new ArrayBlockingQueue<>(blockQueueSize, true);
         this.ackCallback = ackCallback;
     }
     


### PR DESCRIPTION

Changes proposed in this pull request:
  - Support SimpleMemoryPipelineChannel use 0 blocking queue size
  - Enable fair for incremental

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
