### PR TITLE
Updates Curator to 5.6.0 to avoid Cache loading failure when there are too many child nodes

### DIFF
--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -233,9 +233,9 @@ The text of each license is the standard Apache 2.0 license.
     commons-math3 3.6.1: https://commons.apache.org/proper/commons-math, Apache 2.0
     commons-pool2 2.6.1: https://commons.apache.org/proper/commons-pool, Apache 2.0
     commons-logging 1.1.3: https://github.com/apache/commons-logging, Apache 2.0
-    curator-client 5.5.0:  https://github.com/apache/curator, Apache 2.0
-    curator-framework 5.5.0:  https://github.com/apache/curator, Apache 2.0
-    curator-recipes 5.5.0:  https://github.com/apache/curator, Apache 2.0
+    curator-client 5.6.0:  https://github.com/apache/curator, Apache 2.0
+    curator-framework 5.6.0:  https://github.com/apache/curator, Apache 2.0
+    curator-recipes 5.6.0:  https://github.com/apache/curator, Apache 2.0
     error_prone_annotations 2.22.0: https://github.com/google/error-prone, Apache 2.0
     failsafe 2.4.4: https://github.com/jhalterman/failsafe, Apache 2.0
     failureaccess 1.0.1: https://github.com/google/guava, Apache 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <netty.version>4.1.99.Final</netty.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         
-        <curator.version>5.5.0</curator.version>
+        <curator.version>5.6.0</curator.version>
         <zookeeper.version>3.9.1</zookeeper.version>
         <audience-annotations.version>0.12.0</audience-annotations.version>
         <jetcd.version>0.7.6</jetcd.version>


### PR DESCRIPTION
Fixes #29624.

Changes proposed in this pull request:
  - Updates Curator to 5.6.0 to avoid Cache loading failure when there are too many child nodes. Refer to https://github.com/apache/curator/pull/480 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
