### PR TITLE
Remove incorrect SqlServer annotation syntax

### DIFF
--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/Comments.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/Comments.g4
@@ -20,4 +20,4 @@ lexer grammar Comments;
 import Symbol;
 
 BLOCK_COMMENT:  '/*' .*? '*/' -> channel(HIDDEN);
-INLINE_COMMENT: (('-- ' | '#') ~[\r\n]* ('\r'? '\n' | EOF) | '--' ('\r'? '\n' | EOF)) -> channel(HIDDEN);
+INLINE_COMMENT: ('-- ' ~[\r\n]* ('\r'? '\n' | EOF) | '--' ('\r'? '\n' | EOF)) -> channel(HIDDEN);


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove incorrect SqlServer annotation syntax
 
There are only two annotation rules '--'and '/* */' in the syntax of sqlServer, and there is no '#'，Below is the official website address
 https://learn.microsoft.com/zh-cn/sql/t-sql/language-elements/comment-transact-sql?view=sql-server-ver16

This problem will cause the SQL similar to 'SELECT COUNT(*) AS [Number of rows] FROM #Test' to be parsed correctly in DMLStatement.g4, but it will be parsed incorrectly in SQLServerStatement.g4 with an error message indicating a missing EOF because '#' is defined as a comment in Comments.g4, which can lead to confusion when writing parsing rules. like #29230 

**result In DMLStatement.g4**
![image](https://github.com/apache/shardingsphere/assets/124348939/f4303249-f6d2-4cf8-a3ca-42e51cee8f3a)

**result In SQLServerStatement.g4**
![image](https://github.com/apache/shardingsphere/assets/124348939/17b9b7bc-7e35-49cb-a843-46f451e1205d)

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [] I have made corresponding changes to the documentation.
- [] I have added corresponding unit tests for my changes.
