### PR TITLE
Fix label of ShowDatabasesExecutor

### DIFF
--- a/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowDatabasesExecutor.java
+++ b/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowDatabasesExecutor.java
@@ -72,6 +72,6 @@ public final class ShowDatabasesExecutor implements DatabaseAdminQueryExecutor {
     
     @Override
     public QueryResultMetaData getQueryResultMetaData() {
-        return new RawQueryResultMetaData(Collections.singletonList(new RawQueryResultColumnMetaData("SCHEMATA", "Database", "schema_name", Types.VARCHAR, "VARCHAR", 255, 0)));
+        return new RawQueryResultMetaData(Collections.singletonList(new RawQueryResultColumnMetaData("SCHEMATA", "SCHEMA_NAME", "Database", Types.VARCHAR, "VARCHAR", 255, 0)));
     }
 }

--- a/proxy/backend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowDatabasesExecutorTest.java
+++ b/proxy/backend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowDatabasesExecutorTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.authority.model.ShardingSpherePrivileges;
 import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResultMetaData;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
@@ -76,7 +77,11 @@ class ShowDatabasesExecutorTest {
         when(ProxyContext.getInstance().getAllDatabaseNames()).thenReturn(IntStream.range(0, 10).mapToObj(each -> String.format("database_%s", each)).collect(Collectors.toList()));
         ShowDatabasesExecutor executor = new ShowDatabasesExecutor(new MySQLShowDatabasesStatement());
         executor.execute(mockConnectionSession());
-        assertThat(executor.getQueryResultMetaData().getColumnCount(), is(1));
+        QueryResultMetaData queryResultMetaData = executor.getQueryResultMetaData();
+        assertThat(queryResultMetaData.getColumnCount(), is(1));
+        assertThat(queryResultMetaData.getTableName(1), is("SCHEMATA"));
+        assertThat(queryResultMetaData.getColumnLabel(1), is("Database"));
+        assertThat(queryResultMetaData.getColumnName(1), is("SCHEMA_NAME"));
         assertThat(getActual(executor), is(getExpected()));
     }
     

--- a/test/e2e/sql/src/test/resources/cases/dal/dataset/db/mysql/show_databases.xml
+++ b/test/e2e/sql/src/test/resources/cases/dal/dataset/db/mysql/show_databases.xml
@@ -17,7 +17,7 @@
 
 <dataset>
     <metadata>
-        <column name="schema_name" />
+        <column name="database" />
     </metadata>
     <row values="db" />
     <row values="information_schema" />

--- a/test/e2e/sql/src/test/resources/cases/dal/dataset/dbtbl_with_readwrite_splitting/mysql/show_databases.xml
+++ b/test/e2e/sql/src/test/resources/cases/dal/dataset/dbtbl_with_readwrite_splitting/mysql/show_databases.xml
@@ -17,7 +17,7 @@
 
 <dataset>
     <metadata>
-        <column name="schema_name" />
+        <column name="database" />
     </metadata>
     <row values="dbtbl_with_readwrite_splitting" />
     <row values="information_schema" />

--- a/test/e2e/sql/src/test/resources/cases/dal/dataset/dbtbl_with_readwrite_splitting_and_encrypt/mysql/show_databases.xml
+++ b/test/e2e/sql/src/test/resources/cases/dal/dataset/dbtbl_with_readwrite_splitting_and_encrypt/mysql/show_databases.xml
@@ -17,7 +17,7 @@
 
 <dataset>
     <metadata>
-        <column name="schema_name" />
+        <column name="database" />
     </metadata>
     <row values="dbtbl_with_readwrite_splitting_and_encrypt" />
     <row values="information_schema" />

--- a/test/e2e/sql/src/test/resources/cases/dal/dataset/encrypt/mysql/show_databases.xml
+++ b/test/e2e/sql/src/test/resources/cases/dal/dataset/encrypt/mysql/show_databases.xml
@@ -17,7 +17,7 @@
 
 <dataset>
     <metadata>
