### PR TITLE
Manually dispatch pipeline ElasticJob events when ShardingSphere-Proxy start

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/listener/PipelineContextManagerLifecycleListener.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/listener/PipelineContextManagerLifecycleListener.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContext;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContextKey;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContextManager;
+import org.apache.shardingsphere.data.pipeline.core.exception.job.PipelineJobNotFoundException;
 import org.apache.shardingsphere.data.pipeline.core.job.api.PipelineAPIFactory;
 import org.apache.shardingsphere.data.pipeline.core.job.id.PipelineJobIdUtils;
 import org.apache.shardingsphere.data.pipeline.core.job.type.PipelineJobType;
@@ -63,9 +64,7 @@ public final class PipelineContextManagerLifecycleListener implements ContextMan
         ElasticJobServiceLoader.registerTypedService(ElasticJobListener.class);
         try {
             dispatchEnablePipelineJobStartEvent(contextKey);
-            // CHECKSTYLE:OFF
-        } catch (final RuntimeException ex) {
-            // CHECKSTYLE:ON
+        } catch (final IllegalArgumentException | PipelineJobNotFoundException ex) {
             log.error("Dispatch enable pipeline job start event failed", ex);
         }
     }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/listener/PipelineContextManagerLifecycleListener.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/listener/PipelineContextManagerLifecycleListener.java
@@ -21,7 +21,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContext;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContextKey;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContextManager;
-import org.apache.shardingsphere.data.pipeline.core.exception.job.PipelineJobNotFoundException;
 import org.apache.shardingsphere.data.pipeline.core.job.api.PipelineAPIFactory;
 import org.apache.shardingsphere.data.pipeline.core.job.id.PipelineJobIdUtils;
 import org.apache.shardingsphere.data.pipeline.core.job.type.PipelineJobType;
@@ -64,7 +63,9 @@ public final class PipelineContextManagerLifecycleListener implements ContextMan
         ElasticJobServiceLoader.registerTypedService(ElasticJobListener.class);
         try {
             dispatchEnablePipelineJobStartEvent(contextKey);
-        } catch (final IllegalArgumentException | UnsupportedOperationException | PipelineJobNotFoundException ex) {
+            // CHECKSTYLE:OFF
+        } catch (final RuntimeException ex) {
+            // CHECKSTYLE:ON
             log.error("Dispatch enable pipeline job start event failed", ex);
         }
     }
@@ -72,7 +73,7 @@ public final class PipelineContextManagerLifecycleListener implements ContextMan
     private void dispatchEnablePipelineJobStartEvent(final PipelineContextKey contextKey) {
         JobConfigurationAPI jobConfigAPI = PipelineAPIFactory.getJobConfigurationAPI(contextKey);
         List<JobBriefInfo> allJobsBriefInfo = PipelineAPIFactory.getJobStatisticsAPI(contextKey).getAllJobsBriefInfo()
-                .stream().filter(each -> !each.getJobName().startsWith("_") && !each.getJobName().startsWith("j02")).collect(Collectors.toList());
+                .stream().filter(each -> !each.getJobName().startsWith("_")).collect(Collectors.toList());
         for (JobBriefInfo each : allJobsBriefInfo) {
             PipelineJobType jobType = PipelineJobIdUtils.parseJobType(each.getJobName());
             PipelineJobInfo jobInfo = jobType.getJobInfo(each.getJobName());

--- a/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/ConsistencyCheckJobType.java
+++ b/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/ConsistencyCheckJobType.java
@@ -60,7 +60,7 @@ public final class ConsistencyCheckJobType implements PipelineJobType {
     
     @Override
     public PipelineJobInfo getJobInfo(final String jobId) {
-        throw new UnsupportedOperationException();
+        return null;
     }
     
     @Override


### PR DESCRIPTION


Changes proposed in this pull request:
  - Manually dispatch pipeline ElasticJob events if job `disable=false`

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
