### PR TITLE
Fix consistency check job id not persisted in parent job after starting

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNode.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNode.java
@@ -147,17 +147,6 @@ public final class PipelineMetaDataNode {
     }
     
     /**
-     * Get check job id path.
-     *
-     * @param jobId job id
-     * @param checkJobId check job id
-     * @return check job id path
-     */
-    public static String getCheckJobIdPath(final String jobId, final String checkJobId) {
-        return String.join("/", getCheckJobIdsRootPath(jobId), checkJobId);
-    }
-    
-    /**
      * Get job barrier enable path.
      *
      * @param jobId job id

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/registrycenter/repository/job/PipelineJobCheckGovernanceRepository.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/registrycenter/repository/job/PipelineJobCheckGovernanceRepository.java
@@ -105,6 +105,16 @@ public final class PipelineJobCheckGovernanceRepository {
     }
     
     /**
+     * Init check job result.
+     *
+     * @param parentJobId parent job id
+     * @param checkJobId check job id
+     */
+    public void initCheckJobResult(final String parentJobId, final String checkJobId) {
+        repository.persist(PipelineMetaDataNode.getCheckJobResultPath(parentJobId, checkJobId), "");
+    }
+    
+    /**
      * Persist check job result.
      *
      * @param parentJobId parent job id

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNodeTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNodeTest.java
@@ -86,12 +86,6 @@ class PipelineMetaDataNodeTest {
     }
     
     @Test
-    void assertGetCheckJobIdPath() {
-        String checkJobId = "j0201001";
-        assertThat(PipelineMetaDataNode.getCheckJobIdPath(jobId, checkJobId), is(jobCheckRootPath + "/job_ids/" + checkJobId));
-    }
-    
-    @Test
     void assertGetJobBarrierEnablePath() {
         assertThat(PipelineMetaDataNode.getJobBarrierEnablePath(jobId), is(jobRootPath + "/barrier/enable"));
     }

--- a/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/api/ConsistencyCheckJobAPI.java
+++ b/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/api/ConsistencyCheckJobAPI.java
@@ -99,7 +99,7 @@ public final class ConsistencyCheckJobAPI {
         String result = PipelineJobIdUtils.marshal(
                 latestCheckJobId.map(optional -> new ConsistencyCheckJobId(contextKey, parentJobId, optional)).orElseGet(() -> new ConsistencyCheckJobId(contextKey, parentJobId)));
         governanceFacade.getJobFacade().getCheck().persistLatestCheckJobId(parentJobId, result);
-        governanceFacade.getJobFacade().getCheck().deleteCheckJobResult(parentJobId, result);
+        governanceFacade.getJobFacade().getCheck().initCheckJobResult(parentJobId, result);
         jobManager.drop(result);
         jobManager.start(new YamlConsistencyCheckJobConfigurationSwapper().swapToObject(getYamlConfiguration(result, parentJobId, param)));
         return result;

--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/registrycenter/repository/PipelineGovernanceFacadeTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/test/it/data/pipeline/core/registrycenter/repository/PipelineGovernanceFacadeTest.java
@@ -17,18 +17,18 @@
 
 package org.apache.shardingsphere.test.it.data.pipeline.core.registrycenter.repository;
 
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableDataConsistencyCheckResult;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContextManager;
+import org.apache.shardingsphere.data.pipeline.core.importer.Importer;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.Dumper;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.InventoryDumperContext;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.type.placeholder.IngestPlaceholderPosition;
+import org.apache.shardingsphere.data.pipeline.core.job.api.PipelineAPIFactory;
 import org.apache.shardingsphere.data.pipeline.core.job.progress.JobOffsetInfo;
 import org.apache.shardingsphere.data.pipeline.core.metadata.node.PipelineNodePath;
 import org.apache.shardingsphere.data.pipeline.core.registrycenter.repository.PipelineGovernanceFacade;
 import org.apache.shardingsphere.data.pipeline.core.registrycenter.repository.item.PipelineJobItemErrorMessageGovernanceRepository;
 import org.apache.shardingsphere.data.pipeline.core.registrycenter.repository.item.PipelineJobItemProcessGovernanceRepository;
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableDataConsistencyCheckResult;
-import org.apache.shardingsphere.data.pipeline.core.importer.Importer;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.Dumper;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.InventoryDumperContext;
-import org.apache.shardingsphere.data.pipeline.core.job.api.PipelineAPIFactory;
 import org.apache.shardingsphere.data.pipeline.core.task.InventoryTask;
 import org.apache.shardingsphere.data.pipeline.core.task.PipelineTaskUtils;
 import org.apache.shardingsphere.data.pipeline.scenario.migration.config.MigrationTaskConfiguration;
@@ -44,6 +44,7 @@ import org.apache.shardingsphere.test.it.data.pipeline.core.util.PipelineContext
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -127,6 +128,18 @@ class PipelineGovernanceFacadeTest {
         assertThat(actualCheckJobIdOpt.get(), is(expectedCheckJobId));
         governanceFacade.getJobFacade().getCheck().deleteLatestCheckJobId(parentJobId);
         assertFalse(governanceFacade.getJobFacade().getCheck().findLatestCheckJobId(parentJobId).isPresent());
+    }
+    
+    @Test
+    void assertInitCheckJobResult() {
+        MigrationJobItemContext jobItemContext = mockJobItemContext();
+        String checkJobId = "j02101";
+        governanceFacade.getJobFacade().getCheck().initCheckJobResult(jobItemContext.getJobId(), checkJobId);
+        Collection<String> actualCheckJobIds = governanceFacade.getJobFacade().getCheck().listCheckJobIds(jobItemContext.getJobId());
+        assertThat(actualCheckJobIds.size(), is(1));
+        assertThat(actualCheckJobIds.iterator().next(), is(checkJobId));
+        governanceFacade.getJobFacade().getCheck().deleteCheckJobResult(jobItemContext.getJobId(), checkJobId);
+        assertThat(governanceFacade.getJobFacade().getCheck().listCheckJobIds(jobItemContext.getJobId()).size(), is(0));
     }
     
     @Test


### PR DESCRIPTION

Changes proposed in this pull request:
  - Fix consistency check job id not persisted in parent job after starting. If commit/rollback migration job before consistency check is finished, then consistency check job could not be dropped.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
