### PR TITLE
Add GraalVM Reachability Metadata and corresponding nativeTest for MS SQL Server integration

### DIFF
--- a/distribution/proxy-native/pom.xml
+++ b/distribution/proxy-native/pom.xml
@@ -86,6 +86,7 @@
                             <mainClass>org.apache.shardingsphere.proxy.Bootstrap</mainClass>
                             <buildArgs>
                                 <arg>-J-Xmx7g</arg>
+                                <arg>-H:+AddAllCharsets</arg>
                             </buildArgs>
                             <metadataRepository>
                                 <enabled>true</enabled>

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.en.md
@@ -43,9 +43,12 @@ and the documentation of GraalVM Native Build Tools shall prevail.
                  <version>0.9.28</version>
                  <extensions>true</extensions>
                  <configuration>
-                     <metadataRepository>
-                         <enabled>true</enabled>
-                     </metadataRepository>
+                    <buildArgs>
+                       <buildArg>-H:+AddAllCharsets</buildArg>
+                    </buildArgs>
+                    <metadataRepository>
+                       <enabled>true</enabled>
+                    </metadataRepository>
                  </configuration>
                  <executions>
                      <execution>
@@ -85,9 +88,17 @@ dependencies {
 }
 
 graalvmNative {
-     metadataRepository {
-         enabled = true
-     }
+   binaries {
+      main {
+         buildArgs.add('-H:+AddAllCharsets')
+      }
+      test {
+         buildArgs.add('-H:+AddAllCharsets')
+      }
+   }
+   metadataRepository {
+      enabled = true
+   }
 }
 ```
 
@@ -201,7 +212,22 @@ rules:
 folder or `src/test/resources/META-INF/native-image` folder. Users can quickly collect GraalVM Reachability Metadata through 
 the GraalVM Tracing Agent of GraalVM Native Build Tools. 
 
-4. DistSQL availability has not been verified. Users need to add additional GraalVM Reachability Metadata by themselves.
+4. Maven modules such as `com.microsoft.sqlserver:mssql-jdbc`, represented by the JDBC Driver of MS SQL Server,
+will dynamically load different character sets based on the encoding used in the database, which is unpredictable behavior. 
+When encountering the following Error, users need to add the `buildArg` of `-H:+AddAllCharsets` to the configuration of GraalVM Native Build Tools.
+
+```shell
+Caused by: java.io.UnsupportedEncodingException: SQL Server collation SQL_Latin1_General_CP1_CI_AS is not supported by this driver.
+ com.microsoft.sqlserver.jdbc.SQLCollation.encodingFromSortId(SQLCollation.java:506)
+ com.microsoft.sqlserver.jdbc.SQLCollation.<init>(SQLCollation.java:63)
+ com.microsoft.sqlserver.jdbc.SQLServerConnection.processEnvChange(SQLServerConnection.java:3174)
+ [...]
+Caused by: java.io.UnsupportedEncodingException: Codepage Cp1252 is not supported by the Java environment.
+ com.microsoft.sqlserver.jdbc.Encoding.checkSupported(SQLCollation.java:572)
+ com.microsoft.sqlserver.jdbc.SQLCollation$SortOrder.getEncoding(SQLCollation.java:473)
+ com.microsoft.sqlserver.jdbc.SQLCollation.encodingFromSortId(SQLCollation.java:501)
+ [...]
+```
 
 ## Contribute GraalVM Reachability Metadata
 

--- a/infra/database/type/sqlserver/src/main/java/org/apache/shardingsphere/infra/database/sqlserver/connector/SQLServerConnectionPropertiesParser.java
+++ b/infra/database/type/sqlserver/src/main/java/org/apache/shardingsphere/infra/database/sqlserver/connector/SQLServerConnectionPropertiesParser.java
@@ -34,7 +34,7 @@ public final class SQLServerConnectionPropertiesParser implements ConnectionProp
     
     private static final int DEFAULT_PORT = 1433;
     
-    private static final Pattern URL_PATTERN = Pattern.compile("jdbc:(microsoft:)?sqlserver://([\\w\\-\\.]+):?(\\d*);\\S*(DatabaseName|database)=([\\w\\-\\.]+);?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern URL_PATTERN = Pattern.compile("jdbc:(microsoft:|tc:)?sqlserver:.*//([\\w\\-\\.]+):?(\\d*);\\S*(databaseName|database)=([\\w\\-\\.]+);?", Pattern.CASE_INSENSITIVE);
     
     @Override
     public ConnectionProperties parse(final String url, final String username, final String catalog) {

--- a/infra/database/type/sqlserver/src/test/java/org/apache/shardingsphere/infra/database/sqlserver/connector/SQLServerConnectionPropertiesParserTest.java
+++ b/infra/database/type/sqlserver/src/test/java/org/apache/shardingsphere/infra/database/sqlserver/connector/SQLServerConnectionPropertiesParserTest.java
@@ -67,7 +67,8 @@ class SQLServerConnectionPropertiesParserTest {
                     Arguments.of("defaultPortAndMicrosoft", "jdbc:microsoft:sqlserver://127.0.0.1;DatabaseName=foo_ds", "127.0.0.1", 1433, "foo_ds", null),
                     Arguments.of("defaultPortWithoutMicrosoft", "jdbc:sqlserver://127.0.0.1;DatabaseName=foo_ds", "127.0.0.1", 1433, "foo_ds", null),
                     Arguments.of("databaseNameContainDotAndMicrosoft", "jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=foo_0.0.0", "127.0.0.1", 9999, "foo_0.0.0", null),
-                    Arguments.of("databaseNameContainDotAndWithoutMicrosoft", "jdbc:sqlserver://127.0.0.1:9999;DatabaseName=foo_0.0.0", "127.0.0.1", 9999, "foo_0.0.0", null));
+                    Arguments.of("databaseNameContainDotAndWithoutMicrosoft", "jdbc:sqlserver://127.0.0.1:9999;DatabaseName=foo_0.0.0", "127.0.0.1", 9999, "foo_0.0.0", null),
+                    Arguments.of("testcontainers", "jdbc:tc:sqlserver:2022-CU10-ubuntu-22.04://test-hostname;databaseName=test_database", "test-hostname", 1433, "test_database", null));
         }
     }
 }

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reflect-config.json
@@ -19,7 +19,7 @@
   "name":"org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.broadcast.yaml.swapper.NewYamlBroadcastRuleConfigurationSwapper"},
   "name":"org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
@@ -34,7 +34,7 @@
   "name":"org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfigurationCustomizer"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.DatabaseTypeEngine"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.state.datasource.DataSourceStateManager"},
   "name":"org.apache.shardingsphere.driver.ShardingSphereDriver"
 },
 {
@@ -67,7 +67,7 @@
   "name":"org.apache.shardingsphere.encrypt.yaml.config.YamlCompatibleEncryptRuleConfiguration"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"},
   "name":"org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
@@ -206,7 +206,7 @@
   "methods":[{"name":"getRows","parameterTypes":[] }, {"name":"getUniqueKey","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.builder.SystemSchemaBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
@@ -221,7 +221,7 @@
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumnCustomizer"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.builder.SystemSchemaBuilder"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
@@ -236,7 +236,7 @@
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndexCustomizer"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.metadata.persist.service.schema.NewTableMetaDataPersistService"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
@@ -406,7 +406,7 @@
   "name":"org.apache.shardingsphere.parser.yaml.config.YamlSQLParserCacheOptionRuleConfigurationCustomizer"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"},
   "name":"org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
@@ -613,7 +613,7 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
@@ -628,7 +628,7 @@
   "name":"org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfigurationCustomizer"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.yaml.swapper.NewYamlShardingRuleConfigurationSwapper"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
@@ -658,7 +658,7 @@
   "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfigurationCustomizer"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.yaml.swapper.NewYamlShardingRuleConfigurationSwapper"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
@@ -756,6 +756,11 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.opengauss.visitor.statement.type.OpenGaussDMLStatementVisitor"},
+  "name":"org.apache.shardingsphere.sql.parser.opengauss.visitor.statement.type.OpenGaussDMLStatementVisitor",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
   "name":"org.apache.shardingsphere.sql.parser.oracle.visitor.statement.OracleStatementVisitorFacade",
   "methods":[{"name":"<init>","parameterTypes":[] }]
@@ -831,9 +836,34 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dml.SQLServerDeleteStatement"},
+  "name":"org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dml.SQLServerDeleteStatement",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dml.SQLServerInsertStatement"},
+  "name":"org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dml.SQLServerInsertStatement",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dml.SQLServerSelectStatement"},
+  "name":"org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dml.SQLServerSelectStatement",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
   "name":"org.apache.shardingsphere.sql.parser.sql92.visitor.statement.SQL92StatementVisitorFacade",
   "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.sqlserver.parser.SQLServerLexer"},
+  "name":"org.apache.shardingsphere.sql.parser.sqlserver.parser.SQLServerLexer",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.CharStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.sqlserver.parser.SQLServerParser"},
+  "name":"org.apache.shardingsphere.sql.parser.sqlserver.parser.SQLServerParser",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.TokenStream"] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
@@ -841,7 +871,12 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.sqlserver.visitor.statement.type.SQLServerDDLStatementVisitor"},
+  "name":"org.apache.shardingsphere.sql.parser.sqlserver.visitor.statement.type.SQLServerDDLStatementVisitor",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.rule.SQLFederationRule"},
   "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils",
   "queryAllPublicMethods":true
 },
@@ -867,8 +902,8 @@
   "name":"org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.opengauss.visitor.statement.type.OpenGaussDMLStatementVisitor"},
-  "name":"org.apache.shardingsphere.sql.parser.opengauss.visitor.statement.type.OpenGaussDMLStatementVisitor",
+  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.sqlserver.visitor.statement.type.SQLServerDMLStatementVisitor"},
+  "name":"org.apache.shardingsphere.sql.parser.sqlserver.visitor.statement.type.SQLServerDMLStatementVisitor",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 }
 ]

--- a/pom.xml
+++ b/pom.xml
@@ -1078,6 +1078,9 @@
                             <version>${native-maven-plugin.version}</version>
                             <extensions>true</extensions>
                             <configuration>
+                                <buildArgs>
+                                    <buildArg>-H:+AddAllCharsets</buildArg>
+                                </buildArgs>
                                 <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                                 <metadataRepository>
                                     <enabled>true</enabled>

--- a/test/native/native-image-filter/extra-filter.json
+++ b/test/native/native-image-filter/extra-filter.json
@@ -20,7 +20,7 @@
     {"excludeClasses": "com.ibm.icu.text.**"},
     {"excludeClasses": "com.mysql.cj.**"},
     {"excludeClasses": "com.zaxxer.hikari.**"},
-    {"excludeClasses": "javax.xml.bind.annotation.**"},
+    {"excludeClasses": "javax.xml.**"},
     {"excludeClasses": "groovy.**"},
     {"excludeClasses": "org.apache.calcite.**"},
     {"excludeClasses": "org.codehaus.groovy.**"},

--- a/test/native/pom.xml
+++ b/test/native/pom.xml
@@ -66,8 +66,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mssqlserver</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/commons/repository/AddressRepository.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/commons/repository/AddressRepository.java
@@ -51,6 +51,24 @@ public final class AddressRepository {
     }
     
     /**
+     * create table t_address in MS SQL Server.
+     * This also ignored the default schema of the `dbo`.
+     * @throws SQLException SQL exception
+     */
+    public void createTableInSQLServer() throws SQLException {
+        String sql = "CREATE TABLE [t_address] (\n"
+                + "    address_id bigint NOT NULL,\n"
+                + "    address_name varchar(100) NOT NULL,\n"
+                + "    PRIMARY KEY (address_id)\n"
+                + ");";
+        try (
+                Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.executeUpdate(sql);
+        }
+    }
+    
+    /**
      * drop table t_address.
      * @throws SQLException SQL exception
      */

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/commons/repository/OrderItemRepository.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/commons/repository/OrderItemRepository.java
@@ -71,6 +71,27 @@ public final class OrderItemRepository {
     }
     
     /**
+     * create table in MS SQL Server. `order_item_id` is not set to `IDENTITY(1,1)` to simplify the unit test.
+     * This also ignored the default schema of the `dbo`.
+     * @throws SQLException SQL exception
+     */
+    public void createTableInSQLServer() throws SQLException {
+        String sql = "CREATE TABLE [t_order_item] (\n"
+                + "    order_item_id bigint NOT NULL,\n"
+                + "    order_id bigint NOT NULL,\n"
+                + "    user_id int NOT NULL,\n"
+                + "    phone varchar(50),\n"
+                + "    status varchar(50),\n"
+                + "    PRIMARY KEY (order_item_id)\n"
+                + ");";
+        try (
+                Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.executeUpdate(sql);
+        }
+    }
+    
+    /**
      * drop table.
      * @throws SQLException SQL exception
      */

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/commons/repository/OrderRepository.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/commons/repository/OrderRepository.java
@@ -71,6 +71,27 @@ public final class OrderRepository {
     }
     
     /**
+     * create table in MS SQL Server. `order_item_id` is not set to `IDENTITY(1,1)` to simplify the unit test.
+     * This also ignored the default schema of the `dbo`.
+     * @throws SQLException SQL exception
+     */
+    public void createTableInSQLServer() throws SQLException {
+        String sql = "CREATE TABLE [t_order] (\n"
+                + "    order_id bigint NOT NULL,\n"
+                + "    order_type int NOT NULL,\n"
+                + "    user_id int NOT NULL,\n"
+                + "    address_id bigint NOT NULL,\n"
+                + "    status varchar(50),\n"
+                + "    PRIMARY KEY (order_id)\n"
+                + ");";
+        try (
+                Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.executeUpdate(sql);
+        }
+    }
+    
+    /**
      * drop table.
      * TODO There is a bug in this function in shadow's unit test and requires additional fixes.
      * @throws SQLException SQL exception

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/MSSQLServerTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/MSSQLServerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.natived.jdbc.databases;
+
+import org.apache.shardingsphere.driver.api.yaml.YamlShardingSphereDataSourceFactory;
+import org.apache.shardingsphere.test.natived.jdbc.commons.AbstractShardingCommonTest;
+import org.apache.shardingsphere.test.natived.jdbc.commons.FileTestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledInNativeImage;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class MSSQLServerTest {
+    
+    private AbstractShardingCommonTest abstractShardingCommonTest;
+    
+    @Test
+    @EnabledInNativeImage
+    void assertShardingInLocalTransactions() throws SQLException, IOException {
+        DataSource dataSource = YamlShardingSphereDataSourceFactory.createDataSource(FileTestUtils.readFromFileURLString("test-native/yaml/databases/mssqlserver.yaml"));
+        abstractShardingCommonTest = new AbstractShardingCommonTest(dataSource);
+        this.initEnvironment();
+        abstractShardingCommonTest.processSuccess();
+        abstractShardingCommonTest.cleanEnvironment();
+    }
+    
+    private void initEnvironment() throws SQLException {
+        abstractShardingCommonTest.getOrderRepository().createTableInSQLServer();
+        abstractShardingCommonTest.getOrderItemRepository().createTableInSQLServer();
+        abstractShardingCommonTest.getAddressRepository().createTableInSQLServer();
+        abstractShardingCommonTest.getOrderRepository().truncateTable();
+        abstractShardingCommonTest.getOrderItemRepository().truncateTable();
+        abstractShardingCommonTest.getAddressRepository().truncateTable();
+    }
+}

--- a/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native-test-metadata/resource-config.json
+++ b/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native-test-metadata/resource-config.json
@@ -1,6 +1,12 @@
 {
   "resources":{
   "includes":[{
+    "condition":{"typeReachable":"org.apache.shardingsphere.test.natived.jdbc.databases.MSSQLServerTest"},
+    "pattern":"\\Qcontainer-license-acceptance.txt\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.test.natived.jdbc.databases.MSSQLServerTest"},
+    "pattern":"\\Qtest-native/yaml/databases/mssqlserver.yaml\\E"
+  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.test.natived.jdbc.databases.MySQLTest"},
     "pattern":"\\Qtest-native/yaml/databases/mysql.yaml\\E"
   }, {

--- a/test/native/src/test/resources/container-license-acceptance.txt
+++ b/test/native/src/test/resources/container-license-acceptance.txt
@@ -1,0 +1,1 @@
+mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04

--- a/test/native/src/test/resources/test-native/yaml/databases/mssqlserver.yaml
+++ b/test/native/src/test/resources/test-native/yaml/databases/mssqlserver.yaml
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mode:
+  type: Standalone
+  repository:
+    type: JDBC
+
+dataSources:
+  ds_0:
+    dataSourceClassName: com.zaxxer.hikari.HikariDataSource
+    driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
+    jdbcUrl: jdbc:tc:sqlserver:2022-CU10-ubuntu-22.04://test-native-databases-mssqlserver;databaseName=demo_ds_0;TC_DAEMON=true;
+  ds_1:
+    dataSourceClassName: com.zaxxer.hikari.HikariDataSource
+    driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
+    jdbcUrl: jdbc:tc:sqlserver:2022-CU10-ubuntu-22.04://test-native-databases-mssqlserver;databaseName=demo_ds_1;TC_DAEMON=true;
+  ds_2:
+    dataSourceClassName: com.zaxxer.hikari.HikariDataSource
+    driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
+    jdbcUrl: jdbc:tc:sqlserver:2022-CU10-ubuntu-22.04://test-native-databases-mssqlserver;databaseName=demo_ds_2;TC_DAEMON=true;
+
+rules:
+- !SHARDING
+  tables:
+    t_order:
+      actualDataNodes:
+      keyGenerateStrategy:
+        column: order_id
+        keyGeneratorName: snowflake
+    t_order_item:
+      actualDataNodes:
+      keyGenerateStrategy:
+        column: order_item_id
+        keyGeneratorName: snowflake
+  defaultDatabaseStrategy:
+    standard:
+      shardingColumn: user_id
+      shardingAlgorithmName: inline
+  shardingAlgorithms:
+    inline:
+      type: CLASS_BASED
+      props:
+        strategy: STANDARD
+        algorithmClassName: org.apache.shardingsphere.test.natived.jdbc.commons.algorithm.ClassBasedInlineShardingAlgorithmFixture
+  keyGenerators:
+    snowflake:
+      type: SNOWFLAKE
+  auditors:
+    sharding_key_required_auditor:
+      type: DML_SHARDING_CONDITIONS
+
+- !BROADCAST
+  tables:
+    - t_address
+
+props:
+  sql-show: false


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Add GraalVM Reachability Metadata and corresponding nativeTest for MS SQL Server integration.
  - Examples like https://github.com/apache/beam/blob/v2.52.0/it/jdbc/src/main/java/org/apache/beam/it/jdbc/MSSQLResourceManager.java show that ASF allows the EULA for MS SQL Server's Docker Image during testing. Therefore, I think there is no problem in using the corresponding Docker Image in unit testing.
  - Modifications to `SQLServerConnectionPropertiesParser` are unavoidable and cannot be avoided by implementing a new `ConnectionPropertiesParser`. Because in `TcSQLServerDatabaseType.getTrunkDatabaseType()`, all jdbcUrls with the prefix `jdbc:tc:sqlserver:` will be routed to `SQLServer`’s `DatabaseType`. 
  - The reason why jdbcUrl prefixed with `jdbc:tc:postgresql:` does not need to be done is that `PostgreSQLConnectionPropertiesParser` uses the public `StandardJdbcUrlParser` to parse jdbcUrl, and `StandardJdbcUrlParser` always supports testcontainers and contains corresponding unit tests.
  - Maven modules such as `com.microsoft.sqlserver:mssql-jdbc`, represented by the JDBC Driver of MS SQL Server,
will dynamically load different character sets based on the encoding used in the database, which is unpredictable behavior under GraalVM Native Image. I've specified the relevant settings in the documentation.
```shell
Failures (1):
  JUnit Jupiter:MSSQLServerTest:assertShardingInLocalTransactions()
    MethodSource [className = 'org.apache.shardingsphere.test.natived.jdbc.databases.MSSQLServerTest', methodName = 'assertShardingInLocalTransactions', methodParameterTypes = '']
    => com.zaxxer.hikari.pool.HikariPool$PoolInitializationException: Failed to initialize pool: Container startup failed for image mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04
       com.zaxxer.hikari.pool.HikariPool.throwPoolInitializationException(HikariPool.java:596)
       com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:582)
       com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:115)
       com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:112)
       org.apache.shardingsphere.infra.datasource.pool.CatalogSwitchableDataSource.getConnection(CatalogSwitchableDataSource.java:46)
       [...]
     Caused by: org.testcontainers.containers.ContainerLaunchException: Container startup failed for image mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04
       org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:362)
       org.testcontainers.containers.GenericContainer.start(GenericContainer.java:333)
       org.testcontainers.jdbc.ContainerDatabaseDriver.connect(ContainerDatabaseDriver.java:134)
       com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:121)
       com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:364)
       [...]
     Caused by: org.rnorth.ducttape.RetryCountExceededException: Retry limit hit with exception
       org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:88)
       org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:347)
       [...]
     Caused by: org.testcontainers.containers.ContainerLaunchException: Could not create/start container
       org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:566)
       org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:357)
       org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
       [...]
     Caused by: java.lang.IllegalStateException: Container is started, but cannot be accessed by (JDBC URL: jdbc:sqlserver://localhost:62038;encrypt=false), please check container logs
       org.testcontainers.containers.JdbcDatabaseContainer.waitUntilContainerStarted(JdbcDatabaseContainer.java:176)
       org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:503)
       [...]
     Caused by: java.sql.SQLException: Could not create new connection
       org.testcontainers.containers.JdbcDatabaseContainer.createConnection(JdbcDatabaseContainer.java:262)
       org.testcontainers.containers.JdbcDatabaseContainer.createConnection(JdbcDatabaseContainer.java:218)
       org.testcontainers.containers.JdbcDatabaseContainer.waitUntilContainerStarted(JdbcDatabaseContainer.java:158)
       [...]
     Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: SQL Server collation SQL_Latin1_General_CP1_CI_AS is not supported by this driver. ClientConnectionId:5810036a-9e38-463b-a09a-8db2864d3647
       com.microsoft.sqlserver.jdbc.SQLServerConnection.terminate(SQLServerConnection.java:2374)
       com.microsoft.sqlserver.jdbc.SQLServerConnection.processEnvChange(SQLServerConnection.java:3177)
       com.microsoft.sqlserver.jdbc.TDSTokenHandler.onEnvChange(tdsparser.java:187)
       com.microsoft.sqlserver.jdbc.TDSParser.parse(tdsparser.java:62)
       com.microsoft.sqlserver.jdbc.SQLServerConnection.sendLogon(SQLServerConnection.java:4214)
       [...]
     Caused by: java.io.UnsupportedEncodingException: SQL Server collation SQL_Latin1_General_CP1_CI_AS is not supported by this driver.
       com.microsoft.sqlserver.jdbc.SQLCollation.encodingFromSortId(SQLCollation.java:506)
       com.microsoft.sqlserver.jdbc.SQLCollation.<init>(SQLCollation.java:63)
       com.microsoft.sqlserver.jdbc.SQLServerConnection.processEnvChange(SQLServerConnection.java:3174)
       [...]
     Caused by: java.io.UnsupportedEncodingException: Codepage Cp1252 is not supported by the Java environment.
       com.microsoft.sqlserver.jdbc.Encoding.checkSupported(SQLCollation.java:572)
       com.microsoft.sqlserver.jdbc.SQLCollation$SortOrder.getEncoding(SQLCollation.java:473)
       com.microsoft.sqlserver.jdbc.SQLCollation.encodingFromSortId(SQLCollation.java:501)
       [...]
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
