### PR TITLE
Check specific properties when deserializing XML file

### DIFF
--- a/kernel/sql-federation/optimizer/src/test/java/org/apache/shardingsphere/sqlfederation/optimizer/it/TestCases.java
+++ b/kernel/sql-federation/optimizer/src/test/java/org/apache/shardingsphere/sqlfederation/optimizer/it/TestCases.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sqlfederation.optimizer.it;
 
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import lombok.Getter;
@@ -32,5 +33,6 @@ import java.util.LinkedList;
 public final class TestCases {
     
     @JacksonXmlProperty(localName = "test-case")
+    @JacksonXmlElementWrapper(useWrapping = false)
     private final Collection<TestCase> testCases = new LinkedList<>();
 }

--- a/kernel/sql-federation/optimizer/src/test/java/org/apache/shardingsphere/sqlfederation/optimizer/it/TestCasesLoader.java
+++ b/kernel/sql-federation/optimizer/src/test/java/org/apache/shardingsphere/sqlfederation/optimizer/it/TestCasesLoader.java
@@ -34,7 +34,7 @@ public final class TestCasesLoader {
     
     private static final TestCasesLoader INSTANCE = new TestCasesLoader();
     
-    private static final ObjectMapper XML_MAPPER = XmlMapper.builder().defaultUseWrapper(false).build();
+    private static final ObjectMapper XML_MAPPER = XmlMapper.builder().build();
     
     /**
      * Get singleton instance.

--- a/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQL.java
+++ b/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQL.java
@@ -17,41 +17,54 @@
 
 package org.apache.shardingsphere.mode.repository.standalone.jdbc.sql;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import lombok.Getter;
 
 /**
  * JDBC repository SQL.
+ * `required` in {@link com.fasterxml.jackson.annotation.JsonProperty} only provides Metadata without detecting Null values, which is actually consistent with the design of the JAXB API.
+ * See <a href="https://github.com/FasterXML/jackson-dataformat-xml/issues/625">FasterXML/jackson-dataformat-xml#625</a>
+ *
+ * @see JsonProperty
  */
 @JacksonXmlRootElement(localName = "sql")
 @Getter
 public final class JDBCRepositorySQL {
     
+    @JsonProperty(required = true)
     @JacksonXmlProperty(isAttribute = true)
     private String type;
     
+    @JsonProperty(required = true)
     @JacksonXmlProperty(localName = "driver-class-name", isAttribute = true)
     private String driverClassName;
     
     @JacksonXmlProperty(localName = "default", isAttribute = true)
     private boolean isDefault;
     
+    @JsonProperty(required = true)
     @JacksonXmlProperty(localName = "create-table")
     private String createTableSQL;
     
+    @JsonProperty(required = true)
     @JacksonXmlProperty(localName = "select-by-key")
     private String selectByKeySQL;
     
+    @JsonProperty(required = true)
     @JacksonXmlProperty(localName = "select-by-parent")
     private String selectByParentKeySQL;
     
+    @JsonProperty(required = true)
     @JacksonXmlProperty(localName = "insert")
     private String insertSQL;
     
+    @JsonProperty(required = true)
     @JacksonXmlProperty(localName = "update")
     private String updateSQL;
     
+    @JsonProperty(required = true)
     @JacksonXmlProperty(localName = "delete")
     private String deleteSQL;
 }

--- a/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQLLoader.java
+++ b/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQLLoader.java
@@ -58,7 +58,7 @@ public final class JDBCRepositorySQLLoader {
     
     private static final Collection<String> JAR_URL_PROTOCOLS = new HashSet<>(Arrays.asList("jar", "war", "zip", "wsjar", "vfszip"));
     
-    private static final ObjectMapper XML_MAPPER = XmlMapper.builder().defaultUseWrapper(false).build();
+    private static final ObjectMapper XML_MAPPER = XmlMapper.builder().build();
     
     /**
      * Load JDBC repository SQL.


### PR DESCRIPTION
For #29384.

Changes proposed in this pull request:
  - Check specific properties when deserializing XML file. This is an alignment to the behavior of the JAXB API. Refer to https://github.com/apache/shardingsphere/pull/29384#discussion_r1424781057 .
  - `required` only provides Metadata without detecting Null values, which is actually consistent with the design of the JAXB API. See https://github.com/FasterXML/jackson-dataformat-xml/issues/625 .  I don't think using `@JsonCreator` is a reasonable choice, it brings maintenance trouble. Maybe we can check the Annotation Metadata when needed.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
