### PR TITLE
Fixes ClasspathResourceDirectoryReaderTest execution failing on Windows 11 CI

### DIFF
--- a/infra/util/src/test/java/org/apache/shardingsphere/infra/util/directory/ClasspathResourceDirectoryReaderTest.java
+++ b/infra/util/src/test/java/org/apache/shardingsphere/infra/util/directory/ClasspathResourceDirectoryReaderTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.infra.util.directory;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,9 +42,8 @@ class ClasspathResourceDirectoryReaderTest {
     void assertReadTest() {
         List<String> resourceNameList = ClasspathResourceDirectoryReader.read("yaml").collect(Collectors.toList());
         assertThat(resourceNameList.size(), is(5));
-        final String separator = File.separator;
-        assertThat(resourceNameList, hasItems("yaml" + separator + "accepted-class.yaml", "yaml" + separator + "customized-obj.yaml", "yaml" + separator + "empty-config.yaml",
-                "yaml" + separator + "shortcuts-fixture.yaml", "yaml/fixture/fixture.yaml"));
+        assertThat(resourceNameList, hasItems("yaml/accepted-class.yaml", "yaml/customized-obj.yaml", "yaml/empty-config.yaml",
+                "yaml/shortcuts-fixture.yaml", "yaml/fixture/fixture.yaml"));
     }
     
     @Test


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/actions/runs/8176654071/job/22356570385 .

Changes proposed in this pull request:
  - Fixes ClasspathResourceDirectoryReaderTest execution failing on Windows 11 CI .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
