### PR TITLE
Remove encrypt and encrypt_and_readwrite_splitting non-standard tables

### DIFF
--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-join.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-join.xml
@@ -104,8 +104,8 @@
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
     
-    <!-- TODO add encrypt scenario when use standard table -->
-    <test-case sql="SELECT * FROM t_single_table s INNER JOIN t_user o ON s.id = o.user_id" db-types="MySQL,Oracle,SQLServer" scenario-types="dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+    <!-- TODO add encrypt,encrypt_and_readwrite_splitting scenario when use standard table -->
+    <test-case sql="SELECT * FROM t_single_table s INNER JOIN t_user o ON s.id = o.user_id" db-types="MySQL,Oracle,SQLServer" scenario-types="dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
     

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-join.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-join.xml
@@ -104,7 +104,8 @@
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
     
-    <test-case sql="SELECT * FROM t_single_table s INNER JOIN t_user o ON s.id = o.user_id" db-types="MySQL,Oracle,SQLServer" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+    <!-- TODO add encrypt scenario when use standard table -->
+    <test-case sql="SELECT * FROM t_single_table s INNER JOIN t_user o ON s.id = o.user_id" db-types="MySQL,Oracle,SQLServer" scenario-types="dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
     
@@ -121,10 +122,10 @@
         <assertion parameters="1000:int" expected-data-source-name="read_dataset" />
     </test-case>
     
-    <!-- TODO add dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting scenario when use standard t_user table in issue#21286 -->
-    <test-case sql="SELECT * FROM t_user u INNER JOIN t_user_item m ON u.user_id = m.user_id WHERE u.user_id IN (10, 11)" scenario-types="encrypt">
+    <!-- TODO add dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting,encrypt scenario when use standard t_user table in issue#21286 -->
+    <!--<test-case sql="SELECT * FROM t_user u INNER JOIN t_user_item m ON u.user_id = m.user_id WHERE u.user_id IN (10, 11)" scenario-types="encrypt">
         <assertion expected-data-source-name="read_dataset" />
-    </test-case>
+    </test-case>-->
     
     <test-case sql="SELECT * FROM t_merchant m1 INNER JOIN t_merchant m2 ON m1.merchant_id = m2.merchant_id WHERE m2.business_code LIKE '%18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator percentage wildcard in select join statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in select join statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />

--- a/test/e2e/sql/src/test/resources/cases/rql/rql-integration-count.xml
+++ b/test/e2e/sql/src/test/resources/cases/rql/rql-integration-count.xml
@@ -17,8 +17,8 @@
   -->
 
 <integration-test-cases>
-    <!-- TODO add db,tbl,dbtbl_with_readwrite_splitting scenario when use standard table -->
-    <test-case sql="COUNT SINGLE TABLE" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+    <!-- TODO add db,tbl,dbtbl_with_readwrite_splitting,encrypt scenario when use standard table -->
+    <test-case sql="COUNT SINGLE TABLE" scenario-types="dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
         <assertion expected-data-file="count_single_table.xml" />
     </test-case>
     

--- a/test/e2e/sql/src/test/resources/cases/rql/rql-integration-count.xml
+++ b/test/e2e/sql/src/test/resources/cases/rql/rql-integration-count.xml
@@ -17,8 +17,8 @@
   -->
 
 <integration-test-cases>
-    <!-- TODO add db,tbl,dbtbl_with_readwrite_splitting,encrypt scenario when use standard table -->
-    <test-case sql="COUNT SINGLE TABLE" scenario-types="dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+    <!-- TODO add db,tbl,dbtbl_with_readwrite_splitting,encrypt,encrypt_and_readwrite_splitting scenario when use standard table -->
+    <test-case sql="COUNT SINGLE TABLE" scenario-types="dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt">
         <assertion expected-data-file="count_single_table.xml" />
     </test-case>
     

--- a/test/e2e/sql/src/test/resources/cases/rql/rql-integration-show.xml
+++ b/test/e2e/sql/src/test/resources/cases/rql/rql-integration-show.xml
@@ -95,13 +95,13 @@
         <assertion expected-data-file="show_single_table_rules.xml" />
     </test-case>
     
-    <!-- TODO add db,tbl,dbtbl_with_readwrite_splitting scenario when use standard table -->
-    <test-case sql="SHOW SINGLE TABLE t_single_table" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+    <!-- TODO add db,tbl,dbtbl_with_readwrite_splitting,encrypt scenario when use standard table -->
+    <test-case sql="SHOW SINGLE TABLE t_single_table" scenario-types="dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
         <assertion expected-data-file="show_single_table.xml" />
     </test-case>
     
