### PR TITLE
Fix wrong parameter bind logic for sql translator hint bind

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/MergeStatementBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/MergeStatementBinder.java
@@ -93,7 +93,7 @@ public final class MergeStatementBinder implements SQLStatementBinder<MergeState
                 optional -> result.setInsert(bindMergeInsert(optional, (SimpleTableSegment) boundedTargetTableSegment, statementBinderContext, targetTableBinderContexts, sourceTableBinderContexts)));
         sqlStatement.getUpdate().ifPresent(
                 optional -> result.setUpdate(bindMergeUpdate(optional, (SimpleTableSegment) boundedTargetTableSegment, statementBinderContext, targetTableBinderContexts, sourceTableBinderContexts)));
-        addParameterMarkerSegments(sqlStatement, result);
+        addParameterMarkerSegments(result, sqlStatement);
         result.getCommentSegments().addAll(sqlStatement.getCommentSegments());
         return result;
     }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix wrong parameter bind logic for sql translator hint bind

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
