### PR TITLE
Refactor : refactor the jandex and source plugin into release profile (#29990)

### DIFF
--- a/distribution/agent/pom.xml
+++ b/distribution/agent/pom.xml
@@ -83,6 +83,9 @@
                         <artifactId>checksum-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                    </plugin>
+                    <plugin>
                         <groupId>io.smallrye</groupId>
                         <artifactId>jandex-maven-plugin</artifactId>
                         <executions>

--- a/distribution/agent/pom.xml
+++ b/distribution/agent/pom.xml
@@ -82,6 +82,18 @@
                         <groupId>net.nicoulaj.maven.plugins</groupId>
                         <artifactId>checksum-maven-plugin</artifactId>
                     </plugin>
+                    <plugin>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>jandex-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>make-index</id>
+                                <goals>
+                                    <goal>jandex</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/distribution/jdbc/pom.xml
+++ b/distribution/jdbc/pom.xml
@@ -90,6 +90,18 @@
                         <groupId>net.nicoulaj.maven.plugins</groupId>
                         <artifactId>checksum-maven-plugin</artifactId>
                     </plugin>
+                    <plugin>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>jandex-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>make-index</id>
+                                <goals>
+                                    <goal>jandex</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/distribution/jdbc/pom.xml
+++ b/distribution/jdbc/pom.xml
@@ -91,6 +91,9 @@
                         <artifactId>checksum-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                    </plugin>
+                    <plugin>
                         <groupId>io.smallrye</groupId>
                         <artifactId>jandex-maven-plugin</artifactId>
                         <executions>

--- a/distribution/proxy/pom.xml
+++ b/distribution/proxy/pom.xml
@@ -96,6 +96,18 @@
                         <groupId>net.nicoulaj.maven.plugins</groupId>
                         <artifactId>checksum-maven-plugin</artifactId>
                     </plugin>
+                    <plugin>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>jandex-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>make-index</id>
+                                <goals>
+                                    <goal>jandex</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/distribution/proxy/pom.xml
+++ b/distribution/proxy/pom.xml
@@ -97,6 +97,9 @@
                         <artifactId>checksum-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                    </plugin>
+                    <plugin>
                         <groupId>io.smallrye</groupId>
                         <artifactId>jandex-maven-plugin</artifactId>
                         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -827,9 +827,6 @@
         <plugins>
             <!-- Release plugins -->
             <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -825,20 +825,6 @@
         </pluginManagement>
         
         <plugins>
-            <!-- Compile plugins -->
-            <plugin>
-                <groupId>io.smallrye</groupId>
-                <artifactId>jandex-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>make-index</id>
-                        <goals>
-                            <goal>jandex</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            
             <!-- Release plugins -->
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Fixes #29990.

Changes proposed in this pull request:
  - refactor the jandex plugin into release profile 
  - refactor the maven-source-plugin into release profile

<img width="681" alt="image" src="https://github.com/apache/shardingsphere/assets/4112856/d98c1d50-8ab8-481a-b0f9-3f9d81c1071a">

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
