### PR TITLE
Fix incorrect parsing of URLs in some template files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ gen/
 public/
 .hugo_build.lock
 *.html-e
+docs/blog/resources/_gen

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Follow the steps below to deploy ShardingSphere website,
 ### Note:
 
 1. If you modify `docs/build.sh`, please test it locally.
+2. You need to install `Hugo` on your local device in advance. Refer to https://gohugo.io/installation/ .
 
 ## HOW to insert a video of Bilibili or YouTube?
 

--- a/docs/document/themes/hugo-theme-learn/layouts/partials/language.html
+++ b/docs/document/themes/hugo-theme-learn/layouts/partials/language.html
@@ -21,8 +21,6 @@
               {{ range . }}
                 {{ $version := . }}
                   <option id="{{ $version }}" value="{{ replaceRE "document/[^/]*" (printf "document/%s" $version) $permalink }}" {{ if in $permalink $version }} selected {{end}} >{{ $version }}</option>
-              {{ end }}
-              {{ end }}
                   <!-- <option id="legacy" value="https://shardingsphere.apache.org/legacy.html">Legacy</option> -->
                 </select>
                 <svg t="1645437162166" class="icon" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="2449" width="32" height="32"><path d="M483.072 714.496l30.165333 30.208 415.957334-415.829333a42.837333 42.837333 0 0 0 0-60.288 42.538667 42.538667 0 0 0-60.330667-0.042667l-355.541333 355.413333-355.242667-355.413333a42.496 42.496 0 0 0-60.288 0 42.837333 42.837333 0 0 0-0.085333 60.330667l383.701333 383.872 1.706667 1.749333z" fill="#3D3D3D" p-id="2450"></path></svg>
@@ -40,12 +38,15 @@
                       {{ if eq $translation.Lang .Lang }}
                         {{ $selected := false }}
                         {{ if eq $pageLang .Lang}}
-                          <option id="{{ $translation.Language }}" value="{{ $translation.URL }}" selected>{{ .LanguageName }}</option>
+                          <option id="{{ $translation.Language }}" value="document/{{ $version }}/{{ $translation.URL }}" selected>{{ .LanguageName }}</option>
                         {{ else }}
-                          <option id="{{ $translation.Language }}" value="{{ $translation.URL }}">{{ .LanguageName }}</option>
+                          <option id="{{ $translation.Language }}" value="document/{{ $version }}/{{ $translation.URL }}">{{ .LanguageName }}</option>
                         {{ end }}
                       {{ end }}
                   {{ end }}
+              {{ end }}
+
+              {{ end }}
               {{ end }}
             </select>
             <svg t="1645437162166" class="icon" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="2449" width="32" height="32"><path d="M483.072 714.496l30.165333 30.208 415.957334-415.829333a42.837333 42.837333 0 0 0 0-60.288 42.538667 42.538667 0 0 0-60.330667-0.042667l-355.541333 355.413333-355.242667-355.413333a42.496 42.496 0 0 0-60.288 0 42.837333 42.837333 0 0 0-0.085333 60.330667l383.701333 383.872 1.706667 1.749333z" fill="#3D3D3D" p-id="2450"></path></svg>


### PR DESCRIPTION
For https://shardingsphere.apache.org/document/current/en/overview/ .

