### PR TITLE
Refactor InlineExpressionParser to prevent exposing Groovy API

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/hint/HintInlineShardingAlgorithm.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/hint/HintInlineShardingAlgorithm.java
@@ -17,8 +17,6 @@
 
 package org.apache.shardingsphere.sharding.algorithm.sharding.hint;
 
-import groovy.lang.Closure;
-import groovy.util.Expando;
 import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.expr.core.InlineExpressionParserFactory;
 import org.apache.shardingsphere.sharding.api.sharding.hint.HintShardingAlgorithm;
@@ -27,6 +25,8 @@ import org.apache.shardingsphere.sharding.exception.algorithm.sharding.ShardingA
 import org.apache.shardingsphere.sharding.exception.data.NullShardingValueException;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -61,15 +61,9 @@ public final class HintInlineShardingAlgorithm implements HintShardingAlgorithm<
     
     private String doSharding(final Comparable<?> shardingValue) {
         ShardingSpherePreconditions.checkNotNull(shardingValue, NullShardingValueException::new);
-        Closure<?> closure = createClosure();
-        closure.setProperty(HINT_INLINE_VALUE_PROPERTY_NAME, shardingValue);
-        return closure.call().toString();
-    }
-    
-    private Closure<?> createClosure() {
-        Closure<?> result = InlineExpressionParserFactory.newInstance(algorithmExpression).evaluateClosure().rehydrate(new Expando(), null, null);
-        result.setResolveStrategy(Closure.DELEGATE_ONLY);
-        return result;
+        Map<String, Comparable<?>> map = new LinkedHashMap<>();
+        map.put(HINT_INLINE_VALUE_PROPERTY_NAME, shardingValue);
+        return InlineExpressionParserFactory.newInstance(algorithmExpression).evaluateWithArgs(map);
     }
     
     @Override

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/inline/ComplexInlineShardingAlgorithm.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/inline/ComplexInlineShardingAlgorithm.java
@@ -18,11 +18,9 @@
 package org.apache.shardingsphere.sharding.algorithm.sharding.inline;
 
 import com.google.common.base.Strings;
-import groovy.lang.Closure;
-import groovy.util.Expando;
-import org.apache.shardingsphere.infra.expr.core.InlineExpressionParserFactory;
 import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.exception.core.external.sql.type.generic.UnsupportedSQLOperationException;
+import org.apache.shardingsphere.infra.expr.core.InlineExpressionParserFactory;
 import org.apache.shardingsphere.sharding.api.sharding.complex.ComplexKeysShardingAlgorithm;
 import org.apache.shardingsphere.sharding.api.sharding.complex.ComplexKeysShardingValue;
 import org.apache.shardingsphere.sharding.exception.algorithm.sharding.MismatchedComplexInlineShardingAlgorithmColumnAndValueSizeException;
@@ -93,12 +91,8 @@ public final class ComplexInlineShardingAlgorithm implements ComplexKeysSharding
     }
     
     private String doSharding(final Map<String, Comparable<?>> columnNameAndShardingValueMap) {
-        Closure<?> closure = createClosure();
-        for (Entry<String, Comparable<?>> entry : columnNameAndShardingValueMap.entrySet()) {
-            ShardingSpherePreconditions.checkNotNull(entry.getValue(), NullShardingValueException::new);
-            closure.setProperty(entry.getKey(), entry.getValue());
-        }
-        return closure.call().toString();
+        columnNameAndShardingValueMap.forEach((key, value) -> ShardingSpherePreconditions.checkNotNull(value, NullShardingValueException::new));
+        return InlineExpressionParserFactory.newInstance(algorithmExpression).evaluateWithArgs(columnNameAndShardingValueMap);
     }
     
     private Collection<Map<String, Comparable<?>>> flatten(final Map<String, Collection<Comparable<?>>> columnNameAndShardingValuesMap) {
@@ -128,12 +122,6 @@ public final class ComplexInlineShardingAlgorithm implements ComplexKeysSharding
                 result.add(item);
             }
         }
