### PR TITLE
Add support to TestContainers JDBC URL of TiDB to the optional module

### DIFF
--- a/infra/database/type/testcontainers/src/main/java/org/apache/shardingsphere/infra/database/testcontainers/type/TcTiDBDatabaseType.java
+++ b/infra/database/type/testcontainers/src/main/java/org/apache/shardingsphere/infra/database/testcontainers/type/TcTiDBDatabaseType.java
@@ -18,10 +18,29 @@
 package org.apache.shardingsphere.infra.database.testcontainers.type;
 
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
 
 /**
- * Database type for Testcontainers.
- * All jdbcUrl prefixes supported by testcontainers-java should extend this class.
+ * Database type of TiDB in testcontainers-java.
  */
-public interface TestcontainersDatabaseType extends DatabaseType {
+public final class TcTiDBDatabaseType implements TestcontainersDatabaseType {
+    
+    @Override
+    public Collection<String> getJdbcUrlPrefixes() {
+        return Collections.singleton("jdbc:tc:tidb:");
+    }
+    
+    @Override
+    public Optional<DatabaseType> getTrunkDatabaseType() {
+        return Optional.of(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
+    }
+    
+    @Override
+    public String getType() {
+        return "TC-TiDB";
+    }
 }

--- a/infra/database/type/testcontainers/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.database.core.type.DatabaseType
+++ b/infra/database/type/testcontainers/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.database.core.type.DatabaseType
@@ -21,3 +21,4 @@ org.apache.shardingsphere.infra.database.testcontainers.type.TcMySQLDatabaseType
 org.apache.shardingsphere.infra.database.testcontainers.type.TcOracleDatabaseType
 org.apache.shardingsphere.infra.database.testcontainers.type.TcPostgreSQLDatabaseType
 org.apache.shardingsphere.infra.database.testcontainers.type.TcSQLServerDatabaseType
+org.apache.shardingsphere.infra.database.testcontainers.type.TcTiDBDatabaseType

--- a/infra/database/type/testcontainers/src/test/java/org/apache/shardingsphere/infra/database/testcontainers/type/TestcontainersDatabaseTypeTest.java
+++ b/infra/database/type/testcontainers/src/test/java/org/apache/shardingsphere/infra/database/testcontainers/type/TestcontainersDatabaseTypeTest.java
@@ -36,5 +36,6 @@ class TestcontainersDatabaseTypeTest {
         assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-Oracle").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:oracle:")));
         assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-PostgreSQL").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:postgresql:")));
         assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-SQLServer").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:sqlserver:")));
+        assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-TiDB").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:tidb:")));
     }
 }


### PR DESCRIPTION
For #29388.

Changes proposed in this pull request:
  - Add support to TestContainers JDBC URL of TiDB to the optional module. Such as `jdbc:tc:tidb://hostname/databasename`. Refer to https://github.com/testcontainers/testcontainers-java/blob/1.19.4/modules/tidb/src/test/java/org/testcontainers/jdbc/tidb/TiDBJDBCDriverTest.java .
  - Since TiDB uses MySQL's JDBC Driver, it is routed to the MySQL dialect. Refer to https://docs.pingcap.com/tidb/stable/dev-guide-choose-driver-or-orm#java-drivers .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
