### PR TITLE
Optimize MySQLComStmtPrepareExecutor logic

### DIFF
--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatement.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatement.java
@@ -18,18 +18,19 @@
 package org.apache.shardingsphere.proxy.backend.connector.jdbc.statement;
 
 import org.apache.shardingsphere.db.protocol.parameter.TypeUnspecifiedSQLParameter;
+import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMode;
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.jdbc.ExecutorJDBCStatementManager;
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.jdbc.StatementOption;
-import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,13 +56,16 @@ public final class JDBCBackendStatement implements ExecutorJDBCStatementManager 
         PreparedStatement result = option.isReturnGeneratedKeys()
                 ? connection.prepareStatement(executionUnit.getSqlUnit().getSql(), Statement.RETURN_GENERATED_KEYS)
                 : connection.prepareStatement(sql);
-        for (int i = 0; i < params.size(); i++) {
-            Object param = params.get(i);
+        Iterator<Object> paramIterator = params.iterator();
+        int index = 0;
+        while (paramIterator.hasNext()) {
+            Object param = paramIterator.next();
             if (param instanceof TypeUnspecifiedSQLParameter) {
-                result.setObject(i + 1, param, Types.OTHER);
+                result.setObject(index + 1, param, Types.OTHER);
             } else {
-                result.setObject(i + 1, param);
+                result.setObject(index + 1, param);
             }
+            index++;
         }
         if (ConnectionMode.MEMORY_STRICTLY == connectionMode) {
             setFetchSize(result, databaseType);

--- a/proxy/frontend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareParameterMarkerExtractorTest.java
+++ b/proxy/frontend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareParameterMarkerExtractorTest.java
@@ -24,15 +24,11 @@ import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSp
 import org.apache.shardingsphere.infra.parser.ShardingSphereSQLParserEngine;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.api.CacheOption;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.ParameterMarkerSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Types;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -44,12 +40,11 @@ class MySQLComStmtPrepareParameterMarkerExtractorTest {
         String sql = "insert into user (id, name, age) values (1, ?, ?), (?, 'bar', ?)";
         SQLStatement sqlStatement = new ShardingSphereSQLParserEngine(TypedSPILoader.getService(DatabaseType.class, "MySQL"), new CacheOption(0, 0), new CacheOption(0, 0), false).parse(sql, false);
         ShardingSphereSchema schema = prepareSchema();
-        Map<ParameterMarkerSegment, ShardingSphereColumn> actual = MySQLComStmtPrepareParameterMarkerExtractor.findColumnsOfParameterMarkers(sqlStatement, schema);
-        List<ParameterMarkerSegment> parameterMarkerSegments = new ArrayList<>(((AbstractSQLStatement) sqlStatement).getParameterMarkerSegments());
-        assertThat(actual.get(parameterMarkerSegments.get(0)), is(schema.getTable("user").getColumn("name")));
-        assertThat(actual.get(parameterMarkerSegments.get(1)), is(schema.getTable("user").getColumn("age")));
-        assertThat(actual.get(parameterMarkerSegments.get(2)), is(schema.getTable("user").getColumn("id")));
-        assertThat(actual.get(parameterMarkerSegments.get(3)), is(schema.getTable("user").getColumn("age")));
+        List<ShardingSphereColumn> actual = MySQLComStmtPrepareParameterMarkerExtractor.findColumnsOfParameterMarkers(sqlStatement, schema);
+        assertThat(actual.get(0), is(schema.getTable("user").getColumn("name")));
+        assertThat(actual.get(1), is(schema.getTable("user").getColumn("age")));
+        assertThat(actual.get(2), is(schema.getTable("user").getColumn("id")));
+        assertThat(actual.get(3), is(schema.getTable("user").getColumn("age")));
     }
     
     private ShardingSphereSchema prepareSchema() {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Optimize MySQLComStmtPrepareExecutor logic

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
