### PR TITLE
Fixes `@EnabledInNativeImage` failure in some unit tests

### DIFF
--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/PostgresTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/PostgresTest.java
@@ -26,11 +26,11 @@ import org.junit.jupiter.api.condition.EnabledInNativeImage;
 import javax.sql.DataSource;
 import java.sql.SQLException;
 
-@EnabledInNativeImage
 class PostgresTest {
     
     private TestShardingService testShardingService;
     
+    @EnabledInNativeImage
     @Test
     void assertShardingInLocalTransactions() throws SQLException {
         HikariConfig config = new HikariConfig();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/SQLServerTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/SQLServerTest.java
@@ -26,11 +26,11 @@ import org.junit.jupiter.api.condition.EnabledInNativeImage;
 import javax.sql.DataSource;
 import java.sql.SQLException;
 
-@EnabledInNativeImage
 class SQLServerTest {
     
     private TestShardingService testShardingService;
     
+    @EnabledInNativeImage
     @Test
     void assertShardingInLocalTransactions() throws SQLException {
         HikariConfig config = new HikariConfig();


### PR DESCRIPTION
For #30003.

Changes proposed in this pull request:
  - Fixes `@EnabledInNativeImage` failure in some unit tests. According to https://github.com/apache/shardingsphere/actions/runs/7804087102/job/21285307640 , unit tests under GraalVM Native Image do not execute when `@EnabledInNativeImage` is on the class. This needs to be investigated on the Junit5 side.
```shell
JUnit Platform on Native Image - report
----------------------------------------

org.apache.shardingsphere.test.natived.jdbc.features.MaskTest > assertMaskInLocalTransactions() SUCCESSFUL

org.apache.shardingsphere.test.natived.jdbc.features.ShadowTest > assertShadowInLocalTransactions() SUCCESSFUL

org.apache.shardingsphere.test.natived.jdbc.features.ShardingTest > assertShardingInLocalTransactions() SUCCESSFUL

org.apache.shardingsphere.test.natived.jdbc.features.EncryptTest > assertEncryptInLocalTransactions() SUCCESSFUL

org.apache.shardingsphere.test.natived.jdbc.features.ReadWriteSplittingTest > assertReadWriteSplittingInLocalTransactions() SUCCESSFUL

org.apache.shardingsphere.test.natived.jdbc.mode.cluster.ZookeeperTest > assertShardingInLocalTransactions() SUCCESSFUL

org.apache.shardingsphere.test.natived.jdbc.databases.MySQLTest > assertShardingInLocalTransactions() SUCCESSFUL

org.apache.shardingsphere.test.natived.jdbc.databases.OpenGaussTest > assertShardingInLocalTransactions() SUCCESSFUL


Test run finished after 70780 ms
[         9 containers found      ]
[         0 containers skipped    ]
[         9 containers started    ]
[         0 containers aborted    ]
[         9 containers successful ]
[         0 containers failed     ]
[         8 tests found           ]
[         0 tests skipped         ]
[         8 tests started         ]
[         0 tests aborted         ]
[         8 tests successful      ]
[         0 tests failed          ]
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
