### PR TITLE
Fixes ClasspathResourceDirectoryReaderTest failure on Windows 11

### DIFF
--- a/infra/util/src/test/java/org/apache/shardingsphere/infra/util/directory/ClasspathResourceDirectoryReaderTest.java
+++ b/infra/util/src/test/java/org/apache/shardingsphere/infra/util/directory/ClasspathResourceDirectoryReaderTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.util.directory;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -41,6 +42,8 @@ class ClasspathResourceDirectoryReaderTest {
     void read() {
         List<String> resourceNameList = ClasspathResourceDirectoryReader.read("yaml").collect(Collectors.toList());
         assertThat(resourceNameList.size(), is(4));
-        assertThat(resourceNameList, hasItems("yaml/accepted-class.yaml", "yaml/customized-obj.yaml", "yaml/empty-config.yaml", "yaml/shortcuts-fixture.yaml"));
+        final String separator = File.separator;
+        assertThat(resourceNameList, hasItems("yaml" + separator + "accepted-class.yaml", "yaml" + separator + "customized-obj.yaml", "yaml" + separator + "empty-config.yaml",
+                "yaml" + separator + "shortcuts-fixture.yaml"));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/actions/runs/8100557441/job/22138852967 .

Changes proposed in this pull request:
  - Fixes ClasspathResourceDirectoryReaderTest failure on Windows 11.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
