### PR TITLE
Host GraalVM Reachability Metadata of `ch.qos.logback:logback-core` to fix Error Log in NativeTest

### DIFF
--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/ch.qos.logback/logback-core/1.2.12/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/ch.qos.logback/logback-core/1.2.12/reflect-config.json
@@ -1,0 +1,82 @@
+[
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.joran.action.NestedComplexPropertyIA"},
+  "name":"ch.qos.logback.classic.encoder.PatternLayoutEncoder",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.joran.util.beans.BeanDescriptionFactory"},
+  "name":"ch.qos.logback.classic.encoder.PatternLayoutEncoder",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.pattern.parser.Compiler"},
+  "name":"ch.qos.logback.classic.pattern.DateConverter",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.pattern.parser.Compiler"},
+  "name":"ch.qos.logback.classic.pattern.LevelConverter",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.pattern.parser.Compiler"},
+  "name":"ch.qos.logback.classic.pattern.LineSeparatorConverter",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.pattern.parser.Compiler"},
+  "name":"ch.qos.logback.classic.pattern.LoggerConverter",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.pattern.parser.Compiler"},
+  "name":"ch.qos.logback.classic.pattern.MessageConverter",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.pattern.parser.Compiler"},
+  "name":"ch.qos.logback.classic.pattern.ThreadConverter",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.joran.action.AppenderAction"},
+  "name":"ch.qos.logback.core.ConsoleAppender",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.joran.util.beans.BeanDescriptionFactory"},
+  "name":"ch.qos.logback.core.ConsoleAppender",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.joran.util.PropertySetter"},
+  "name":"ch.qos.logback.core.OutputStreamAppender",
+  "methods":[{"name":"setEncoder","parameterTypes":["ch.qos.logback.core.encoder.Encoder"] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.joran.action.NestedComplexPropertyIA"},
+  "name":"ch.qos.logback.core.encoder.Encoder",
+  "methods":[{"name":"valueOf","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.joran.util.PropertySetter"},
+  "name":"ch.qos.logback.core.encoder.LayoutWrappingEncoder",
+  "methods":[{"name":"setParent","parameterTypes":["ch.qos.logback.core.spi.ContextAware"] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.joran.util.PropertySetter"},
+  "name":"ch.qos.logback.core.pattern.PatternLayoutEncoderBase",
+  "methods":[{"name":"setPattern","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.joran.action.NestedComplexPropertyIA"},
+  "name":"ch.qos.logback.core.spi.ContextAware",
+  "methods":[{"name":"valueOf","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"ch.qos.logback.core.joran.action.StatusListenerAction"},
+  "name":"ch.qos.logback.core.status.NopStatusListener",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+}
+]

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/com.mysql/mysql-connector-j/8.0.31/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/com.mysql/mysql-connector-j/8.0.31/reflect-config.json
@@ -32,10 +32,5 @@
   "condition":{"typeReachable":"com.mysql.cj.NativeSession"},
   "name":"com.mysql.cj.util.PerVmServerConfigCacheFactory",
   "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"com.mysql.cj.protocol.StandardSocketFactory"},
-  "name":"java.lang.Thread",
-  "fields":[{"name":"threadLocalRandomProbe"}]
 }
 ]

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.calcite/calcite-core/1.35.0/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.calcite/calcite-core/1.35.0/reflect-config.json
@@ -1,17 +1,5 @@
 [
 {
-  "condition":{"typeReachable":"org.apache.calcite.plan.RelOptCluster"},
-  "name":"[B"
-},
-{
-  "condition":{"typeReachable":"org.apache.calcite.plan.RelOptCluster"},
-  "name":"[Ljava.lang.String;"
-},
-{
-  "condition":{"typeReachable":"org.apache.calcite.plan.RelOptCluster"},
-  "name":"[Lsun.security.pkcs.SignerInfo;"
-},
-{
   "condition":{"typeReachable":"org.apache.calcite.linq4j.tree.Types"},
   "name":"java.lang.Boolean",
   "fields":[{"name":"FALSE"}, {"name":"TRUE"}]

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere.elasticjob/elasticjob-lite-core/3.0.4/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere.elasticjob/elasticjob-lite-core/3.0.4/reflect-config.json
@@ -1,30 +1,5 @@
 [
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.elasticjob.executor.ElasticJobExecutor"},
-  "name":"java.util.Properties",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.elasticjob.lite.internal.failover.FailoverListenerManager"},
-  "name":"java.util.Properties",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.elasticjob.lite.internal.reconcile.ReconcileService"},
-  "name":"java.util.Properties",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingListenerManager$ListenServersChangedJobListener"},
-  "name":"java.util.Properties",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingListenerManager$ShardingTotalCountChangedJobListener"},
-  "name":"java.util.Properties",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.elasticjob.lite.internal.instance.InstanceNode"},
   "name":"org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance",
   "allDeclaredFields":true,

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reflect-config.json
@@ -5,16 +5,6 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.authority.rule.AuthorityRule"},
-  "name":"org.apache.shardingsphere.authority.provider.database.DatabasePermittedAuthorityRegistryProvider",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.authority.rule.AuthorityRule"},
-  "name":"org.apache.shardingsphere.authority.provider.simple.AllPermittedAuthorityRegistryProvider",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"},
   "name":"org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"
 },
@@ -1063,6 +1053,61 @@
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.connection.refresher.type.table.CreateTableStatementSchemaRefresher"},
   "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils",
   "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.connection.refresher.type.table.DropTableStatementSchemaRefresher"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.NewClusterContextManagerBuilder"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.context.ConfigurationContextManager"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.context.ResourceMetaDataContextManager"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.NewStandaloneModeContextManager"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.NewMetaDataContextsFactory"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.optimizer.context.OptimizerContextFactory"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.optimizer.context.planner.OptimizerPlannerContextFactory"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationPlannerUtils"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.rule.SQLFederationRule"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.rule.builder.SQLFederationRuleBuilder"},
+  "name":"org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationFunctionUtils"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"},

--- a/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native-test-metadata/resource-config.json
+++ b/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native-test-metadata/resource-config.json
@@ -4,6 +4,9 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.test.natived.jdbc.databases.MSSQLServerTest"},
     "pattern":"\\Qcontainer-license-acceptance.txt\\E"
   }, {
+    "condition":{"typeReachable":"ch.qos.logback.core.util.Loader"},
+    "pattern":"\\Qlogback-test.xml\\E"
+  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.test.natived.jdbc.databases.MSSQLServerTest"},
     "pattern":"\\Qtest-native/yaml/databases/mssqlserver.yaml\\E"
   }, {

--- a/test/native/src/test/resources/logback-test.xml
+++ b/test/native/src/test/resources/logback-test.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="org.apache.shardingsphere" level="warn" additivity="false">
+        <appender-ref ref="console" />
+    </logger>
+
+    <root>
+        <level value="error" />
+        <appender-ref ref="console" />
+    </root>
+</configuration>


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Host GraalVM Reachability Metadata of `ch.qos.logback:logback-core` to fix Error Log in NativeTest. This brought back the previously deleted https://github.com/apache/shardingsphere/blob/57f947153271ab6b55b4c39004b89dab4692c678/test/native/src/test/resources/logback-test.xml file.
  - The GraalVM Reachability Metadata of `ch.qos.logback:logback-core` is also temporarily hosted.
  - These Error Logs are similar to the following.
```shell
21:34:27,940 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback-test.xml] at [resource:/logback-test.xml]
21:34:27,940 |-WARN in ch.qos.logback.classic.LoggerContext[default] - Resource [logback-test.xml] occurs multiple times on the classpath.
21:34:27,940 |-WARN in ch.qos.logback.classic.LoggerContext[default] - Resource [logback-test.xml] occurs at [resource:/logback-test.xml#1]
21:34:27,940 |-WARN in ch.qos.logback.classic.LoggerContext[default] - Resource [logback-test.xml] occurs at [resource:/logback-test.xml]
21:34:27,940 |-INFO in ch.qos.logback.core.joran.spi.ConfigurationWatchList@4c34cb2e - URL [resource:/logback-test.xml] is not of type file
21:34:27,940 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - debug attribute not set
21:34:27,941 |-ERROR in ch.qos.logback.core.joran.action.StatusListenerAction - Could not create an StatusListener of type [ch.qos.logback.core.status.NopStatusListener]. ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type ch.qos.logback.core.status.NopStatusListener
        at ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type ch.qos.logback.core.status.NopStatusListener
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassNameAndParameter(OptionHelper.java:68)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassName(OptionHelper.java:44)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassName(OptionHelper.java:33)
        at      at ch.qos.logback.core.joran.action.StatusListenerAction.begin(StatusListenerAction.java:42)
        at      at ch.qos.logback.core.joran.spi.Interpreter.callBeginAction(Interpreter.java:269)
        at      at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:145)
        at      at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:128)
        at      at ch.qos.logback.core.joran.spi.EventPlayer.play(EventPlayer.java:50)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:165)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:152)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:110)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:53)
        at      at ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:64)
        at      at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:134)
        at      at org.slf4j.impl.StaticLoggerBinder.init(StaticLoggerBinder.java:84)
        at      at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:55)
        at      at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
        at      at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
        at      at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:417)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:362)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:388)
        at      at org.testcontainers.containers.wait.strategy.HostPortWaitStrategy.<clinit>(HostPortWaitStrategy.java:26)
        at      at org.testcontainers.containers.wait.strategy.Wait.forListeningPort(Wait.java:25)
        at      at org.testcontainers.containers.wait.strategy.Wait.defaultWaitStrategy(Wait.java:15)
        at      at org.testcontainers.containers.GenericContainer.<clinit>(GenericContainer.java:187)
        at      at org.apache.shardingsphere.test.natived.jdbc.mode.cluster.ZookeeperTest.assertShardingInLocalTransactions(ZookeeperTest.java:58)
        at      at java.base@17.0.9/java.lang.reflect.Method.invoke(Method.java:568)
        at      at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:728)
        at      at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
        at      at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
        at      at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
        at      at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:218)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:214)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:139)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:69)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at      at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at      at java.base@17.0.9/java.util.ArrayList.forEach(ArrayList.java:1511)
        at      at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at      at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at      at java.base@17.0.9/java.util.ArrayList.forEach(ArrayList.java:1511)
        at      at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at      at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at      at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
        at      at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
        at      at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
        at      at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
        at      at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:94)
        at      at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:52)
        at      at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:70)
        at      at org.graalvm.junit.platform.NativeImageJUnitLauncher.execute(NativeImageJUnitLauncher.java:74)
        at      at org.graalvm.junit.platform.NativeImageJUnitLauncher.main(NativeImageJUnitLauncher.java:129)
Caused by: java.lang.ClassNotFoundException: ch.qos.logback.core.status.NopStatusListener
        at      at java.base@17.0.9/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:52)
        at      at java.base@17.0.9/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at      at java.base@17.0.9/java.lang.ClassLoader.loadClass(ClassLoader.java:133)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassNameAndParameter(OptionHelper.java:55)
        at      ... 88 common frames omitted
21:34:27,941 |-ERROR in ch.qos.logback.core.joran.spi.Interpreter@20:76 - ActionException in Action for tag [statusListener] ch.qos.logback.core.joran.spi.ActionException: ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type ch.qos.logback.core.status.NopStatusListener
        at ch.qos.logback.core.joran.spi.ActionException: ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type ch.qos.logback.core.status.NopStatusListener
        at      at ch.qos.logback.core.joran.action.StatusListenerAction.begin(StatusListenerAction.java:52)
        at      at ch.qos.logback.core.joran.spi.Interpreter.callBeginAction(Interpreter.java:269)
        at      at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:145)
        at      at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:128)
        at      at ch.qos.logback.core.joran.spi.EventPlayer.play(EventPlayer.java:50)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:165)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:152)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:110)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:53)
        at      at ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:64)
        at      at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:134)
        at      at org.slf4j.impl.StaticLoggerBinder.init(StaticLoggerBinder.java:84)
        at      at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:55)
        at      at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
        at      at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
        at      at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:417)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:362)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:388)
        at      at org.testcontainers.containers.wait.strategy.HostPortWaitStrategy.<clinit>(HostPortWaitStrategy.java:26)
        at      at org.testcontainers.containers.wait.strategy.Wait.forListeningPort(Wait.java:25)
        at      at org.testcontainers.containers.wait.strategy.Wait.defaultWaitStrategy(Wait.java:15)
        at      at org.testcontainers.containers.GenericContainer.<clinit>(GenericContainer.java:187)
        at      at org.apache.shardingsphere.test.natived.jdbc.mode.cluster.ZookeeperTest.assertShardingInLocalTransactions(ZookeeperTest.java:58)
        at      at java.base@17.0.9/java.lang.reflect.Method.invoke(Method.java:568)
        at      at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:728)
        at      at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
        at      at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
        at      at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
        at      at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:218)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:214)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:139)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:69)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at      at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at      at java.base@17.0.9/java.util.ArrayList.forEach(ArrayList.java:1511)
        at      at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at      at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at      at java.base@17.0.9/java.util.ArrayList.forEach(ArrayList.java:1511)
        at      at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at      at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at      at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
        at      at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
        at      at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
        at      at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
        at      at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:94)
        at      at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:52)
        at      at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:70)
        at      at org.graalvm.junit.platform.NativeImageJUnitLauncher.execute(NativeImageJUnitLauncher.java:74)
        at      at org.graalvm.junit.platform.NativeImageJUnitLauncher.main(NativeImageJUnitLauncher.java:129)
Caused by: ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type ch.qos.logback.core.status.NopStatusListener
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassNameAndParameter(OptionHelper.java:68)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassName(OptionHelper.java:44)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassName(OptionHelper.java:33)
        at      at ch.qos.logback.core.joran.action.StatusListenerAction.begin(StatusListenerAction.java:42)
        at      ... 85 common frames omitted
Caused by: java.lang.ClassNotFoundException: ch.qos.logback.core.status.NopStatusListener
        at      at java.base@17.0.9/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:52)
        at      at java.base@17.0.9/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at      at java.base@17.0.9/java.lang.ClassLoader.loadClass(ClassLoader.java:133)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassNameAndParameter(OptionHelper.java:55)
        at      ... 88 common frames omitted
21:34:27,941 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
21:34:27,941 |-ERROR in ch.qos.logback.core.joran.action.AppenderAction - Could not create an Appender of type [ch.qos.logback.core.ConsoleAppender]. ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type ch.qos.logback.core.ConsoleAppender
        at ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type ch.qos.logback.core.ConsoleAppender
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassNameAndParameter(OptionHelper.java:68)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassName(OptionHelper.java:44)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassName(OptionHelper.java:33)
        at      at ch.qos.logback.core.joran.action.AppenderAction.begin(AppenderAction.java:52)
        at      at ch.qos.logback.core.joran.spi.Interpreter.callBeginAction(Interpreter.java:269)
        at      at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:145)
        at      at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:128)
        at      at ch.qos.logback.core.joran.spi.EventPlayer.play(EventPlayer.java:50)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:165)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:152)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:110)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:53)
        at      at ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:64)
        at      at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:134)
        at      at org.slf4j.impl.StaticLoggerBinder.init(StaticLoggerBinder.java:84)
        at      at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:55)
        at      at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
        at      at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
        at      at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:417)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:362)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:388)
        at      at org.testcontainers.containers.wait.strategy.HostPortWaitStrategy.<clinit>(HostPortWaitStrategy.java:26)
        at      at org.testcontainers.containers.wait.strategy.Wait.forListeningPort(Wait.java:25)
        at      at org.testcontainers.containers.wait.strategy.Wait.defaultWaitStrategy(Wait.java:15)
        at      at org.testcontainers.containers.GenericContainer.<clinit>(GenericContainer.java:187)
        at      at org.apache.shardingsphere.test.natived.jdbc.mode.cluster.ZookeeperTest.assertShardingInLocalTransactions(ZookeeperTest.java:58)
        at      at java.base@17.0.9/java.lang.reflect.Method.invoke(Method.java:568)
        at      at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:728)
        at      at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
        at      at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
        at      at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
        at      at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:218)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:214)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:139)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:69)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at      at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at      at java.base@17.0.9/java.util.ArrayList.forEach(ArrayList.java:1511)
        at      at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at      at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at      at java.base@17.0.9/java.util.ArrayList.forEach(ArrayList.java:1511)
        at      at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at      at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at      at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
        at      at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
        at      at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
        at      at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
        at      at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:94)
        at      at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:52)
        at      at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:70)
        at      at org.graalvm.junit.platform.NativeImageJUnitLauncher.execute(NativeImageJUnitLauncher.java:74)
        at      at org.graalvm.junit.platform.NativeImageJUnitLauncher.main(NativeImageJUnitLauncher.java:129)
Caused by: java.lang.ClassNotFoundException: ch.qos.logback.core.ConsoleAppender
        at      at java.base@17.0.9/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:52)
        at      at java.base@17.0.9/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at      at java.base@17.0.9/java.lang.ClassLoader.loadClass(ClassLoader.java:133)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassNameAndParameter(OptionHelper.java:55)
        at      ... 88 common frames omitted
21:34:27,941 |-ERROR in ch.qos.logback.core.joran.spi.Interpreter@21:74 - ActionException in Action for tag [appender] ch.qos.logback.core.joran.spi.ActionException: ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type ch.qos.logback.core.ConsoleAppender
        at ch.qos.logback.core.joran.spi.ActionException: ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type ch.qos.logback.core.ConsoleAppender
        at      at ch.qos.logback.core.joran.action.AppenderAction.begin(AppenderAction.java:76)
        at      at ch.qos.logback.core.joran.spi.Interpreter.callBeginAction(Interpreter.java:269)
        at      at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:145)
        at      at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:128)
        at      at ch.qos.logback.core.joran.spi.EventPlayer.play(EventPlayer.java:50)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:165)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:152)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:110)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:53)
        at      at ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:64)
        at      at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:134)
        at      at org.slf4j.impl.StaticLoggerBinder.init(StaticLoggerBinder.java:84)
        at      at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:55)
        at      at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
        at      at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
        at      at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:417)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:362)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:388)
        at      at org.testcontainers.containers.wait.strategy.HostPortWaitStrategy.<clinit>(HostPortWaitStrategy.java:26)
        at      at org.testcontainers.containers.wait.strategy.Wait.forListeningPort(Wait.java:25)
        at      at org.testcontainers.containers.wait.strategy.Wait.defaultWaitStrategy(Wait.java:15)
        at      at org.testcontainers.containers.GenericContainer.<clinit>(GenericContainer.java:187)
        at      at org.apache.shardingsphere.test.natived.jdbc.mode.cluster.ZookeeperTest.assertShardingInLocalTransactions(ZookeeperTest.java:58)
        at      at java.base@17.0.9/java.lang.reflect.Method.invoke(Method.java:568)
        at      at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:728)
        at      at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
        at      at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
        at      at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
        at      at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
        at      at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
        at      at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:218)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:214)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:139)
        at      at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:69)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at      at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at      at java.base@17.0.9/java.util.ArrayList.forEach(ArrayList.java:1511)
        at      at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at      at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at      at java.base@17.0.9/java.util.ArrayList.forEach(ArrayList.java:1511)
        at      at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at      at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at      at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at      at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at      at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
        at      at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
        at      at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
        at      at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
        at      at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
        at      at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:94)
        at      at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:52)
        at      at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:70)
        at      at org.graalvm.junit.platform.NativeImageJUnitLauncher.execute(NativeImageJUnitLauncher.java:74)
        at      at org.graalvm.junit.platform.NativeImageJUnitLauncher.main(NativeImageJUnitLauncher.java:129)
Caused by: ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type ch.qos.logback.core.ConsoleAppender
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassNameAndParameter(OptionHelper.java:68)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassName(OptionHelper.java:44)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassName(OptionHelper.java:33)
        at      at ch.qos.logback.core.joran.action.AppenderAction.begin(AppenderAction.java:52)
        at      ... 85 common frames omitted
Caused by: java.lang.ClassNotFoundException: ch.qos.logback.core.ConsoleAppender
        at      at java.base@17.0.9/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:52)
        at      at java.base@17.0.9/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at      at java.base@17.0.9/java.lang.ClassLoader.loadClass(ClassLoader.java:133)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassNameAndParameter(OptionHelper.java:55)
        at      ... 88 common frames omitted
21:34:27,941 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.apache.shardingsphere] to WARN
21:34:27,941 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting additivity of logger [org.apache.shardingsphere] to false
21:34:27,941 |-ERROR in ch.qos.logback.core.joran.action.AppenderRefAction - Could not find an appender named [console]. Did you define it below instead of above in the configuration file?
21:34:27,941 |-ERROR in ch.qos.logback.core.joran.action.AppenderRefAction - See http://logback.qos.ch/codes.html#appender_order for more details.
21:34:27,941 |-INFO in ch.qos.logback.classic.joran.action.LevelAction - ROOT level set to ERROR
21:34:27,941 |-ERROR in ch.qos.logback.core.joran.action.AppenderRefAction - Could not find an appender named [console]. Did you define it below instead of above in the configuration file?
21:34:27,941 |-ERROR in ch.qos.logback.core.joran.action.AppenderRefAction - See http://logback.qos.ch/codes.html#appender_order for more details.
21:34:27,941 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - End of configuration.
21:34:27,941 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@628ba5d1 - Registering current configuration as safe fallback point

```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
