### PR TITLE
Fix oracle merge parameter index parser when write not matched first

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/MergeStatementBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/MergeStatementBinder.java
@@ -92,13 +92,13 @@ public final class MergeStatementBinder implements SQLStatementBinder<MergeState
                 optional -> result.setInsert(bindMergeInsert(optional, (SimpleTableSegment) boundedTargetTableSegment, statementBinderContext, targetTableBinderContexts, sourceTableBinderContexts)));
         sqlStatement.getUpdate().ifPresent(
                 optional -> result.setUpdate(bindMergeUpdate(optional, (SimpleTableSegment) boundedTargetTableSegment, statementBinderContext, targetTableBinderContexts, sourceTableBinderContexts)));
-        addParameterMarkerSegments(result, sqlStatement);
+        addParameterMarkerSegments(result);
         result.getCommentSegments().addAll(sqlStatement.getCommentSegments());
         return result;
     }
     
-    private void addParameterMarkerSegments(final MergeStatement mergeStatement, final MergeStatement originalSQLStatement) {
-        mergeStatement.addParameterMarkerSegments(originalSQLStatement.getParameterMarkerSegments());
+    private void addParameterMarkerSegments(final MergeStatement mergeStatement) {
+        // TODO bind parameter marker segments for merge statement
         mergeStatement.getInsert().ifPresent(optional -> mergeStatement.addParameterMarkerSegments(optional.getParameterMarkerSegments()));
         mergeStatement.getUpdate().ifPresent(optional -> mergeStatement.addParameterMarkerSegments(optional.getParameterMarkerSegments()));
     }

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
@@ -1297,12 +1297,19 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
                 (ExpressionSegment) visit(ctx.usingClause().expr()));
         onExpression.getParameterMarkerSegments().addAll(popAllStatementParameterMarkerSegments());
         result.setExpression(onExpression);
+        if (null != ctx.mergeUpdateClause() && null != ctx.mergeInsertClause() && ctx.mergeUpdateClause().start.getStartIndex() > ctx.mergeInsertClause().start.getStartIndex()) {
+            result.setInsert((InsertStatement) visitMergeInsertClause(ctx.mergeInsertClause()));
+            result.setUpdate((UpdateStatement) visitMergeUpdateClause(ctx.mergeUpdateClause()));
+            result.addParameterMarkerSegments(ctx.getParent() instanceof ExecuteContext ? getGlobalParameterMarkerSegments() : popAllStatementParameterMarkerSegments());
+            return result;
+        }
         if (null != ctx.mergeUpdateClause()) {
             result.setUpdate((UpdateStatement) visitMergeUpdateClause(ctx.mergeUpdateClause()));
         }
         if (null != ctx.mergeInsertClause()) {
             result.setInsert((InsertStatement) visitMergeInsertClause(ctx.mergeInsertClause()));
         }
+        result.addParameterMarkerSegments(ctx.getParent() instanceof ExecuteContext ? getGlobalParameterMarkerSegments() : popAllStatementParameterMarkerSegments());
         return result;
     }
     

--- a/test/it/parser/src/main/resources/case/dml/merge.xml
+++ b/test/it/parser/src/main/resources/case/dml/merge.xml
@@ -333,7 +333,7 @@
             </where>
         </insert>
     </merge>
-    <merge sql-case-id="merge_insert_and_update_table">
+    <merge sql-case-id="merge_insert_and_update_table" parameters="1, 1, 1, 1, 1, 1, 1, 1, 1, 1">
         <target>
             <simple-table alias="t1" name="t_order" start-index="11" stop-index="20" />
         </target>
@@ -343,9 +343,11 @@
                     <select>
                         <projections start-index="92" stop-index="116">
                             <expression-projection text="1" start-index="92" stop-index="102" alias="userId">
+                                <parameter-marker-expression parameter-index="0" start-index="92" stop-index="92" />
                                 <literal-expression value="1" start-index="92" stop-index="92" />
                             </expression-projection>
                             <expression-projection text="1" start-index="105" stop-index="116" alias="orderId">
+                                <parameter-marker-expression parameter-index="1" start-index="105" stop-index="105" />
                                 <literal-expression value="1" start-index="105" stop-index="105" />
                             </expression-projection>
                         </projections>
@@ -391,28 +393,6 @@
                 </right>
             </binary-operation-expression>
         </expr>
-        <update>
-            <set start-index="824" stop-index="1000">
-                <assignment>
-                    <columns name="merchant_id" start-index="824" stop-index="834" />
-                    <assignment-value>
-                        <literal-expression value="1" start-index="838" stop-index="838" />
-                    </assignment-value>
-                </assignment>
-                <assignment>
-                    <columns name="remark" start-index="905" stop-index="910" />
-                    <assignment-value>
-                        <literal-expression value="1" start-index="919" stop-index="919" />
-                    </assignment-value>
-                </assignment>
-                <assignment>
-                    <columns name="status" start-index="986" stop-index="991" />
-                    <assignment-value>
-                        <literal-expression value="1" start-index="1000" stop-index="1000" />
-                    </assignment-value>
-                </assignment>
-            </set>
-        </update>
         <insert>
             <columns start-index="453" stop-index="515">
                 <column name="order_id" start-index="454" stop-index="461" />