-        return result;
-    }
-    
-    private Closure<?> createClosure() {
-        Closure<?> result = InlineExpressionParserFactory.newInstance(algorithmExpression).evaluateClosure().rehydrate(new Expando(), null, null);
-        result.setResolveStrategy(Closure.DELEGATE_ONLY);
         return result;
     }
     

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/fixture/sharding/CoreHintShardingAlgorithmFixture.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/fixture/sharding/CoreHintShardingAlgorithmFixture.java
@@ -18,13 +18,13 @@
 package org.apache.shardingsphere.sharding.distsql.fixture.sharding;
 
 import com.google.common.base.Preconditions;
-import groovy.lang.Closure;
-import groovy.util.Expando;
 import org.apache.shardingsphere.infra.expr.core.InlineExpressionParserFactory;
 import org.apache.shardingsphere.sharding.api.sharding.hint.HintShardingAlgorithm;
 import org.apache.shardingsphere.sharding.api.sharding.hint.HintShardingValue;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -55,15 +55,9 @@ public final class CoreHintShardingAlgorithmFixture implements HintShardingAlgor
     }
     
     private String doSharding(final Comparable<?> shardingValue) {
-        Closure<?> closure = createClosure();
-        closure.setProperty(HINT_INLINE_VALUE_PROPERTY_NAME, shardingValue);
-        return closure.call().toString();
-    }
-    
-    private Closure<?> createClosure() {
-        Closure<?> result = InlineExpressionParserFactory.newInstance(algorithmExpression).evaluateClosure().rehydrate(new Expando(), null, null);
-        result.setResolveStrategy(Closure.DELEGATE_ONLY);
-        return result;
+        Map<String, Comparable<?>> map = new LinkedHashMap<>();
+        map.put(HINT_INLINE_VALUE_PROPERTY_NAME, shardingValue);
+        return InlineExpressionParserFactory.newInstance(algorithmExpression).evaluateWithArgs(map);
     }
     
     @Override

--- a/infra/expr/core/src/test/java/org/apache/shardingsphere/infra/expr/core/InlineExpressionParserFactoryTest.java
+++ b/infra/expr/core/src/test/java/org/apache/shardingsphere/infra/expr/core/InlineExpressionParserFactoryTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.infra.expr.core;
 
 import org.apache.shardingsphere.infra.spi.exception.ServiceProviderNotFoundException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledInNativeImage;
 
 import java.util.Arrays;
 
