### PR TITLE
Fixes ShardingSphereURLLoadEngineTest failure on Windows 11

### DIFF
--- a/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/ShardingSphereURLLoadEngineTest.java
+++ b/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/ShardingSphereURLLoadEngineTest.java
@@ -33,7 +33,8 @@ class ShardingSphereURLLoadEngineTest {
     
     @Test
     void assertLoadContent() {
-        String content = "foo_driver_fixture_db=2\nstorage_unit_count=2\n";
+        final String lineSeparator = System.lineSeparator();
+        String content = "foo_driver_fixture_db=2" + lineSeparator + "storage_unit_count=2" + lineSeparator;
         ShardingSphereURLLoader urlLoader = mock(ShardingSphereURLLoader.class);
         when(urlLoader.load(any(), any())).thenReturn(content);
         try (MockedStatic<TypedSPILoader> typedSPILoaderMockedStatic = mockStatic(TypedSPILoader.class)) {


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/actions/runs/8085008196/job/22091618196.

Changes proposed in this pull request:
  - Fixes ShardingSphereURLLoadEngineTest failure on Windows 11 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
