### PR TITLE
Fix binlog protocol parse of zero time with fractional seconds

### DIFF
--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/column/value/time/MySQLTime2BinlogProtocolValue.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/column/value/time/MySQLTime2BinlogProtocolValue.java
@@ -40,13 +40,13 @@ public final class MySQLTime2BinlogProtocolValue implements MySQLBinlogProtocolV
     @Override
     public Serializable read(final MySQLBinlogColumnDef columnDef, final MySQLPacketPayload payload) {
         int time = payload.getByteBuf().readUnsignedMedium();
+        int nanos = new MySQLFractionalSeconds(columnDef.getColumnMeta(), payload).getNanos();
         if (0x800000 == time) {
-            return MySQLTimeValueUtils.ZERO_OF_TIME;
+            return nanos > 0 ? MySQLTimeValueUtils.ZERO_OF_TIME + "." + String.valueOf(nanos).substring(0, columnDef.getColumnMeta()) : MySQLTimeValueUtils.ZERO_OF_TIME;
         }
-        MySQLFractionalSeconds fractionalSeconds = new MySQLFractionalSeconds(columnDef.getColumnMeta(), payload);
         int hour = (time >> 12) % (1 << 10);
         int minute = (time >> 6) % (1 << 6);
         int second = time % (1 << 6);
-        return LocalTime.of(hour, minute, second).withNano(fractionalSeconds.getNanos());
+        return LocalTime.of(hour, minute, second).withNano(nanos);
     }
 }

