### PR TITLE
Refactor : update the JDK from 11 to 17 for sonar related plugin

### DIFF
--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v3
         with:
           path: ~/.sonar/cache

--- a/.github/workflows/schedule-report.yml
+++ b/.github/workflows/schedule-report.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v3
         with:
           path: ~/.sonar/cache


### PR DESCRIPTION
Changes proposed in this pull request:
  - update the JDK from 11 to 17 for sonar related plugin

all sonar plugin deprecated JDK 11 support, force to use JDK 17.
> The version of Java (11.0.21) used to run this analysis is deprecated, and SonarCloud no longer supports it. Please upgrade to Java 17 or later.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
