### PR TITLE
Support parsing Oracle CREATE Table Annotations and parallel clause

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -242,7 +242,7 @@ oidIndexClause
     ;
 
 createRelationalTableClause
-    : (LP_ relationalProperties RP_)? immutableTableClauses? blockchainTableClauses? collationClause? commitClause? physicalProperties? tableProperties?
+    : (LP_ relationalProperties RP_)? immutableTableClauses? blockchainTableClauses? collationClause? commitClause? parallelClause? physicalProperties? tableProperties?
     ;
 
 createParentClause
@@ -1057,7 +1057,7 @@ clusterRelatedClause
 
 tableProperties
     : columnProperties? readOnlyClause? indexingClause? tablePartitioningClauses? attributeClusteringClause? (CACHE | NOCACHE)? parallelClause?
-    ( RESULT_CACHE (MODE (DEFAULT | FORCE)))? (ROWDEPENDENCIES | NOROWDEPENDENCIES)? enableDisableClause* rowMovementClause? logicalReplicationClause? flashbackArchiveClause?
+    ( RESULT_CACHE (LP_ MODE (DEFAULT | FORCE) RP_))? (ROWDEPENDENCIES | NOROWDEPENDENCIES)? enableDisableClause* rowMovementClause? logicalReplicationClause? flashbackArchiveClause?
     ( ROW ARCHIVAL)? (AS selectSubquery | FOR EXCHANGE WITH TABLE tableName)?
     ;
 

--- a/test/it/parser/src/main/resources/case/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-table.xml
@@ -2349,4 +2349,38 @@
     <create-table sql-case-id="create_table_cluster_with_select3">
         <table name="customers_demo" start-index="13" stop-index="26" />
     </create-table>
+
+    <create-table sql-case-id="create_table_with_ref_type_column_department_typ">
+        <table name="employees_obj" start-index="13" stop-index="25"/>
+        <column-definition type="VARCHAR2" start-index="28" stop-index="49">
+            <column name="e_name" start-index="28" stop-index="33"/>
+        </column-definition>
+        <column-definition type="NUMBER" start-index="52" stop-index="66">
+            <column name="e_number" start-index="52" stop-index="59"/>
+        </column-definition>
+        <column-definition type="department_typ" start-index="69" stop-index="122">
+            <column name="e_dept" start-index="69" stop-index="74"/>
+            <referenced-table name="departments_obj_t" start-index="106" stop-index="122"/>
+        </column-definition>
+    </create-table>
+
+    <create-table sql-case-id="create_table_with_result_cache_annotations">
+        <table name="foo" start-index="13" stop-index="15"/>
+        <column-definition type="NUMBER" start-index="18" stop-index="25">
+            <column name="a" start-index="18" stop-index="18"/>
+        </column-definition>
+        <column-definition type="VARCHAR2" start-index="28" stop-index="41">
+            <column name="b" start-index="28" stop-index="28"/>
+        </column-definition>
+    </create-table>
+
+    <create-table sql-case-id="create_table_with_as_sub_query">
+        <table name="employees_temp" start-index="13" stop-index="26"/>
+    </create-table>
+
+    <create-table sql-case-id="create_table_parallel_with_as_sub_query">
+        <table name="admin_emp_dept" start-index="13" stop-index="29">
+            <owner name="hr" start-index="13" stop-index="14"/>
+        </table>
+    </create-table>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
@@ -318,4 +318,8 @@
     <sql-case id="create_table_cluster_with_select1" value="CREATE TABLE dept_10 CLUSTER personnel (department_id) AS SELECT * FROM employees WHERE department_id = 10" db-types="Oracle" />
     <sql-case id="create_table_cluster_with_select2" value="CREATE TABLE dept_20 CLUSTER personnel (department_id) AS SELECT * FROM employees WHERE department_id = 20" db-types="Oracle" />
     <sql-case id="create_table_cluster_with_select3" value="CREATE TABLE customers_demo AS SELECT * FROM customers" db-types="Oracle" />
+    <sql-case id="create_table_with_ref_type_column_department_typ" value="CREATE TABLE employees_obj( e_name   VARCHAR2(100), e_number NUMBER, e_dept   REF department_typ SCOPE IS departments_obj_t );" db-types="Oracle"/>
+    <sql-case id="create_table_with_result_cache_annotations" value="CREATE TABLE foo (a NUMBER, b VARCHAR2(20)) RESULT_CACHE (MODE FORCE);" db-types="Oracle"/>
+    <sql-case id="create_table_with_as_sub_query" value="CREATE TABLE employees_temp AS SELECT * FROM EMPLOYEES;" db-types="Oracle"/>
+    <sql-case id="create_table_parallel_with_as_sub_query" value="CREATE TABLE hr.admin_emp_dept PARALLEL COMPRESS AS SELECT * FROM hr.employees WHERE department_id = 10;" db-types="Oracle"/>
 </sql-cases>


### PR DESCRIPTION
Fixes #27099.

Changes proposed in this pull request:
  - support parsing create table table annotations [Table Annotations](https://docs.oracle.com/en/database/oracle/oracle-database/21/jjdbc/statement-and-resultset-caching.html#GUID-1764F69A-8E6B-4B78-AAF0-1D6257B3BBE5)
<img width="717" alt="image" src="https://github.com/apache/shardingsphere/assets/124348939/463d4901-5c0b-4451-ba73-ae612780538b">

  - support parsing create table parallel clause [Parallel](https://docs.oracle.com/cd/A97630_01/server.920/a96524/c20paral.htm)

#### Support for the following sql
```sql
CREATE TABLE employees_obj
   ( e_name   VARCHAR2(100),
     e_number NUMBER,
     e_dept   REF department_typ SCOPE IS departments_obj_t );
```

```sql
CREATE TABLE foo (a NUMBER, b VARCHAR2(20)) RESULT_CACHE (MODE FORCE);
```
```sql
CREATE TABLE employees_temp AS SELECT * FROM EMPLOYEES;
```
```sql
CREATE TABLE hr.admin_emp_dept
 PARALLEL COMPRESS
 AS SELECT * FROM hr.employees
 WHERE department_id = 10;
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