-    <!-- TODO add db,tbl,dbtbl_with_readwrite_splitting scenario when use standard table -->
-    <test-case sql="SHOW SINGLE TABLES" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+    <!-- TODO add db,tbl,dbtbl_with_readwrite_splitting,encrypt scenario when use standard table -->
+    <test-case sql="SHOW SINGLE TABLES" scenario-types="dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
         <assertion expected-data-file="show_single_tables.xml" />
     </test-case>
     

--- a/test/e2e/sql/src/test/resources/cases/rql/rql-integration-show.xml
+++ b/test/e2e/sql/src/test/resources/cases/rql/rql-integration-show.xml
@@ -95,13 +95,13 @@
         <assertion expected-data-file="show_single_table_rules.xml" />
     </test-case>
     
-    <!-- TODO add db,tbl,dbtbl_with_readwrite_splitting,encrypt scenario when use standard table -->
-    <test-case sql="SHOW SINGLE TABLE t_single_table" scenario-types="dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+    <!-- TODO add db,tbl,dbtbl_with_readwrite_splitting,encrypt,encrypt_and_readwrite_splitting scenario when use standard table -->
+    <test-case sql="SHOW SINGLE TABLE t_single_table" scenario-types="dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt">
         <assertion expected-data-file="show_single_table.xml" />
     </test-case>
     
-    <!-- TODO add db,tbl,dbtbl_with_readwrite_splitting,encrypt scenario when use standard table -->
-    <test-case sql="SHOW SINGLE TABLES" scenario-types="dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+    <!-- TODO add db,tbl,dbtbl_with_readwrite_splitting,encrypt,encrypt_and_readwrite_splitting scenario when use standard table -->
+    <test-case sql="SHOW SINGLE TABLES" scenario-types="dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt">
         <assertion expected-data-file="show_single_tables.xml" />
     </test-case>
     

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/dataset.xml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/dataset.xml
@@ -42,17 +42,6 @@
         <column name="user_telephone_like" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
-    <metadata data-nodes="encrypt.t_user_item">
-        <column name="item_id" type="numeric" />
-        <column name="user_id" type="numeric" />
-        <column name="status" type="varchar" />
-        <column name="creation_date" type="datetime" />
-    </metadata>
-    <metadata data-nodes="encrypt.t_single_table">
-        <column name="single_id" type="numeric" />
-        <column name="id" type="numeric" />
-        <column name="status" type="varchar" />
-    </metadata>
     <metadata data-nodes="encrypt.t_merchant">
         <column name="merchant_id" type="numeric" />
         <column name="country_id" type="numeric" />
@@ -183,10 +172,6 @@
     <row data-node="encrypt.t_order_item" values="290002, 2900, 29, 19, 1, 2017-08-08" />
     <row data-node="encrypt.t_order_item" values="290101, 2901, 29, 20, 1, 2017-08-08" />
     <row data-node="encrypt.t_order_item" values="290102, 2901, 29, 20, 1, 2017-08-08" />
-    <row data-node="encrypt.t_single_table" values="1, 10, init" />
-    <row data-node="encrypt.t_single_table" values="2, 11, init" />
-    <row data-node="encrypt.t_single_table" values="3, 12, init" />
-    <row data-node="encrypt.t_single_table" values="4, 13, init" />
     <row data-node="encrypt.t_user" values="10, sVq8Lmm+j6bZE5EKSilJEQ==, yi`mht`m, aQol0b6th65d0aXe+zFPsQ==, WM0fHOH91JNWnHTkiqBdyNmzk4uJ7CCz4mB1va9Ya1M=, kLjLJIMnfyHT2nA+viaoaQ==, 01454589811, 2017-08-08" />
     <row data-node="encrypt.t_user" values="11, fQ7IzBxKVuNHtUF6h6WSBg==, mhth, wuhmEKgdgrWQYt+Ev0hgGA==, svATu3uWv9KfiloWJeWx3A==, 0kDFxndQdzauFwL/wyCsNQ==, 01454589810, 2017-08-08" />
     <row data-node="encrypt.t_user" values="12, AQRWSlufQPog/b64YRhu6Q==, x`mhxt, x7A+2jq9B6DSOSFtSOibdA==, nHJv9e6NiClIuGHOjHLvCAq2ZLhWcqfQ8/EQnIqMx+g=, a/SzSJLapt5iBXvF2c9ycw==, 01454589811, 2017-08-08" />