--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/column/value/time/MySQLTimestamp2BinlogProtocolValue.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/column/value/time/MySQLTimestamp2BinlogProtocolValue.java
@@ -37,10 +37,10 @@ public final class MySQLTimestamp2BinlogProtocolValue implements MySQLBinlogProt
     @Override
     public Serializable read(final MySQLBinlogColumnDef columnDef, final MySQLPacketPayload payload) {
         int seconds = payload.getByteBuf().readInt();
+        int nanos = new MySQLFractionalSeconds(columnDef.getColumnMeta(), payload).getNanos();
         if (0 == seconds) {
-            return MySQLTimeValueUtils.DATETIME_OF_ZERO;
+            return nanos > 0 ? MySQLTimeValueUtils.DATETIME_OF_ZERO + "." + String.valueOf(nanos).substring(0, columnDef.getColumnMeta()) : MySQLTimeValueUtils.DATETIME_OF_ZERO;
         }
-        int nanos = columnDef.getColumnMeta() > 0 ? new MySQLFractionalSeconds(columnDef.getColumnMeta(), payload).getNanos() : 0;
         Timestamp result = new Timestamp(seconds * 1000L);
         result.setNanos(nanos);
         return result;

--- a/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/column/value/time/MySQLDatetime2BinlogProtocolValueTest.java
+++ b/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/column/value/time/MySQLDatetime2BinlogProtocolValueTest.java
@@ -66,6 +66,15 @@ class MySQLDatetime2BinlogProtocolValueTest {
     }
     
     @Test
+    void assertReadZeroTimeWithoutFraction1() {
+        columnDef.setColumnMeta(1);
+        when(payload.readInt1()).thenReturn(128, 0, 0, 0, 0);
+        assertThat(new MySQLDatetime2BinlogProtocolValue().read(columnDef, payload), is(MySQLTimeValueUtils.DATETIME_OF_ZERO));
+        when(payload.readInt1()).thenReturn(128, 0, 0, 0, 0, 1);
+        assertThat(new MySQLDatetime2BinlogProtocolValue().read(columnDef, payload), is(MySQLTimeValueUtils.DATETIME_OF_ZERO + ".1"));
+    }
+    
+    @Test
     void assertReadWithoutFraction3() {
         columnDef.setColumnMeta(3);
         when(payload.readInt1()).thenReturn(0xfe, 0xf3, 0xff, 0x7e, 0xfb);
@@ -73,6 +82,15 @@ class MySQLDatetime2BinlogProtocolValueTest {
         when(byteBuf.readUnsignedShort()).thenReturn(9990);
         LocalDateTime expected = LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999 * 1000 * 1000);
         assertThat(new MySQLDatetime2BinlogProtocolValue().read(columnDef, payload), is(Timestamp.valueOf(expected)));
+    }
+    
+    @Test
+    void assertReadZeroTimeWithoutFraction3() {
+        columnDef.setColumnMeta(3);
+        when(payload.readInt1()).thenReturn(128, 0, 0, 0, 0);
+        when(byteBuf.readUnsignedShort()).thenReturn(246);
+        when(payload.getByteBuf()).thenReturn(byteBuf);
+        assertThat(new MySQLDatetime2BinlogProtocolValue().read(columnDef, payload), is(MySQLTimeValueUtils.DATETIME_OF_ZERO + ".246"));
     }
     
     @Test

--- a/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/column/value/time/MySQLTime2BinlogProtocolValueTest.java
+++ b/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/column/value/time/MySQLTime2BinlogProtocolValueTest.java
@@ -67,6 +67,15 @@ class MySQLTime2BinlogProtocolValueTest {
     }
     
     @Test
+    void assertReadZeroTimeWithFraction1() {
+        columnDef.setColumnMeta(1);
+        when(payload.getByteBuf()).thenReturn(byteBuf);
+        when(payload.readInt1()).thenReturn(1);
+        when(byteBuf.readUnsignedMedium()).thenReturn(0x800000);
+        assertThat(new MySQLTime2BinlogProtocolValue().read(columnDef, payload), is(MySQLTimeValueUtils.ZERO_OF_TIME + ".1"));
+    }
+    
+    @Test
     void assertReadWithFraction3() {
         columnDef.setColumnMeta(3);
         when(payload.getByteBuf()).thenReturn(byteBuf);
@@ -76,11 +85,28 @@ class MySQLTime2BinlogProtocolValueTest {
     }
     
     @Test
+    void assertReadZeroTimeWithFraction3() {
+        columnDef.setColumnMeta(3);
+        when(payload.getByteBuf()).thenReturn(byteBuf);
+        when(byteBuf.readUnsignedShort()).thenReturn(159);
+        when(byteBuf.readUnsignedMedium()).thenReturn(0x800000);
+        assertThat(new MySQLTime2BinlogProtocolValue().read(columnDef, payload), is(MySQLTimeValueUtils.ZERO_OF_TIME + ".159"));
+    }
+    
+    @Test
     void assertReadWithFraction6() {
         columnDef.setColumnMeta(6);
         when(payload.getByteBuf()).thenReturn(byteBuf);
         when(byteBuf.readUnsignedMedium()).thenReturn(0x800000 | (0x10 << 12) | (0x08 << 6) | 0x04, 10123);
         assertThat(new MySQLTime2BinlogProtocolValue().read(columnDef, payload), is(LocalTime.of(16, 8, 4).withNano(10123000)));
+    }
+    
+    @Test
+    void assertReadZeroTimeWithFraction6() {
+        columnDef.setColumnMeta(6);
+        when(payload.getByteBuf()).thenReturn(byteBuf);
+        when(byteBuf.readUnsignedMedium()).thenReturn(0x800000, 123);
+        assertThat(new MySQLTime2BinlogProtocolValue().read(columnDef, payload), is(MySQLTimeValueUtils.ZERO_OF_TIME + ".123000"));
     }
     
     @Test

--- a/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/column/value/time/MySQLTimestamp2BinlogProtocolValueTest.java
+++ b/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/column/value/time/MySQLTimestamp2BinlogProtocolValueTest.java
@@ -69,6 +69,14 @@ class MySQLTimestamp2BinlogProtocolValueTest {
     }
     
     @Test
+    void assertReadZeroTimeWithFraction() {
+        columnDef.setColumnMeta(1);
+        when(byteBuf.readInt()).thenReturn(0);
+        when(payload.readInt1()).thenReturn(9);
+        assertThat(new MySQLTimestamp2BinlogProtocolValue().read(columnDef, payload), is(MySQLTimeValueUtils.DATETIME_OF_ZERO + ".9"));
+    }
+    
+    @Test
     void assertReadNullTime() {
         when(byteBuf.readInt()).thenReturn(0);
         assertThat(new MySQLTimestamp2BinlogProtocolValue().read(columnDef, payload), is(MySQLTimeValueUtils.DATETIME_OF_ZERO));

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLMigrationGeneralE2EIT.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLMigrationGeneralE2EIT.java
@@ -84,6 +84,9 @@ class MySQLMigrationGeneralE2EIT extends AbstractMigrationE2EIT {
                     new E2EIncrementalTask(containerComposer.getSourceDataSource(), SOURCE_TABLE_NAME, new SnowflakeKeyGenerateAlgorithm(), containerComposer.getDatabaseType(), 30));
             TimeUnit.SECONDS.timedJoin(containerComposer.getIncreaseTaskThread(), 30);
             containerComposer.sourceExecuteWithLog(String.format("INSERT INTO %s (order_id, user_id, status) VALUES (10000, 1, 'OK')", SOURCE_TABLE_NAME));
+            // TODO If the fractional seconds > 0 , query from JDBC will thrown Zero date value prohibited SqlTimestampValueFactory.localCreateFromDatetime, zeroDateTimeBehavior not effect
+            DataSourceExecuteUtils.execute(containerComposer.getSourceDataSource(), String.format("UPDATE %s SET t_datetime='0000-00-00 00:00:00.000000', t_timestamp='0000-00-00 00:00:00', "
+                    + "t_time='00:00:00.0' WHERE order_id = 1", SOURCE_TABLE_NAME));
             containerComposer.sourceExecuteWithLog("INSERT INTO t_order_item (item_id, order_id, user_id, status) VALUES (10000, 10000, 1, 'OK')");
             stopMigrationByJobId(containerComposer, orderJobId);
             startMigrationByJobId(containerComposer, orderJobId);


### PR DESCRIPTION
According to doc https://mariadb.com/kb/en/rows_event_v1v2-rows_compressed_event_v1/, if the fractional part not null, it's need to be parsed event if is zero time.

Changes proposed in this pull request:
  - Fix binlog protocol parse of zero time with fractional seconds
  - Add E2E and IT 

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
