### PR TITLE
Add coverage for SchemaMetaDataReviseEngineTest

### DIFF
--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/schema/SchemaMetaDataReviseEngineTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/schema/SchemaMetaDataReviseEngineTest.java
@@ -18,13 +18,21 @@
 package org.apache.shardingsphere.infra.metadata.database.schema.reviser.schema;
 
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.metadata.data.model.ColumnMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.data.model.ConstraintMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.data.model.IndexMetaData;
 import org.apache.shardingsphere.infra.database.core.metadata.data.model.SchemaMetaData;
 import org.apache.shardingsphere.infra.database.core.metadata.data.model.TableMetaData;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.rule.builder.fixture.FixtureGlobalRule;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -41,4 +49,24 @@ class SchemaMetaDataReviseEngineTest {
         assertThat(actual.getName(), is(schemaMetaData.getName()));
         assertThat(actual.getTables(), is(schemaMetaData.getTables()));
     }
+    
+    @Test
+    void assertReviseWithMetaDataReviseEntry() {
+        SchemaMetaData schemaMetaData = new SchemaMetaData("expected", Collections.singletonList(createTableMetaData()));
+        SchemaMetaData actual = new SchemaMetaDataReviseEngine(Collections.singleton(new FixtureGlobalRule()),
+                new ConfigurationProperties(new Properties()), mock(DatabaseType.class), mock(DataSource.class))
+                        .revise(schemaMetaData);
+        assertThat(actual.getName(), is(schemaMetaData.getName()));
+        assertThat(actual.getTables(), is(schemaMetaData.getTables()));
+    }
+    
+    private TableMetaData createTableMetaData() {
+        Collection<ColumnMetaData> columns = new LinkedHashSet<>(Arrays.asList(new ColumnMetaData("id", Types.INTEGER, true, true, true, true, false, false),
+                new ColumnMetaData("pwd_cipher", Types.VARCHAR, false, false, true, true, false, false),
+                new ColumnMetaData("pwd_like", Types.VARCHAR, false, false, true, true, false, false)));
+        IndexMetaData indexMetaData = new IndexMetaData("index_name");
+        ConstraintMetaData constraintMetaData = new ConstraintMetaData("constraint_name", "table_name_2");
+        return new TableMetaData("table_name", columns, Collections.singletonList(indexMetaData), Collections.singleton(constraintMetaData));
+    }
+    
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/rule/builder/fixture/FixtureMetaDataRevise.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/rule/builder/fixture/FixtureMetaDataRevise.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.rule.builder.fixture;
+
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.metadata.database.schema.reviser.MetaDataReviseEntry;
+import org.apache.shardingsphere.infra.metadata.database.schema.reviser.schema.SchemaTableAggregationReviser;
+
+import java.util.Optional;
+
+public final class FixtureMetaDataRevise implements MetaDataReviseEntry<FixtureGlobalRule> {
+    
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+    
+    @Override
+    public Class<FixtureGlobalRule> getTypeClass() {
+        return FixtureGlobalRule.class;
+    }
+    
+    @Override
+    public Optional<SchemaTableAggregationReviser<FixtureGlobalRule>> getSchemaTableAggregationReviser(final ConfigurationProperties props) {
+        return Optional.of(new FixtureSchemaTableAggregationReviser());
+    }
+}

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/rule/builder/fixture/FixtureSchemaTableAggregationReviser.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/rule/builder/fixture/FixtureSchemaTableAggregationReviser.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.rule.builder.fixture;
+
+import org.apache.shardingsphere.infra.database.core.metadata.data.model.TableMetaData;
+import org.apache.shardingsphere.infra.metadata.database.schema.reviser.schema.SchemaTableAggregationReviser;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+public class FixtureSchemaTableAggregationReviser implements SchemaTableAggregationReviser<FixtureGlobalRule> {
+    
+    private final Collection<TableMetaData> tables = new LinkedList<>();
+    
+    @Override
+    public void add(final TableMetaData metaData) {
+        tables.add(metaData);
+    }
+    
+    @Override
+    public Collection<TableMetaData> aggregate(final FixtureGlobalRule rule) {
+        return tables;
+    }
+}

--- a/infra/common/src/test/resources/META-INF/services/org.apache.shardingsphere.infra.metadata.database.schema.reviser.MetaDataReviseEntry
+++ b/infra/common/src/test/resources/META-INF/services/org.apache.shardingsphere.infra.metadata.database.schema.reviser.MetaDataReviseEntry
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.infra.rule.builder.fixture.FixtureMetaDataRevise


### PR DESCRIPTION
Fixes #29856.

Changes proposed in this pull request:
  - Add test when SchemaMetaDataReviseEngine use SchemaTableAggregationReviser

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
