### PR TITLE
Oracle g4 specialDataType conflict with aggregateClause

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/PLSQL.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/PLSQL.g4
@@ -64,10 +64,9 @@ plsqlFunctionSource
     | deterministicClause
     | parallelEnableClause
     | resultCacheClause
-    | aggregateClause
     | pipelinedClause
-    | sqlMacroClause)* 
-    (IS | AS) (callSpec | declareSection? body)
+    | sqlMacroClause)*
+    (aggregateClause | ((IS | AS) (callSpec | declareSection? body)))
     ;
     
 body

--- a/test/it/parser/src/main/resources/case/ddl/create-function.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-function.xml
@@ -29,4 +29,5 @@
     <create-function sql-case-id="create_function_with_set_var" />
     <create-function sql-case-id="create_function_with_create_view" />
     <create-function sql-case-id="create_function_with_loop" />
+    <create-function sql-case-id="create_function_with_aggregate_using_function" />
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-function.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-function.xml
@@ -73,4 +73,5 @@
     <sql-case id="create_function_with_set_var" value="CREATE DEFINER = u1@localhost FUNCTION f2() RETURNS int BEGIN DECLARE n int; DECLARE m int; SET n:= (SELECT min(a) FROM t1); SET m:= (SELECT max(a) FROM t1); RETURN n &lt; m; END ;" db-types="MySQL" />
     <sql-case id="create_function_with_create_view" value="CREATE FUNCTION bug_13627_f() returns int BEGIN create view v1 as select 1; return 1; END" db-types="MySQL" />
     <sql-case id="create_function_with_loop" value="CREATE FUNCTION f(cur SYS_REFCURSOR, mgr_hiredate DATE) RETURN NUMBER IS emp_hiredate DATE; before number :=0; after number:=0; begin loop fetch cur into emp_hiredate; exit when cur%NOTFOUND; if emp_hiredate > mgr_hiredate then after:=after+1; else before:=before+1; end if; end loop; close cur; if before > after then return 1; else return 0; end if; end;" db-types="Oracle" />
+    <sql-case id="create_function_with_aggregate_using_function" value="CREATE OR REPLACE EDITIONABLE FUNCTION MY_FUNC (P1 VARCHAR2) RETURN VARCHAR2 AGGREGATE USING MY_AGG_FUNC;" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Fixes #27920.

Changes proposed in this pull request:
  - Oracle g4 specialDataType conflict with aggregateClause

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
