### PR TITLE
Change the JDK runtime of the Dockerfile that builds ShardingSphere Proxy from JDK17 to JDK21

### DIFF
--- a/distribution/proxy/Dockerfile
+++ b/distribution/proxy/Dockerfile
@@ -22,7 +22,7 @@ ENV LOCAL_PATH /opt/shardingsphere-proxy
 ADD target/${APP_NAME}.tar.gz /opt
 RUN mv /opt/${APP_NAME} ${LOCAL_PATH} && mkdir -p ${LOCAL_PATH}/ext-lib
 
-FROM eclipse-temurin:17-jdk
+FROM eclipse-temurin:21-jdk
 MAINTAINER ShardingSphere "dev@shardingsphere.apache.org"
 
 ENV LOCAL_PATH /opt/shardingsphere-proxy


### PR DESCRIPTION
Fixes #29847.

Changes proposed in this pull request:
  - Change the JDK runtime of the Dockerfile that builds ShardingSphere Proxy from JDK17 to JDK21.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
