### PR TITLE
Adjust proxy-meta-data-collector-enabled default value to false

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/config/props/temporary/TemporaryConfigurationPropertyKey.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/config/props/temporary/TemporaryConfigurationPropertyKey.java
@@ -35,7 +35,7 @@ public enum TemporaryConfigurationPropertyKey implements TypedPropertyKey {
     /**
      * Proxy meta data collector enabled.
      */
-    PROXY_META_DATA_COLLECTOR_ENABLED("proxy-meta-data-collector-enabled", String.valueOf(Boolean.TRUE), boolean.class, true),
+    PROXY_META_DATA_COLLECTOR_ENABLED("proxy-meta-data-collector-enabled", String.valueOf(Boolean.FALSE), boolean.class, true),
     
     /**
      * System schema metadata enabled.

--- a/test/e2e/sql/src/test/resources/env/scenario/db/proxy/mode/cluster/server.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/db/proxy/mode/cluster/server.yaml
@@ -55,3 +55,4 @@ props:
   proxy-frontend-flush-threshold: 128  # The default value is 128.
   sql-show: false
   proxy-frontend-ssl-enabled: true
+  proxy-meta-data-collector-enabled: true

--- a/test/e2e/sql/src/test/resources/env/scenario/empty_rules/proxy/mode/cluster/server.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/empty_rules/proxy/mode/cluster/server.yaml
@@ -55,3 +55,4 @@ props:
   proxy-frontend-flush-threshold: 128  # The default value is 128.
   sql-show: false
   proxy-frontend-ssl-enabled: true
+  proxy-meta-data-collector-enabled: true

--- a/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/mode/cluster/server.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/mode/cluster/server.yaml
@@ -55,3 +55,4 @@ props:
   proxy-frontend-flush-threshold: 128  # The default value is 128.
   sql-show: false
   proxy-frontend-ssl-enabled: true
+  proxy-meta-data-collector-enabled: true


### PR DESCRIPTION
Fixes #29536.

Changes proposed in this pull request:
  - Adjust proxy-meta-data-collector-enabled default value to false

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
