### PR TITLE
Updates documentation for using Java Agent when building ShardingSphere Proxy Native

### DIFF
--- a/docs/document/content/user-manual/common-config/builtin-algorithm/expr.cn.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/expr.cn.md
@@ -49,6 +49,14 @@ weight = 10
 7. `C` 代表 chronology 的缩写，意为日历系统，必须遵循 Java `java.time.chrono.Chronology#getId()` 的格式。
 例如：`Japanese`，`Minguo`，`ThaiBuddhist`。存在默认值为 `ISO`。
 
+对于 `C` 的 Key 对应的 Value 是否可用，这取决于 JVM 所处的系统环境。
+这意味着如果用户需要设置 `C=Japanese`，则可能需要在应用的启动类调用 `java.util.Locale.setDefault(java.util.Locale.JAPAN);` 以修改系统环境。
+讨论两种 JVM 环境。
+
+1. Hotspot JVM 在 RunTime 决定 `java.util.Locale.getDefault()` 的返回值。
+
+2. GraalVM Native Image 在 BuildTime 决定 `java.util.Locale.Locale.getDefault()` 的返回值，与 Hotspot JVM 的表现并不一致，参考 https://github.com/oracle/graal/issues/8022 。
+
 类型：INTERVAL
 
 用例：

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/expr.en.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/expr.en.md
@@ -57,6 +57,15 @@ It must follow the enumeration value of Java `java.time.temporal.ChronoUnit#toSt
 7. `C` stands for the abbreviation of chronology, which means calendar system and must follow the format of Java `java.time.chrono.Chronology#getId()`.
 For example: `Japanese`, `Minguo`, `ThaiBuddhist`. There is a default value of `ISO`.
 
+Whether the Value corresponding to the Key of `C` is available depends on the system environment in which the JVM is located. 
+This means that if the user needs to set `C=Japanese`, they may need to call `java.util.Locale.setDefault(java.util.Locale.JAPAN);` in the application's startup class to modify the system environment. 
+Discuss two JVM environments.
+
+1. Hotspot JVM determines the return value of `java.util.Locale.getDefault()` at RunTime.
+
+2. GraalVM Native Image determines the return value of `java.util.Locale.Locale.getDefault()` at BuildTime, which is inconsistent with the performance of Hotspot JVM. 
+Refer to https://github.com/oracle/graal/issues/8022 .
+
 Type: INTERVAL
 
 Example:

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/metadata-repository.cn.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/metadata-repository.cn.md
@@ -60,9 +60,9 @@ Apache ShardingSphere 为不同的运行模式提供了不同的元数据持久�
 
 `Consul` 实现的 `serverLists` 属性受设计使然，仅可通过 HTTP 端点连接到单个 Consul Agent。
 `serverLists` 使用了宽松的 URL 匹配原则。
-1. 当 `serverLists` 为空时，将解析到 `http://localhost:8500` 的 Consul Agent 实例。
-2. 当 `serverLists` 为 `hostname` 时，将解析到 `http://hostname:8500` 的 Consul Agent 实例。
-3. 当 `serverLists` 为 `hostname:port` 时，将解析到 `http://hostname:port` 的 Consul Agent 实例。
+1. 当 `serverLists` 为空时，将解析到 `http://127.0.0.1:8500` 的 Consul Agent 实例。
+2. 当 `serverLists` 为 `hostName` 时，将解析到 `http://hostName:8500` 的 Consul Agent 实例。
+3. 当 `serverLists` 为 `hostName:port` 时，将解析到 `http://hostName:port` 的 Consul Agent 实例。
 4. 当 `serverLists` 为 `http://hostName:port` 时，将解析到 `http://hostName:port` 的 Consul Agent 实例。
 5. 当 `serverLists` 为 `https://hostName:port` 时，将解析到 `https://hostName:port` 的 Consul Agent 实例。
 

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/metadata-repository.en.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/metadata-repository.en.md
@@ -60,11 +60,11 @@ Due to the limitation of the Maven module of `com.ecwid.consul:consul-api:1.4.5`
 
 The `serverLists` property of the `Consul` implementation is by design and can only be connected to a single Consul Agent via an HTTP endpoint.
 `serverLists` uses relaxed URL matching principles.