@@ -425,18 +405,23 @@
             <values>
                 <value>
                     <assignment-value>
+                        <parameter-marker-expression parameter-index="2" start-index="585" stop-index="585" />
                         <literal-expression value="1" start-index="585" stop-index="585" />
                     </assignment-value>
                     <assignment-value>
+                        <parameter-marker-expression parameter-index="3" start-index="588" stop-index="588" />
                         <literal-expression value="1" start-index="588" stop-index="588" />
                     </assignment-value>
                     <assignment-value>
+                        <parameter-marker-expression parameter-index="4" start-index="591" stop-index="591" />
                         <literal-expression value="1" start-index="591" stop-index="591" />
                     </assignment-value>
                     <assignment-value>
+                        <parameter-marker-expression parameter-index="5" start-index="594" stop-index="594" />
                         <literal-expression value="1" start-index="594" stop-index="594" />
                     </assignment-value>
                     <assignment-value>
+                        <parameter-marker-expression parameter-index="6" start-index="597" stop-index="597" />
                         <literal-expression value="1" start-index="597" stop-index="597" />
                     </assignment-value>
                     <assignment-value>
@@ -445,6 +430,31 @@
                 </value>
             </values>
         </insert>
+        <update>
+            <set start-index="824" stop-index="1000">
+                <assignment>
+                    <columns name="merchant_id" start-index="824" stop-index="834" />
+                    <assignment-value>
+                        <parameter-marker-expression parameter-index="7" start-index="838" stop-index="838" />
+                        <literal-expression value="1" start-index="838" stop-index="838" />
+                    </assignment-value>
+                </assignment>
+                <assignment>
+                    <columns name="remark" start-index="905" stop-index="910" />
+                    <assignment-value>
+                        <parameter-marker-expression parameter-index="8" start-index="919" stop-index="919" />
+                        <literal-expression value="1" start-index="919" stop-index="919" />
+                    </assignment-value>
+                </assignment>
+                <assignment>
+                    <columns name="status" start-index="986" stop-index="991" />
+                    <assignment-value>
+                        <parameter-marker-expression parameter-index="9" start-index="1000" stop-index="1000" />
+                        <literal-expression value="1" start-index="1000" stop-index="1000" />
+                    </assignment-value>
+                </assignment>
+            </set>
+        </update>
     </merge>
     <merge sql-case-id="merge_into_select">
         <target>

--- a/test/it/parser/src/main/resources/sql/supported/dml/merge.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/merge.xml
@@ -23,16 +23,16 @@
     <sql-case id="merge_update_table_with_delete" value="MERGE INTO bonuses D USING (SELECT employee_id, salary, department_id FROM employees WHERE department_id = 80) S ON (D.employee_id = S.employee_id) WHEN MATCHED THEN UPDATE SET D.bonus = D.bonus + S.salary*.01 DELETE WHERE (S.salary > 8000)" db-types="Oracle" />
     <sql-case id="merge_update_and_insert_table" value="MERGE INTO bonuses D    USING (SELECT employee_id, salary, department_id FROM hr.employees    WHERE department_id = 80) S    ON (D.employee_id = S.employee_id)    WHEN MATCHED THEN UPDATE SET D.bonus = D.bonus + S.salary*.01      DELETE WHERE (S.salary = 8000)    WHEN NOT MATCHED THEN INSERT (D.employee_id, D.bonus)      VALUES (S.employee_id, S.salary*.01)      WHERE (S.salary &lt;= 8000);"  db-types="Oracle" />
     <sql-case id="merge_insert_and_update_table" value="MERGE INTO t_order t1
-                                                        USING (SELECT 1 AS userId, 1 AS orderId
+                                                        USING (SELECT ? AS userId, ? AS orderId
                                                                FROM DUAL) t2
                                                         ON (t1.user_id = t2.userId AND t1.order_id = t2.orderId)
                                                         WHEN NOT MATCHED THEN
                                                             INSERT (order_id, user_id, status, merchant_id, remark, creation_date)
-                                                            VALUES (1, 1, 1, 1, 1, DATE '2017-08-08')
+                                                            VALUES (?, ?, ?, ?, ?, DATE '2017-08-08')
                                                         WHEN MATCHED THEN
                                                             UPDATE
-                                                            SET merchant_id = 1,
-                                                                remark      = 1,
-                                                                status      = 1;"  db-types="Oracle" />
+                                                            SET merchant_id = ?,
+                                                                remark      = ?,
+                                                                status      = ?;"  db-types="Oracle" />
     <sql-case id="merge_into_select" value="MERGE INTO (SELECT * FROM bonuses WHERE department_id = 80) D USING (SELECT employee_id, salary, department_id FROM employees WHERE department_id = 80) S ON (D.employee_id = S.employee_id) WHEN MATCHED THEN UPDATE SET D.bonus = D.bonus + S.salary*.01 DELETE WHERE (S.salary > 8000)" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix oracle merge parameter index parser when write not matched first

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
