### PR TITLE
Support parsing SQL Server distinct from

### DIFF
--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
@@ -223,6 +223,7 @@ primaryKey
 expr
     : expr andOperator expr
     | expr orOperator expr
+    | expr distinctFrom expr
     | notOperator expr
     | LP_ expr RP_
     | booleanPrimary
@@ -234,6 +235,10 @@ andOperator
 
 orOperator
     : OR | OR_
+    ;
+
+distinctFrom
+    : IS NOT? DISTINCT FROM
     ;
 
 notOperator

--- a/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
+++ b/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
@@ -398,6 +398,9 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
         if (null != ctx.orOperator()) {
             return createBinaryOperationExpression(ctx, ctx.orOperator().getText());
         }
+        if (null != ctx.distinctFrom()) {
+            return createBinaryOperationExpression(ctx, ctx.distinctFrom().getText());
+        }
         return new NotExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), (ExpressionSegment) visit(ctx.expr(0)), false);
     }
     

--- a/test/it/parser/src/main/resources/case/dml/insert.xml
+++ b/test/it/parser/src/main/resources/case/dml/insert.xml
@@ -3073,4 +3073,34 @@
             </value>
         </values>
     </insert>
+
+    <insert sql-case-id="insert_into_temp_table_with_null_value">
+        <columns start-index="28" stop-index="28"/>
+        <table name="#SampleTempTable" start-index="12" stop-index="27"/>
+        <values>
+            <value>
+                <assignment-value>
+                    <literal-expression value="10" start-index="37" stop-index="38"/>
+                </assignment-value>
+                <assignment-value>
+                    <literal-expression value="null" start-index="41" stop-index="44"/>
+                </assignment-value>
+            </value>
+        </values>
+    </insert>
+
+    <insert sql-case-id="insert_into_temp_table_with_all_null_value">
+        <columns start-index="28" stop-index="28"/>
+        <table name="#SampleTempTable" start-index="12" stop-index="27"/>
+        <values>
+            <value>
+                <assignment-value>
+                    <literal-expression value="null" start-index="37" stop-index="40"/>
+                </assignment-value>
+                <assignment-value>
+                    <literal-expression value="null" start-index="43" stop-index="46"/>
+                </assignment-value>
+            </value>
+        </values>
+    </insert>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -8026,4 +8026,48 @@
             </expr>
         </where>
     </select>
+
+    <select sql-case-id="select_with_not_distinct_from">
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <from start-index="14" stop-index="29">
+            <simple-table name="#SampleTempTable" start-index="14" stop-index="29"/>
+        </from>
+        <where start-index="31" stop-index="64">
+            <expr>
+                <binary-operation-expression start-index="37" stop-index="64">
+                    <left>
+                        <column name="id" start-index="37" stop-index="38"/>
+                    </left>
+                    <right>
+                        <literal-expression start-index="61" stop-index="64" value="null"/>
+                    </right>
+                    <operator>ISNOTDISTINCTFROM</operator>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_with_distinct_from">
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <from start-index="14" stop-index="29">
+            <simple-table name="#SampleTempTable" start-index="14" stop-index="29"/>
+        </from>
+        <where start-index="31" stop-index="58">
+            <expr>
+                <binary-operation-expression start-index="37" stop-index="58">
+                    <left>
+                        <column name="id" start-index="37" stop-index="38"/>
+                    </left>
+                    <right>
+                        <literal-expression value="17" start-index="57" stop-index="58"/>
+                    </right>
+                    <operator>ISDISTINCTFROM</operator>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/insert.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/insert.xml
@@ -111,4 +111,6 @@
     <sql-case id="insert_with_exec" value="INSERT INTO iris_rx_data (&quot;Sepal.Length&quot;, &quot;Sepal.Width&quot;, &quot;Petal.Length&quot;, &quot;Petal.Width&quot; , &quot;Species&quot;) EXECUTE sp_execute_external_script @language = N'R' , @script = N'iris_data &lt;- iris'" db-types="SQLServer"/>
     <sql-case id="insert_with_db_schema_name" value="INSERT INTO ContosoWarehouse.dbo.Affiliation SELECT * FROM My_Lakehouse.dbo.Affiliation" db-types="SQLServer"/>
     <sql-case id="insert_into_temp_table" value="INSERT INTO #NonExistentTable values (10)" db-types="SQLServer"/>
+    <sql-case id="insert_into_temp_table_with_null_value" value="INSERT INTO #SampleTempTable VALUES (10, null)" db-types="SQLServer"/>
+    <sql-case id="insert_into_temp_table_with_all_null_value" value="INSERT INTO #SampleTempTable VALUES (null, null)" db-types="SQLServer"/>
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -243,4 +243,6 @@
     <sql-case id="select_with_object_id_function" value="SELECT OBJECT_NAME(object_id) AS referencing_object_name,COALESCE(COL_NAME(object_id, column_id), '(n/a)') AS referencing_column_name,* FROM sys.sql_dependencies WHERE referenced_major_id = OBJECT_ID('&lt;schema_name.table_name&gt;') ORDER BY OBJECT_NAME(object_id), COL_NAME(object_id, column_id)" db-types="SQLServer"/>
     <sql-case id="select_from_sys_views" value="SELECT name AS view_name,SCHEMA_NAME(schema_id) AS schema_name,OBJECTPROPERTYEX(object_id,'IsIndexed') AS IsIndexed,OBJECTPROPERTYEX(object_id,'IsIndexable') AS IsIndexable,create_date,modify_date FROM sys.views" db-types="SQLServer"/>
     <sql-case id="select_with_substring_function" value="SELECT ProductID, Name, ProductNumber FROM [Production].[Product] WHERE SUBSTRING(ProductNumber, 0, 4) =  'HN-'" db-types="SQLServer"/>
+    <sql-case id="select_with_not_distinct_from" value="SELECT * FROM #SampleTempTable WHERE id IS NOT DISTINCT FROM NULL" db-types="SQLServer"/>
+    <sql-case id="select_with_distinct_from" value="SELECT * FROM #SampleTempTable WHERE id IS DISTINCT FROM 17;" db-types="SQLServer"/>
 </sql-cases>


### PR DESCRIPTION
Fixes #29168, #29167, #29166, #29165.

Changes proposed in this pull request:
  - support parsing SQL Server distinct from syntax [offical link](https://learn.microsoft.com/zh-cn/sql/t-sql/queries/is-distinct-from-transact-sql?view=sql-server-ver16)
  -  provide test case for the issues above
<img width="742" alt="image" src="https://github.com/apache/shardingsphere/assets/124348939/554259ac-d503-44d2-8806-89cd1b3a7d33">
 

```sql
SELECT * FROM #SampleTempTable WHERE id IS NOT DISTINCT FROM NULL
```

```sql
SELECT * FROM #SampleTempTable WHERE id IS DISTINCT FROM 17
```

```sql
INSERT INTO #SampleTempTable VALUES (10, null)
```

```sql
INSERT INTO #SampleTempTable VALUES (null, null)
```
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
