### PR TITLE
Fixes Proxy Native not finding `native-image.properties` in `infra-reachability-metadata` module

### DIFF
--- a/distribution/proxy-native/pom.xml
+++ b/distribution/proxy-native/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>shardingsphere-proxy-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-reachability-metadata</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         
         <dependency>
             <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/actions/runs/7991966581/job/21827813593 .

Changes proposed in this pull request:
  - Fixes Proxy Native not finding `native-image.properties` in `infra-reachability-metadata` module. This is caused by #30143 removing the `jdbc` dependency in the `proxy-bootstrap` module.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
