### PR TITLE
Fix oracle parse show roles error when add EOF

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/OracleStatement.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/OracleStatement.g4
@@ -17,7 +17,7 @@
 
 grammar OracleStatement;
 
-import DMLStatement, DDLStatement, TCLStatement, DCLStatement, DALStatement, PLSQL;
+import DMLStatement, DCLStatement, DDLStatement, TCLStatement, DALStatement, PLSQL;
 
 execute
     : (select

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserIT.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserIT.java
@@ -69,8 +69,7 @@ public abstract class InternalSQLParserIT {
             "grant_program", "grant_role", "grant_roles_to_programs", "grant_roles_to_users", "grant_system_privilege", "grant_system_privilege_to_users", "grant_system_privileges",
             "grant_user_with_admin", "grant_user_with_grant", "grant_user_without_hostname", "revoke_all_system_privileges", "revoke_all_object_privileges", "revoke_object_privilege",
             "revoke_object_privilege_column", "revoke_object_privilege_from_users", "revoke_object_privileges", "revoke_program", "revoke_role", "revoke_role_from_user", "revoke_roles_from_programs",
-            "revoke_system_privilege_from_users", "revoke_system_privilege", "revoke_system_privileges", "revoke_user_from", "revoke_user_without_hostname", "select_with_expressions_in_projection",
-            "select_with_model_in", "set_all_expect_roles", "set_all_expect_role"));
+            "revoke_system_privilege_from_users", "revoke_system_privilege", "revoke_system_privileges", "revoke_user_from", "revoke_user_without_hostname"));
     // CHECKSTYLE:ON
     
     @ParameterizedTest(name = "{0} ({1}) -> {2}")

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -5063,6 +5063,9 @@
             <column-projection name="order_id_value" start-index="7" stop-index="20" />
             <column-projection name="order_item_id_value" start-index="22" stop-index="40" />
         </projections>
+        <model start-index="120" stop-index="236">
+            <cell-assignment-column name="order_id_value" start-index="211" stop-index="224"/>
+        </model>
     </select>
     
     <select sql-case-id="select_with_dollar_parameter_for_postgresql" parameters="1, 12" >
@@ -7342,8 +7345,147 @@
             </expression-projection>
         </projections>
         <from>
-            <simple-table alias="aWHERE" name="employee" start-index="88" stop-index="102" literal-start-index="88" literal-stop-index="102" />
+            <simple-table alias="a" name="employee" start-index="88" stop-index="97"/>
         </from>
