### PR TITLE
Updates documentation for restrictions on Seata’s Spring Boot Starter

### DIFF
--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/type/UnsupportedStorageTypeException.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/type/UnsupportedStorageTypeException.java
@@ -28,17 +28,14 @@ import org.apache.shardingsphere.infra.exception.core.external.sql.type.kernel.c
  * // CHECKSTYLE:OFF
  * <pre class="code">
  * public final class VerticaDatabaseType implements DatabaseType {
- * <p/>
  *     &#064;Override
  *     public Collection<String> getJdbcUrlPrefixes() {
  *         return Collections.singleton("jdbc:vertica:");
  *     }
- * <p/>
  *     &#064;Override
  *     public Optional<DatabaseType> getTrunkDatabaseType() {
  *         return Optional.of(TypedSPILoader.getService(DatabaseType.class, "SQL92"));
  *     }
- * <p/>
  *     &#064;Override
  *     public String getType() {
  *         return "Vertica";

--- a/infra/expr/spi/src/main/java/org/apache/shardingsphere/infra/expr/spi/InlineExpressionParser.java
+++ b/infra/expr/spi/src/main/java/org/apache/shardingsphere/infra/expr/spi/InlineExpressionParser.java
@@ -51,6 +51,13 @@ public interface InlineExpressionParser extends TypedSPI {
     
     /**
      * Evaluate with arguments.
+     * Normally there is no need to use this method downstream, because this method only encapsulates the use of Groovy syntax
+     * by ShardingSphere's existing algorithm classes.
+     * An {@link org.apache.shardingsphere.infra.expr.spi.InlineExpressionParser} implementation that implements this method
+     * will provide the following algorithm classes with the ability to use expressions outside the Groovy language.
+     * 1. `org.apache.shardingsphere.sharding.algorithm.sharding.hint.HintInlineShardingAlgorithm`
+     * 2. `org.apache.shardingsphere.sharding.algorithm.sharding.inline.ComplexInlineShardingAlgorithm`
+     * 3. `org.apache.shardingsphere.sharding.algorithm.sharding.inline.InlineShardingAlgorithm`
      *
      * @param map map
      * @return closure


### PR DESCRIPTION
Fixes #29712.

Changes proposed in this pull request:
  - Updates documentation for restrictions on Seata’s Spring Boot Starter and RPC.
    - Fixes #29681
    - Fixes #29712
  - Added a missing JavaDoc description For `InlineExpressionParser`. For #30038 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