@@ -217,26 +202,6 @@
     <row data-node="encrypt.t_user" values="37, aXS0VfnqHIAnOAtDjsF/9Q==, 伈嶱啴, bO/8ha1eS/H8/3DugjdOAQ==, fwyOxfHtLxNuSCFmghYiY0qMsgbpjg5UIo3xmJOLGu0=, 60fpnMdKCWeyKzxkdthn2Q==, 09101401454, 2017-08-08" />
     <row data-node="encrypt.t_user" values="38, 59/68izQEdnwNSueX1lPAA==, 伈乄, ilD/Tk7DUG4+EuznS1bNLg==, 2emhAeiXPr0kHbFrhYlM1dmzk4uJ7CCz4mB1va9Ya1M=, 60fpnMdKCWeyKzxkdthn2Q==, 09101401454, 2017-08-08" />
     <row data-node="encrypt.t_user" values="39, fn9LnNltUAOWO0F0iy0+Jw==, 伈妅, qe/WdUiSPP1RAsSSuejGJw==, zx2omwIbXHpEJeh8ta7HqQq2ZLhWcqfQ8/EQnIqMx+g=, 60fpnMdKCWeyKzxkdthn2Q==, 09101401454, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="100000, 10, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="110000, 11, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="120000, 12, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="130000, 13, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="140000, 14, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="150000, 15, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="160000, 16, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="170000, 17, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="180000, 18, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="190000, 19, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="200000, 20, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="210000, 21, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="220000, 22, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="230000, 23, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="240000, 24, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="250000, 25, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="260000, 26, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="270000, 27, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="280000, 28, init, 2017-08-08" />
-    <row data-node="encrypt.t_user_item" values="290000, 29, init, 2017-08-08" />
     <row data-node="encrypt.t_merchant" values="1, 86, tencent, k/LC4zsaZ+N6RgluwW+8BQ==, 95111110, hRoqv9Jw8ZFM6Zdt3PL1Aw==, 95011111110, 2017-08-08" />
     <row data-node="encrypt.t_merchant" values="2, 86, haier, RINN9TpLonpAT8bAdJmKbA==, 95111111, 9SCFkitrhrqandvIXg2U5Q==, 95011111111, 2017-08-08" />
     <row data-node="encrypt.t_merchant" values="3, 86, huawei, 3S6kkaTmrJNzCfuy07df4A==, 95111114, L1okJVzt5ixaGjd1fUmujA==, 95011111114, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/h2/01-actual-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/h2/01-actual-init.sql
@@ -18,15 +18,11 @@
 DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, user_telephone_cipher CHAR(50) NOT NULL, user_telephone_like CHAR(11) NOT NULL, creation_date DATE NOT NULL);
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, merchant_telephone_cipher CHAR(50) NOT NULL, merchant_telephone_like CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/mysql/01-actual-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/mysql/01-actual-init.sql
@@ -24,8 +24,6 @@ CREATE DATABASE encrypt;
 CREATE TABLE encrypt.t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE encrypt.t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE encrypt.t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, user_telephone_cipher CHAR(50) NOT NULL, user_telephone_like CHAR(11) NOT NULL, creation_date DATE NOT NULL);
-CREATE TABLE encrypt.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE encrypt.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE encrypt.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, merchant_telephone_cipher CHAR(50) NOT NULL, merchant_telephone_like CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON encrypt.t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/opengauss/01-actual-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/opengauss/01-actual-init.sql
@@ -24,15 +24,11 @@ GRANT ALL PRIVILEGES ON DATABASE encrypt TO test_user;
 DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, user_telephone_cipher CHAR(50) NOT NULL, user_telephone_like CHAR(11) NOT NULL, creation_date DATE NOT NULL);
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, merchant_telephone_cipher CHAR(50) NOT NULL, merchant_telephone_like CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/postgresql/01-actual-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/postgresql/01-actual-init.sql
@@ -31,8 +31,6 @@ DROP TABLE IF EXISTS t_merchant;
 CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, user_telephone_cipher CHAR(50) NOT NULL, user_telephone_like CHAR(11) NOT NULL, creation_date DATE NOT NULL);
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, merchant_telephone_cipher CHAR(50) NOT NULL, merchant_telephone_like CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/dataset.xml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/dataset.xml
@@ -40,17 +40,6 @@
         <column name="telephone" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
-    <metadata data-nodes="expected_dataset.t_user_item">
-        <column name="item_id" type="numeric" />
-        <column name="user_id" type="numeric" />
-        <column name="status" type="varchar" />
-        <column name="creation_date" type="datetime" />
-    </metadata>
-    <metadata data-nodes="expected_dataset.t_single_table">
-        <column name="single_id" type="numeric" />
-        <column name="id" type="numeric" />
-        <column name="status" type="varchar" />
-    </metadata>
     <metadata data-nodes="expected_dataset.t_merchant">
         <column name="merchant_id" type="numeric" />
         <column name="country_id" type="numeric" />
@@ -179,10 +168,6 @@
     <row data-node="expected_dataset.t_order_item" values="290002, 2900, 29, 19, 1, 2017-08-08" />
     <row data-node="expected_dataset.t_order_item" values="290101, 2901, 29, 20, 1, 2017-08-08" />
     <row data-node="expected_dataset.t_order_item" values="290102, 2901, 29, 20, 1, 2017-08-08" />
