### PR TITLE
Fix SQLServer parameter index binding error

### DIFF
--- a/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
+++ b/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
@@ -1038,7 +1038,7 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
                 offset = new NumberLiteralLimitValueSegment(ctx.expr(0).start.getStartIndex(), ctx.expr(0).stop.getStopIndex(),
                         ((Number) ((LiteralExpressionSegment) astNode).getLiterals()).longValue());
             } else if (astNode instanceof ParameterMarkerExpressionSegment) {
-                offset = new ParameterMarkerLimitValueSegment(ctx.expr(0).start.getStartIndex(), ctx.expr(0).stop.getStopIndex(), parameterMarkerSegments.size());
+                offset = new ParameterMarkerLimitValueSegment(ctx.expr(0).start.getStartIndex(), ctx.expr(0).stop.getStopIndex(), parameterMarkerSegments.size() - 1);
             }
         }
         if (null != ctx.FETCH()) {
@@ -1047,7 +1047,7 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
                 rowcount = new NumberLiteralLimitValueSegment(ctx.expr(1).start.getStartIndex(), ctx.expr(1).stop.getStopIndex(),
                         ((Number) ((LiteralExpressionSegment) astNode).getLiterals()).longValue());
             } else if (astNode instanceof ParameterMarkerExpressionSegment) {
-                rowcount = new ParameterMarkerLimitValueSegment(ctx.expr(1).start.getStartIndex(), ctx.expr(1).stop.getStopIndex(), parameterMarkerSegments.size());
+                rowcount = new ParameterMarkerLimitValueSegment(ctx.expr(1).start.getStartIndex(), ctx.expr(1).stop.getStopIndex(), parameterMarkerSegments.size() - 1);
             }
         }
         if (null != offset) {

--- a/test/it/parser/src/main/resources/case/dml/select-pagination.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-pagination.xml
@@ -2004,7 +2004,7 @@
         </order-by>
         <limit literal-start-index="40" literal-stop-index="75" start-index="40" stop-index="74">
             <offset value="0" start-index="47" stop-index="47" literal-start-index="47" literal-stop-index="47" />
-            <row-count value="20" parameter-index="1" literal-start-index="64" literal-stop-index="65" start-index="64" stop-index="64" />
+            <row-count value="20" parameter-index="0" literal-start-index="64" literal-stop-index="65" start-index="64" stop-index="64" />
         </limit>
     </select>
 


### PR DESCRIPTION
Fixes #30405.

Changes proposed in this pull request:
  - Fix SQLServer parameter index binding error
  - Error creating the wrong Parameter index when parsing the `OFFSET ? ROW FETCH NEXT ? ROWS ONLY `statement in sqlServer，This leads the org.apache.shardingsphere.infra.binder.context.segment.select.pagination.PaginationContext#getValue method to cause an index out of bounds in getParameterIndex().
  - I will refactor the operation of parameterMarkerSegments later to make it more elegant.


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
