### PR TITLE
Refactor PipelineDataSourceSink

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/importer/sink/type/PipelineDataSourceSink.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/importer/sink/type/PipelineDataSourceSink.java
@@ -91,7 +91,7 @@ public final class PipelineDataSourceSink implements PipelineSink {
         }
         for (int i = 0; !Thread.interrupted() && i <= importerConfig.getRetryTimes(); i++) {
             try {
-                doWrite(records);
+                doWrite(records, 0 == i);
                 break;
             } catch (final SQLException ex) {
                 log.error("Flush failed {}/{} times.", i, importerConfig.getRetryTimes(), ex);
@@ -103,55 +103,81 @@ public final class PipelineDataSourceSink implements PipelineSink {
         }
     }
     
-    private void doWrite(final Collection<DataRecord> records) throws SQLException {
-        try (Connection connection = dataSource.getConnection()) {
-            boolean enableTransaction = records.size() > 1;
-            if (enableTransaction) {
-                connection.setAutoCommit(false);
-            }
-            switch (records.iterator().next().getType()) {
-                case INSERT:
-                    Optional.ofNullable(importerConfig.getRateLimitAlgorithm()).ifPresent(optional -> optional.intercept(PipelineSQLOperationType.INSERT, 1));
-                    executeBatchInsert(connection, records);
-                    break;
-                case UPDATE:
-                    Optional.ofNullable(importerConfig.getRateLimitAlgorithm()).ifPresent(optional -> optional.intercept(PipelineSQLOperationType.UPDATE, 1));
-                    executeUpdate(connection, records);
-                    break;
-                case DELETE:
-                    Optional.ofNullable(importerConfig.getRateLimitAlgorithm()).ifPresent(optional -> optional.intercept(PipelineSQLOperationType.DELETE, 1));
-                    executeBatchDelete(connection, records);
-                    break;
-                default:
-                    break;
-            }
-            if (enableTransaction) {
-                connection.commit();
-            }
+    private void doWrite(final Collection<DataRecord> records, final boolean firstTimeRun) throws SQLException {
+        switch (records.iterator().next().getType()) {
+            case INSERT:
+                Optional.ofNullable(importerConfig.getRateLimitAlgorithm()).ifPresent(optional -> optional.intercept(PipelineSQLOperationType.INSERT, 1));
+                executeBatchInsert(records, firstTimeRun);
+                break;
+            case UPDATE:
+                Optional.ofNullable(importerConfig.getRateLimitAlgorithm()).ifPresent(optional -> optional.intercept(PipelineSQLOperationType.UPDATE, 1));
+                executeUpdate(records, firstTimeRun);
+                break;
+            case DELETE:
+                Optional.ofNullable(importerConfig.getRateLimitAlgorithm()).ifPresent(optional -> optional.intercept(PipelineSQLOperationType.DELETE, 1));
+                executeBatchDelete(records);
+                break;
+            default:
+                break;
         }
     }
     
-    private void executeBatchInsert(final Connection connection, final Collection<DataRecord> dataRecords) throws SQLException {
+    private void executeBatchInsert(final Collection<DataRecord> dataRecords, final boolean firstTimeRun) throws SQLException {
         DataRecord dataRecord = dataRecords.iterator().next();
         String sql = importSQLBuilder.buildInsertSQL(importerConfig.findSchemaName(dataRecord.getTableName()).orElse(null), dataRecord);
-        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+        try (
+                Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
             runningStatement.set(preparedStatement);
-            preparedStatement.setQueryTimeout(30);
-            for (DataRecord each : dataRecords) {
-                for (int i = 0; i < each.getColumnCount(); i++) {
-                    preparedStatement.setObject(i + 1, each.getColumn(i).getValue());
-                }
-                preparedStatement.addBatch();
+            if (firstTimeRun) {
+                executeBatchInsertFirstTime(connection, preparedStatement, dataRecords);
+            } else {
+                retryBatchInsert(preparedStatement, dataRecords);
             }
-            preparedStatement.executeBatch();
         } finally {
             runningStatement.set(null);
         }
     }
     
-    private void executeUpdate(final Connection connection, final Collection<DataRecord> dataRecords) throws SQLException {
+    private void executeBatchInsertFirstTime(final Connection connection, final PreparedStatement preparedStatement, final Collection<DataRecord> dataRecords) throws SQLException {
+        boolean transactionEnabled = dataRecords.size() > 1;
+        if (transactionEnabled) {
+            connection.setAutoCommit(false);
+        }
+        preparedStatement.setQueryTimeout(30);
         for (DataRecord each : dataRecords) {
-            executeUpdate(connection, each);
+            for (int i = 0; i < each.getColumnCount(); i++) {
+                preparedStatement.setObject(i + 1, each.getColumn(i).getValue());
+            }
+            preparedStatement.addBatch();
+        }
+        preparedStatement.executeBatch();
+        if (transactionEnabled) {
+            connection.commit();
+        }
+    }
+    
+    private void retryBatchInsert(final PreparedStatement preparedStatement, final Collection<DataRecord> dataRecords) throws SQLException {
+        for (DataRecord each : dataRecords) {
+            for (int i = 0; i < each.getColumnCount(); i++) {
+                preparedStatement.setObject(i + 1, each.getColumn(i).getValue());
+            }
+            preparedStatement.executeUpdate();
+        }
+    }
+    
+    private void executeUpdate(final Collection<DataRecord> dataRecords, final boolean firstTimeRun) throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            boolean transactionEnabled = dataRecords.size() > 1 && firstTimeRun;
+            if (transactionEnabled) {
+                connection.setAutoCommit(false);
+            }
+            for (DataRecord each : dataRecords) {
+                executeUpdate(connection, each);
+            }
+            if (transactionEnabled) {
+                connection.commit();
+            }
         }
     }
     
@@ -184,25 +210,34 @@ public final class PipelineDataSourceSink implements PipelineSink {
         }
     }
     
-    private void executeBatchDelete(final Connection connection, final Collection<DataRecord> dataRecords) throws SQLException {
+    private void executeBatchDelete(final Collection<DataRecord> dataRecords) throws SQLException {
         DataRecord dataRecord = dataRecords.iterator().next();
         String sql = importSQLBuilder.buildDeleteSQL(importerConfig.findSchemaName(dataRecord.getTableName()).orElse(null), dataRecord,
                 RecordUtils.extractConditionColumns(dataRecord, importerConfig.getShardingColumns(dataRecord.getTableName())));
-        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+        try (
+                Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
             runningStatement.set(preparedStatement);
+            boolean transactionEnabled = dataRecords.size() > 1;
+            if (transactionEnabled) {
+                connection.setAutoCommit(false);
+            }
             preparedStatement.setQueryTimeout(30);
             for (DataRecord each : dataRecords) {
                 List<Column> conditionColumns = RecordUtils.extractConditionColumns(each, importerConfig.getShardingColumns(dataRecord.getTableName()));
                 for (int i = 0; i < conditionColumns.size(); i++) {
                     Object oldValue = conditionColumns.get(i).getOldValue();
                     if (null == oldValue) {
-                        log.warn("Record old value is null, record={}", each);
+                        log.warn("Record old value is null, record: {}", each);
                     }
                     preparedStatement.setObject(i + 1, oldValue);
                 }
                 preparedStatement.addBatch();
             }
             preparedStatement.executeBatch();
+            if (transactionEnabled) {
+                connection.commit();
+            }
         } finally {
             runningStatement.set(null);
         }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Refactor PipelineDataSourceSink: 1) Disable connection one global transaction on error retry, 2) Add log on update error

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
