### PR TITLE
Block unit tests that execute EspressoInlineExpressionParserTest on MacOS and Windows

### DIFF
--- a/docs/document/content/user-manual/common-config/builtin-algorithm/expr.cn.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/expr.cn.md
@@ -75,6 +75,9 @@ weight = 10
 
 此为可选实现，你需要在自有项目的 `pom.xml` 主动声明如下依赖。并且请确保自有项目通过 OpenJDK 21+ 或其下游发行版编译。
 
+由于 https://www.graalvm.org/jdk21/reference-manual/java-on-truffle/faq/#does-java-running-on-truffle-run-on-hotspot-too 的限制，
+当此模块在非 GraalVM Native Image 的环境中被使用时，仅在 Linux 上就绪。
+
 ```xml
 <dependencies>
     <dependency>

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/expr.en.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/expr.en.md
@@ -85,6 +85,9 @@ Example:
 This is an optional implementation. You need to actively declare the following dependencies in the `pom.xml` of your own project. 
 And please make sure your own projects are compiled with OpenJDK 21+ or its downstream distribution.
 
+Due to the limitations of https://www.graalvm.org/jdk21/reference-manual/java-on-truffle/faq/#does-java-running-on-truffle-run-on-hotspot-too , 
+this module is only ready on Linux when used in environments other than GraalVM Native Image.
+
 ```xml
 <dependencies>
     <dependency>

--- a/infra/expr/type/espresso/src/test/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParserTest.java
+++ b/infra/expr/type/espresso/src/test/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParserTest.java
@@ -22,7 +22,9 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.condition.OS;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -35,6 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @EnabledForJreRange(min = JRE.JAVA_21)
+@EnabledOnOs(value = OS.LINUX, disabledReason = "Refer to https://www.graalvm.org/jdk21/reference-manual/java-on-truffle/faq/#does-java-running-on-truffle-run-on-hotspot-too .")
 class EspressoInlineExpressionParserTest {
     
     @Test


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/actions/runs/7804087102/job/21285309544 .

Changes proposed in this pull request:
  - Block unit tests that execute EspressoInlineExpressionParserTest on MacOS and Windows. 
  - Due to the limitations of https://www.graalvm.org/jdk21/reference-manual/java-on-truffle/faq/#does-java-running-on-truffle-run-on-hotspot-too , this module is only ready on Linux when used in environments other than GraalVM Native Image.
  - I know this is kind of funny, but Espresso is an implementation of the Truffle API and it can be used in Native Image built in MacOS/Windows/Linux. But if the standard core Java library is provided by HotSpot JDK, it is only available under Linux. Espresso relies on glibc's [dlmopen](https://man7.org/linux/man-pages/man3/dlopen.3.html) to run on HotSpot.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
