### PR TITLE
Convert `Locale` when executing JapaneseDate related unit tests to fix CI

### DIFF
--- a/docs/document/content/user-manual/common-config/builtin-algorithm/expr.cn.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/expr.cn.md
@@ -48,7 +48,6 @@ weight = 10
 6. `DU` 代表 datetime upper 的缩写，意为时间上界值，格式与 `SP` 定义的时间戳格式一致。
 7. `C` 代表 chronology 的缩写，意为日历系统，必须遵循 Java `java.time.chrono.Chronology#getId()` 的格式。
 例如：`Japanese`，`Minguo`，`ThaiBuddhist`。存在默认值为 `ISO`。
-受 https://bugs.openjdk.org/browse/JDK-8068571 影响，`Japanese` 仅在 JDK 11+ 上可用。
 
 类型：INTERVAL
 

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/expr.en.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/expr.en.md
@@ -56,7 +56,6 @@ It must follow the enumeration value of Java `java.time.temporal.ChronoUnit#toSt
 6. `DU` stands for the abbreviation of datetime upper, which means the upper bound value of time. The format is consistent with the timestamp format defined by `SP`.
 7. `C` stands for the abbreviation of chronology, which means calendar system and must follow the format of Java `java.time.chrono.Chronology#getId()`.
 For example: `Japanese`, `Minguo`, `ThaiBuddhist`. There is a default value of `ISO`.
-Affected by https://bugs.openjdk.org/browse/JDK-8068571, `Japanese` is only available on JDK 11+.
 
 Type: INTERVAL
 


### PR DESCRIPTION
For #29309 .

Changes proposed in this pull request:
  - Convert `Locale` when executing JapaneseDate related unit tests.
  - Refer to https://github.com/apache/shardingsphere/actions/runs/7185460184/job/19568814086 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
