### PR TITLE
Bump pgjbdc version to prevent CVE from being passed in Proxy

### DIFF
--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -332,7 +332,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     commons-compiler 3.1.9: https://github.com/janino-compiler/janino, BSD-3-Clause
     janino 3.1.9: https://github.com/janino-compiler/janino, BSD-3-Clause
     opengauss-jdbc 3.1.0-og: https://gitee.com/opengauss/openGauss-connector-jdbc, BSD-2-Clause
-    postgresql 42.4.3: https://github.com/pgjdbc/pgjdbc, BSD-2-Clause
+    postgresql 42.7.2: https://github.com/pgjdbc/pgjdbc, BSD-2-Clause
     protobuf-java 3.21.12: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
     protobuf-java-util 3.21.12: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
     jts-io-common 1.19.0: https://github.com/locationtech/jts, EDL 1.0

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/narayana.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/narayana.cn.md
@@ -13,8 +13,8 @@ Apache ShardingSphere 提供 XA 事务，集成了 Narayana 的实现。
 
 ```xml
 <properties>
-    <narayana.version>5.12.4.Final</narayana.version>
-    <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
+    <narayana.version>5.12.7.Final</narayana.version>
+    <jboss-transaction-spi.version>7.6.1.Final</jboss-transaction-spi.version>
     <jboss-logging.version>3.2.1.Final</jboss-logging.version>
 </properties>
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/narayana.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/narayana.en.md
@@ -13,8 +13,8 @@ Introducing Maven dependency
 
 ```xml
 <properties>
-    <narayana.version>5.12.4.Final</narayana.version>
-    <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
+    <narayana.version>5.12.7.Final</narayana.version>
+    <jboss-transaction-spi.version>7.6.1.Final</jboss-transaction-spi.version>
     <jboss-logging.version>3.2.1.Final</jboss-logging.version>
 </properties>
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/transaction.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/transaction.cn.md
@@ -38,14 +38,14 @@ transaction:
 手动添加 Narayana 相关依赖：
 
 ```
-jta-5.12.4.Final.jar
-arjuna-5.12.4.Final.jar
-common-5.12.4.Final.jar
+jta-5.12.7.Final.jar
+arjuna-5.12.7.Final.jar
+common-5.12.7.Final.jar
 jboss-connector-api_1.7_spec-1.0.0.Final.jar
 jboss-logging-3.2.1.Final.jar
 jboss-transaction-api_1.2_spec-1.0.0.Alpha3.jar
-jboss-transaction-spi-7.6.0.Final.jar
-narayana-jts-integration-5.12.4.Final.jar
+jboss-transaction-spi-7.6.1.Final.jar
+narayana-jts-integration-5.12.7.Final.jar
 shardingsphere-transaction-xa-narayana-x.x.x-SNAPSHOT.jar
 ```
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/transaction.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/transaction.en.md
@@ -38,14 +38,14 @@ transaction:
 To manually add Narayana-related dependencies:
 
 ```
-jta-5.12.4.Final.jar
-arjuna-5.12.4.Final.jar
-common-5.12.4.Final.jar
+jta-5.12.7.Final.jar
+arjuna-5.12.7.Final.jar
+common-5.12.7.Final.jar
 jboss-connector-api_1.7_spec-1.0.0.Final.jar
 jboss-logging-3.2.1.Final.jar
 jboss-transaction-api_1.2_spec-1.0.0.Alpha3.jar
-jboss-transaction-spi-7.6.0.Final.jar
-narayana-jts-integration-5.12.4.Final.jar
+jboss-transaction-spi-7.6.1.Final.jar
+narayana-jts-integration-5.12.7.Final.jar
 shardingsphere-transaction-xa-narayana-x.x.x-SNAPSHOT.jar
 ```
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/dependencies-download/add_Narayana_dependency.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/dependencies-download/add_Narayana_dependency.cn.md
@@ -9,14 +9,14 @@ weight = 2
 
 ### jar 文件下载地址
 
