### PR TITLE
Use CaseInsensitiveMap to replace LinkedHashMap in TableNamesMapper

### DIFF
--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
@@ -444,7 +444,7 @@ class ShardingRuleTest {
     
     @Test
     void assertGetTables() {
-        assertThat(new LinkedList<>(createMaximumShardingRule().getLogicTableMapper().getTableNames()), is(Arrays.asList("LOGIC_TABLE", "SUB_LOGIC_TABLE")));
+        assertThat(new LinkedList<>(createMaximumShardingRule().getLogicTableMapper().getTableNames()), is(Arrays.asList("SUB_LOGIC_TABLE", "LOGIC_TABLE")));
     }
     
     @Test

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/TableNamesMapper.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/TableNamesMapper.java
@@ -17,8 +17,9 @@
 
 package org.apache.shardingsphere.infra.rule.identifier.type;
 
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -26,7 +27,7 @@ import java.util.Map;
  */
 public final class TableNamesMapper {
     
-    private final Map<String, String> lowerCaseTableNames = new LinkedHashMap<>();
+    private final Map<String, String> lowerCaseTableNames = new CaseInsensitiveMap<>();
     
     /**
      * Judge whether contains table or not.
@@ -35,7 +36,7 @@ public final class TableNamesMapper {
      * @return whether contains table or not
      */
     public boolean contains(final String tableName) {
-        return lowerCaseTableNames.containsKey(tableName.toLowerCase());
+        return lowerCaseTableNames.containsKey(tableName);
     }
     
     /**
@@ -53,7 +54,7 @@ public final class TableNamesMapper {
      * @param tableName table name
      */
     public void put(final String tableName) {
-        lowerCaseTableNames.put(tableName.toLowerCase(), tableName);
+        lowerCaseTableNames.put(tableName, tableName);
     }
     
     /**
@@ -62,6 +63,6 @@ public final class TableNamesMapper {
      * @param tableName table name
      */
     public void remove(final String tableName) {
-        lowerCaseTableNames.remove(tableName.toLowerCase());
+        lowerCaseTableNames.remove(tableName);
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Use CaseInsensitiveMap to replace LinkedHashMap in TableNamesMapper

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