@@ -30,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class InlineExpressionParserFactoryTest {
     
     @Test
-    @DisabledInNativeImage
     void assertNewInstance() {
         assertThat(InlineExpressionParserFactory.newInstance("t_order_0, t_order_1").getType(), is("GROOVY"));
         assertThat(InlineExpressionParserFactory.newInstance("t_order_0, t_order_1").handlePlaceHolder(), is("t_order_0, t_order_1"));

--- a/infra/expr/spi/pom.xml
+++ b/infra/expr/spi/pom.xml
@@ -32,10 +32,5 @@
             <artifactId>shardingsphere-infra-util</artifactId>
             <version>${project.version}</version>
         </dependency>
-        
-        <dependency>
-            <groupId>org.apache.groovy</groupId>
-            <artifactId>groovy</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/infra/expr/spi/src/main/java/org/apache/shardingsphere/infra/expr/spi/InlineExpressionParser.java
+++ b/infra/expr/spi/src/main/java/org/apache/shardingsphere/infra/expr/spi/InlineExpressionParser.java
@@ -17,11 +17,11 @@
 
 package org.apache.shardingsphere.infra.expr.spi;
 
-import groovy.lang.Closure;
 import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPI;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Inline expression parser.
@@ -50,12 +50,13 @@ public interface InlineExpressionParser extends TypedSPI {
     List<String> splitAndEvaluate();
     
     /**
-     * Evaluate closure.
+     * Evaluate with arguments.
      *
+     * @param map map
      * @return closure
-     * @throws UnsupportedOperationException In most cases, users should not implement this method, and the return value of this method can only be a Groovy closure
+     * @throws UnsupportedOperationException By default, users do not need to consider passing in additional parameters.
      */
-    default Closure<?> evaluateClosure() {
+    default String evaluateWithArgs(final Map<String, Comparable<?>> map) {
         throw new UnsupportedOperationException("This SPI implementation does not support the use of this method.");
     }
 }

--- a/infra/expr/type/espresso/src/main/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParser.java
+++ b/infra/expr/type/espresso/src/main/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParser.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.infra.expr.espresso;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
-import groovy.lang.GroovyShell;
 import org.apache.shardingsphere.infra.expr.spi.InlineExpressionParser;
 import org.apache.shardingsphere.infra.util.groovy.GroovyUtils;
 
@@ -93,7 +92,7 @@ public final class EspressoInlineExpressionParser implements InlineExpressionPar
     
     private ReflectValue evaluate(final String expression) {
         return context.getBindings("java")
-                .getMember(GroovyShell.class.getName())
+                .getMember("groovy.lang.GroovyShell")
                 .newInstance()
                 .invokeMember("parse", expression)
                 .invokeMember("run");
@@ -103,7 +102,7 @@ public final class EspressoInlineExpressionParser implements InlineExpressionPar
      * Flatten.
      *
      * @param segments Actually corresponds to some class instance of {@link java.lang.Object}.
-     *                 This Object may or may not correspond to a class instance of {@link groovy.lang.GString}.
+     *                 This Object may or may not correspond to a class instance of `groovy.lang.GString`.
      * @return List of String
      */
     private List<String> flatten(final List<ReflectValue> segments) {
@@ -112,7 +111,7 @@ public final class EspressoInlineExpressionParser implements InlineExpressionPar
             if (!each.isString()) {
                 result.addAll(assemblyCartesianSegments(each));
             } else {
-                result.add(each.toStringForValue());
+                result.add(each.as(String.class));
             }
         }
         return result;
@@ -121,7 +120,7 @@ public final class EspressoInlineExpressionParser implements InlineExpressionPar
     /**
      * Assembly cartesian segments.
      *
-     * @param segment Actually corresponds to a class instance of {@link groovy.lang.GString}.
+     * @param segment Actually corresponds to a class instance of `groovy.lang.GString`.
      * @return List of String
      */
     private List<String> assemblyCartesianSegments(final ReflectValue segment) {
@@ -136,7 +135,7 @@ public final class EspressoInlineExpressionParser implements InlineExpressionPar
     /**
      * Get cartesian values.
      *
-     * @param segment Actually corresponds to a class instance of {@link groovy.lang.GString}.
+     * @param segment Actually corresponds to a class instance of `groovy.lang.GString`.
      * @return A Set consisting of a List of Strings
      */
     @SuppressWarnings("unchecked")
@@ -160,7 +159,7 @@ public final class EspressoInlineExpressionParser implements InlineExpressionPar
      * Assembly segment.
      *
      * @param cartesianValue List of String
-     * @param segment        Actually corresponds to a class instance of {@link groovy.lang.GString}.
+     * @param segment        Actually corresponds to a class instance of `groovy.lang.GString`.
      * @return {@link java.lang.String}
      */
     private String assemblySegment(final List<String> cartesianValue, final ReflectValue segment) {

--- a/infra/expr/type/espresso/src/main/java/org/apache/shardingsphere/infra/expr/espresso/ReflectValue.java
+++ b/infra/expr/type/espresso/src/main/java/org/apache/shardingsphere/infra/expr/espresso/ReflectValue.java
@@ -97,15 +97,4 @@ public class ReflectValue {
                 .getMethod("as", Class.class)
                 .invoke(valueInstance, targetType);
     }
-    
-    /**
-     * Converts this value to a human-readable string.
-     * @return {@link String}
-     */
-    @SneakyThrows
-    public String toStringForValue() {
-        return (String) Class.forName(VALUE_CLASS_NAME)
-                .getMethod("toString")
-                .invoke(valueInstance);
-    }
 }

--- a/infra/expr/type/espresso/src/test/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParserTest.java
+++ b/infra/expr/type/espresso/src/test/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParserTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Properties;
 
@@ -133,17 +134,10 @@ class EspressoInlineExpressionParserTest {
                 new PropertiesBuilder.Property(InlineExpressionParser.INLINE_EXPRESSION_KEY, "t_${[\"new$->{1+2}\"]}"))).handlePlaceHolder(), is("t_${[\"new${1+2}\"]}"));
     }
     
-    /**
-     * This method needs to avoid returning a `Closure` class instance, and instead return the result of `Closure#call`.
-     * Because `Value#as` does not allow this type to be returned from the guest JVM.
-     *
-     * @see groovy.lang.Closure
-     * @see org.graalvm.polyglot.Value
-     */
     @Test
-    void assertEvaluateClosure() {
+    void assertEvaluateWithArgs() {
         assertThrows(UnsupportedOperationException.class, () -> TypedSPILoader.getService(
                 InlineExpressionParser.class, "ESPRESSO",
-                PropertiesBuilder.build(new PropertiesBuilder.Property(InlineExpressionParser.INLINE_EXPRESSION_KEY, "${1+2}"))).evaluateClosure().call().toString());
+                PropertiesBuilder.build(new PropertiesBuilder.Property(InlineExpressionParser.INLINE_EXPRESSION_KEY, "${1+2}"))).evaluateWithArgs(new LinkedHashMap<>()));
     }
 }

