### PR TITLE
Recover DataRecordGroupEngine

### DIFF
--- a/docs/document/content/user-manual/error-code/sql-error-code.cn.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.cn.md
@@ -118,6 +118,7 @@ SQL 错误码以标准的 SQL State，Vendor Code 和详细错误信息提供，
 | HY000     | 18020       | Failed to get DDL for table \`%s\`.                                                |
 | 42S01     | 18030       | Duplicate storage unit names \`%s\`.                                               |
 | 42S02     | 18031       | Storage units names \`%s\` do not exist.                                           |
+| HY000     | 18050       | Before data record is \`%s\`, after data record is \`%s\`.                         |
 | 08000     | 18051       | Data check table \`%s\` failed.                                                    |
 | 0A000     | 18052       | Unsupported pipeline database type \`%s\`.                                         |
 | 0A000     | 18053       | Unsupported CRC32 data consistency calculate algorithm with database type \`%s\`.  |

--- a/docs/document/content/user-manual/error-code/sql-error-code.en.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.en.md
@@ -118,6 +118,7 @@ SQL error codes provide by standard `SQL State`, `Vendor Code` and `Reason`, whi
 | HY000     | 18020       | Failed to get DDL for table \`%s\`.                                                |
 | 42S01     | 18030       | Duplicate storage unit names \`%s\`.                                               |
 | 42S02     | 18031       | Storage units names \`%s\` do not exist.                                           |
+| HY000     | 18050       | Before data record is \`%s\`, after data record is \`%s\`.                         |
 | 08000     | 18051       | Data check table \`%s\` failed.                                                    |
 | 0A000     | 18052       | Unsupported pipeline database type \`%s\`.                                         |
 | 0A000     | 18053       | Unsupported CRC32 data consistency calculate algorithm with database type \`%s\`.  |

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/data/PipelineUnexpectedDataRecordOrderException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/data/PipelineUnexpectedDataRecordOrderException.java
@@ -15,23 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.data.pipeline.core.ingest.record.group;
+package org.apache.shardingsphere.data.pipeline.core.exception.data;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.data.pipeline.core.ingest.record.DataRecord;
+import org.apache.shardingsphere.infra.exception.core.external.sql.sqlstate.XOpenSQLState;
+import org.apache.shardingsphere.infra.exception.core.external.sql.type.kernel.category.PipelineSQLException;
 
-import java.util.Collection;
-
-@RequiredArgsConstructor
-@Getter
-public final class GroupedDataRecord {
+/**
+ * Pipeline unexpected data record order exception.
+ */
+public final class PipelineUnexpectedDataRecordOrderException extends PipelineSQLException {
     
-    private final String tableName;
+    private static final long serialVersionUID = 6023695604738387750L;
     
-    private final Collection<DataRecord> insertDataRecords;
-    
-    private final Collection<DataRecord> updateDataRecords;
-    
-    private final Collection<DataRecord> deleteDataRecords;
+    public PipelineUnexpectedDataRecordOrderException(final DataRecord beforeDataRecord, final DataRecord afterDataRecord) {
+        super(XOpenSQLState.GENERAL_ERROR, 50, String.format("Before data record is `%s`, after data record is `%s`.", beforeDataRecord, afterDataRecord));
+    }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/record/DataRecord.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/record/DataRecord.java
@@ -105,7 +105,16 @@ public final class DataRecord extends Record {
      * @return key
      */
     public Key getKey() {
-        return PipelineSQLOperationType.DELETE == type ? new Key(tableName, oldUniqueKeyValues) : new Key(tableName, uniqueKeyValue);
+        return new Key(tableName, uniqueKeyValue);
+    }
+    
+    /**
+     * Get old key.
+     *
+     * @return key
+     */
+    public Key getOldKey() {
+        return new Key(tableName, oldUniqueKeyValues);
     }
     
     @RequiredArgsConstructor

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/record/group/DataRecordGroupEngine.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/record/group/DataRecordGroupEngine.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.infra.exception.core.ShardingSpherePrecondition
 import org.apache.shardingsphere.infra.exception.core.external.sql.type.generic.UnsupportedSQLOperationException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,8 +80,8 @@ public final class DataRecordGroupEngine {
         Map<String, List<DataRecord>> tableGroup = mergedDataRecords.stream().collect(Collectors.groupingBy(DataRecord::getTableName));
         for (Entry<String, List<DataRecord>> entry : tableGroup.entrySet()) {
             Map<PipelineSQLOperationType, List<DataRecord>> typeGroup = entry.getValue().stream().collect(Collectors.groupingBy(DataRecord::getType));
-            result.add(new GroupedDataRecord(entry.getKey(), typeGroup.get(PipelineSQLOperationType.INSERT),
-                    typeGroup.get(PipelineSQLOperationType.UPDATE), typeGroup.get(PipelineSQLOperationType.DELETE)));
+            result.add(new GroupedDataRecord(entry.getKey(), typeGroup.getOrDefault(PipelineSQLOperationType.INSERT, Collections.emptyList()),
+                    typeGroup.getOrDefault(PipelineSQLOperationType.UPDATE, Collections.emptyList()), typeGroup.getOrDefault(PipelineSQLOperationType.DELETE, Collections.emptyList())));
         }
         return result;
     }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/record/group/DataRecordGroupEngine.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/record/group/DataRecordGroupEngine.java
@@ -18,18 +18,17 @@
 package org.apache.shardingsphere.data.pipeline.core.ingest.record.group;
 
 import org.apache.shardingsphere.data.pipeline.core.constant.PipelineSQLOperationType;
+import org.apache.shardingsphere.data.pipeline.core.exception.data.PipelineUnexpectedDataRecordOrderException;
+import org.apache.shardingsphere.data.pipeline.core.ingest.record.Column;
 import org.apache.shardingsphere.data.pipeline.core.ingest.record.DataRecord;
-import org.apache.shardingsphere.data.pipeline.core.ingest.record.DataRecord.Key;
+import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
+import org.apache.shardingsphere.infra.exception.core.external.sql.type.generic.UnsupportedSQLOperationException;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumMap;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 /**
@@ -38,41 +37,124 @@ import java.util.stream.Collectors;
 public final class DataRecordGroupEngine {
     
     /**
-     * Group by table and operation type.
+     * Merge data record.
+     * <pre>
+     * insert + insert -&gt; exception
+     * update + insert -&gt; exception
+     * delete + insert -&gt; insert
+     * insert + update -&gt; insert
+     * update + update -&gt; update
+     * delete + update -&gt; exception
+     * insert + delete -&gt; delete
+     * update + delete -&gt; delete
+     * delete + delete -&gt; exception
+     * </pre>
      *
-     * @param records data records
-     * @return grouped data records
+     * @param dataRecords data records
+     * @return merged data records
      */
-    public Collection<GroupedDataRecord> group(final Collection<DataRecord> records) {
-        Map<Key, Boolean> duplicateKeys = getDuplicateKeys(records);
-        Collection<String> tableNames = new LinkedHashSet<>();
-        Map<String, List<DataRecord>> nonBatchRecords = new LinkedHashMap<>();
-        Map<String, Map<PipelineSQLOperationType, Collection<DataRecord>>> batchDataRecords = new LinkedHashMap<>();
-        for (DataRecord each : records) {
-            tableNames.add(each.getTableName());
-            if (duplicateKeys.getOrDefault(each.getKey(), false)) {
-                nonBatchRecords.computeIfAbsent(each.getTableName(), ignored -> new LinkedList<>()).add(each);
-            } else {
-                batchDataRecords.computeIfAbsent(
-                        each.getTableName(), ignored -> new EnumMap<>(PipelineSQLOperationType.class)).computeIfAbsent(each.getType(), ignored -> new LinkedList<>()).add(each);
+    public List<DataRecord> merge(final List<DataRecord> dataRecords) {
+        Map<DataRecord.Key, DataRecord> result = new HashMap<>();
+        dataRecords.forEach(each -> {
+            if (PipelineSQLOperationType.INSERT.equals(each.getType())) {
+                mergeInsert(each, result);
+            } else if (PipelineSQLOperationType.UPDATE.equals(each.getType())) {
+                mergeUpdate(each, result);
+            } else if (PipelineSQLOperationType.DELETE.equals(each.getType())) {
+                mergeDelete(each, result);
             }
-        }
-        return tableNames.stream().map(each -> getGroupedDataRecord(
-                each, batchDataRecords.getOrDefault(each, Collections.emptyMap()), nonBatchRecords.getOrDefault(each, Collections.emptyList()))).collect(Collectors.toList());
+        });
+        return new ArrayList<>(result.values());
     }
     
-    private Map<Key, Boolean> getDuplicateKeys(final Collection<DataRecord> records) {
-        Map<Key, Boolean> result = new HashMap<>();
-        for (DataRecord each : records) {
-            Key key = each.getKey();
-            result.put(key, result.containsKey(key));
+    /**
+     * Group by table and type.
+     *
+     * @param dataRecords data records
+     * @return grouped data records
+     */
+    public List<GroupedDataRecord> group(final List<DataRecord> dataRecords) {
+        List<GroupedDataRecord> result = new ArrayList<>(100);
+        List<DataRecord> mergedDataRecords = dataRecords.get(0).getUniqueKeyValue().isEmpty() ? dataRecords : merge(dataRecords);
+        Map<String, List<DataRecord>> tableGroup = mergedDataRecords.stream().collect(Collectors.groupingBy(DataRecord::getTableName));
+        for (Entry<String, List<DataRecord>> entry : tableGroup.entrySet()) {
+            Map<PipelineSQLOperationType, List<DataRecord>> typeGroup = entry.getValue().stream().collect(Collectors.groupingBy(DataRecord::getType));
+            result.add(new GroupedDataRecord(entry.getKey(), typeGroup.get(PipelineSQLOperationType.INSERT),
+                    typeGroup.get(PipelineSQLOperationType.UPDATE), typeGroup.get(PipelineSQLOperationType.DELETE)));
         }
         return result;
     }
     
-    private GroupedDataRecord getGroupedDataRecord(final String tableName, final Map<PipelineSQLOperationType, Collection<DataRecord>> batchRecords, final Collection<DataRecord> nonBatchRecords) {
-        return new GroupedDataRecord(tableName, batchRecords.getOrDefault(PipelineSQLOperationType.INSERT, Collections.emptyList()),
-                batchRecords.getOrDefault(PipelineSQLOperationType.UPDATE, Collections.emptyList()), batchRecords.getOrDefault(PipelineSQLOperationType.DELETE, Collections.emptyList()),
-                nonBatchRecords);
+    private void mergeInsert(final DataRecord dataRecord, final Map<DataRecord.Key, DataRecord> dataRecords) {
+        DataRecord beforeDataRecord = dataRecords.get(dataRecord.getKey());
+        ShardingSpherePreconditions.checkState(null == beforeDataRecord
+                || PipelineSQLOperationType.DELETE.equals(beforeDataRecord.getType()), () -> new PipelineUnexpectedDataRecordOrderException(beforeDataRecord, dataRecord));
+        dataRecords.put(dataRecord.getKey(), dataRecord);
+    }
+    
+    private void mergeUpdate(final DataRecord dataRecord, final Map<DataRecord.Key, DataRecord> dataRecords) {
+        DataRecord beforeDataRecord = checkUpdatedUniqueKey(dataRecord) ? dataRecords.get(dataRecord.getOldKey()) : dataRecords.get(dataRecord.getKey());
+        if (null == beforeDataRecord) {
+            dataRecords.put(dataRecord.getKey(), dataRecord);
+            return;
+        }
+        ShardingSpherePreconditions.checkState(!PipelineSQLOperationType.DELETE.equals(beforeDataRecord.getType()), () -> new UnsupportedSQLOperationException("Not Delete"));
+        if (checkUpdatedUniqueKey(dataRecord)) {
+            dataRecords.remove(dataRecord.getOldKey());
+        }
+        if (PipelineSQLOperationType.INSERT.equals(beforeDataRecord.getType())) {
+            DataRecord mergedDataRecord = mergeColumn(PipelineSQLOperationType.INSERT, dataRecord.getTableName(), beforeDataRecord, dataRecord);
+            dataRecords.put(mergedDataRecord.getKey(), mergedDataRecord);
+            return;
+        }
+        if (PipelineSQLOperationType.UPDATE.equals(beforeDataRecord.getType())) {
+            DataRecord mergedDataRecord = mergeColumn(PipelineSQLOperationType.UPDATE, dataRecord.getTableName(), beforeDataRecord, dataRecord);
+            dataRecords.put(mergedDataRecord.getKey(), mergedDataRecord);
+        }
+    }
+    
+    private void mergeDelete(final DataRecord dataRecord, final Map<DataRecord.Key, DataRecord> dataRecords) {
+        DataRecord beforeDataRecord = dataRecords.get(dataRecord.getOldKey());
+        ShardingSpherePreconditions.checkState(null == beforeDataRecord
+                || !PipelineSQLOperationType.DELETE.equals(beforeDataRecord.getType()), () -> new PipelineUnexpectedDataRecordOrderException(beforeDataRecord, dataRecord));
+        if (null != beforeDataRecord && PipelineSQLOperationType.UPDATE.equals(beforeDataRecord.getType()) && checkUpdatedUniqueKey(beforeDataRecord)) {
+            DataRecord mergedDataRecord = new DataRecord(PipelineSQLOperationType.DELETE, dataRecord.getTableName(), dataRecord.getPosition(), dataRecord.getColumnCount());
+            for (int i = 0; i < dataRecord.getColumnCount(); i++) {
+                mergedDataRecord.addColumn(new Column(dataRecord.getColumn(i).getName(),
+                        dataRecord.getColumn(i).isUniqueKey() ? beforeDataRecord.getColumn(i).getOldValue() : beforeDataRecord.getColumn(i).getValue(), true, dataRecord.getColumn(i).isUniqueKey()));
+            }
+            dataRecords.remove(beforeDataRecord.getKey());
+            dataRecords.put(mergedDataRecord.getKey(), mergedDataRecord);
+        } else {
+            dataRecords.put(dataRecord.getOldKey(), dataRecord);
+        }
+    }
+    
+    private boolean checkUpdatedUniqueKey(final DataRecord dataRecord) {
+        for (Column each : dataRecord.getColumns()) {
+            if (each.isUniqueKey() && each.isUpdated()) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private DataRecord mergeColumn(final PipelineSQLOperationType type, final String tableName, final DataRecord preDataRecord, final DataRecord curDataRecord) {
+        DataRecord result = new DataRecord(type, tableName, curDataRecord.getPosition(), curDataRecord.getColumnCount());
+        for (int i = 0; i < curDataRecord.getColumnCount(); i++) {
+            result.addColumn(new Column(
+                    curDataRecord.getColumn(i).getName(),
+                    preDataRecord.getColumn(i).isUniqueKey()
+                            ? mergePrimaryKeyOldValue(preDataRecord.getColumn(i), curDataRecord.getColumn(i))
+                            : null,
+                    curDataRecord.getColumn(i).getValue(),
+                    preDataRecord.getColumn(i).isUpdated() || curDataRecord.getColumn(i).isUpdated(),
+                    curDataRecord.getColumn(i).isUniqueKey()));
+        }
+        return result;
+    }
+    
+    private Object mergePrimaryKeyOldValue(final Column beforeColumn, final Column column) {
+        return beforeColumn.isUpdated() ? beforeColumn.getOldValue() : (column.isUpdated() ? column.getOldValue() : null);
     }
 }

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/ingest/record/DataRecordTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/ingest/record/DataRecordTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class DataRecordTest {
     
     @Test
-    void assertGetKeyWithUpdate() {
+    void assertGetKey() {
         DataRecord beforeDataRecord = new DataRecord(PipelineSQLOperationType.UPDATE, "foo_tbl", new IngestPlaceholderPosition(), 1);
         beforeDataRecord.addColumn(new Column("id", 1, true, true));
         DataRecord afterDataRecord = new DataRecord(PipelineSQLOperationType.UPDATE, "foo_tbl", new IngestPlaceholderPosition(), 1);
@@ -36,11 +36,11 @@ class DataRecordTest {
     }
     
     @Test
-    void assertGetKeyWithDelete() {
+    void assertGetOldKey() {
         DataRecord beforeDataRecord = new DataRecord(PipelineSQLOperationType.DELETE, "foo_tbl", new IngestPlaceholderPosition(), 1);
         beforeDataRecord.addColumn(new Column("id", 1, 2, true, true));
         DataRecord afterDataRecord = new DataRecord(PipelineSQLOperationType.DELETE, "foo_tbl", new IngestPlaceholderPosition(), 1);
         afterDataRecord.addColumn(new Column("id", 1, 3, true, true));
-        assertThat(beforeDataRecord.getKey(), is(afterDataRecord.getKey()));
+        assertThat(beforeDataRecord.getOldKey(), is(afterDataRecord.getOldKey()));
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Recover DataRecordMerger by revert PR 25307

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
