### PR TITLE
Modify unmarshal method to return a default object when yaml is empty

### DIFF
--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
@@ -23,7 +23,7 @@ package org.apache.shardingsphere.infra.util.yaml;
 public interface YamlConfiguration {
     
     /**
-     * Check if the YAML configuration is empty, indicating the absence of any valid configuration items.
+     * Check whether the YAML configuration is empty, indicating the absence of any valid configuration items.
      * 
      * @return check whether the YAML configuration is empty or not
      */

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
@@ -30,7 +30,6 @@ public interface YamlConfiguration {
      */
     default boolean isEmpty() {
         // TODO Currently, only global.yaml and database.yaml handle the case of empty YAML file content. In the future, other scenarios that read YAML files should also consider whether to override
-        // this method to determine if the YAML file is empty.
         return false;
     }
 }

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
@@ -26,8 +26,9 @@ public interface YamlConfiguration {
      * Check if the YAML configuration is empty, indicating the absence of any valid configuration items.
      * 
      * @return Judge whether the YAML configuration is empty or not
+     * @throws UnsupportedOperationException unsupported operation exception
      */
     default boolean isEmpty() {
-        return false;
+        throw new UnsupportedOperationException("Must be overridden.");
     }
 }

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
@@ -28,8 +28,7 @@ public interface YamlConfiguration {
      * @return check whether the YAML configuration is empty or not
      */
     default boolean isEmpty() {
-        // TODO Currently, only global.yaml and database.yaml handle the case of empty YAML file content. 
-        // In the future, other scenarios that read YAML files should also consider whether to override this method to determine if the YAML file is empty.
+        // TODO Only global.yaml and database.yaml handle empty YAML file currently.Other scenarios reading YAML files should also consider overriding this method to check for empty files.
         return false;
     }
 }

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
@@ -26,7 +26,6 @@ public interface YamlConfiguration {
      * Check if the YAML configuration is empty, indicating the absence of any valid configuration items.
      * 
      * @return Judge whether the YAML configuration is empty or not
-     * @throws UnsupportedOperationException unsupported operation exception
      */
     default boolean isEmpty() {
         // TODO Currently, only global.yaml and database.yaml handle the case of empty YAML file content. 

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
@@ -25,11 +25,11 @@ public interface YamlConfiguration {
     /**
      * Check if the YAML configuration is empty, indicating the absence of any valid configuration items.
      * 
-     * @return Judge whether the YAML configuration is empty or not
+     * @return Check whether the YAML configuration is empty or not
      */
     default boolean isEmpty() {
         // TODO Currently, only global.yaml and database.yaml handle the case of empty YAML file content. 
-        // TODO In the future, other scenarios that read YAML files should also consider whether to override this method to determine if the YAML file is empty.
+        // In the future, other scenarios that read YAML files should also consider whether to override this method to determine if the YAML file is empty.
         return false;
     }
 }

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
@@ -25,7 +25,7 @@ public interface YamlConfiguration {
     /**
      * Check if the YAML configuration is empty, indicating the absence of any valid configuration items.
      * 
-     * @return Check whether the YAML configuration is empty or not
+     * @return check whether the YAML configuration is empty or not
      */
     default boolean isEmpty() {
         // TODO Currently, only global.yaml and database.yaml handle the case of empty YAML file content. 

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
@@ -21,4 +21,13 @@ package org.apache.shardingsphere.infra.util.yaml;
  * YAML configuration.
  */
 public interface YamlConfiguration {
+    
+    /**
+     * Check if the YAML configuration is empty, indicating the absence of any valid configuration items.
+     * 
+     * @return Judge whether the YAML configuration is empty or not
+     */
+    default boolean isEmpty() {
+        return false;
+    }
 }

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
@@ -29,7 +29,8 @@ public interface YamlConfiguration {
      * @throws UnsupportedOperationException unsupported operation exception
      */
     default boolean isEmpty() {
-        // TODO Currently, only global.yaml and database.yaml handle the case of empty YAML file content. In the future, other scenarios that read YAML files should also consider whether to override
+        // TODO Currently, only global.yaml and database.yaml handle the case of empty YAML file content. 
+        // TODO In the future, other scenarios that read YAML files should also consider whether to override this method to determine if the YAML file is empty.
         return false;
     }
 }

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlConfiguration.java
@@ -29,6 +29,8 @@ public interface YamlConfiguration {
      * @throws UnsupportedOperationException unsupported operation exception
      */
     default boolean isEmpty() {
-        throw new UnsupportedOperationException("Must be overridden.");
+        // TODO Currently, only global.yaml and database.yaml handle the case of empty YAML file content. In the future, other scenarios that read YAML files should also consider whether to override
+        // this method to determine if the YAML file is empty.
+        return false;
     }
 }

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlEngine.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlEngine.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.util.yaml;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 import org.apache.shardingsphere.infra.util.yaml.constructor.ShardingSphereYamlConstructor;
 import org.apache.shardingsphere.infra.util.yaml.representer.ShardingSphereYamlRepresenter;
 import org.yaml.snakeyaml.DumperOptions;
@@ -49,9 +50,11 @@ public final class YamlEngine {
      * @return object from YAML
      * @throws IOException IO Exception
      */
+    @SneakyThrows(ReflectiveOperationException.class)
     public static <T extends YamlConfiguration> T unmarshal(final File yamlFile, final Class<T> classType) throws IOException {
         try (BufferedReader inputStreamReader = Files.newBufferedReader(Paths.get(yamlFile.toURI()))) {
-            return new Yaml(new ShardingSphereYamlConstructor(classType)).loadAs(inputStreamReader, classType);
+            T result = new Yaml(new ShardingSphereYamlConstructor(classType)).loadAs(inputStreamReader, classType);
+            return null == result ? classType.getConstructor().newInstance() : result;
         }
     }
     
@@ -64,9 +67,11 @@ public final class YamlEngine {
      * @return object from YAML
      * @throws IOException IO Exception
      */
+    @SneakyThrows(ReflectiveOperationException.class)
     public static <T extends YamlConfiguration> T unmarshal(final byte[] yamlBytes, final Class<T> classType) throws IOException {
         try (InputStream inputStream = new ByteArrayInputStream(yamlBytes)) {
-            return new Yaml(new ShardingSphereYamlConstructor(classType)).loadAs(inputStream, classType);
+            T result = new Yaml(new ShardingSphereYamlConstructor(classType)).loadAs(inputStream, classType);
+            return null == result ? classType.getConstructor().newInstance() : result;
         }
     }
     
@@ -78,8 +83,10 @@ public final class YamlEngine {
      * @param <T> type of class
      * @return object from YAML
      */
+    @SneakyThrows(ReflectiveOperationException.class)
     public static <T> T unmarshal(final String yamlContent, final Class<T> classType) {
-        return new Yaml(new ShardingSphereYamlConstructor(classType)).loadAs(yamlContent, classType);
+        T result = new Yaml(new ShardingSphereYamlConstructor(classType)).loadAs(yamlContent, classType);
+        return null == result ? classType.getConstructor().newInstance() : result;
     }
     
     /**
@@ -91,10 +98,12 @@ public final class YamlEngine {
      * @param <T> type of class
      * @return object from YAML
      */
+    @SneakyThrows(ReflectiveOperationException.class)
     public static <T> T unmarshal(final String yamlContent, final Class<T> classType, final boolean skipMissingProps) {
         Representer representer = new Representer(new DumperOptions());
         representer.getPropertyUtils().setSkipMissingProperties(skipMissingProps);
-        return new Yaml(new ShardingSphereYamlConstructor(classType), representer).loadAs(yamlContent, classType);
+        T result = new Yaml(new ShardingSphereYamlConstructor(classType), representer).loadAs(yamlContent, classType);
+        return null == result ? classType.getConstructor().newInstance() : result;
     }
     
     /**

--- a/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/YamlEngineTest.java
+++ b/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/YamlEngineTest.java
@@ -94,6 +94,13 @@ class YamlEngineTest {
     }
     
     @Test
+    void assertUnmarshalWithEmptyProperties() {
+        Properties actual = YamlEngine.unmarshal("", Properties.class);
+        assertNotNull(actual);
+        assertTrue(actual.isEmpty());
+    }
+    
+    @Test
     void assertMarshal() {
         YamlShortcutsConfigurationFixture actual = new YamlShortcutsConfigurationFixture();
         actual.setName("test");

--- a/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/YamlEngineTest.java
+++ b/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/YamlEngineTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class YamlEngineTest {
     
@@ -47,20 +48,31 @@ class YamlEngineTest {
     }
     
     @Test
+    void assertUnmarshalWithEmptyFile() throws IOException {
+        URL url = getClass().getClassLoader().getResource("yaml/empty-config.yaml");
+        assertNotNull(url);
+        YamlShortcutsConfigurationFixture actual = YamlEngine.unmarshal(new File(url.getFile()), YamlShortcutsConfigurationFixture.class);
+        assertNotNull(actual);
+        assertTrue(actual.isEmpty());
+    }
+    
+    @Test
     void assertUnmarshalWithYamlBytes() throws IOException {
         URL url = getClass().getClassLoader().getResource("yaml/shortcuts-fixture.yaml");
         assertNotNull(url);
-        StringBuilder yamlContent = new StringBuilder();
-        try (
-                FileReader fileReader = new FileReader(url.getFile());
-                BufferedReader reader = new BufferedReader(fileReader)) {
-            String line;
-            while (null != (line = reader.readLine())) {
-                yamlContent.append(line).append(System.lineSeparator());
-            }
-        }
-        YamlShortcutsConfigurationFixture actual = YamlEngine.unmarshal(yamlContent.toString().getBytes(), YamlShortcutsConfigurationFixture.class);
+        String yamlContent = readContent(url);
+        YamlShortcutsConfigurationFixture actual = YamlEngine.unmarshal(yamlContent.getBytes(), YamlShortcutsConfigurationFixture.class);
         assertThat(actual.getName(), is("test"));
+    }
+    
+    @Test
+    void assertUnmarshalWithEmptyYamlBytes() throws IOException {
+        URL url = getClass().getClassLoader().getResource("yaml/empty-config.yaml");
+        assertNotNull(url);
+        String yamlContent = readContent(url);
+        YamlShortcutsConfigurationFixture actual = YamlEngine.unmarshal(yamlContent.getBytes(), YamlShortcutsConfigurationFixture.class);
+        assertNotNull(actual);
+        assertTrue(actual.isEmpty());
     }
     
     @Test
@@ -92,16 +104,8 @@ class YamlEngineTest {
     void assertUnmarshalInvalidYaml() throws IOException {
         URL url = getClass().getClassLoader().getResource("yaml/accepted-class.yaml");
         assertNotNull(url);
-        StringBuilder yamlContent = new StringBuilder();
-        try (
-                FileReader fileReader = new FileReader(url.getFile());
-                BufferedReader reader = new BufferedReader(fileReader)) {
-            String line;
-            while (null != (line = reader.readLine())) {
-                yamlContent.append(line).append(System.lineSeparator());
-            }
-        }
-        assertThrows(ComposerException.class, () -> YamlEngine.unmarshal(yamlContent.toString(), Object.class));
+        String yamlContent = readContent(url);
+        assertThrows(ComposerException.class, () -> YamlEngine.unmarshal(yamlContent, Object.class));
     }
     
     @Test
@@ -113,5 +117,18 @@ class YamlEngineTest {
         String res = "- !FIXTURE" + System.lineSeparator() + "  name: test" + System.lineSeparator() + "- !FIXTURE"
                 + System.lineSeparator() + "  name: test" + System.lineSeparator();
         assertThat(YamlEngine.marshal(Arrays.asList(actual, actualAnother)), is(res));
+    }
+    
+    private String readContent(final URL url) throws IOException {
+        StringBuilder result = new StringBuilder();
+        try (
+                FileReader fileReader = new FileReader(url.getFile());
+                BufferedReader reader = new BufferedReader(fileReader)) {
+            String line;
+            while (null != (line = reader.readLine())) {
+                result.append(line).append(System.lineSeparator());
+            }
+        }
+        return result.toString();
     }
 }

--- a/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/fixture/shortcuts/YamlShortcutsConfigurationFixture.java
+++ b/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/fixture/shortcuts/YamlShortcutsConfigurationFixture.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.util.yaml.fixture.shortcuts;
 
+import com.google.common.base.Strings;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.infra.util.yaml.YamlConfiguration;
@@ -26,4 +27,9 @@ import org.apache.shardingsphere.infra.util.yaml.YamlConfiguration;
 public final class YamlShortcutsConfigurationFixture implements YamlConfiguration {
     
     private String name;
+    
+    @Override
+    public boolean isEmpty() {
+        return Strings.isNullOrEmpty(name);
+    }
 }

--- a/infra/util/src/test/resources/yaml/empty-config.yaml
+++ b/infra/util/src/test/resources/yaml/empty-config.yaml
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/config/yaml/config/YamlPipelineProcessConfiguration.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/config/yaml/config/YamlPipelineProcessConfiguration.java
@@ -35,12 +35,8 @@ public final class YamlPipelineProcessConfiguration implements YamlConfiguration
     
     private YamlAlgorithmConfiguration streamChannel;
     
-    /**
-     * Check all fields is null.
-     *
-     * @return true if all fields is null, otherwise is false.
-     */
-    public boolean isAllFieldsNull() {
+    @Override
+    public boolean isEmpty() {
         return null == read && null == write && null == streamChannel;
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/PipelineProcessConfigurationPersistService.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/PipelineProcessConfigurationPersistService.java
@@ -39,7 +39,7 @@ public final class PipelineProcessConfigurationPersistService implements Pipelin
             return null;
         }
         YamlPipelineProcessConfiguration yamlConfig = YamlEngine.unmarshal(yamlText, YamlPipelineProcessConfiguration.class, true);
-        return null == yamlConfig || yamlConfig.isAllFieldsNull() ? null : swapper.swapToObject(yamlConfig);
+        return yamlConfig.isEmpty() ? null : swapper.swapToObject(yamlConfig);
     }
     
     @Override

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/result/yaml/YamlTableDataConsistencyCheckResultSwapperTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/result/yaml/YamlTableDataConsistencyCheckResultSwapperTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -102,11 +103,11 @@ class YamlTableDataConsistencyCheckResultSwapperTest {
     
     @Test
     void assertSwapToObjectWithEmptyString() {
-        assertNull(yamlTableDataConsistencyCheckResultSwapper.swapToObject(""));
+        assertNotNull(yamlTableDataConsistencyCheckResultSwapper.swapToObject(""));
     }
     
     @Test
     void assertSwapToObjectWithBlankString() {
-        assertNull(yamlTableDataConsistencyCheckResultSwapper.swapToObject(" "));
+        assertNotNull(yamlTableDataConsistencyCheckResultSwapper.swapToObject(" "));
     }
 }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
@@ -92,7 +92,7 @@ public final class ProxyConfigurationLoader {
     
     private static YamlProxyServerConfiguration loadServerConfiguration(final File yamlFile) throws IOException {
         YamlProxyServerConfiguration result = YamlEngine.unmarshal(yamlFile, YamlProxyServerConfiguration.class);
-        return null == result ? new YamlProxyServerConfiguration() : rebuildGlobalRuleConfiguration(result);
+        return rebuildGlobalRuleConfiguration(result);
     }
     
     private static YamlProxyServerConfiguration rebuildGlobalRuleConfiguration(final YamlProxyServerConfiguration serverConfig) {
@@ -138,7 +138,7 @@ public final class ProxyConfigurationLoader {
     
     private static Optional<YamlProxyDatabaseConfiguration> loadDatabaseConfiguration(final File yamlFile) throws IOException {
         YamlProxyDatabaseConfiguration result = YamlEngine.unmarshal(yamlFile, YamlProxyDatabaseConfiguration.class);
-        if (null == result) {
+        if (result.isEmpty()) {
             return Optional.empty();
         }
         Preconditions.checkNotNull(result.getDatabaseName(), "Property `databaseName` in file `%s` is required.", yamlFile.getName());

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/yaml/YamlProxyDatabaseConfiguration.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/yaml/YamlProxyDatabaseConfiguration.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.proxy.backend.config.yaml;
 
+import com.google.common.base.Strings;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.infra.util.yaml.YamlConfiguration;
@@ -39,4 +40,9 @@ public final class YamlProxyDatabaseConfiguration implements YamlConfiguration {
     private Map<String, YamlProxyDataSourceConfiguration> dataSources = new HashMap<>();
     
     private Collection<YamlRuleConfiguration> rules = new LinkedList<>();
+    
+    @Override
+    public boolean isEmpty() {
+        return Strings.isNullOrEmpty(databaseName) && dataSources.isEmpty() && rules.isEmpty();
+    }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Modify unmarshal method to return a default object when yaml is empty

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