-    <row data-node="expected_dataset.t_single_table" values="1, 10, init" />
-    <row data-node="expected_dataset.t_single_table" values="2, 11, init" />
-    <row data-node="expected_dataset.t_single_table" values="3, 12, init" />
-    <row data-node="expected_dataset.t_single_table" values="4, 13, init" />
     <row data-node="expected_dataset.t_user" values="10, zhangsan, 111111, zhangsan@gmail.com, 12345678900, 2017-08-08" />
     <row data-node="expected_dataset.t_user" values="11, lisi, 222222, lisi@gmail.com, 12345678901, 2017-08-08" />
     <row data-node="expected_dataset.t_user" values="12, wangwu, 333333, wangwu@gmail.com, 12345678902, 2017-08-08" />
@@ -213,26 +198,6 @@
     <row data-node="expected_dataset.t_user" values="37, 王羲之, 345345, wangxizhi@gmail.com, 18012512345, 2017-08-08" />
     <row data-node="expected_dataset.t_user" values="38, 王莽, 456456, wangmang@gmail.com, 18012512345, 2017-08-08" />
     <row data-node="expected_dataset.t_user" values="39, 王勃, 567567, wangbo@gmail.com, 18012512345, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="100000, 10, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="110000, 11, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="120000, 12, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="130000, 13, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="140000, 14, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="150000, 15, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="160000, 16, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="170000, 17, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="180000, 18, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="190000, 19, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="200000, 20, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="210000, 21, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="220000, 22, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="230000, 23, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="240000, 24, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="250000, 25, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="260000, 26, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="270000, 27, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="280000, 28, init, 2017-08-08" />
-    <row data-node="expected_dataset.t_user_item" values="290000, 29, init, 2017-08-08" />
     <row data-node="expected_dataset.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
     <row data-node="expected_dataset.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
     <row data-node="expected_dataset.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/h2/01-expected-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/h2/01-expected-init.sql
@@ -18,15 +18,11 @@
 DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/mysql/01-expected-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/mysql/01-expected-init.sql
@@ -24,8 +24,6 @@ CREATE DATABASE expected_dataset;
 CREATE TABLE expected_dataset.t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE expected_dataset.t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE expected_dataset.t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
-CREATE TABLE expected_dataset.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE expected_dataset.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE expected_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON expected_dataset.t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/opengauss/01-expected-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/opengauss/01-expected-init.sql
@@ -25,15 +25,11 @@ GRANT ALL PRIVILEGES ON DATABASE expected_dataset TO test_user;
 DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/postgresql/01-expected-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/postgresql/01-expected-init.sql
@@ -25,15 +25,11 @@ GRANT ALL PRIVILEGES ON DATABASE expected_dataset TO test_user;
 DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/dataset.xml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/dataset.xml
@@ -22,21 +22,6 @@
         <column name="pwd_cipher" type="varchar" />
         <column name="status" type="varchar" />
     </metadata>
-    <metadata data-nodes="encrypt_write_ds.t_user_item,encrypt_read_ds.t_user_item">
-        <column name="item_id" type="numeric" />
-        <column name="user_id" type="numeric" />
-        <column name="status" type="varchar" />
-        <column name="creation_date" type="datetime" />
-    </metadata>
-    <metadata data-nodes="encrypt_write_ds.t_single_table,encrypt_read_ds.t_single_table">
-        <column name="single_id" type="numeric" />
-        <column name="id" type="numeric" />
-        <column name="status" type="varchar" />
-    </metadata>
-    <metadata data-nodes="encrypt_write_ds.t_user_info,encrypt_read_ds.t_user_info">
-        <column name="user_id" type="numeric" />
-        <column name="information" type="varchar" />
-    </metadata>
     <metadata data-nodes="encrypt_write_ds.t_merchant,encrypt_read_ds.t_merchant">
         <column name="merchant_id" type="numeric" />
         <column name="country_id" type="numeric" />
@@ -45,10 +30,6 @@
         <column name="telephone" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
-    <row data-node="encrypt_write_ds.t_single_table" values="1, 0, init" />
-    <row data-node="encrypt_write_ds.t_single_table" values="2, 11, init" />
-    <row data-node="encrypt_write_ds.t_single_table" values="3, 22, init" />
-    <row data-node="encrypt_write_ds.t_single_table" values="4, 33, init" />
     <row data-node="encrypt_write_ds.t_user" values="0, 10000, dL/JAiR/3cVG8lt6DMDa/A==, init" />
     <row data-node="encrypt_write_ds.t_user" values="1, 11000, wPc6WYJBzQIt4i4T0KhqXA==, init" />
     <row data-node="encrypt_write_ds.t_user" values="2, 12000, HbV7OHLF4nBuOMVCLV5Cbg==, init" />
