### PR TITLE
Support parsing SQL Server UPDATE dbo.Cities sql #29185

### DIFF
--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
@@ -169,7 +169,7 @@ serviceName
     ;
 
 columnName
-    : (owner DOT_)? (name | scriptVariableName)
+    : ((databaseName DOT_)? (owner DOT_))? (name | scriptVariableName)
     ;
 
 scriptVariableName

--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
@@ -48,11 +48,11 @@ exec
     ;
 
 update
-    : withClause? UPDATE top? tableReferences setAssignmentsClause whereClause? (OPTION queryHint)?
+    : withClause? UPDATE top? tableReferences withTableHint? setAssignmentsClause whereClause? optionHint?
     ;
 
 assignment
-    : columnName EQ_ assignmentValue
+    : columnName (EQ_ | DOT_) assignmentValue
     ;
 
 setAssignmentsClause
@@ -69,7 +69,11 @@ assignmentValue
     ;
 
 delete
-    : withClause? DELETE top? (singleTableClause | multipleTablesClause) outputClause? whereClause? (OPTION queryHint)?
+    : withClause? DELETE top? (singleTableClause | multipleTablesClause) outputClause? whereClause? optionHint?
+    ;
+
+optionHint
+    : OPTION queryHint
     ;
 
 singleTableClause
@@ -222,7 +226,7 @@ queryHint
     | MAXDOP INT_NUM_
     | MAXRECURSION INT_NUM_
     | NO_PERFORMANCE_SPOOL
-    | OPTIMIZE FOR LP_ AT_ name (UNKNOWN | EQ_ identifier)* RP_
+    | LP_ OPTIMIZE FOR LP_ variableName (UNKNOWN | EQ_ literals)* RP_ RP_
     | OPTIMIZE FOR UNKNOWN
     | PARAMETERIZATION (SIMPLE | FORCED)
     | QUERYTRACEON INT_NUM_

--- a/parser/sql/dialect/sqlserver/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/SQLServerStatement.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/SQLServerStatement.g4
@@ -19,7 +19,6 @@ grammar SQLServerStatement;
 
 import Comments, TCLStatement, StoreProcedure, DALStatement;
 
