### PR TITLE
Fixes #29429, fix yaml lineBreak on windows

### DIFF
--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlEngine.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlEngine.java
@@ -107,8 +107,8 @@ public final class YamlEngine {
         DumperOptions dumperOptions = new DumperOptions();
         dumperOptions.setLineBreak(DumperOptions.LineBreak.getPlatformLineBreak());
         if (value instanceof Collection) {
-            return new Yaml(new ShardingSphereYamlRepresenter(dumperOptions)).dumpAs(value, null, DumperOptions.FlowStyle.BLOCK);
+            return new Yaml(new ShardingSphereYamlRepresenter(dumperOptions), dumperOptions).dumpAs(value, null, DumperOptions.FlowStyle.BLOCK);
         }
-        return new Yaml(new ShardingSphereYamlRepresenter(dumperOptions)).dumpAsMap(value);
+        return new Yaml(new ShardingSphereYamlRepresenter(dumperOptions), dumperOptions).dumpAsMap(value);
     }
 }


### PR DESCRIPTION
For nightly CI fails on windows, use the Yaml constructor specifying dumperOptions

<img width="867" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/8048143d-7019-4473-b8d3-9dd855ff6688">

### Before (windows)
![image](https://github.com/apache/shardingsphere/assets/5668787/c06d97c3-248f-4b2c-bccf-99733686001b)

### After (windows)
![image](https://github.com/apache/shardingsphere/assets/5668787/7ee630f8-fc47-4978-bb86-b2e6dabba363)