@@ -149,110 +130,6 @@
     <row data-node="encrypt_write_ds.t_user" values="97, 17009, 4cs88JOZMhtFn6C04H+rxA==, init" />
     <row data-node="encrypt_write_ds.t_user" values="98, 18009, bjkyDftrAIaEJSlibxiVkg==, init" />
     <row data-node="encrypt_write_ds.t_user" values="99, 19009, Ou8qESKecbqmABoIo+5Kpg==, init" />
-    <row data-node="encrypt_write_ds.t_user_item" values="100000, 0, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="100001, 10, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="100002, 20, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="100003, 30, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="100004, 40, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="100005, 50, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="100006, 60, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="100007, 70, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="100008, 80, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="100009, 90, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="110000, 1, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="110001, 11, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="110002, 21, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="110003, 31, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="110004, 41, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="110005, 51, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="110006, 61, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="110007, 71, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="110008, 81, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="110009, 91, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="120000, 2, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="120001, 12, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="120002, 22, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="120003, 32, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="120004, 42, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="120005, 52, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="120006, 62, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="120007, 72, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="120008, 82, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="120009, 92, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="130000, 3, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="130001, 13, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="130002, 23, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="130003, 33, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="130004, 43, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="130005, 53, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="130006, 63, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="130007, 73, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="130008, 83, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="130009, 93, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="140000, 4, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="140001, 14, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="140002, 24, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="140003, 34, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="140004, 44, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="140005, 54, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="140006, 64, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="140007, 74, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="140008, 84, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="140009, 94, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="150000, 5, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="150001, 15, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="150002, 25, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="150003, 35, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="150004, 45, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="150005, 55, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="150006, 65, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="150007, 75, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="150008, 85, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="150009, 95, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="160000, 6, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="160001, 16, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="160002, 26, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="160003, 36, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="160004, 46, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="160005, 56, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="160006, 66, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="160007, 76, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="160008, 86, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="160009, 96, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="170000, 7, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="170001, 17, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="170002, 27, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="170003, 37, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="170004, 47, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="170005, 57, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="170006, 67, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="170007, 77, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="170008, 87, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="170009, 97, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="180000, 8, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="180001, 18, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="180002, 28, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="180003, 38, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="180004, 48, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="180005, 58, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="180006, 68, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="180007, 78, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="180008, 88, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="180009, 98, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="190000, 9, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="190001, 19, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="190002, 29, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="190003, 39, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="190004, 49, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="190005, 59, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="190006, 69, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="190007, 79, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="190008, 89, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_item" values="190009, 99, init, 2017-08-08" />
-    <row data-node="encrypt_write_ds.t_user_info" values="0, description0" />
-    <row data-node="encrypt_write_ds.t_user_info" values="1, description1" />
-    <row data-node="encrypt_write_ds.t_user_info" values="2, description2" />
-    <row data-node="encrypt_write_ds.t_user_info" values="3, description3" />
     <row data-node="encrypt_write_ds.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
     <row data-node="encrypt_write_ds.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
     <row data-node="encrypt_write_ds.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />
@@ -273,10 +150,6 @@
     <row data-node="encrypt_write_ds.t_merchant" values="18, 1, intel, 01000018, 01100000018, 2017-08-08" />
     <row data-node="encrypt_write_ds.t_merchant" values="19, 1, hp, 01000019, 01100000019, 2017-08-08" />
     <row data-node="encrypt_write_ds.t_merchant" values="20, 1, tesla, 01000020, 01100000020, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_single_table" values="1, 0, init_read" />
-    <row data-node="encrypt_read_ds.t_single_table" values="2, 11, init_read" />
-    <row data-node="encrypt_read_ds.t_single_table" values="3, 22, init_read" />
-    <row data-node="encrypt_read_ds.t_single_table" values="4, 33, init_read" />
     <row data-node="encrypt_read_ds.t_user" values="0, 10000, dL/JAiR/3cVG8lt6DMDa/A==, init_read" />
     <row data-node="encrypt_read_ds.t_user" values="1, 11000, wPc6WYJBzQIt4i4T0KhqXA==, init_read" />
     <row data-node="encrypt_read_ds.t_user" values="2, 12000, HbV7OHLF4nBuOMVCLV5Cbg==, init_read" />
@@ -377,110 +250,6 @@
     <row data-node="encrypt_read_ds.t_user" values="97, 17009, 4cs88JOZMhtFn6C04H+rxA==, init_read" />
     <row data-node="encrypt_read_ds.t_user" values="98, 18009, bjkyDftrAIaEJSlibxiVkg==, init_read" />
     <row data-node="encrypt_read_ds.t_user" values="99, 19009, Ou8qESKecbqmABoIo+5Kpg==, init_read" />
