### PR TITLE
Fix TestDecodingPlugin.decode BEGIN TX and COMMIT TX event

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/persist/PipelineJobProgressPersistContext.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/persist/PipelineJobProgressPersistContext.java
@@ -37,4 +37,6 @@ public final class PipelineJobProgressPersistContext {
     private final AtomicBoolean hasNewEvents = new AtomicBoolean(false);
     
     private final AtomicReference<Long> beforePersistingProgressMillis = new AtomicReference<>(null);
+    
+    private final AtomicBoolean firstExceptionLogged = new AtomicBoolean(false);
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/persist/PipelineJobProgressPersistService.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/persist/PipelineJobProgressPersistService.java
@@ -101,7 +101,10 @@ public final class PipelineJobProgressPersistService {
      */
     public static void persistNow(final String jobId, final int shardingItem) {
         getPersistContext(jobId, shardingItem).ifPresent(persistContext -> {
-            // TODO Recover persistContext.getBeforePersistingProgressMillis() null check after compatible with PostgreSQLMigrationGeneralE2EIT
+            if (null == persistContext.getBeforePersistingProgressMillis().get()) {
+                log.warn("Force persisting progress is not permitted since there is no previous persisting, jobId={}, shardingItem={}", jobId, shardingItem);
+                return;
+            }
             notifyPersist(persistContext);
             PersistJobContextRunnable.persist(jobId, shardingItem, persistContext);
         });

--- a/kernel/data-pipeline/dialect/postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/decode/TestDecodingPlugin.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/decode/TestDecodingPlugin.java
@@ -48,14 +48,15 @@ public final class TestDecodingPlugin implements DecodingPlugin {
     
     @Override
     public AbstractWALEvent decode(final ByteBuffer data, final BaseLogSequenceNumber logSequenceNumber) {
+        AbstractWALEvent result;
         String type = readEventType(data);
         if (type.startsWith("BEGIN")) {
-            return new BeginTXEvent(Long.parseLong(readNextSegment(data)));
+            result = new BeginTXEvent(Long.parseLong(readNextSegment(data)));
+        } else if (type.startsWith("COMMIT")) {
+            result = new CommitTXEvent(Long.parseLong(readNextSegment(data)), null);
+        } else {
+            result = "table".equals(type) ? readTableEvent(data) : new PlaceholderEvent();
         }
-        if (type.startsWith("COMMIT")) {
-            return new CommitTXEvent(Long.parseLong(readNextSegment(data)), null);
-        }
-        AbstractWALEvent result = "table".equals(type) ? readTableEvent(data) : new PlaceholderEvent();
         result.setLogSequenceNumber(logSequenceNumber);
         return result;
     }

--- a/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/decode/TestDecodingPluginTest.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/decode/TestDecodingPluginTest.java
@@ -19,6 +19,8 @@ package org.apache.shardingsphere.data.pipeline.postgresql.ingest.wal.decode;
 
 import org.apache.shardingsphere.data.pipeline.core.exception.IngestException;
 import org.apache.shardingsphere.data.pipeline.postgresql.ingest.wal.event.AbstractWALEvent;
+import org.apache.shardingsphere.data.pipeline.postgresql.ingest.wal.event.BeginTXEvent;
+import org.apache.shardingsphere.data.pipeline.postgresql.ingest.wal.event.CommitTXEvent;
 import org.apache.shardingsphere.data.pipeline.postgresql.ingest.wal.event.DeleteRowEvent;
 import org.apache.shardingsphere.data.pipeline.postgresql.ingest.wal.event.PlaceholderEvent;
 import org.apache.shardingsphere.data.pipeline.postgresql.ingest.wal.event.UpdateRowEvent;
@@ -44,6 +46,22 @@ class TestDecodingPluginTest {
     private final LogSequenceNumber pgSequenceNumber = LogSequenceNumber.valueOf("0/14EFDB8");
     
     private final PostgreSQLLogSequenceNumber logSequenceNumber = new PostgreSQLLogSequenceNumber(pgSequenceNumber);
+    
+    @Test
+    void assertDecodeBeginTxEvent() {
+        ByteBuffer data = ByteBuffer.wrap("BEGIN 616281".getBytes(StandardCharsets.UTF_8));
+        BeginTXEvent actual = (BeginTXEvent) new TestDecodingPlugin(null).decode(data, logSequenceNumber);
+        assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
+        assertThat(actual.getXid(), is(616281L));
+    }
+    
+    @Test
+    void assertDecodeCommitTxEvent() {
+        ByteBuffer data = ByteBuffer.wrap("COMMIT 616281".getBytes(StandardCharsets.UTF_8));
+        CommitTXEvent actual = (CommitTXEvent) new TestDecodingPlugin(null).decode(data, logSequenceNumber);
+        assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
+        assertThat(actual.getXid(), is(616281L));
+    }
     
     @Test
     void assertDecodeWriteRowEvent() {


### PR DESCRIPTION
Related to #30434

Changes proposed in this pull request:
  - Fix TestDecodingPlugin.decode BEGIN TX and COMMIT TX event. Position lost. Affect breakpoint resuming
  - Recover previous persisting nonnull check on force persisting progress to avoid invalid progress overwriting
  - Print exception on job progress persisting failure. So persisting exception could be found early

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
