### PR TITLE
Fixes #30361 causing ClasspathResourceDirectoryReaderTest to fail on Windows 11

### DIFF
--- a/infra/util/src/test/java/org/apache/shardingsphere/infra/util/directory/ClasspathResourceDirectoryReaderTest.java
+++ b/infra/util/src/test/java/org/apache/shardingsphere/infra/util/directory/ClasspathResourceDirectoryReaderTest.java
@@ -45,13 +45,13 @@ class ClasspathResourceDirectoryReaderTest {
         assertThat(resourceNameList.size(), is(5));
         final String separator = File.separator;
         assertThat(resourceNameList, hasItems("yaml" + separator + "accepted-class.yaml", "yaml" + separator + "customized-obj.yaml", "yaml" + separator + "empty-config.yaml",
-                "yaml" + separator + "shortcuts-fixture.yaml", "yaml/fixture/fixture.yaml"));
+                "yaml" + separator + "shortcuts-fixture.yaml", "yaml" + separator + "fixture" + separator + "fixture.yaml"));
     }
     
     @Test
     void assertReadNestedTest() {
         List<String> resourceNameList = ClasspathResourceDirectoryReader.read("yaml/fixture").collect(Collectors.toList());
         assertThat(resourceNameList.size(), is(1));
-        assertThat(resourceNameList, hasItems("yaml/fixture/fixture.yaml"));
+        assertThat(resourceNameList, hasItems("yaml/fixture" + File.separator + "fixture.yaml"));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/actions/runs/8124502923/job/22206061492 .

Changes proposed in this pull request:
  - Fixes #30361 causing ClasspathResourceDirectoryReaderTest to fail on Windows 11.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