-    <row data-node="encrypt_read_ds.t_user_item" values="100000, 0, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="100001, 10, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="100002, 20, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="100003, 30, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="100004, 40, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="100005, 50, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="100006, 60, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="100007, 70, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="100008, 80, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="100009, 90, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="110000, 1, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="110001, 11, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="110002, 21, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="110003, 31, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="110004, 41, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="110005, 51, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="110006, 61, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="110007, 71, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="110008, 81, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="110009, 91, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="120000, 2, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="120001, 12, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="120002, 22, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="120003, 32, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="120004, 42, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="120005, 52, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="120006, 62, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="120007, 72, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="120008, 82, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="120009, 92, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="130000, 3, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="130001, 13, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="130002, 23, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="130003, 33, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="130004, 43, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="130005, 53, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="130006, 63, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="130007, 73, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="130008, 83, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="130009, 93, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="140000, 4, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="140001, 14, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="140002, 24, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="140003, 34, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="140004, 44, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="140005, 54, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="140006, 64, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="140007, 74, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="140008, 84, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="140009, 94, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="150000, 5, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="150001, 15, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="150002, 25, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="150003, 35, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="150004, 45, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="150005, 55, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="150006, 65, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="150007, 75, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="150008, 85, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="150009, 95, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="160000, 6, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="160001, 16, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="160002, 26, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="160003, 36, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="160004, 46, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="160005, 56, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="160006, 66, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="160007, 76, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="160008, 86, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="160009, 96, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="170000, 7, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="170001, 17, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="170002, 27, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="170003, 37, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="170004, 47, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="170005, 57, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="170006, 67, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="170007, 77, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="170008, 87, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="170009, 97, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="180000, 8, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="180001, 18, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="180002, 28, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="180003, 38, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="180004, 48, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="180005, 58, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="180006, 68, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="180007, 78, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="180008, 88, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="180009, 98, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="190000, 9, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="190001, 19, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="190002, 29, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="190003, 39, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="190004, 49, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="190005, 59, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="190006, 69, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="190007, 79, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="190008, 89, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_item" values="190009, 99, init_read, 2017-08-08" />
-    <row data-node="encrypt_read_ds.t_user_info" values="0, description0" />
-    <row data-node="encrypt_read_ds.t_user_info" values="1, description1" />
-    <row data-node="encrypt_read_ds.t_user_info" values="2, description2" />
-    <row data-node="encrypt_read_ds.t_user_info" values="3, description3" />
     <row data-node="encrypt_read_ds.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
     <row data-node="encrypt_read_ds.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
     <row data-node="encrypt_read_ds.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/h2/01-actual-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/h2/01-actual-init.sql
@@ -16,9 +16,7 @@
 --
 
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
 
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/h2/actual-encrypt_read_ds-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/h2/actual-encrypt_read_ds-init.sql
@@ -15,10 +15,6 @@
 -- limitations under the License.
 --
 
-DROP TABLE IF EXISTS t_user_info;
-DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/h2/actual-encrypt_write_ds-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/h2/actual-encrypt_write_ds-init.sql
@@ -15,10 +15,6 @@
 -- limitations under the License.
 --
 
-DROP TABLE IF EXISTS t_user_info;
-DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/mysql/01-actual-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/mysql/01-actual-init.sql
@@ -25,15 +25,9 @@ CREATE DATABASE encrypt_write_ds;
 CREATE DATABASE encrypt_read_ds;
 
 CREATE TABLE encrypt_write_ds.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE encrypt_write_ds.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE encrypt_write_ds.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE encrypt_write_ds.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_write_ds.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON encrypt_write_ds.t_user (user_id);
 
 CREATE TABLE encrypt_read_ds.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE encrypt_read_ds.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE encrypt_read_ds.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE encrypt_read_ds.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_read_ds.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON encrypt_read_ds.t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/opengauss/01-actual-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/opengauss/01-actual-init.sql
@@ -24,29 +24,17 @@ GRANT ALL PRIVILEGES ON DATABASE encrypt_read_ds TO test_user;
 \c encrypt_write_ds
 
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_single_table;
-DROP TABLE IF EXISTS t_user_info;
 DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON t_user (user_id);
 
 \c encrypt_read_ds
 
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_single_table;
-DROP TABLE IF EXISTS t_user_info;
 DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/postgresql/01-actual-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/postgresql/01-actual-init.sql
@@ -24,29 +24,17 @@ GRANT ALL PRIVILEGES ON DATABASE encrypt_read_ds TO test_user;
 \c encrypt_write_ds
 
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_single_table;
-DROP TABLE IF EXISTS t_user_info;
 DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON t_user (user_id);
 
 \c encrypt_read_ds
 
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_single_table;
-DROP TABLE IF EXISTS t_user_info;
 DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/dataset.xml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/dataset.xml
@@ -22,21 +22,6 @@
         <column name="pwd" type="varchar" />
         <column name="status" type="varchar" />
     </metadata>
