### PR TITLE
Emulate the information_schema.KEYWORDS Table in metadata

### DIFF
--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/SystemSchemaManagerTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/SystemSchemaManagerTest.java
@@ -32,7 +32,7 @@ class SystemSchemaManagerTest {
     @Test
     void assertValueOfSchemaPathSuccess() {
         Collection<String> actualInformationSchema = SystemSchemaManager.getTables("MySQL", "information_schema");
-        assertThat(actualInformationSchema.size(), is(61));
+        assertThat(actualInformationSchema.size(), is(62));
         Collection<String> actualMySQLSchema = SystemSchemaManager.getTables("MySQL", "mysql");
         assertThat(actualMySQLSchema.size(), is(31));
         Collection<String> actualPerformanceSchema = SystemSchemaManager.getTables("MySQL", "performance_schema");

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -39,7 +39,7 @@ class SystemSchemaBuilderTest {
         Map<String, ShardingSphereSchema> actualInformationSchema = SystemSchemaBuilder.build("information_schema", databaseType, configProps);
         assertThat(actualInformationSchema.size(), is(1));
         assertTrue(actualInformationSchema.containsKey("information_schema"));
-        assertThat(actualInformationSchema.get("information_schema").getTables().size(), is(61));
+        assertThat(actualInformationSchema.get("information_schema").getTables().size(), is(62));
         Map<String, ShardingSphereSchema> actualMySQLSchema = SystemSchemaBuilder.build("mysql", databaseType, configProps);
         assertThat(actualMySQLSchema.size(), is(1));
         assertTrue(actualMySQLSchema.containsKey("mysql"));

--- a/infra/database/type/mysql/src/main/resources/schema/mysql/information_schema/keywords.yaml
+++ b/infra/database/type/mysql/src/main/resources/schema/mysql/information_schema/keywords.yaml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: KEYWORDS
+columns:
+  word:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: WORD
+    primaryKey: false
+    unsigned: false
+    visible: true
+  reserved:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: RESERVED
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_keywords.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_keywords.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="word" />
+        <column name="reserved" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema-mysql.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema-mysql.xml
@@ -156,6 +156,11 @@
     <test-case sql="SELECT * FROM information_schema.key_column_usage limit 1" db-types="MySQL" scenario-types="tbl" adapters="proxy">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
+
+    <!--TODO The information_schema.keywords table is only available in MySQL Server 8.0 and higher. Currently, E2E lacks the ability to dynamically change the MySQL Server version-->
+<!--    <test-case sql="SELECT * FROM information_schema.keywords limit 1" db-types="MySQL" scenario-types="tbl" adapters="proxy">-->
+<!--        <assertion expected-data-source-name="read_dataset" />-->
+<!--    </test-case>-->
     
     <test-case sql="SELECT * FROM information_schema.optimizer_trace limit 1" db-types="MySQL" scenario-types="tbl" adapters="proxy">
         <assertion expected-data-source-name="read_dataset" />


### PR DESCRIPTION
Fixes #29388.

Changes proposed in this pull request:
  - Emulate the information_schema.KEYWORDS Table in metadata. Refer to https://dev.mysql.com/doc/refman/8.0/en/information-schema-keywords-table.html .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
