### PR TITLE
Restore original databaseName in connectionSession after unicast

### DIFF
--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/data/impl/UnicastDatabaseBackendHandler.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/data/impl/UnicastDatabaseBackendHandler.java
@@ -53,15 +53,15 @@ public final class UnicastDatabaseBackendHandler implements DatabaseBackendHandl
     
     @Override
     public ResponseHeader execute() throws SQLException {
-        String originDatabase = connectionSession.getDefaultDatabaseName();
-        String databaseName = null == originDatabase ? getFirstDatabaseName() : originDatabase;
-        ShardingSpherePreconditions.checkState(ProxyContext.getInstance().getDatabase(databaseName).containsDataSource(), () -> new StorageUnitNotExistedException(databaseName));
+        String originalDatabaseName = connectionSession.getDefaultDatabaseName();
+        String unicastDatabaseName = null == originalDatabaseName ? getFirstDatabaseName() : originalDatabaseName;
+        ShardingSpherePreconditions.checkState(ProxyContext.getInstance().getDatabase(unicastDatabaseName).containsDataSource(), () -> new StorageUnitNotExistedException(unicastDatabaseName));
         try {
-            connectionSession.setCurrentDatabase(databaseName);
+            connectionSession.setCurrentDatabase(unicastDatabaseName);
             databaseConnector = databaseConnectorFactory.newInstance(queryContext, connectionSession.getDatabaseConnectionManager(), false);
             return databaseConnector.execute();
         } finally {
-            connectionSession.setCurrentDatabase(databaseName);
+            connectionSession.setCurrentDatabase(originalDatabaseName);
         }
     }
     


### PR DESCRIPTION
Currently, performing a unicast will cause the `databaseName` in `connectionSession` changed, which is incorrect.

Related to [#16919](https://github.com/apache/shardingsphere/pull/16919/files#diff-029c44ded8d8f1181a78b83d37adc5f2c7873cbe2c6d16f379f7b36166580f5e)