-- [arjuna-5.12.4.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/arjunacore/arjuna/5.12.4.Final/arjuna-5.12.4.Final.jar)
-- [common-5.12.4.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/common/5.12.4.Final/common-5.12.4.Final.jar)
+- [arjuna-5.12.7.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/arjunacore/arjuna/5.12.7.Final/arjuna-5.12.7.Final.jar)
+- [common-5.12.7.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/common/5.12.7.Final/common-5.12.7.Final.jar)
 - [jboss-connector-api_1.7_spec-1.0.0.Final.jar](https://repo1.maven.org/maven2/org/jboss/spec/javax/resource/jboss-connector-api_1.7_spec/1.0.0.Final/jboss-connector-api_1.7_spec-1.0.0.Final.jar)
 - [jboss-logging-3.2.1.Final.jar](https://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.2.1.Final/jboss-logging-3.2.1.Final.jar)
 - [jboss-transaction-api_1.2_spec-1.0.0.Alpha3.jar](https://repo1.maven.org/maven2/org/jboss/spec/javax/transaction/jboss-transaction-api_1.2_spec/1.0.0.Alpha3/jboss-transaction-api_1.2_spec-1.0.0.Alpha3.jar)
-- [jboss-transaction-spi-7.6.0.Final.jar](https://repo1.maven.org/maven2/org/jboss/jboss-transaction-spi/7.6.0.Final/jboss-transaction-spi-7.6.0.Final.jar)
-- [jta-5.12.4.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/5.12.4.Final/jta-5.12.4.Final.jar)
-- [narayana-jts-integration-5.12.4.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/jts/narayana-jts-integration/5.12.4.Final/narayana-jts-integration-5.12.4.Final.jar)
+- [jboss-transaction-spi-7.6.1.Final.jar](https://repo1.maven.org/maven2/org/jboss/jboss-transaction-spi/7.6.1.Final/jboss-transaction-spi-7.6.1.Final.jar)
+- [jta-5.12.7.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/5.12.7.Final/jta-5.12.7.Final.jar)
+- [narayana-jts-integration-5.12.7.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/jts/narayana-jts-integration/5.12.7.Final/narayana-jts-integration-5.12.7.Final.jar)
 - [shardingsphere-transaction-xa-narayana.jar](https://mvnrepository.com/artifact/org.apache.shardingsphere/shardingsphere-transaction-xa-narayana)
 
 请根据 `proxy` 版本下载对应 `shardingsphere-transaction-xa-narayana.jar` 文件。

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/dependencies-download/add_Narayana_dependency.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/dependencies-download/add_Narayana_dependency.en.md
@@ -9,14 +9,14 @@ Adding Narayana dependencies requires downloading the following jar files and ad
 
 ### jar file downloads
 
-- [arjuna-5.12.4.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/arjunacore/arjuna/5.12.4.Final/arjuna-5.12.4.Final.jar)
-- [common-5.12.4.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/common/5.12.4.Final/common-5.12.4.Final.jar)
+- [arjuna-5.12.7.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/arjunacore/arjuna/5.12.7.Final/arjuna-5.12.7.Final.jar)
+- [common-5.12.7.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/common/5.12.7.Final/common-5.12.7.Final.jar)
 - [jboss-connector-api_1.7_spec-1.0.0.Final.jar](https://repo1.maven.org/maven2/org/jboss/spec/javax/resource/jboss-connector-api_1.7_spec/1.0.0.Final/jboss-connector-api_1.7_spec-1.0.0.Final.jar)
 - [jboss-logging-3.2.1.Final.jar](https://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.2.1.Final/jboss-logging-3.2.1.Final.jar)
 - [jboss-transaction-api_1.2_spec-1.0.0.Alpha3.jar](https://repo1.maven.org/maven2/org/jboss/spec/javax/transaction/jboss-transaction-api_1.2_spec/1.0.0.Alpha3/jboss-transaction-api_1.2_spec-1.0.0.Alpha3.jar)
-- [jboss-transaction-spi-7.6.0.Final.jar](https://repo1.maven.org/maven2/org/jboss/jboss-transaction-spi/7.6.0.Final/jboss-transaction-spi-7.6.0.Final.jar)
-- [jta-5.12.4.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/5.12.4.Final/jta-5.12.4.Final.jar)
-- [narayana-jts-integration-5.12.4.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/jts/narayana-jts-integration/5.12.4.Final/narayana-jts-integration-5.12.4.Final.jar)
+- [jboss-transaction-spi-7.6.1.Final.jar](https://repo1.maven.org/maven2/org/jboss/jboss-transaction-spi/7.6.1.Final/jboss-transaction-spi-7.6.1.Final.jar)
+- [jta-5.12.7.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/jta/jta/5.12.7.Final/jta-5.12.7.Final.jar)
+- [narayana-jts-integration-5.12.7.Final.jar](https://repo1.maven.org/maven2/org/jboss/narayana/jts/narayana-jts-integration/5.12.7.Final/narayana-jts-integration-5.12.7.Final.jar)
 - [shardingsphere-transaction-xa-narayana.jar](https://mvnrepository.com/artifact/org.apache.shardingsphere/shardingsphere-transaction-xa-narayana)
 
 Please download the corresponding `shardingsphere-transaction-xa-narayana.jar` file according to the `proxy` version.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -42,7 +42,7 @@
         <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
         <hikari-cp.version>3.4.2</hikari-cp.version>
         <mysql-connector-java.version>8.0.31</mysql-connector-java.version>
-        <postgresql.version>42.4.3</postgresql.version>
+        <postgresql.version>42.7.2</postgresql.version>
         <h2.version>2.2.224</h2.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.2.13</logback.version>
@@ -64,7 +64,7 @@
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <freemarker.version>2.3.31</freemarker.version>
-        <snakeyaml.version>1.33</snakeyaml.version>
+        <snakeyaml.version>2.2</snakeyaml.version>
         <flatten-maven-plugin.version>1.2.5</flatten-maven-plugin.version>
         
         <javadocExecutable>${java.home}/../bin/javadoc</javadocExecutable>

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,8 @@
         <glassfish-jaxb.version>2.3.9</glassfish-jaxb.version>
         
         <atomikos.version>6.0.0</atomikos.version>
-        <narayana.version>5.12.4.Final</narayana.version>
-        <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
+        <narayana.version>5.12.7.Final</narayana.version>
+        <jboss-transaction-spi.version>7.6.1.Final</jboss-transaction-spi.version>
         <jboss-logging.version>3.2.1.Final</jboss-logging.version>
         <seata.version>2.0.0</seata.version>
         
@@ -117,7 +117,7 @@
         
         <lombok.version>1.18.30</lombok.version>
         
-        <postgresql.version>42.4.3</postgresql.version>
+        <postgresql.version>42.7.2</postgresql.version>
         <mysql-connector-java.version>8.0.31</mysql-connector-java.version>
         <mssql.version>6.1.7.jre8-preview</mssql.version>
         <hbase.client.version>1.7.1</hbase.client.version>


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/security/dependabot/77 .

Changes proposed in this pull request:
  - Bump pgjbdc version to prevent CVE-2024-1597 from being passed in Proxy. Synchronously update the dependencies involved in example. It seems that dependabot has some issues and it does not open PRs for dependencies with full CVE scores.
    - Fixes https://github.com/apache/shardingsphere/security/dependabot/76 . 
    - Fixes #24450 . See CVE-2022-1471.
   -  As part of streamlining the content of #27976, updating narayana will be independently moved onto this PR.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
