### PR TITLE
Remove unused default getRows method from RULExecutor

### DIFF
--- a/infra/distsql-handler/src/main/java/org/apache/shardingsphere/distsql/handler/rul/RULExecutor.java
+++ b/infra/distsql-handler/src/main/java/org/apache/shardingsphere/distsql/handler/rul/RULExecutor.java
@@ -18,12 +18,10 @@
 package org.apache.shardingsphere.distsql.handler.rul;
 
 import org.apache.shardingsphere.distsql.statement.rul.RULStatement;
-import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPI;
 
 import java.util.Collection;
-import java.util.Collections;
 
 /**
  * RUL executor.
@@ -39,16 +37,6 @@ public interface RULExecutor<T extends RULStatement> extends TypedSPI {
      * @return column names
      */
     Collection<String> getColumnNames();
-    
-    /**
-     * Get query result rows.
-     *
-     * @param sqlStatement SQL statement
-     * @return query result rows
-     */
-    default Collection<LocalDataQueryResultRow> getRows(final T sqlStatement) {
-        return Collections.emptyList();
-    }
     
     @Override
     Class<T> getType();

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rul/SQLRULBackendHandler.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rul/SQLRULBackendHandler.java
@@ -62,11 +62,8 @@ public final class SQLRULBackendHandler<T extends RULStatement> extends RULBacke
     }
     
     private MergedResult createMergedResult(final RULExecutor<T> executor) throws SQLException {
-        if (executor instanceof ConnectionSessionRequiredRULExecutor) {
-            ShardingSphereMetaData metaData = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData();
-            return new LocalDataMergedResult(((ConnectionSessionRequiredRULExecutor<T>) executor).getRows(metaData, getConnectionSession(), getSqlStatement()));
-        }
-        return new LocalDataMergedResult(executor.getRows(getSqlStatement()));
+        ShardingSphereMetaData metaData = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData();
+        return new LocalDataMergedResult(((ConnectionSessionRequiredRULExecutor<T>) executor).getRows(metaData, getConnectionSession(), getSqlStatement()));
     }
     
     @Override


### PR DESCRIPTION
Remove unused default getRows method from RULExecutor