### PR TITLE
Remove deprecated schemaName in YamlRootConfiguration

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/YamlRootConfiguration.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/YamlRootConfiguration.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.infra.yaml.config.pojo;
 
-import com.google.common.base.Strings;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.infra.util.yaml.YamlConfiguration;
@@ -39,14 +38,6 @@ public final class YamlRootConfiguration implements YamlConfiguration {
     
     private String databaseName;
     
-    /**
-     * Schema name.
-     * 
-     * @deprecated Should use databaseName, schemaName will remove in next version.
-     */
-    @Deprecated
-    private String schemaName;
-    
     private Map<String, Map<String, Object>> dataSources = new HashMap<>();
     
     private Collection<YamlRuleConfiguration> rules = new LinkedList<>();
@@ -54,13 +45,4 @@ public final class YamlRootConfiguration implements YamlConfiguration {
     private YamlModeConfiguration mode;
     
     private Properties props = new Properties();
-    
-    /**
-     * Get database name.
-     * 
-     * @return database name
-     */
-    public String getDatabaseName() {
-        return Strings.isNullOrEmpty(databaseName) ? schemaName : databaseName;
-    }
 }

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/api/yaml/YamlJDBCConfiguration.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/api/yaml/YamlJDBCConfiguration.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.driver.api.yaml;
 
-import com.google.common.base.Strings;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration;
@@ -47,14 +46,6 @@ public final class YamlJDBCConfiguration implements YamlConfiguration {
     
     private String databaseName;
     
-    /**
-     * Schema name.
-     * 
-     * @deprecated Should use databaseName, schemaName will remove in next version.
-     */
-    @Deprecated
-    private String schemaName;
-    
     private Map<String, Map<String, Object>> dataSources = new HashMap<>();
     
     private Collection<YamlRuleConfiguration> rules = new LinkedList<>();
@@ -78,13 +69,4 @@ public final class YamlJDBCConfiguration implements YamlConfiguration {
     private YamlGlobalClockRuleConfiguration globalClock;
     
     private YamlSQLFederationRuleConfiguration sqlFederation;
-    
-    /**
-     * Get database name.
-     * 
-     * @return database name
-     */
-    public String getDatabaseName() {
-        return Strings.isNullOrEmpty(databaseName) ? schemaName : databaseName;
-    }
 }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
@@ -128,9 +128,6 @@ public final class ProxyConfigurationLoader {
         if (null == result) {
             return Optional.empty();
         }
-        if (null == result.getDatabaseName()) {
-            result.setDatabaseName(result.getSchemaName());
-        }
         Preconditions.checkNotNull(result.getDatabaseName(), "Property `databaseName` in file `%s` is required.", yamlFile.getName());
         checkDuplicateRule(result.getRules(), yamlFile);
         return Optional.of(result);

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/yaml/YamlProxyDatabaseConfiguration.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/yaml/YamlProxyDatabaseConfiguration.java
@@ -36,8 +36,6 @@ public final class YamlProxyDatabaseConfiguration implements YamlConfiguration {
     
     private String databaseName;
     
-    private String schemaName;
-    
     private Map<String, YamlProxyDataSourceConfiguration> dataSources = new HashMap<>();
     
     private Collection<YamlRuleConfiguration> rules = new LinkedList<>();

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ExportMetaDataExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ExportMetaDataExecutorTest.java
@@ -252,7 +252,6 @@ class ExportMetaDataExecutorTest {
     
     private void assertDatabaseConfig(final YamlProxyDatabaseConfiguration actual, final YamlProxyDatabaseConfiguration expected) {
         assertThat(actual.getDatabaseName(), is(expected.getDatabaseName()));
-        assertThat(actual.getSchemaName(), is(expected.getSchemaName()));
         assertDataSources(actual.getDataSources(), expected.getDataSources());
         assertRules(actual.getRules(), expected.getRules());
     }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove deprecated schemaName in YamlRootConfiguration

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
