### PR TITLE
Fix routing error when joining tables in uppercase

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/complex/ShardingComplexRoutingEngine.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/complex/ShardingComplexRoutingEngine.java
@@ -58,7 +58,7 @@ public final class ShardingComplexRoutingEngine implements ShardingRouteEngine {
             Optional<ShardingTable> shardingTable = shardingRule.findShardingTable(each);
             if (shardingTable.isPresent()) {
                 if (!bindingTableNames.contains(each)) {
-                    routeContexts.add(new ShardingStandardRoutingEngine(shardingTable.get().getLogicTable(), shardingConditions, sqlStatementContext, hintValueContext, props).route(shardingRule));
+                    routeContexts.add(new ShardingStandardRoutingEngine(each, shardingConditions, sqlStatementContext, hintValueContext, props).route(shardingRule));
                 }
                 shardingRule.findBindingTableRule(each).ifPresent(optional -> bindingTableNames.addAll(optional.getShardingTables().keySet()));
             }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/complex/ShardingComplexRoutingEngine.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/complex/ShardingComplexRoutingEngine.java
@@ -58,7 +58,7 @@ public final class ShardingComplexRoutingEngine implements ShardingRouteEngine {
             Optional<ShardingTable> shardingTable = shardingRule.findShardingTable(each);
             if (shardingTable.isPresent()) {
                 if (!bindingTableNames.contains(each)) {
-                    routeContexts.add(new ShardingStandardRoutingEngine(each, shardingConditions, sqlStatementContext, hintValueContext, props).route(shardingRule));
+                    routeContexts.add(new ShardingStandardRoutingEngine(shardingTable.get().getLogicTable(), shardingConditions, sqlStatementContext, hintValueContext, props).route(shardingRule));
                 }
                 shardingRule.findBindingTableRule(each).ifPresent(optional -> bindingTableNames.addAll(optional.getShardingTables().keySet()));
             }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRoutingEngine.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRoutingEngine.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sharding.route.engine.type.standard;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.datanode.DataNode;
@@ -235,8 +236,8 @@ public final class ShardingStandardRoutingEngine implements ShardingRouteEngine 
         List<ShardingConditionValue> result = new ArrayList<>(shardingColumns.size());
         for (ShardingConditionValue each : shardingCondition.getValues()) {
             Optional<BindingTableRule> bindingTableRule = shardingRule.findBindingTableRule(each.getTableName());
-            if ((logicTableName.equals(each.getTableName()) || bindingTableRule.isPresent() && bindingTableRule.get().hasLogicTable(logicTableName))
-                    && shardingColumns.contains(each.getColumnName())) {
+            if ((logicTableName.equalsIgnoreCase(each.getTableName()) || bindingTableRule.isPresent() && bindingTableRule.get().hasLogicTable(logicTableName))
+                    && new CaseInsensitiveSet<>(shardingColumns).contains(each.getColumnName())) {
                 result.add(each);
             }
         }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/complex/ShardingComplexRoutingEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/complex/ShardingComplexRoutingEngineTest.java
@@ -76,7 +76,7 @@ class ShardingComplexRoutingEngineTest {
         assertThat(routeUnits.get(0).getDataSourceMapper().getActualName(), is("ds_1"));
         assertThat(routeUnits.get(0).getTableMappers().size(), is(1));
         assertThat(routeUnits.get(0).getTableMappers().iterator().next().getActualName(), is("t_order_1"));
-        assertThat(routeUnits.get(0).getTableMappers().iterator().next().getLogicName(), is("T_ORDER"));
+        assertThat(routeUnits.get(0).getTableMappers().iterator().next().getLogicName(), is("t_order"));
     }
     
     @Test

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/complex/ShardingComplexRoutingEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/complex/ShardingComplexRoutingEngineTest.java
@@ -65,7 +65,7 @@ class ShardingComplexRoutingEngineTest {
         assertThat(routeUnits.get(0).getTableMappers().iterator().next().getActualName(), is("t_order_1"));
         assertThat(routeUnits.get(0).getTableMappers().iterator().next().getLogicName(), is("t_order"));
     }
-
+    
     @Test
     void assertRoutingForShardingTableJoinWithUpperCase() {
         ShardingComplexRoutingEngine complexRoutingEngine = new ShardingComplexRoutingEngine(ShardingRoutingEngineFixtureBuilder.createShardingConditions("T_ORDER"),

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/complex/ShardingComplexRoutingEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/complex/ShardingComplexRoutingEngineTest.java
@@ -65,6 +65,19 @@ class ShardingComplexRoutingEngineTest {
         assertThat(routeUnits.get(0).getTableMappers().iterator().next().getActualName(), is("t_order_1"));
         assertThat(routeUnits.get(0).getTableMappers().iterator().next().getLogicName(), is("t_order"));
     }
+
+    @Test
+    void assertRoutingForShardingTableJoinWithUpperCase() {
+        ShardingComplexRoutingEngine complexRoutingEngine = new ShardingComplexRoutingEngine(ShardingRoutingEngineFixtureBuilder.createShardingConditions("T_ORDER"),
+                mock(SQLStatementContext.class), new HintValueContext(), new ConfigurationProperties(new Properties()), Arrays.asList("T_ORDER", "T_CONFIG"));
+        RouteContext routeContext = complexRoutingEngine.route(ShardingRoutingEngineFixtureBuilder.createBroadcastShardingRule());
+        List<RouteUnit> routeUnits = new ArrayList<>(routeContext.getRouteUnits());
+        assertThat(routeContext.getRouteUnits().size(), is(1));
+        assertThat(routeUnits.get(0).getDataSourceMapper().getActualName(), is("ds_1"));
+        assertThat(routeUnits.get(0).getTableMappers().size(), is(1));
+        assertThat(routeUnits.get(0).getTableMappers().iterator().next().getActualName(), is("t_order_1"));
+        assertThat(routeUnits.get(0).getTableMappers().iterator().next().getLogicName(), is("T_ORDER"));
+    }
     
     @Test
     void assertRoutingForNonLogicTable() {


### PR DESCRIPTION
Fixes #30005.

Changes proposed in this pull request:
  - Fix routing error when joining tables in uppercase
      + When the table sharding rule is lowercase，but the table name is uppercase in the executed sql，the correct logicTableName cannot be found
      + When the query is isShardingStandardQuery, it will enter the getLogicTableName method, but join queries will not enter this method, resulting in an error in obtaining the logic table.

![image](https://github.com/apache/shardingsphere/assets/124348939/8b5a3057-173b-4023-b8f2-efc84ce38a5c)

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