-    <metadata data-nodes="write_dataset.t_user_item,read_dataset.t_user_item">
-        <column name="item_id" type="numeric" />
-        <column name="user_id" type="numeric" />
-        <column name="status" type="varchar" />
-        <column name="creation_date" type="datetime" />
-    </metadata>
-    <metadata data-nodes="read_dataset.t_single_table">
-        <column name="single_id" type="numeric" />
-        <column name="id" type="numeric" />
-        <column name="status" type="varchar" />
-    </metadata>
-    <metadata data-nodes="write_dataset.t_user_info,read_dataset.t_user_info">
-        <column name="user_id" type="numeric" />
-        <column name="information" type="varchar" />
-    </metadata>
     <metadata data-nodes="write_dataset.t_merchant,read_dataset.t_merchant">
         <column name="merchant_id" type="numeric" />
         <column name="country_id" type="numeric" />
@@ -145,110 +130,6 @@
     <row data-node="write_dataset.t_user" values="97, 17009, h97, init" />
     <row data-node="write_dataset.t_user" values="98, 18009, i98, init" />
     <row data-node="write_dataset.t_user" values="99, 19009, j99, init" />
-    <row data-node="write_dataset.t_user_item" values="100000, 0, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="100001, 10, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="100002, 20, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="100003, 30, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="100004, 40, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="100005, 50, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="100006, 60, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="100007, 70, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="100008, 80, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="100009, 90, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="110000, 1, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="110001, 11, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="110002, 21, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="110003, 31, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="110004, 41, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="110005, 51, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="110006, 61, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="110007, 71, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="110008, 81, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="110009, 91, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="120000, 2, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="120001, 12, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="120002, 22, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="120003, 32, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="120004, 42, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="120005, 52, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="120006, 62, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="120007, 72, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="120008, 82, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="120009, 92, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="130000, 3, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="130001, 13, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="130002, 23, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="130003, 33, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="130004, 43, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="130005, 53, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="130006, 63, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="130007, 73, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="130008, 83, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="130009, 93, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="140000, 4, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="140001, 14, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="140002, 24, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="140003, 34, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="140004, 44, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="140005, 54, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="140006, 64, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="140007, 74, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="140008, 84, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="140009, 94, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="150000, 5, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="150001, 15, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="150002, 25, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="150003, 35, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="150004, 45, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="150005, 55, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="150006, 65, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="150007, 75, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="150008, 85, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="150009, 95, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="160000, 6, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="160001, 16, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="160002, 26, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="160003, 36, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="160004, 46, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="160005, 56, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="160006, 66, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="160007, 76, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="160008, 86, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="160009, 96, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="170000, 7, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="170001, 17, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="170002, 27, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="170003, 37, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="170004, 47, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="170005, 57, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="170006, 67, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="170007, 77, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="170008, 87, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="170009, 97, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="180000, 8, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="180001, 18, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="180002, 28, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="180003, 38, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="180004, 48, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="180005, 58, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="180006, 68, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="180007, 78, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="180008, 88, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="180009, 98, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="190000, 9, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="190001, 19, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="190002, 29, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="190003, 39, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="190004, 49, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="190005, 59, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="190006, 69, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="190007, 79, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="190008, 89, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_item" values="190009, 99, init, 2017-08-08" />
-    <row data-node="write_dataset.t_user_info" values="0, description0" />
-    <row data-node="write_dataset.t_user_info" values="1, description1" />
-    <row data-node="write_dataset.t_user_info" values="2, description2" />
-    <row data-node="write_dataset.t_user_info" values="3, description3" />
     <row data-node="write_dataset.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
     <row data-node="write_dataset.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
     <row data-node="write_dataset.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />
@@ -269,10 +150,6 @@
     <row data-node="write_dataset.t_merchant" values="18, 1, intel, 01000018, 01100000018, 2017-08-08" />
     <row data-node="write_dataset.t_merchant" values="19, 1, hp, 01000019, 01100000019, 2017-08-08" />
     <row data-node="write_dataset.t_merchant" values="20, 1, tesla, 01000020, 01100000020, 2017-08-08" />
-    <row data-node="read_dataset.t_single_table" values="1, 0, init_read" />
-    <row data-node="read_dataset.t_single_table" values="2, 11, init_read" />
-    <row data-node="read_dataset.t_single_table" values="3, 22, init_read" />
-    <row data-node="read_dataset.t_single_table" values="4, 33, init_read" />
     <row data-node="read_dataset.t_user" values="0, 10000, a00, init_read" />
     <row data-node="read_dataset.t_user" values="1, 11000, b01, init_read" />
     <row data-node="read_dataset.t_user" values="2, 12000, c02, init_read" />
@@ -373,110 +250,6 @@
     <row data-node="read_dataset.t_user" values="97, 17009, h97, init_read" />
     <row data-node="read_dataset.t_user" values="98, 18009, i98, init_read" />
     <row data-node="read_dataset.t_user" values="99, 19009, j99, init_read" />
