### PR TITLE
Fix weblogic.utils.zip.ZipURLConnection cannot be cast to java.net.JarURLConnection issue.

### DIFF
--- a/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQLLoader.java
+++ b/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQLLoader.java
@@ -29,6 +29,7 @@ import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
@@ -172,7 +173,15 @@ public final class JDBCRepositorySQLLoader {
     
     private static JDBCRepositorySQL loadFromJar(final URL url, final String type) throws IOException {
         JDBCRepositorySQL result = null;
-        try (JarFile jar = ((JarURLConnection) url.openConnection()).getJarFile()) {
+        URL jarUrl = url;
+        if ("zip".equals(url.getProtocol())) {
+            jarUrl = new URL(url.toExternalForm().replace("zip:/", "jar:file:/"));
+        }
+        URLConnection urlConnection = jarUrl.openConnection();
+        if (!(urlConnection instanceof JarURLConnection)) {
+            return null;
+        }
+        try (JarFile jar = ((JarURLConnection) urlConnection).getJarFile()) {
             Enumeration<JarEntry> entries = jar.entries();
             while (entries.hasMoreElements()) {
                 String name = entries.nextElement().getName();


### PR DESCRIPTION
Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
