### PR TITLE
Fix example module failed build on JDK21

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        java-version: [ 11, 17, 21-ea ]
+        java-version: [ 11, 17, 21 ]
     steps:
       - name: Support Long Paths in Windows
         if: matrix.os == 'windows-latest'

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -46,7 +46,7 @@
         <h2.version>2.2.224</h2.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.2.13</logback.version>
-        <lombok.version>1.18.20</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
         <mybatis.version>3.5.9</mybatis.version>
         <mybatis-spring.version>2.0.5</mybatis-spring.version>
         <mybatis-spring-boot.version>2.1.3</mybatis-spring-boot.version>


### PR DESCRIPTION
For #29386.

Changes proposed in this pull request:
  - Fix example module failed build on JDK21. Refer to #28326 and https://github.com/apache/shardingsphere/actions/runs/7199233000/job/19610473126 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