-    <row data-node="read_dataset.t_user_item" values="100000, 0, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="100001, 10, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="100002, 20, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="100003, 30, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="100004, 40, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="100005, 50, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="100006, 60, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="100007, 70, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="100008, 80, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="100009, 90, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="110000, 1, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="110001, 11, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="110002, 21, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="110003, 31, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="110004, 41, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="110005, 51, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="110006, 61, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="110007, 71, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="110008, 81, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="110009, 91, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="120000, 2, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="120001, 12, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="120002, 22, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="120003, 32, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="120004, 42, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="120005, 52, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="120006, 62, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="120007, 72, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="120008, 82, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="120009, 92, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="130000, 3, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="130001, 13, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="130002, 23, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="130003, 33, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="130004, 43, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="130005, 53, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="130006, 63, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="130007, 73, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="130008, 83, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="130009, 93, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="140000, 4, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="140001, 14, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="140002, 24, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="140003, 34, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="140004, 44, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="140005, 54, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="140006, 64, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="140007, 74, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="140008, 84, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="140009, 94, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="150000, 5, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="150001, 15, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="150002, 25, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="150003, 35, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="150004, 45, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="150005, 55, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="150006, 65, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="150007, 75, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="150008, 85, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="150009, 95, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="160000, 6, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="160001, 16, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="160002, 26, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="160003, 36, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="160004, 46, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="160005, 56, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="160006, 66, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="160007, 76, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="160008, 86, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="160009, 96, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="170000, 7, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="170001, 17, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="170002, 27, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="170003, 37, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="170004, 47, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="170005, 57, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="170006, 67, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="170007, 77, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="170008, 87, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="170009, 97, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="180000, 8, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="180001, 18, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="180002, 28, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="180003, 38, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="180004, 48, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="180005, 58, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="180006, 68, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="180007, 78, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="180008, 88, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="180009, 98, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="190000, 9, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="190001, 19, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="190002, 29, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="190003, 39, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="190004, 49, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="190005, 59, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="190006, 69, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="190007, 79, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="190008, 89, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_item" values="190009, 99, init_read, 2017-08-08" />
-    <row data-node="read_dataset.t_user_info" values="0, description0" />
-    <row data-node="read_dataset.t_user_info" values="1, description1" />
-    <row data-node="read_dataset.t_user_info" values="2, description2" />
-    <row data-node="read_dataset.t_user_info" values="3, description3" />
     <row data-node="read_dataset.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
     <row data-node="read_dataset.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
     <row data-node="read_dataset.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/h2/01-expected-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/h2/01-expected-init.sql
@@ -15,16 +15,10 @@
 -- limitations under the License.
 --
 
-DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_user_info;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/mysql/01-expected-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/mysql/01-expected-init.sql
@@ -22,10 +22,7 @@ SET character_set_server='utf8';
 DROP DATABASE IF EXISTS write_dataset;
 CREATE DATABASE write_dataset;
 
-CREATE TABLE write_dataset.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE write_dataset.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE write_dataset.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE write_dataset.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE write_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON write_dataset.t_user (user_id);
@@ -34,11 +31,7 @@ CREATE INDEX user_index_t_user ON write_dataset.t_user (user_id);
 DROP DATABASE IF EXISTS read_dataset;
 CREATE DATABASE read_dataset;
 
-CREATE TABLE read_dataset.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE read_dataset.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE read_dataset.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE read_dataset.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE read_dataset.t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(32) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
 CREATE TABLE read_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON read_dataset.t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/opengauss/01-expected-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/opengauss/01-expected-init.sql
@@ -22,16 +22,10 @@ GRANT ALL PRIVILEGES ON DATABASE write_dataset TO test_user;
 
 \c write_dataset;
 
-DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_user_info;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);
@@ -44,16 +38,10 @@ GRANT ALL PRIVILEGES ON DATABASE read_dataset TO test_user;
 
 \c read_dataset;
 
-DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_user_info;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/postgresql/01-expected-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/postgresql/01-expected-init.sql
@@ -22,16 +22,10 @@ GRANT ALL PRIVILEGES ON DATABASE write_dataset TO test_user;
 
 \c write_dataset;
 
-DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_user_info;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);
@@ -44,16 +38,10 @@ GRANT ALL PRIVILEGES ON DATABASE read_dataset TO test_user;
 
 \c read_dataset;
 
-DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_user;
-DROP TABLE IF EXISTS t_user_item;
-DROP TABLE IF EXISTS t_user_info;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
-CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
-CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);


### PR DESCRIPTION
Ref #21286.

Changes proposed in this pull request:
  - Remove encrypt and encrypt_and_readwrite_splitting non-standard table

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
