### PR TITLE
Add cause exception for OverallConnectionNotEnoughException

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/exception/OverallConnectionNotEnoughException.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/exception/OverallConnectionNotEnoughException.java
@@ -27,8 +27,8 @@ public final class OverallConnectionNotEnoughException extends ConnectionSQLExce
     
     private static final long serialVersionUID = -1297088138042287804L;
     
-    public OverallConnectionNotEnoughException(final int desiredSize, final int actualSize) {
-        super(XOpenSQLState.CONNECTION_EXCEPTION, 20, "Can not get %d connections one time, partition succeed connection(%d) have released. "
-                + "Please consider increasing the `maxPoolSize` of the data sources or decreasing the `max-connections-size-per-query` in properties.", desiredSize, actualSize);
+    public OverallConnectionNotEnoughException(final int desiredSize, final int actualSize, final Exception cause) {
+        super(XOpenSQLState.CONNECTION_EXCEPTION, 20, String.format("Can not get %d connections one time, partition succeed connection(%d) have released. "
+                + "Please consider increasing the `maxPoolSize` of the data sources or decreasing the `max-connections-size-per-query` in properties.", desiredSize, actualSize), cause);
     }
 }

--- a/infra/exception/core/src/main/java/org/apache/shardingsphere/infra/exception/core/external/sql/type/kernel/category/ConnectionSQLException.java
+++ b/infra/exception/core/src/main/java/org/apache/shardingsphere/infra/exception/core/external/sql/type/kernel/category/ConnectionSQLException.java
@@ -32,4 +32,8 @@ public abstract class ConnectionSQLException extends KernelSQLException {
     protected ConnectionSQLException(final SQLState sqlState, final int errorCode, final String reason, final Object... messageArgs) {
         super(sqlState, KERNEL_CODE, errorCode, reason, messageArgs);
     }
+    
+    public ConnectionSQLException(final SQLState sqlState, final int errorCode, final String reason, final Exception cause) {
+        super(sqlState, KERNEL_CODE, errorCode, reason, cause);
+    }
 }

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/DriverDatabaseConnectionManager.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/DriverDatabaseConnectionManager.java
@@ -400,11 +400,11 @@ public final class DriverDatabaseConnectionManager implements DatabaseConnection
                 Connection connection = createConnection(databaseName, dataSourceName, dataSource, transactionConnectionContext);
                 methodInvocationRecorder.replay(connection);
                 result.add(connection);
-            } catch (final SQLException ignored) {
+            } catch (final SQLException ex) {
                 for (Connection each : result) {
                     each.close();
                 }
-                throw new OverallConnectionNotEnoughException(connectionSize, result.size()).toSQLException();
+                throw new OverallConnectionNotEnoughException(connectionSize, result.size(), ex).toSQLException();
             }
         }
         return result;

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/datasource/JDBCBackendDataSource.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/datasource/JDBCBackendDataSource.java
@@ -94,11 +94,11 @@ public final class JDBCBackendDataSource implements BackendDataSource {
         for (int i = 0; i < connectionSize; i++) {
             try {
                 result.add(createConnection(databaseName, dataSourceName, dataSource, transactionType));
-            } catch (final SQLException ignored) {
+            } catch (final SQLException ex) {
                 for (Connection each : result) {
                     each.close();
                 }
-                throw new OverallConnectionNotEnoughException(connectionSize, result.size());
+                throw new OverallConnectionNotEnoughException(connectionSize, result.size(), ex);
             }
         }
         return result;


### PR DESCRIPTION

Changes proposed in this pull request:
  - Add cause exception for OverallConnectionNotEnoughException. Ignored SQLException might be caused by connection timeout etc, it's necessary for troubleshooting, so `cause` is added.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
