### PR TITLE
Add stringtype=unspecified in openGauss jdbc url to solve passthrough uuid insert exception

### DIFF
--- a/test/e2e/sql/src/test/resources/env/scenario/passthrough/proxy/conf/opengauss/database-passthrough.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/passthrough/proxy/conf/opengauss/database-passthrough.yaml
@@ -19,7 +19,7 @@ databaseName: passthrough
 
 dataSources:
   passthrough:
-    url: jdbc:opengauss://opengauss.passthrough.host:5432/passthrough
+    url: jdbc:opengauss://opengauss.passthrough.host:5432/passthrough?stringtype=unspecified
     username: test_user
     password: Test@123
     connectionTimeoutMilliseconds: 30000


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Add stringtype=unspecified in openGauss jdbc url to solve passthrough uuid insert exception

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
