### PR TITLE
Fix typo in URLArgumentLine class

### DIFF
--- a/infra/url/core/src/main/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLine.java
+++ b/infra/url/core/src/main/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLine.java
@@ -39,7 +39,7 @@ public final class URLArgumentLine {
     
     private final String argDefaultValue;
     
-    private final Matcher placehodlerMatcher;
+    private final Matcher placeholderMatcher;
     
     /**
      * Parse URL argument line.
@@ -65,12 +65,12 @@ public final class URLArgumentLine {
     public String replaceArgument(final URLArgumentPlaceholderType type) {
         String argumentValue = getArgumentValue(type);
         if (!Strings.isNullOrEmpty(argumentValue)) {
-            return placehodlerMatcher.replaceAll(argumentValue);
+            return placeholderMatcher.replaceAll(argumentValue);
         }
         if (!argDefaultValue.isEmpty()) {
-            return placehodlerMatcher.replaceAll(argDefaultValue);
+            return placeholderMatcher.replaceAll(argDefaultValue);
         }
-        String modifiedLineWithSpace = placehodlerMatcher.replaceAll("");
+        String modifiedLineWithSpace = placeholderMatcher.replaceAll("");
         return modifiedLineWithSpace.substring(0, modifiedLineWithSpace.length() - 1);
     }
     


### PR DESCRIPTION
Fixes #30289.

Changes proposed in this pull request:
  - https://github.com/apache/shardingsphere/issues/30289

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