-        <column name="schema_name" />
+        <column name="database" />
     </metadata>
     <row values="encrypt" />
     <row values="information_schema" />

--- a/test/e2e/sql/src/test/resources/cases/dal/dataset/encrypt_and_readwrite_splitting/mysql/show_databases.xml
+++ b/test/e2e/sql/src/test/resources/cases/dal/dataset/encrypt_and_readwrite_splitting/mysql/show_databases.xml
@@ -17,7 +17,7 @@
 
 <dataset>
     <metadata>
-        <column name="schema_name" />
+        <column name="database" />
     </metadata>
     <row values="encrypt_and_readwrite_splitting" />
     <row values="information_schema" />

--- a/test/e2e/sql/src/test/resources/cases/dal/dataset/readwrite_splitting/mysql/show_databases.xml
+++ b/test/e2e/sql/src/test/resources/cases/dal/dataset/readwrite_splitting/mysql/show_databases.xml
@@ -17,7 +17,7 @@
 
 <dataset>
     <metadata>
-        <column name="schema_name" />
+        <column name="database" />
     </metadata>
     <row values="information_schema" />
     <row values="mysql" />

--- a/test/e2e/sql/src/test/resources/cases/dal/dataset/sharding_and_encrypt/mysql/show_databases.xml
+++ b/test/e2e/sql/src/test/resources/cases/dal/dataset/sharding_and_encrypt/mysql/show_databases.xml
@@ -17,7 +17,7 @@
 
 <dataset>
     <metadata>
-        <column name="schema_name" />
+        <column name="database" />
     </metadata>
     <row values="information_schema" />
     <row values="mysql" />

--- a/test/e2e/sql/src/test/resources/cases/dal/dataset/tbl/mysql/show_databases.xml
+++ b/test/e2e/sql/src/test/resources/cases/dal/dataset/tbl/mysql/show_databases.xml
@@ -17,7 +17,7 @@
 
 <dataset>
     <metadata>
-        <column name="schema_name" />
+        <column name="database" />
     </metadata>
     <row values="information_schema" />
     <row values="mysql" />


### PR DESCRIPTION
Fixes #29757.

### Before
```sql
mysql> show databases;
+--------------------+
| schema_name        |
+--------------------+
| information_schema |
| mysql              |
| performance_schema |
| shardingsphere     |
| sys                |
+--------------------+
```

### After
```sql
mysql> show databases;
+--------------------+
| Database           |
+--------------------+
| information_schema |
| mysql              |
| performance_schema |
| shardingsphere     |
| sys                |
+--------------------+
```

### Why name is `SCHEMA_NAME` and label is `Database`?
This is come from the result set meta data of native MySQL
```java
// show databases from mysql
com.mysql.jdbc.ResultSetMetaData@197d671 - Field level information: com.mysql.jdbc.Field@402e37bc[catalog=information_schema,tableName=SCHEMATA,originalTableName=SCHEMATA,columnName=Database,originalColumnName=SCHEMA_NAME,mysqlType=253(FIELD_TYPE_VAR_STRING),flags=, charsetIndex=33, charsetName=UTF-8]

// show database from proxy (before)
com.mysql.jdbc.ResultSetMetaData@197d671 - Field level information: com.mysql.jdbc.Field@402e37bc[catalog="",tableName=SCHEMATA,originalTableName=SCHEMATA,columnName=schema_name,originalColumnName=Database,mysqlType=253(FIELD_TYPE_VAR_STRING),flags= UNSIGNED, charsetIndex=33, charsetName=UTF-8]

// show database from proxy (after)
com.mysql.jdbc.ResultSetMetaData@197d671 - Field level information: com.mysql.jdbc.Field@402e37bc[catalog=,tableName=SCHEMATA,originalTableName=SCHEMATA,columnName=Database,originalColumnName=SCHEMA_NAME,mysqlType=253(FIELD_TYPE_VAR_STRING),flags= UNSIGNED, charsetIndex=33, charsetName=UTF-8]
```
 