-1. When `serverLists` is empty, the Consul Agent instance at `http://localhost:8500` will be resolved.
-2. When `serverLists` is `hostname`, it will be resolved to the Consul Agent instance of `http://hostname:8500`.
-3. When `serverLists` is `hostname:port`, it will be resolved to the Consul Agent instance of `http://hostname:port`.
-4. When `serverLists` is `http://hostName:port`, the Consul Agent instance of `http://hostName:port` will be resolved.
-5. When `serverLists` is `https://hostName:port`, the Consul Agent instance of `https://hostName:port` will be resolved.
+1. When `serverLists` is empty, it will be resolved to the Consul Agent instance of `http://127.0.0.1:8500`.
+2. When `serverLists` is `hostName`, it will be resolved to the Consul Agent instance of `http://hostName:8500`.
+3. When `serverLists` is `hostName:port`, it will be resolved to the Consul Agent instance of `http://hostName:port`.
+4. When `serverLists` is `http://hostName:port`, it will be resolved to the Consul Agent instance of `http://hostName:port`.
+5. When `serverLists` is `https://hostName:port`, it will be resolved to the Consul Agent instance of `https://hostName:port`.
 
 Type: Consul
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -133,28 +133,7 @@ services:
   及其后继。如果你使用的不是 Linux，则无法对 GraalVM Native Image 进行 Debug，请关注尚未关闭的
   https://github.com/oracle/graal/issues/5648 。
 
-- 对于使用 `ShardingSphere Agent` 等 APM Java Agent 的情形， GraalVM 的 `native-image` 组件尚未完全支持在构建 Native
+- 对于使用 `ShardingSphere Agent` 等 Java Agent 的情形， GraalVM 的 `native-image` 组件尚未完全支持在构建 Native
   Image 时使用 javaagent，你需要关注尚未关闭的 https://github.com/oracle/graal/issues/1065 。
 
-- 以下部分采用 `Apache SkyWalking Java Agent` 作为示例，可用于跟踪 GraalVM 社区的对应 issue。
-
-1. 下载 https://archive.apache.org/dist/skywalking/java-agent/8.16.0/apache-skywalking-java-agent-8.16.0.tgz ，
-   并解压到 ShardingSphere Git Source 的 `distribution/proxy-native`。
-
-2. 修改 `distribution/proxy-native/pom.xml` 的 `native profile`，
-   为 `org.graalvm.buildtools:native-maven-plugin` 的 `configuration` 添加如下的 `jvmArgs`。
-
-```xml
-
-<jvmArgs>
-    <arg>-Dskywalking.agent.service_name="your service name"</arg>
-    <arg>-Dskywalking.collector.backend_service="your skywalking oap ip and port"</arg>
-    <arg>-javaagent:./skywalking-agent/skywalking-agent.jar</arg>
-</jvmArgs>
-```
-
-3. 通过命令行构建 GraalVM Native Image。
-
-```bash
-./mvnw -am -pl distribution/proxy-native -B -T1C -Prelease.native -DskipTests clean package
-```
+- 若用户期望在 ShardingSphere Proxy Native 下使用 OpenTelemetry Java Agent，则需要关注 https://github.com/oracle/graal/pull/8077 涉及的变动。

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -151,23 +151,4 @@ services:
 - The following sections use the `Apache SkyWalking Java Agent` as an example, which can be used to track corresponding
   issues from the GraalVM community.
 
-1. Download https://archive.apache.org/dist/skywalking/java-agent/8.16.0/apache-skywalking-java-agent-8.16.0.tgz and `untar` it
-   to `distribution/proxy-native` in ShardingSphere Git Source.
-
-2. Modify the `native profile` of `distribution/proxy-native/pom.xml`,
-   Add the following `jvmArgs` to the `configuration` of `org.graalvm.buildtools:native-maven-plugin`.
-
-```xml
-
-<jvmArgs>
-    <arg>-Dskywalking.agent.service_name="your service name"</arg>
-    <arg>-Dskywalking.collector.backend_service="your skywalking oap ip and port"</arg>
-    <arg>-javaagent:./skywalking-agent/skywalking-agent.jar</arg>
-</jvmArgs>
-```
-
-3. Build the GraalVM Native Image from the command line.
-
-```bash
-./mvnw -am -pl distribution/proxy-native -B -T1C -Prelease.native -DskipTests clean package
-```
+- If users expect to use OpenTelemetry Java Agent under ShardingSphere Proxy Native, they need to pay attention to the changes involved in https://github.com/oracle/graal/pull/8077 .


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Updates documentation for using Java Agent when building ShardingSphere Proxy Native.
  - To make a long story short, https://github.com/oracle/graal/pull/8077 gives a solution to use OpenTelemetry Java Agent when building GraalVM Native Image, which requires the introduction of new GraalVM SDK related APIs. This means that the previous section of ShardingSphere Proxy Native on using Java Agent is outdated.
  - This PR also adds to the documentation some phenomena that are only verifiable in unit tests.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
