### PR TITLE
Extracted the DataSource check into RuleDefinationExecuteEngine for all statments that create rule

### DIFF
--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/CreateEncryptRuleExecutor.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/CreateEncryptRuleExecutor.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.encrypt.distsql.handler.update;
 import org.apache.shardingsphere.distsql.handler.exception.algorithm.InvalidAlgorithmConfigurationException;
 import org.apache.shardingsphere.distsql.handler.exception.rule.DuplicateRuleException;
 import org.apache.shardingsphere.distsql.handler.exception.rule.InvalidRuleConfigurationException;
-import org.apache.shardingsphere.distsql.handler.exception.storageunit.EmptyStorageUnitException;
+import org.apache.shardingsphere.distsql.handler.type.rdl.rule.engine.RuleDefinitionExecuteEngine;
 import org.apache.shardingsphere.distsql.handler.type.rdl.rule.spi.database.DatabaseRuleCreateExecutor;
 import org.apache.shardingsphere.distsql.segment.AlgorithmSegment;
 import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
@@ -52,7 +52,7 @@ public final class CreateEncryptRuleExecutor implements DatabaseRuleCreateExecut
         checkColumnNames(sqlStatement);
         checkAlgorithmTypes(sqlStatement);
         checkToBeCreatedEncryptors(sqlStatement);
-        checkDataSources(database);
+        RuleDefinitionExecuteEngine.checkDataSources(database);
     }
     
     private void checkAlgorithmTypes(final CreateEncryptRuleStatement sqlStatement) {
@@ -125,10 +125,6 @@ public final class CreateEncryptRuleExecutor implements DatabaseRuleCreateExecut
             }
         }));
         encryptors.stream().filter(Objects::nonNull).forEach(each -> TypedSPILoader.checkService(EncryptAlgorithm.class, each.getName(), each.getProps()));
-    }
-    
-    private void checkDataSources(final ShardingSphereDatabase database) {
-        ShardingSpherePreconditions.checkState(!database.getResourceMetaData().getStorageUnits().isEmpty(), () -> new EmptyStorageUnitException(database.getName()));
     }
     
     @Override

--- a/infra/distsql-handler/pom.xml
+++ b/infra/distsql-handler/pom.xml
@@ -42,5 +42,11 @@
             <artifactId>shardingsphere-mode-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-readwrite-splitting-distsql-statement</artifactId>
+            <version>5.4.2-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION

Fixes #29233 .

Changes proposed in this pull request:
  Implemented the checkDataSource() method to check if data source exist before creating rule

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
