### PR TITLE
Fix incorrect implementation of AbstractAbsolutePathURLProvider

### DIFF
--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/spi/absolutepath/AbstractAbsolutePathURLProvider.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/spi/absolutepath/AbstractAbsolutePathURLProvider.java
@@ -18,12 +18,12 @@
 package org.apache.shardingsphere.driver.jdbc.core.driver.spi.absolutepath;
 
 import com.google.common.base.Preconditions;
-import org.apache.shardingsphere.driver.jdbc.core.driver.spi.classpath.AbstractClasspathURLProvider;
+import org.apache.shardingsphere.driver.jdbc.core.driver.ShardingSphereURLProvider;
 
 /**
  * Abstract absolute path URL provider.
  */
-public abstract class AbstractAbsolutePathURLProvider extends AbstractClasspathURLProvider {
+public abstract class AbstractAbsolutePathURLProvider implements ShardingSphereURLProvider {
     
     String getConfigurationFile(final String url, final String urlPrefix, final String pathType) {
         String configuredFile = url.substring(urlPrefix.length(), url.contains("?") ? url.indexOf('?') : url.length());


### PR DESCRIPTION
Fixes https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&types=BUG&id=apache_shardingsphere&open=AY1YzHwRFXNlR4nWuJUU&tab=code .

Changes proposed in this pull request:
  - Fix incorrect implementation of AbstractAbsolutePathURLProvider. Refer to https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&types=BUG&id=apache_shardingsphere&open=AY1YzHwRFXNlR4nWuJUU&tab=code .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
