### PR TITLE
Refactor EspressoInlineExpressionParser to use Truffle Context with life cycle

### DIFF
--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -240,7 +240,7 @@ The text of each license is the standard Apache 2.0 license.
     failsafe 2.4.4: https://github.com/jhalterman/failsafe, Apache 2.0
     failureaccess 1.0.1: https://github.com/google/guava, Apache 2.0
     freemarker 2.3.31: https://freemarker.apache.org/, Apache 2.0
-    groovy 4.0.10: https://groovy.apache.org/, Apache 2.0
+    groovy 4.0.19: https://groovy.apache.org/, Apache 2.0
     grpc-api 1.58.0: https://github.com/grpc/grpc-java, Apache 2.0
     grpc-context 1.58.0: https://github.com/grpc/grpc-java, Apache 2.0
     grpc-core 1.58.0: https://github.com/grpc/grpc-java, Apache 2.0

--- a/infra/expr/type/espresso/pom.xml
+++ b/infra/expr/type/espresso/pom.xml
@@ -42,12 +42,6 @@
             <artifactId>shardingsphere-infra-util</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-test-util</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
         
         <dependency>
             <groupId>org.graalvm.polyglot</groupId>

--- a/infra/expr/type/espresso/src/main/java/org/apache/shardingsphere/infra/expr/espresso/ReflectContext.java
+++ b/infra/expr/type/espresso/src/main/java/org/apache/shardingsphere/infra/expr/espresso/ReflectContext.java
@@ -23,7 +23,7 @@ import lombok.SneakyThrows;
  * Reflect Context.
  * Avoid using JDK21 bytecode during compilation. Refer to `org.graalvm.polyglot.Context`.
  */
-public final class ReflectContext {
+public final class ReflectContext implements AutoCloseable {
     
     private static final String CONTEXT_CLASS_NAME = "org.graalvm.polyglot.Context";
     
@@ -48,7 +48,7 @@ public final class ReflectContext {
     public ReflectContext(final String javaClassPath) {
         Object builderInstance = Class.forName(CONTEXT_CLASS_NAME)
                 .getMethod("newBuilder", String[].class)
-                .invoke(null, (Object) new String[]{});
+                .invoke(null, (Object) new String[0]);
         builderInstance = builderInstance.getClass()
                 .getMethod("allowAllAccess", boolean.class)
                 .invoke(builderInstance, true);
@@ -72,5 +72,11 @@ public final class ReflectContext {
                 .getMethod("getBindings", String.class)
                 .invoke(contextInstance, languageId);
         return new ReflectValue(valueInstance);
+    }
+    
+    @Override
+    @SneakyThrows
+    public void close() {
+        Class.forName(CONTEXT_CLASS_NAME).getMethod("close").invoke(contextInstance);
     }
 }

--- a/infra/expr/type/espresso/src/main/java/org/apache/shardingsphere/infra/expr/espresso/ReflectValue.java
+++ b/infra/expr/type/espresso/src/main/java/org/apache/shardingsphere/infra/expr/espresso/ReflectValue.java
@@ -19,6 +19,8 @@ package org.apache.shardingsphere.infra.expr.espresso;
 
 import lombok.SneakyThrows;
 
+import java.util.stream.Stream;
+
 /**
  * Reflect Value.
  * Avoid using JDK21 bytecode during compilation. Refer to `org.graalvm.polyglot.Value`.
@@ -55,7 +57,7 @@ public class ReflectValue {
     public ReflectValue newInstance(final Object... arguments) {
         Object resultValueInstance = Class.forName(VALUE_CLASS_NAME)
                 .getMethod("newInstance", Object[].class)
-                .invoke(valueInstance, (Object) arguments);
+                .invoke(valueInstance, new Object[]{Stream.of(arguments).toArray()});
         return new ReflectValue(resultValueInstance);
     }
     

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <json-smart.version>2.4.10</json-smart.version>
         <accessors-smart.version>2.4.9</accessors-smart.version>
         <asm.version>9.3</asm.version>
-        <groovy.version>4.0.10</groovy.version>
+        <groovy.version>4.0.19</groovy.version>
         <freemarker.version>2.3.31</freemarker.version>
         <bytebuddy.version>1.14.8</bytebuddy.version>
         


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/actions/runs/8144874341/job/22259936246 .

Changes proposed in this pull request:
  - Refactor EspressoInlineExpressionParser to use Truffle Context with life cycle. Logically no Context instance should be retained here.
  - Bump Groovy version to 4.0.19 to try to get around unit test timeouts. 
  - Prevent related unit tests from running on stock JDK21. For https://github.com/apache/shardingsphere/actions/runs/8144874341/job/22259936246 . This problem seems quite strange, because https://github.com/apache/shardingsphere/actions/runs/8039815962/job/21957220025 from a week ago is still working fine. Maybe there is something wrong on the GraalVM Truffle side. This requires additional investigation.
  - Fix incorrect file separator used by espresso classpath, although on Windows 11 this module may only run under MSVC-supported Nativve Image.
  - Prevent Groovy 5.0 overloading of specific method signatures via `method descriptor`. Reference https://www.graalvm.org/jdk21/reference-manual/java-on-truffle/interoperability/#embedding-in-host-java .


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
