### PR TITLE
Fix SimpleMemoryPipelineChannelTest.assertFetchRecordsTimeoutCorrectly in nightly CI

### DIFF
--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/memory/SimpleMemoryPipelineChannelTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/memory/SimpleMemoryPipelineChannelTest.java
@@ -48,13 +48,13 @@ class SimpleMemoryPipelineChannelTest {
     @Test
     void assertFetchRecordsTimeoutCorrectly() {
         SimpleMemoryPipelineChannel channel = new SimpleMemoryPipelineChannel(10, new EmptyAckCallback());
-        long startMills = System.currentTimeMillis();
+        long startMillis = System.currentTimeMillis();
         channel.fetchRecords(1, 1, TimeUnit.MILLISECONDS);
-        long delta = System.currentTimeMillis() - startMills;
+        long delta = System.currentTimeMillis() - startMillis;
         assertTrue(delta >= 1 && delta < 50, "Delta is not in [1,50) : " + delta);
-        startMills = System.currentTimeMillis();
+        startMillis = System.currentTimeMillis();
         channel.fetchRecords(1, 500, TimeUnit.MILLISECONDS);
-        delta = System.currentTimeMillis() - startMills;
-        assertTrue(delta >= 500 && delta < 650, "Delta is not in [500,650) : " + delta);
+        delta = System.currentTimeMillis() - startMillis;
+        assertTrue(delta >= 500 && delta < 750, "Delta is not in [500,750) : " + delta);
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Fix SimpleMemoryPipelineChannelTest.assertFetchRecordsTimeoutCorrectly in nightly CI

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