--- a/infra/expr/type/groovy/pom.xml
+++ b/infra/expr/type/groovy/pom.xml
@@ -39,5 +39,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/infra/expr/type/groovy/src/test/java/org/apache/shardingsphere/infra/expr/groovy/GroovyInlineExpressionParserTest.java
+++ b/infra/expr/type/groovy/src/test/java/org/apache/shardingsphere/infra/expr/groovy/GroovyInlineExpressionParserTest.java
@@ -21,9 +21,9 @@ import org.apache.shardingsphere.infra.expr.spi.InlineExpressionParser;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledInNativeImage;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Properties;
 
@@ -31,7 +31,6 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@DisabledInNativeImage
 class GroovyInlineExpressionParserTest {
     
     @Test
@@ -132,8 +131,8 @@ class GroovyInlineExpressionParserTest {
     }
     
     @Test
-    void assertEvaluateClosure() {
+    void assertEvaluateWithArgs() {
         assertThat(TypedSPILoader.getService(InlineExpressionParser.class, "GROOVY", PropertiesBuilder.build(
-                new PropertiesBuilder.Property(InlineExpressionParser.INLINE_EXPRESSION_KEY, "${1+2}"))).evaluateClosure().call().toString(), is("3"));
+                new PropertiesBuilder.Property(InlineExpressionParser.INLINE_EXPRESSION_KEY, "${1+2}"))).evaluateWithArgs(new LinkedHashMap<>()), is("3"));
     }
 }

--- a/infra/expr/type/literal/src/test/java/org/apache/shardingsphere/infra/expr/literal/LiteralInlineExpressionParserTest.java
+++ b/infra/expr/type/literal/src/test/java/org/apache/shardingsphere/infra/expr/literal/LiteralInlineExpressionParserTest.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Properties;
 
@@ -75,8 +76,8 @@ class LiteralInlineExpressionParserTest {
     }
     
     @Test
-    void assertEvaluateClosure() {
+    void assertEvaluateWithArgs() {
         assertThrows(UnsupportedOperationException.class, () -> TypedSPILoader.getService(InlineExpressionParser.class, "LITERAL", PropertiesBuilder.build(
-                new PropertiesBuilder.Property(InlineExpressionParser.INLINE_EXPRESSION_KEY, "${1+2}"))).evaluateClosure().call().toString());
+                new PropertiesBuilder.Property(InlineExpressionParser.INLINE_EXPRESSION_KEY, "${1+2}"))).evaluateWithArgs(new LinkedHashMap<>()));
     }
 }


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Refactor InlineExpressionParser to prevent exposing Groovy API. Looking at the overall situation, the use of `groovy.lang.Closure` is rigid, and there is no need to expose additional Groovy classes. This also helps further encapsulate other languages under the GraalVM Truffle API. Such as JavaScript( https://www.graalvm.org/javascript/ ), Python( https://www.graalvm.org/python/ ) and Ruby( https://www.graalvm.org/ruby/ ).
  - Avoid using `org.graalvm.polyglot.Value.toString()` in EspressoInlineExpressionParser. The call to `toString()` seems to be due to a limitation of early graal-sdk, where the String should be fetched directly from the guest JVM.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