Changes proposed in this pull request:
  - Fix incorrect parsing of URLs in some template files.
  - For https://shardingsphere.apache.org/document/current/en/overview/ , part of the URL uses the wrong redirect URL. It will jump to a URL that does not exist. For example, selecting `简体中文` will jump to https://shardingsphere.apache.org/cn/overview/ which does not exist.
    - ![image](https://github.com/apache/shardingsphere/assets/20187731/fcbfd506-909e-4ec9-9ec1-134e1e75088f)
 
    - ![image](https://github.com/apache/shardingsphere/assets/20187731/0a1a072f-5014-4349-a3fe-9effa494c6b0)
  - To be honest I don't understand why the older version documents don't have this problem. Refer to https://shardingsphere.apache.org/document/5.4.1/en/overview/ .
  - This also relates to a strange issue, before this PR, the way versions and languages generated `value` in URLs were inconsistent.
```
# versions 
{{ replaceRE "document/[^/]*" (printf "document/%s" $version) $permalink }}

# languages 
{{ $translation.URL }}

```
  - There is a problem with `build.sh`. I cannot build the document directly through `build.sh` locally. To reproduce this issue, just execute `sudo snap install hugo` on Ubuntu 22.04.3.
```shell
$ /bin/bash /home/linghengqian/TwinklingLiftWorks/git/public/shardingsphere/docs/build.sh
2023/12/26 01:15:26.791402 system_key.go:129: cannot determine nfs usage in generateSystemKey: cannot parse mountinfo: incorrect number of tail fields, expected 3 but found 4
2023/12/26 01:15:26.798928 cmd_run.go:1046: WARNING: cannot create user data directory: cannot determine SELinux status: failed to obtain SELinux mount path: incorrect number of tail fields, expected 3 but found 4
Start building sites … 
hugo v0.121.1-00b46fed8e47f7bb0a85d7cfc2d9f1356379b740+extended linux/amd64 BuildDate=2023-12-08T08:47:45Z VendorInfo=snap:0.121.1

ERROR render of "page" failed: "/home/linghengqian/TwinklingLiftWorks/git/public/shardingsphere/docs/document/themes/hugo-theme-learn/layouts/_default/single.html:1:3": execute of template failed: template: _default/single.html:1:3: executing "_default/single.html" at <partial "header.html" .>: error calling partial: "/home/linghengqian/TwinklingLiftWorks/git/public/shardingsphere/docs/document/themes/hugo-theme-learn/layouts/partials/header.html:68:11": execute of template failed: template: partials/header.html:68:11: executing "partials/header.html" at <partial "language.html" .>: error calling partial: "/home/linghengqian/TwinklingLiftWorks/git/public/shardingsphere/docs/document/themes/hugo-theme-learn/layouts/partials/language.html:43:89": execute of template failed: template: partials/language.html:43:89: executing "partials/language.html" at <$translation.URL>: can't evaluate field URL in type page.Page
Total in 237 ms
Error: error building site: render: failed to render pages: render of "page" failed: "/home/linghengqian/TwinklingLiftWorks/git/public/shardingsphere/docs/document/themes/hugo-theme-learn/layouts/_default/single.html:1:3": execute of template failed: template: _default/single.html:1:3: executing "_default/single.html" at <partial "header.html" .>: error calling partial: "/home/linghengqian/TwinklingLiftWorks/git/public/shardingsphere/docs/document/themes/hugo-theme-learn/layouts/partials/header.html:68:11": execute of template failed: template: partials/header.html:68:11: executing "partials/header.html" at <partial "language.html" .>: error calling partial: "/home/linghengqian/TwinklingLiftWorks/git/public/shardingsphere/docs/document/themes/hugo-theme-learn/layouts/partials/language.html:43:89": execute of template failed: template: partials/language.html:43:89: executing "partials/language.html" at <$translation.URL>: can't evaluate field URL in type page.Page
2023/12/26 01:15:27.145724 system_key.go:129: cannot determine nfs usage in generateSystemKey: cannot parse mountinfo: incorrect number of tail fields, expected 3 but found 4
2023/12/26 01:15:27.151788 cmd_run.go:1046: WARNING: cannot create user data directory: cannot determine SELinux status: failed to obtain SELinux mount path: incorrect number of tail fields, expected 3 but found 4
Start building sites … 
hugo v0.121.1-00b46fed8e47f7bb0a85d7cfc2d9f1356379b740+extended linux/amd64 BuildDate=2023-12-08T08:47:45Z VendorInfo=snap:0.121.1

ERROR render of "page" failed: "/home/linghengqian/TwinklingLiftWorks/git/public/shardingsphere/docs/community/themes/hugo-theme-learn/layouts/_default/single.html:1:3": execute of template failed: template: _default/single.html:1:3: executing "_default/single.html" at <partial "header.html" .>: error calling partial: "/home/linghengqian/TwinklingLiftWorks/git/public/shardingsphere/docs/community/themes/hugo-theme-learn/layouts/partials/header.html:6:12": execute of template failed: template: partials/header.html:6:12: executing "partials/header.html" at <.Hugo.Generator>: can't evaluate field Hugo in type *hugolib.pageState
Total in 37 ms
Error: error building site: render: failed to render pages: render of "page" failed: "/home/linghengqian/TwinklingLiftWorks/git/public/shardingsphere/docs/community/themes/hugo-theme-learn/layouts/_default/single.html:1:3": execute of template failed: template: _default/single.html:1:3: executing "_default/single.html" at <partial "header.html" .>: error calling partial: "/home/linghengqian/TwinklingLiftWorks/git/public/shardingsphere/docs/community/themes/hugo-theme-learn/layouts/partials/header.html:6:12": execute of template failed: template: partials/header.html:6:12: executing "partials/header.html" at <.Hugo.Generator>: can't evaluate field Hugo in type *hugolib.pageState
2023/12/26 01:15:27.280129 system_key.go:129: cannot determine nfs usage in generateSystemKey: cannot parse mountinfo: incorrect number of tail fields, expected 3 but found 4
2023/12/26 01:15:27.285511 cmd_run.go:1046: WARNING: cannot create user data directory: cannot determine SELinux status: failed to obtain SELinux mount path: incorrect number of tail fields, expected 3 but found 4
WARN  deprecated: config: languages.cn.disablesearch: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in a future release. Put the value below [languages.cn.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN  deprecated: config: languages.cn.editurl: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in a future release. Put the value below [languages.cn.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
WARN  deprecated: config: languages.cn.themevariant: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in a future release. Put the value below [languages.cn.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
Start building sites … 
hugo v0.121.1-00b46fed8e47f7bb0a85d7cfc2d9f1356379b740+extended linux/amd64 BuildDate=2023-12-08T08:47:45Z VendorInfo=snap:0.121.1


                   | EN  | CN   
-------------------+-----+------
  Pages            | 118 |  44  
  Paginator pages  |  10 |   2  
  Non-page files   |   0 |   0  
  Static files     | 555 | 555  
  Processed images |   0 |   0  
  Aliases          |   5 |   4  
  Sitemaps         |   2 |   1  
  Cleaned          |   0 |   0  

Total in 515 ms

```
  - On the premise that the build fails, there are unexcluded files in `docs/blog/resources/_gen`. Add `.gitignore`.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
