### PR TITLE
Support parsing SQL Server SELECT page_count, sql

### DIFF
--- a/test/it/parser/src/main/resources/case/dml/insert.xml
+++ b/test/it/parser/src/main/resources/case/dml/insert.xml
@@ -3554,4 +3554,22 @@
             </projections>
         </select>
     </insert>
+
+    <insert sql-case-id="insert_sales_with_nchar_3">
+        <table name="sales" start-index="12" stop-index="16"/>
+        <columns start-index="17" stop-index="17"/>
+        <values>
+            <value>
+                <assignment-value>
+                    <literal-expression value="Canada" start-index="26" stop-index="34"/>
+                </assignment-value>
+                <assignment-value>
+                    <literal-expression value="Alberta" start-index="37" stop-index="46"/>
+                </assignment-value>
+                <assignment-value>
+                    <literal-expression value="100" start-index="49" stop-index="51"/>
+                </assignment-value>
+            </value>
+        </values>
+    </insert>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -8353,4 +8353,61 @@
             </expr>
         </where>
     </select>
+
+    <select sql-case-id="select_from_physical_stats_function">
+        <projections start-index="7" stop-index="66">
+            <column-projection name="page_count" start-index="7" stop-index="16"/>
+            <column-projection name="compressed_page_count" start-index="19" stop-index="39"/>
+            <column-projection name="forwarded_record_count" start-index="42" stop-index="63"/>
+            <shorthand-projection start-index="66" stop-index="66"/>
+        </projections>
+        <from>
+            <function-table start-index="73" stop-index="151">
+                <table-function text="sys.dm_db_index_physical_stats(db_id(), object_id('t3'), NULL, NULL, 'SAMPLED')" function-name="sys.dm_db_index_physical_stats">
+                    <parameter>
+                        <function function-name="db_id" text="db_id()" start-index="104" stop-index="110"/>
+                    </parameter>
+                    <parameter>
+                        <function function-name="object_id" text="object_id('t3')" start-index="113" stop-index="127">
+                            <parameter>
+                                <literal-expression value="t3" start-index="123" stop-index="126"/>
+                            </parameter>
+                        </function>
+                    </parameter>
+                    <parameter>
+                        <literal-expression start-index="130" stop-index="133"/>
+                    </parameter>
+                    <parameter>
+                        <literal-expression start-index="136" stop-index="139"/>
+                    </parameter>
+                    <parameter>
+                        <literal-expression start-index="142" stop-index="150"/>
+                    </parameter>
+                </table-function>
+            </function-table>
+        </from>
+    </select>
+
+    <select sql-case-id="select_from_msdb_default_schema">
+        <projections start-index="7" stop-index="40">
+            <expression-projection text="backup_size/compressed_backup_size" start-index="7" stop-index="40">
+                <expr>
+                    <binary-operation-expression start-index="7" stop-index="40">
+                        <left>
+                            <column name="backup_size" start-index="7" stop-index="17"/>
+                        </left>
+                        <operator>/</operator>
+                        <right>
+                            <column name="compressed_backup_size" start-index="19" stop-index="40"/>
+                        </right>
+                    </binary-operation-expression>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table name="backupset" start-index="47" stop-index="61">
+                <owner name="msdb" start-index="47" stop-index="50"/>
+            </simple-table>
+        </from>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/insert.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/insert.xml
@@ -120,6 +120,7 @@
     <sql-case id="insert_with_table_hint" value="INSERT INTO cci_target WITH (TABLOCK) SELECT TOP 300000 * FROM staging" db-types="SQLServer"/>
     <sql-case id="insert_sales_with_nchar" value="INSERT INTO sales VALUES (N'Canada', N'British Columbia', 300)" db-types="SQLServer"/>
     <sql-case id="insert_sales_with_nchar_2" value="INSERT INTO sales VALUES (N'United States', N'Montana', 100)" db-types="SQLServer"/>
+    <sql-case id="insert_sales_with_nchar_3" value="INSERT INTO sales VALUES (N'Canada', N'Alberta', 100)" db-types="SQLServer"/>
     <sql-case id="insert_with_currency_value" value="INSERT INTO [HR].[Employees]([SSN], [FirstName], [LastName], [Salary]) VALUES ('795-73-9838', N'Catherine', N'Abel', $31692)" db-types="SQLServer"/>
     <sql-case id="insert_with_select_from_open_row_1" value="INSERT INTO myTable(FileName, FileType, Document) SELECT 'Text1.txt' AS FileName, '.txt' AS FileType, * FROM OPENROWSET(BULK N'C:\Text1.txt', SINGLE_BLOB) AS Document" db-types="SQLServer"/>
     <sql-case id="insert_with_select_from_open_row_2" value="INSERT INTO achievements with (TABLOCK) (id, description) SELECT * FROM OPENROWSET(BULK 'csv/achievements.csv', DATA_SOURCE = 'MyAzureBlobStorage', FORMAT ='CSV', FORMATFILE='csv/achievements-c.xml', FORMATFILE_DATA_SOURCE = 'MyAzureBlobStorage') AS DataFile" db-types="SQLServer"/>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -255,4 +255,6 @@
     <sql-case id="select_from_table_openrowset" value="SELECT TOP 100 id=CAST(_id as VARBINARY(1000)) FROM OPENROWSET('CosmosDB', 'Your-account;Database=your-database;Key=your-key',HTAP) WITH (_id VARCHAR(1000)) as HTAP" db-types="SQLServer"/>
     <sql-case id="select_from_with_contains_function" value="SELECT candidate_name,SSN FROM candidates WHERE CONTAINS(candidate_resume, '&quot;SQL Server&quot;') AND candidate_division = 'DBA'" db-types="SQLServer"/>
     <sql-case id="select_escape_quotes_from_sys_table" value="SELECT 'DECLARE @serverName NVARCHAR(512) = N''' + value + '''' FROM sys.dm_hadr_fabric_config_parameters WHERE parameter_name = 'DnsRecordName'" db-types="SQLServer"/>
+    <sql-case id="select_from_physical_stats_function" value="SELECT page_count, compressed_page_count, forwarded_record_count, * FROM sys.dm_db_index_physical_stats(db_id(), object_id('t3'), NULL, NULL, 'SAMPLED')" db-types="SQLServer"/>
+    <sql-case id="select_from_msdb_default_schema" value="SELECT backup_size/compressed_backup_size FROM msdb..backupset" db-types="SQLServer"/>
 </sql-cases>


### PR DESCRIPTION
Fixes #29191.

Changes proposed in this pull request:
  - Support the SQL case parse in issue 29191.

#### Add the following SQL statement
``` sql 
SELECT page_count,
    compressed_page_count,
    forwarded_record_count,
    *
FROM sys.dm_db_index_physical_stats(db_id(), object_id('t3'), NULL, NULL, 'SAMPLED')
```

```sql
SELECT backup_size/compressed_backup_size FROM msdb..backupset
```

```sql
INSERT INTO sales VALUES (N'Canada', N'Alberta', 100)
```
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