-
 execute
     : (select
     | insert

--- a/parser/sql/dialect/sqlserver/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/SQLServerStatement.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/SQLServerStatement.g4
@@ -19,6 +19,7 @@ grammar SQLServerStatement;
 
 import Comments, TCLStatement, StoreProcedure, DALStatement;
 
+
 execute
     : (select
     | insert

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/dml/UpdateStatementHandler.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/dml/UpdateStatementHandler.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.predicate.Whe
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.WithSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.UpdateStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.SQLStatementHandler;
+import org.apache.shardingsphere.sql.parser.sql.dialect.segment.sqlserver.hint.OptionHintSegment;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLUpdateStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.dml.OracleUpdateStatement;
@@ -87,6 +88,19 @@ public final class UpdateStatementHandler implements SQLStatementHandler {
     public static Optional<WhereSegment> getDeleteWhereSegment(final UpdateStatement updateStatement) {
         if (updateStatement instanceof OracleUpdateStatement) {
             return Optional.ofNullable(((OracleUpdateStatement) updateStatement).getDeleteWhere());
+        }
+        return Optional.empty();
+    }
+    
+    /**
+     * Get option hint segment.
+     *
+     * @param updateStatement update statement
+     * @return option hint segment
+     */
+    public static Optional<OptionHintSegment> getOptionHintSegment(final UpdateStatement updateStatement) {
+        if (updateStatement instanceof SQLServerStatement) {
+            return ((SQLServerUpdateStatement) updateStatement).getOptionHintSegment();
         }
         return Optional.empty();
     }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/segment/sqlserver/hint/OptionHintSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/segment/sqlserver/hint/OptionHintSegment.java
@@ -15,29 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.common.segment.dml.assignment;
+package org.apache.shardingsphere.sql.parser.sql.dialect.segment.sqlserver.hint;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.SQLSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
-
-import java.util.Collection;
 
 /**
- * Set assignment segment.
+ * Option hint segment.
  */
 @RequiredArgsConstructor
 @Getter
-public final class SetAssignmentSegment implements SQLSegment {
+public final class OptionHintSegment implements SQLSegment {
     
     private final int startIndex;
     
     private final int stopIndex;
     
-    private final Collection<ColumnAssignmentSegment> assignments;
-    
-    @Setter
-    private TableSegment from;
+    private final String text;
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dml/SQLServerUpdateStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dml/SQLServerUpdateStatement.java
@@ -20,6 +20,8 @@ package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dml
 import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.WithSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.UpdateStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.segment.sqlserver.hint.OptionHintSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.segment.sqlserver.hint.WithTableHintSegment;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
 
 import java.util.Optional;
@@ -32,6 +34,10 @@ public final class SQLServerUpdateStatement extends UpdateStatement implements S
     
     private WithSegment withSegment;
     
+    private WithTableHintSegment withTableHintSegment;
+    
+    private OptionHintSegment optionHintSegment;
+    
     /**
      * Get with segment.
      *
@@ -39,5 +45,23 @@ public final class SQLServerUpdateStatement extends UpdateStatement implements S
      */
     public Optional<WithSegment> getWithSegment() {
         return Optional.ofNullable(withSegment);
+    }
+    
+    /**
+     * Get with table hint segment.
+     *
+     * @return with table hint segment.
+     */
+    public Optional<WithTableHintSegment> getWithTableHintSegment() {
+        return Optional.ofNullable(withTableHintSegment);
+    }
+    
+    /**
+     * Get option hint segment.
+     *
+     * @return option hint segment.
+     */
+    public Optional<OptionHintSegment> getOptionHintSegment() {
+        return Optional.ofNullable(optionHintSegment);
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dml/impl/UpdateStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dml/impl/UpdateStatementAssert.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.OrderBy
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.pagination.limit.LimitSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.UpdateStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.dml.UpdateStatementHandler;
+import org.apache.shardingsphere.sql.parser.sql.dialect.segment.sqlserver.hint.OptionHintSegment;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.limit.LimitClauseAssert;
@@ -34,6 +35,8 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 
 import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -46,7 +49,7 @@ public final class UpdateStatementAssert {
     
     /**
      * Assert update statement is correct with expected parser result.
-     * 
+     *
      * @param assertContext assert context
      * @param actual actual update statement
      * @param expected expected parser result
@@ -57,6 +60,7 @@ public final class UpdateStatementAssert {
         assertWhereClause(assertContext, actual, expected);
         assertOrderByClause(assertContext, actual, expected);
         assertLimitClause(assertContext, actual, expected);
+        assertOptionHint(assertContext, actual, expected);
     }
     
     private static void assertTable(final SQLCaseAssertContext assertContext, final UpdateStatement actual, final UpdateStatementTestCase expected) {
@@ -98,6 +102,17 @@ public final class UpdateStatementAssert {
             assertTrue(limitSegment.isPresent(), assertContext.getText("Actual limit segment should exist."));
             LimitClauseAssert.assertRowCount(assertContext, limitSegment.get().getRowCount().orElse(null), expected.getLimitClause().getRowCount());
             SQLSegmentAssert.assertIs(assertContext, limitSegment.get(), expected.getLimitClause());
+        }
+    }
+    
+    private static void assertOptionHint(final SQLCaseAssertContext assertContext, final UpdateStatement actual, final UpdateStatementTestCase expected) {
+        Optional<OptionHintSegment> optionHintSegment = UpdateStatementHandler.getOptionHintSegment(actual);
+        if (null == expected.getOptionHint()) {
+            assertFalse(optionHintSegment.isPresent(), assertContext.getText("Actual option hint segment should not exist."));
+        } else {
+            assertTrue(optionHintSegment.isPresent(), assertContext.getText("Actual option hint segment should exist."));
+            assertThat(assertContext.getText("Option hint text assertion error: "), optionHintSegment.get().getText(), is(expected.getOptionHint().getText()));
+            SQLSegmentAssert.assertIs(assertContext, optionHintSegment.get(), expected.getOptionHint());
         }
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/hint/ExpectedOptionHint.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/hint/ExpectedOptionHint.java
@@ -15,29 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.common.segment.dml.assignment;
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.hint;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.SQLSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.AbstractExpectedSQLSegment;
 
-import java.util.Collection;
+import javax.xml.bind.annotation.XmlAttribute;
 
 /**
- * Set assignment segment.
- */
+ * Expected option hint.
+ **/
 @RequiredArgsConstructor
 @Getter
-public final class SetAssignmentSegment implements SQLSegment {
+public class ExpectedOptionHint extends AbstractExpectedSQLSegment {
     
-    private final int startIndex;
-    
-    private final int stopIndex;
-    
-    private final Collection<ColumnAssignmentSegment> assignments;
-    
-    @Setter
-    private TableSegment from;
+    @XmlAttribute
+    private String text;
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dml/UpdateStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dml/UpdateStatementTestCase.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.hint.ExpectedOptionHint;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.limit.ExpectedLimitClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.orderby.ExpectedOrderByClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.set.ExpectedSetClause;
@@ -49,4 +50,7 @@ public final class UpdateStatementTestCase extends SQLParserTestCase {
     
     @XmlElement(name = "limit")
     private ExpectedLimitClause limitClause;
+    
+    @XmlElement(name = "option-hint")
+    private ExpectedOptionHint optionHint;
 }

--- a/test/it/parser/src/main/resources/case/dml/update.xml
+++ b/test/it/parser/src/main/resources/case/dml/update.xml
@@ -1453,4 +1453,264 @@
             </expr>
         </where>
     </update>
+    
+    <update sql-case-id="update_with_point_type">
+        <table start-index="7" stop-index="16">
+            <simple-table name="Cities" start-index="7" stop-index="16">
+                <owner name="dbo" start-index="7" stop-index="9" />
+            </simple-table>
+        </table>
+        <set start-index="18" stop-index="47">
+            <assignment start-index="22" stop-index="47">
+                <column name="Location" start-index="22" stop-index="29"/>
+                <assignment-value>
+                    <function function-name="SetXY" text="SetXY(23.5, 23.5)" start-index="31" stop-index="47">
+                        <parameter>
+                            <literal-expression value="23.5" start-index="37" stop-index="40" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="23.5" start-index="43" stop-index="46" />
+                        </parameter>
+                    </function>
+                </assignment-value>
+            </assignment>
+        </set>
+        <where start-index="49" stop-index="72">
+            <expr>
+                <binary-operation-expression start-index="55" stop-index="72">
+                    <left>
+                        <column name="Name" start-index="55" stop-index="58" />
+                    </left>
+                    <right>
+                        <literal-expression value="Anchorage" start-index="62" stop-index="72" />
+                    </right>
+                    <operator>=</operator>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </update>
+    
+    <update sql-case-id="update_with_table_hint">
+        <table start-index="7" stop-index="24">
+            <simple-table name="Product" start-index="7" stop-index="24">
+                <owner name="Production" start-index="7" stop-index="16" />
+            </simple-table>
+        </table>
+        <table-hints start-index="26" stop-index="39">
+            <table-hint value="TABLOCK" start-index="32" stop-index="38" />
+        </table-hints>
+        <set start-index="41" stop-index="72">
+            <assignment start-index="45" stop-index="72">
+                <column name="ListPrice" start-index="45" stop-index="53" />
+                <assignment-value>
+                    <binary-operation-expression start-index="57" stop-index="72">
+                        <left>
+                            <column name="ListPrice" start-index="57" stop-index="65" />
+                        </left>
+                        <right>
+                            <literal-expression value="1.10" start-index="69" stop-index="72" />
+                        </right>
+                        <operator>*</operator>
+                    </binary-operation-expression>
+                </assignment-value>
+            </assignment>
+        </set>
+        <where start-index="74" stop-index="104">
+            <expr>
+                <binary-operation-expression start-index="80" stop-index="104">
+                    <left>
+                        <column name="ProductNumber" start-index="80" stop-index="92" />
+                    </left>
+                    <right>
+                        <list-expression start-index="99" stop-index="104" >
+                            <items>
+                                <literal-expression value="BK-%" start-index="99" stop-index="104" />
+                            </items>
+                        </list-expression>
+                    </right>
+                    <operator>LIKE</operator>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </update>
+    
+    <update sql-case-id="update_with_option_hint">
+        <table start-index="7" stop-index="24">
+            <simple-table name="Product" start-index="7" stop-index="24">
+                <owner name="Production" start-index="7" stop-index="16" />
+            </simple-table>
+        </table>
+        <set start-index="26" stop-index="57">
+            <assignment start-index="30" stop-index="57">
+                <column name="ListPrice" start-index="30" stop-index="38" />
+                <assignment-value>
+                    <binary-operation-expression start-index="42" stop-index="57">
+                        <left>
+                            <column name="ListPrice" start-index="42" stop-index="50" />
+                        </left>
+                        <right>
+                            <literal-expression value="1.10" start-index="54" stop-index="57" />
+                        </right>
+                        <operator>*</operator>
+                    </binary-operation-expression>
+                </assignment-value>
+            </assignment>
+        </set>
+        <where start-index="59" stop-index="91">
+            <expr>
+                <binary-operation-expression start-index="65" stop-index="91">
+                    <left>
+                        <column name="ProductNumber" start-index="65" stop-index="77" />
+                    </left>
+                    <right>
+                        <list-expression start-index="84" stop-index="91">
+                            <items>
+                                <column name="@Product" start-index="84" stop-index="91" />
+                            </items>
+                        </list-expression>
+                    </right>
+                    <operator>LIKE</operator>
+                </binary-operation-expression>
+            </expr>
+        </where>
+        <option-hint start-index="93" stop-index="133" text="OPTION (OPTIMIZE FOR (@Product = 'BK-%'))" />
+    </update>
+    
+    <update sql-case-id="update_sales_table_with_subquery">
+        <table start-index="7" stop-index="22">
+            <simple-table name="YearlyTotalSales" start-index="7" stop-index="22" />
+        </table>
+        <set start-index="24" stop-index="151">
+            <assignment start-index="28" stop-index="151">
+                <column name="YearlySalesAmount" start-index="28" stop-index="44" />
+                <assignment-value>
+                    <subquery start-index="46" stop-index="151">
+                        <select>
+                            <projections start-index="54" stop-index="69">
+                                <aggregation-projection type="SUM" expression="SUM(SalesAmount)" start-index="54" stop-index="69">
+                                    <parameter>
+                                        <column name="SalesAmount" start-index="58" stop-index="68" />
+                                    </parameter>
+                                </aggregation-projection>
+                            </projections>
+                            <from start-index="76" stop-index="92">
+                                <simple-table name="FactInternetSales" start-index="76" stop-index="92" />
+                            </from>
+                            <where start-index="94" stop-index="150">
+                                <expr>
+                                    <binary-operation-expression start-index="100" stop-index="150">
+                                        <left>
+                                            <binary-operation-expression start-index="100" stop-index="122">
+                                                <left>
+                                                    <column name="OrderDateKey" start-index="100" stop-index="111" />
+                                                </left>
+                                                <right>
+                                                    <literal-expression value="20040000" start-index="115" stop-index="122" />
+                                                </right>
+                                                <operator>>=</operator>
+                                            </binary-operation-expression>
+                                        </left>
+                                        <right>
+                                            <binary-operation-expression start-index="128" stop-index="150">
+                                                <left>
+                                                    <column name="OrderDateKey" start-index="128" stop-index="139" />
+                                                </left>
+                                                <right>
+                                                    <literal-expression value="20050000" start-index="143" stop-index="150" />
+                                                </right>
+                                                <operator>&lt;</operator>
+                                            </binary-operation-expression>
+                                        </right>
+                                        <operator>AND</operator>
+                                    </binary-operation-expression>
+                                </expr>
+                            </where>
+                        </select>
+                    </subquery>
+                </assignment-value>
+            </assignment>
+        </set>
+        <where start-index="153" stop-index="167">
+            <expr>
+                <binary-operation-expression start-index="159" stop-index="167">
+                    <left>
+                        <column name="Year" start-index="159" stop-index="162" />
+                    </left>
+                    <right>
+                        <literal-expression value="2004" start-index="164" stop-index="167" />
+                    </right>
+                    <operator>=</operator>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </update>
+    
+    <update sql-case-id="update_with_inner_join_and_database_table_column">
+        <table start-index="7" stop-index="16">
+            <simple-table name="Table2" start-index="7" stop-index="16">
+                <owner name="dbo" start-index="7" stop-index="9" />
+            </simple-table>
+        </table>
+        <set start-index="18" stop-index="150">
+            <assignment start-index="22" stop-index="72">
+                <column name="ColB" start-index="22" stop-index="36">
+                    <owner name="Table2" start-index="26" stop-index="31">
+                        <owner name="dbo" start-index="22" stop-index="24" />
+                    </owner>
+                </column>
+                <assignment-value>
+                    <binary-operation-expression start-index="40" stop-index="72">
+                        <left>
+                            <column name="ColB" start-index="40" stop-index="54">
+                                <owner name="Table2" start-index="44" stop-index="49">
+                                    <owner name="dbo" start-index="40" stop-index="42" />
+                                </owner>
+                            </column>
+                        </left>
+                        <right>
+                            <column name="ColB" start-index="58" stop-index="72">
+                                <owner name="Table1" start-index="62" stop-index="67">
+                                    <owner name="dbo" start-index="58" stop-index="60" />
+                                </owner>
+                            </column>
+                        </right>
+                        <operator>+</operator>
+                    </binary-operation-expression>
+                </assignment-value>
+            </assignment>
+            <from start-index="80" stop-index="150">
+                <join-table join-type="INNER">
+                    <left>
+                        <simple-table name="Table2" start-index="80" stop-index="89">
+                            <owner name="dbo" start-index="80" stop-index="82" />
+                        </simple-table>
+                    </left>
+                    <right>
+                        <simple-table name="Table1" start-index="102" stop-index="111">
+                            <owner name="dbo" start-index="102" stop-index="104" />
+                        </simple-table>
+                    </right>
+                    <on-condition>
+                        <binary-operation-expression start-index="117" stop-index="149">
+                            <left>
+                                <column name="ColA" start-index="117" stop-index="131">
+                                    <owner name="Table2" start-index="117" stop-index="126">
+                                        <owner name="dbo" start-index="117" stop-index="119" />
+                                    </owner>
+                                </column>
+                            </left>
+                            <right>
+                                <column name="ColA" start-index="135" stop-index="149">
+                                    <owner name="Table1" start-index="135" stop-index="144">
+                                        <owner name="dbo" start-index="135" stop-index="137" />
+                                    </owner>
+                                </column>
+                            </right>
+                            <operator>=</operator>
+                        </binary-operation-expression>
+                    </on-condition>
+                </join-table>
+            </from>
+        </set>
+    </update>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/update.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/update.xml
@@ -48,4 +48,9 @@
     <sql-case id="update_with_dot_column_name" value="UPDATE employees SET salary =.salary + 10  WHERE employee_id BETWEEN 1 and 10; " db-types="Oracle" />
     <sql-case id="update_with_set_value_clause" value="UPDATE ot1 SET VALUE(ot1.x) = t1(20) WHERE VALUE(ot1.x) = t1(10);" db-types="Oracle" />
     <sql-case id="update_with_open_row_set_function" value="UPDATE T SET XmlCol = ( SELECT * FROM OPENROWSET(BULK 'C:\SampleFolder\SampleData3.txt', SINGLE_BLOB) AS x) WHERE IntCol = 1" db-types="SQLServer"/>
+    <sql-case id="update_with_point_type" value="UPDATE dbo.Cities SET Location.SetXY(23.5, 23.5) WHERE Name = 'Anchorage'" db-types="SQLServer"/>
+    <sql-case id="update_with_table_hint" value="UPDATE Production.Product WITH (TABLOCK) SET ListPrice = ListPrice * 1.10 WHERE ProductNumber LIKE 'BK-%'" db-types="SQLServer"/>
+    <sql-case id="update_with_option_hint" value="UPDATE Production.Product SET ListPrice = ListPrice * 1.10 WHERE ProductNumber LIKE @Product OPTION (OPTIMIZE FOR (@Product = 'BK-%'))" db-types="SQLServer"/>
+    <sql-case id="update_sales_table_with_subquery" value="UPDATE YearlyTotalSales SET YearlySalesAmount=(SELECT SUM(SalesAmount) FROM FactInternetSales WHERE OrderDateKey >=20040000 AND OrderDateKey &lt; 20050000) WHERE Year=2004" db-types="SQLServer"/>
+    <sql-case id="update_with_inner_join_and_database_table_column" value="UPDATE dbo.Table2 SET dbo.Table2.ColB = dbo.Table2.ColB + dbo.Table1.ColB  FROM dbo.Table2 INNER JOIN dbo.Table1 ON (dbo.Table2.ColA = dbo.Table1.ColA)" db-types="SQLServer"/>
 </sql-cases>


### PR DESCRIPTION
Fixes #29185.

Changes proposed in this pull request:
  - support point setXY function feature
  - support with table hint and option hint feature
  - fix visitSetAssignmentsClause duplicate column
  - support sql
 
```
1. UPDATE dbo.Cities  
SET Location.SetXY(23.5, 23.5)  
WHERE Name = 'Anchorage'

2. UPDATE Production.Product  
WITH (TABLOCK)  
SET ListPrice = ListPrice * 1.10  
WHERE ProductNumber LIKE 'BK-%'

3. UPDATE Production.Product  
SET ListPrice = ListPrice * 1.10  
WHERE ProductNumber LIKE @Product  
OPTION (OPTIMIZE FOR (@Product = 'BK-%') )

4. UPDATE YearlyTotalSales  
SET YearlySalesAmount=  
(SELECT SUM(SalesAmount) FROM FactInternetSales WHERE OrderDateKey >=20040000 AND OrderDateKey < 20050000)  
WHERE Year=2004

5. UPDATE dbo.Table2   
SET dbo.Table2.ColB = dbo.Table2.ColB + dbo.Table1.ColB  
FROM dbo.Table2   
    INNER JOIN dbo.Table1   
    ON (dbo.Table2.ColA = dbo.Table1.ColA)
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
