### PR TITLE
Allow `ConsulRawClient` of `cluster-mode-repository-consul` to be configured on ports other than `8500`

### DIFF
--- a/docs/document/content/user-manual/common-config/builtin-algorithm/metadata-repository.cn.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/metadata-repository.cn.md
@@ -56,6 +56,16 @@ Apache ShardingSphere 为不同的运行模式提供了不同的元数据持久�
 
 ### Consul 持久化
 
+受 `com.ecwid.consul:consul-api:1.4.5` 的 Maven 模块的限制，使用者无法通过 gRPC 端口来连接到  Consul Agent。
+
+`Consul` 实现的 `serverLists` 属性受设计使然，仅可通过 HTTP 端点连接到单个 Consul Agent。
+`serverLists` 使用了宽松的 URL 匹配原则。
+1. 当 `serverLists` 为空时，将解析到 `http://localhost:8500` 的 Consul Agent 实例。
+2. 当 `serverLists` 为 `hostname` 时，将解析到 `http://hostname:8500` 的 Consul Agent 实例。
+3. 当 `serverLists` 为 `hostname:port` 时，将解析到 `http://hostname:port` 的 Consul Agent 实例。
+4. 当 `serverLists` 为 `http://hostName:port` 时，将解析到 `http://hostName:port` 的 Consul Agent 实例。
+5. 当 `serverLists` 为 `https://hostName:port` 时，将解析到 `https://hostName:port` 的 Consul Agent 实例。
+
 类型：Consul
 
 适用模式：Cluster

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/metadata-repository.en.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/metadata-repository.en.md
@@ -56,6 +56,16 @@ Attributes:
 
 ### Consul Repository
 
+Due to the limitation of the Maven module of `com.ecwid.consul:consul-api:1.4.5`, users cannot connect to the Consul Agent through the gRPC port.
+
+The `serverLists` property of the `Consul` implementation is by design and can only be connected to a single Consul Agent via an HTTP endpoint.
+`serverLists` uses relaxed URL matching principles.
+1. When `serverLists` is empty, the Consul Agent instance at `http://localhost:8500` will be resolved.
+2. When `serverLists` is `hostname`, it will be resolved to the Consul Agent instance of `http://hostname:8500`.
+3. When `serverLists` is `hostname:port`, it will be resolved to the Consul Agent instance of `http://hostname:port`.
+4. When `serverLists` is `http://hostName:port`, the Consul Agent instance of `http://hostName:port` will be resolved.
+5. When `serverLists` is `https://hostName:port`, the Consul Agent instance of `https://hostName:port` will be resolved.
+
 Type: Consul
 
 Mode: Cluster


### PR DESCRIPTION
Fixes #29419.

Changes proposed in this pull request:
  - Allow `ConsulRawClient` of `cluster-mode-repository-consul` to be configured on ports other than `8500`. This is a practical requirement for integration testing by `testcontainers-java`. It is impossible for Consul Agent to always occupy port `8500`.
  - Solve the problem of multiple undetermined null values. Fixes #29509 . 
  - This PR was split from #29588 . This PR only solves a partial problem, it still does not solve the bug that `ConsulRepository.watch()` cannot update the local data source with Consul `1.10.12`/`1.15.8`/ `1.17.1`.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