+        <where start-index="99" stop-index="306">
+            <expr>
+                <binary-operation-expression start-index="105" stop-index="306">
+                    <operator>AND</operator>
+                    <left>
+                        <binary-operation-expression start-index="105" stop-index="169">
+                            <operator>AND</operator>
+                            <left>
+                                <binary-operation-expression start-index="105" stop-index="124">
+                                    <operator>=</operator>
+                                    <left>
+                                        <function text="nvl(disabled, 0)" function-name="nvl" start-index="105" stop-index="120">
+                                            <parameter>
+                                                <column name="disabled" start-index="109" stop-index="116"/>
+                                            </parameter>
+                                            <parameter>
+                                                <literal-expression value="0" start-index="119" stop-index="119"/>
+                                            </parameter>
+                                        </function>
+                                    </left>
+                                    <right>
+                                        <literal-expression value="1" start-index="124" stop-index="124"/>
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <right>
+                                <between-expression start-index="131" stop-index="169">
+                                    <left>
+                                        <column name="enddate" start-index="131" stop-index="137"/>
+                                    </left>
+                                    <between-expr>
+                                        <column name="term" start-index="147" stop-index="150"/>
+                                    </between-expr>
+                                    <and-expr>
+                                        <function text="last_day(term)" function-name="last_day" start-index="156" stop-index="169">
+                                            <parameter>
+                                                <column name="term" start-index="165" stop-index="168"/>
+                                            </parameter>
+                                        </function>
+                                    </and-expr>
+                                </between-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <right>
+                        <subquery start-index="176" stop-index="306">
+                            <select>
+                                <projections start-index="191" stop-index="191">
+                                    <expression-projection text="1" start-index="191" stop-index="191"/>
+                                </projections>
+                                <from start-index="198" stop-index="203">
+                                    <simple-table name="post" start-index="198" stop-index="203" alias="d"/>
+                                </from>
+                                <where start-index="205" stop-index="305">
+                                    <expr>
+                                        <binary-operation-expression start-index="211" stop-index="305">
+                                            <operator>AND</operator>
+                                            <left>
+                                                <binary-operation-expression start-index="211" stop-index="277">
+                                                    <operator>AND</operator>
+                                                    <left>
+                                                        <binary-operation-expression start-index="211" stop-index="253">
+                                                            <operator>AND</operator>
+                                                            <left>
+                                                                <binary-operation-expression start-index="211" stop-index="227">
+                                                                    <operator>=</operator>
+                                                                    <left>
+                                                                        <column name="orgid" start-index="211" stop-index="217">
+                                                                            <owner name="a" start-index="211" stop-index="211"/>
+                                                                        </column>
+                                                                    </left>
+                                                                    <right>
+                                                                        <column name="orgid" start-index="221" stop-index="227">
+                                                                            <owner name="d" start-index="221" stop-index="221"/>
+                                                                        </column>
+                                                                    </right>
+                                                                </binary-operation-expression>
+                                                            </left>
+                                                            <right>
+                                                                <binary-operation-expression start-index="235" stop-index="253">
+                                                                    <operator>=</operator>
+                                                                    <left>
+                                                                        <column name="postid" start-index="235" stop-index="242">
+                                                                            <owner name="a" start-index="235" stop-index="235"/>
+                                                                        </column>
+                                                                    </left>
+                                                                    <right>
+                                                                        <column name="postid" start-index="246" stop-index="253">
+                                                                            <owner name="d" start-index="246" stop-index="246"/>
+                                                                        </column>
+                                                                    </right>
+                                                                </binary-operation-expression>
+                                                            </right>
+                                                        </binary-operation-expression>
+                                                    </left>
+                                                    <right>
+                                                        <binary-operation-expression start-index="261" stop-index="277">
+                                                            <operator>!=</operator>
+                                                            <left>
+                                                                <column name="title" start-index="261" stop-index="267">
+                                                                    <owner name="d" start-index="261" stop-index="261"/>
+                                                                </column>
+                                                            </left>
+                                                            <right>
+                                                                <literal-expression value="TEST" start-index="272" stop-index="277"/>
+                                                            </right>
+                                                        </binary-operation-expression>
+                                                    </right>
+                                                </binary-operation-expression>
+                                            </left>
+                                            <right>
+                                                <binary-operation-expression start-index="285" stop-index="305">
+                                                    <operator>!=</operator>
+                                                    <left>
+                                                        <function text="nvl(d.postid, 0)" start-index="285" stop-index="300" function-name="nvl">
+                                                            <parameter>
+                                                                <column name="postid" start-index="289" stop-index="296">
+                                                                    <owner name="d" start-index="289" stop-index="289"/>
+                                                                </column>
+                                                            </parameter>
+                                                            <parameter>
+                                                                <literal-expression value="0" start-index="299" stop-index="299"/>
+                                                            </parameter>
+                                                        </function>
+                                                    </left>
+                                                    <right>
+                                                        <literal-expression value="0" start-index="305" stop-index="305"/>
+                                                    </right>
+                                                </binary-operation-expression>
+                                            </right>
+                                        </binary-operation-expression>
+                                    </expr>
+                                </where>
+                            </select>
+                        </subquery>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
     </select>
     <select sql-case-id="select_with_custom_table_function">
         <projections start-index="7" stop-index="18" literal-start-index="7" literal-stop-index="18">

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -225,7 +225,7 @@
     <sql-case id="select_with_collection_table" value="SELECT VALUE(p) FROM warehouses w, TABLE(XMLSEQUENCE(EXTRACT(warehouse_spec, '/Warehouse/*'))) p;" db-types="Oracle" />
     <sql-case id="select_with_group_by_and_having" value="select cfg_name from bmsql_config group by cfg_name having cfg_name='1';" db-types="openGauss" />
     <sql-case id="select_with_to_date_function" value="SELECT TO_DATE('Febuary 15, 2016, 11:00 A.M.' DEFAULT 'January 01, 2016 12:00 A.M.' ON CONVERSION ERROR, 'Month dd, YYYY, HH:MI A.M.') FROM DUAL;" db-types="Oracle" />
-    <sql-case id="select_with_expressions_in_projection" value="SELECT ((a.enddate - term + term2 + 1) / (last_day(term) - term + 1)) cnt, a.empid FROM employee aWHERE nvl(disabled, 0) = 1  AND enddate BETWEEN term AND last_day(term)  AND EXISTS (SELECT 1 FROM post d WHERE a.orgid = d.orgid   AND a.postid = d.postid   AND d.title != 'TEST'   AND nvl(d.postid, 0) != 0)" db-types="Oracle" />
+    <sql-case id="select_with_expressions_in_projection" value="SELECT ((a.enddate - term + term2 + 1) / (last_day(term) - term + 1)) cnt, a.empid FROM employee a WHERE nvl(disabled, 0) = 1  AND enddate BETWEEN term AND last_day(term)  AND EXISTS (SELECT 1 FROM post d WHERE a.orgid = d.orgid   AND a.postid = d.postid   AND d.title != 'TEST'   AND nvl(d.postid, 0) != 0)" db-types="Oracle" />
     <sql-case id="select_with_custom_table_function" value="SELECT COUNT(empid) FROM EMPLOYEE b, custom_function(b.orgid) a WHERE a.postid = b.postid" db-types="Oracle" />
     <sql-case id="select_numeric_operator" value="SELECT 5! AS RESULT;" db-types="openGauss" />
     <sql-case id="select_with_custom_distinct_function" value="select custom_concat(distinct a.P1) From TEST a;" db-types="Oracle" />


### PR DESCRIPTION
Link #29988.

Changes proposed in this pull request:
  - Fix oracle parse show roles error when add EOF
  - Fix cases
      + select_with_expressions_in_projection
      + select_with_model_in
      + set_all_expect_roles
      + set_all_expect_role cases

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
