### PR TITLE
Pipeline support parallel decoding plugin of opengauss

### DIFF
--- a/.github/workflows/e2e-operation.yml
+++ b/.github/workflows/e2e-operation.yml
@@ -60,12 +60,12 @@ jobs:
       fail-fast: false
       matrix:
         operation: [ transaction, pipeline, showprocesslist ]
-        image: [ { type: "it.docker.mysql.version", version: "mysql:5.7" }, { type: "it.docker.postgresql.version", version: "postgres:12-alpine" }, { type: "it.docker.opengauss.version", version: "enmotech/opengauss:2.1.0" } ]
+        image: [ { type: "it.docker.mysql.version", version: "mysql:5.7" }, { type: "it.docker.postgresql.version", version: "postgres:12-alpine" }, { type: "it.docker.opengauss.version", version: "enmotech/opengauss:2.1.0,enmotech/opengauss:3.1.0" } ]
         exclude:
           - operation: showprocesslist
             image: { type: "it.docker.postgresql.version", version: "postgres:12-alpine" }
           - operation: showprocesslist
-            image: { type: "it.docker.opengauss.version", version: "enmotech/opengauss:2.1.0" }
+            image: { type: "it.docker.opengauss.version", version: "enmotech/opengauss:2.1.0,enmotech/opengauss:3.1.0" }
     steps:
       - env:
           changed_operations: ${{ needs.detect-changed-files.outputs.changed_operations }}

--- a/kernel/data-pipeline/dialect/opengauss/src/main/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/wal/decode/MppdbDecodingPlugin.java
+++ b/kernel/data-pipeline/dialect/opengauss/src/main/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/wal/decode/MppdbDecodingPlugin.java
@@ -57,9 +57,7 @@ public final class MppdbDecodingPlugin implements DecodingPlugin {
     
     private final boolean decodeWithTX;
     
-    public MppdbDecodingPlugin(final BaseTimestampUtils timestampUtils) {
-        this(timestampUtils, false);
-    }
+    private final int majorVersion;
     
     @Override
     public AbstractWALEvent decode(final ByteBuffer data, final BaseLogSequenceNumber logSequenceNumber) {
@@ -78,15 +76,28 @@ public final class MppdbDecodingPlugin implements DecodingPlugin {
     
     private AbstractWALEvent decodeDataWithTX(final String dataText) {
         AbstractWALEvent result = new PlaceholderEvent();
-        if (dataText.startsWith("BEGIN")) {
-            int beginIndex = dataText.indexOf("BEGIN") + "BEGIN".length() + 1;
-            result = new BeginTXEvent(Long.parseLong(dataText.substring(beginIndex)));
-        } else if (dataText.startsWith("COMMIT")) {
-            int commitBeginIndex = dataText.indexOf("COMMIT") + "COMMIT".length() + 1;
-            int csnBeginIndex = dataText.indexOf("CSN") + "CSN".length() + 1;
-            result = new CommitTXEvent(Long.parseLong(dataText.substring(commitBeginIndex, dataText.indexOf(' ', commitBeginIndex))), Long.parseLong(dataText.substring(csnBeginIndex)));
-        } else if (dataText.startsWith("{")) {
-            result = readTableEvent(dataText);
+        if (majorVersion <= 2) {
+            if (dataText.startsWith("BEGIN")) {
+                int beginIndex = dataText.indexOf("BEGIN") + "BEGIN".length() + 1;
+                result = new BeginTXEvent(Long.parseLong(dataText.substring(beginIndex)), null);
+            } else if (dataText.startsWith("COMMIT")) {
+                int commitBeginIndex = dataText.indexOf("COMMIT") + "COMMIT".length() + 1;
+                int csnBeginIndex = dataText.indexOf("CSN") + "CSN".length() + 1;
+                result = new CommitTXEvent(Long.parseLong(dataText.substring(commitBeginIndex, dataText.indexOf(' ', commitBeginIndex))), Long.parseLong(dataText.substring(csnBeginIndex)));
+            } else if (dataText.startsWith("{")) {
+                result = readTableEvent(dataText);
+            }
+        } else {
+            if (dataText.startsWith("BEGIN")) {
+                int beginIndex = dataText.indexOf("CSN:") + "CSN:".length() + 1;
+                int endIndex = dataText.indexOf("first_lsn") - 1;
+                result = new BeginTXEvent(null, Long.parseLong(dataText.substring(beginIndex, endIndex)));
+            } else if (dataText.startsWith("commit")) {
+                int beginIndex = dataText.indexOf("xid:") + "xid:".length() + 1;
+                result = new CommitTXEvent(Long.parseLong(dataText.substring(beginIndex)), null);
+            } else if (dataText.startsWith("{")) {
+                result = readTableEvent(dataText);
+            }
         }
         return result;
     }

--- a/kernel/data-pipeline/dialect/opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/OpenGaussWALDumperTest.java
+++ b/kernel/data-pipeline/dialect/opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/OpenGaussWALDumperTest.java
@@ -17,41 +17,23 @@
 
 package org.apache.shardingsphere.data.pipeline.opengauss.ingest;
 
-import org.apache.shardingsphere.data.pipeline.api.type.StandardPipelineDataSourceConfiguration;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.DumperCommonContext;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.incremental.IncrementalDumperContext;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.mapper.ActualAndLogicTableNameMapper;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.mapper.TableAndSchemaNameMapper;
 import org.apache.shardingsphere.infra.util.reflection.ReflectionUtils;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class OpenGaussWALDumperTest {
     
     @Test
-    void assertGetVersion() throws NoSuchMethodException, SQLException {
-        StandardPipelineDataSourceConfiguration mockDataSourceConfig = new StandardPipelineDataSourceConfiguration("jdbc:mysql://127.0.0.1:3306/test", "root", "root");
-        IncrementalDumperContext dumperContext = new IncrementalDumperContext(new DumperCommonContext("", mockDataSourceConfig, mock(ActualAndLogicTableNameMapper.class),
-                mock(TableAndSchemaNameMapper.class)), "1", true);
-        OpenGaussWALDumper dumper = new OpenGaussWALDumper(dumperContext, null, null, null);
-        Connection connection = mock(Connection.class);
-        Statement statement = mock(Statement.class);
-        ResultSet resultSet = mock(ResultSet.class);
-        when(connection.createStatement()).thenReturn(statement);
-        when(statement.executeQuery(anyString())).thenReturn(resultSet);
-        when(resultSet.next()).thenReturn(true);
-        when(resultSet.getString(1)).thenReturn("(openGauss 3.1.0 build ) compiled at 2023-02-17 16:13:51 commit 0 last mr   on x86_64-unknown-linux-gnu, compiled by g++ (GCC) 7.3.0, 64-bit");
-        int version = ReflectionUtils.invokeMethod(dumper.getClass().getDeclaredMethod("getMajorVersion", Connection.class), dumper, connection);
+    void assertGetVersion() throws NoSuchMethodException {
+        OpenGaussWALDumper dumper = mock(OpenGaussWALDumper.class);
+        int version = ReflectionUtils.invokeMethod(OpenGaussWALDumper.class.getDeclaredMethod("parseMajorVersion", String.class), dumper,
+                "(openGauss 3.1.0 build ) compiled at 2023-02-17 16:13:51 commit 0 last mr   on x86_64-unknown-linux-gnu, compiled by g++ (GCC) 7.3.0, 64-bit");
         assertThat(version, is(3));
+        OpenGaussWALDumper mock = mock(OpenGaussWALDumper.class);
+        version = ReflectionUtils.invokeMethod(OpenGaussWALDumper.class.getDeclaredMethod("parseMajorVersion", String.class), mock, "(openGauss 5.0.1 build )");
+        assertThat(version, is(5));
     }
 }

--- a/kernel/data-pipeline/dialect/opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/OpenGaussWALDumperTest.java
+++ b/kernel/data-pipeline/dialect/opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/OpenGaussWALDumperTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.opengauss.ingest;
+
+import org.apache.shardingsphere.data.pipeline.api.type.StandardPipelineDataSourceConfiguration;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.DumperCommonContext;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.incremental.IncrementalDumperContext;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.mapper.ActualAndLogicTableNameMapper;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.mapper.TableAndSchemaNameMapper;
+import org.apache.shardingsphere.infra.util.reflection.ReflectionUtils;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OpenGaussWALDumperTest {
+    
+    @Test
+    void assertGetVersion() throws NoSuchMethodException, SQLException {
+        StandardPipelineDataSourceConfiguration mockDataSourceConfig = new StandardPipelineDataSourceConfiguration("jdbc:mysql://127.0.0.1:3306/test", "root", "root");
+        IncrementalDumperContext dumperContext = new IncrementalDumperContext(new DumperCommonContext("", mockDataSourceConfig, mock(ActualAndLogicTableNameMapper.class),
+                mock(TableAndSchemaNameMapper.class)), "1", true);
+        OpenGaussWALDumper dumper = new OpenGaussWALDumper(dumperContext, null, null, null);
+        Connection connection = mock(Connection.class);
+        Statement statement = mock(Statement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeQuery(anyString())).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(1)).thenReturn("(openGauss 3.1.0 build ) compiled at 2023-02-17 16:13:51 commit 0 last mr   on x86_64-unknown-linux-gnu, compiled by g++ (GCC) 7.3.0, 64-bit");
+        int version = ReflectionUtils.invokeMethod(dumper.getClass().getDeclaredMethod("getMajorVersion", Connection.class), dumper, connection);
+        assertThat(version, is(3));
+    }
+}

--- a/kernel/data-pipeline/dialect/opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/OpenGaussWALDumperTest.java
+++ b/kernel/data-pipeline/dialect/opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/OpenGaussWALDumperTest.java
@@ -35,5 +35,7 @@ class OpenGaussWALDumperTest {
         OpenGaussWALDumper mock = mock(OpenGaussWALDumper.class);
         version = ReflectionUtils.invokeMethod(OpenGaussWALDumper.class.getDeclaredMethod("parseMajorVersion", String.class), mock, "(openGauss 5.0.1 build )");
         assertThat(version, is(5));
+        version = ReflectionUtils.invokeMethod(OpenGaussWALDumper.class.getDeclaredMethod("parseMajorVersion", String.class), mock, "not match");
+        assertThat(version, is(2));
     }
 }

--- a/kernel/data-pipeline/dialect/opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/wal/decode/MppdbDecodingPluginTest.java
+++ b/kernel/data-pipeline/dialect/opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/wal/decode/MppdbDecodingPluginTest.java
@@ -66,7 +66,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsName(IntStream.range(0, insertTypes.length).mapToObj(idx -> "data" + idx).toArray(String[]::new));
         tableData.setColumnsVal(IntStream.range(0, insertTypes.length).mapToObj(idx -> "'1 2 3'").toArray(String[]::new));
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         IntStream.range(0, insertTypes.length).forEach(each -> assertThat(actual.getAfterRow().get(each), is("1 2 3")));
@@ -81,7 +81,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"character varying"});
         tableData.setColumnsVal(new String[]{"'1 2 3'"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        UpdateRowEvent actual = (UpdateRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
+        UpdateRowEvent actual = (UpdateRowEvent) new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         assertThat(actual.getAfterRow().get(0), is("1 2 3"));
@@ -98,7 +98,7 @@ class MppdbDecodingPluginTest {
         tableData.setOldKeysName(IntStream.range(0, deleteTypes.length).mapToObj(idx -> "data" + idx).toArray(String[]::new));
         tableData.setOldKeysVal(deleteValues);
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        DeleteRowEvent actual = (DeleteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
+        DeleteRowEvent actual = (DeleteRowEvent) new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         IntStream.range(0, deleteTypes.length).forEach(each -> assertThat(actual.getPrimaryKeys().get(each).toString(), is(deleteValues[each])));
@@ -113,7 +113,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"money"});
         tableData.setColumnsVal(new String[]{"'$1.08'"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         Object byteaObj = actual.getAfterRow().get(0);
@@ -129,7 +129,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"boolean"});
         tableData.setColumnsVal(new String[]{Boolean.TRUE.toString()});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         Object byteaObj = actual.getAfterRow().get(0);
@@ -156,7 +156,7 @@ class MppdbDecodingPluginTest {
         when(timestampUtils.toTimestamp(null, "2010-12-12")).thenReturn(Timestamp.valueOf("2010-12-12 00:00:00.0"));
         when(timestampUtils.toTimestamp(null, "2013-12-11 pst")).thenReturn(Timestamp.valueOf("2013-12-11 16:00:00.0"));
         when(timestampUtils.toTimestamp(null, "2003-04-12 04:05:06")).thenReturn(Timestamp.valueOf("2003-04-12 04:05:00.0"));
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(new OpenGaussTimestampUtils(timestampUtils), false, 2).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(new OpenGaussTimestampUtils(timestampUtils), false, false).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         IntStream.range(0, insertTypes.length).forEach(each -> assertThat(actual.getAfterRow().get(each).toString(), is(compareValues[each])));
@@ -171,7 +171,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"bytea"});
         tableData.setColumnsVal(new String[]{"'\\xff00ab'"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         Object byteaObj = actual.getAfterRow().get(0);
@@ -188,7 +188,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"raw"});
         tableData.setColumnsVal(new String[]{"'7D'"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         Object byteaObj = actual.getAfterRow().get(0);
@@ -199,7 +199,7 @@ class MppdbDecodingPluginTest {
     @Test
     void assertDecodeUnknownTableType() {
         ByteBuffer data = ByteBuffer.wrap("unknown".getBytes());
-        assertThat(new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber), instanceOf(PlaceholderEvent.class));
+        assertThat(new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber), instanceOf(PlaceholderEvent.class));
     }
     
     @Test
@@ -211,7 +211,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"character varying"});
         tableData.setColumnsVal(new String[]{"1 2 3"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        assertThrows(IngestException.class, () -> new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber));
+        assertThrows(IngestException.class, () -> new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber));
     }
     
     @Test
@@ -225,7 +225,7 @@ class MppdbDecodingPluginTest {
         TimestampUtils timestampUtils = mock(TimestampUtils.class);
         when(timestampUtils.toTime(null, "1 2 3")).thenThrow(new SQLException(""));
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        assertThrows(DecodingException.class, () -> new MppdbDecodingPlugin(new OpenGaussTimestampUtils(timestampUtils), true, 2).decode(data, logSequenceNumber));
+        assertThrows(DecodingException.class, () -> new MppdbDecodingPlugin(new OpenGaussTimestampUtils(timestampUtils), true, false).decode(data, logSequenceNumber));
     }
     
     @Test
@@ -238,7 +238,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsVal(new String[]{"'7D'"});
         List<String> dataList = Arrays.asList("BEGIN 1", JsonUtils.toJsonString(tableData), JsonUtils.toJsonString(tableData),
                 "COMMIT 1 (at 2022-10-27 04:19:39.476261+00) CSN 3468");
-        MppdbDecodingPlugin mppdbDecodingPlugin = new MppdbDecodingPlugin(null, true, 2);
+        MppdbDecodingPlugin mppdbDecodingPlugin = new MppdbDecodingPlugin(null, true, false);
         List<AbstractWALEvent> expectedEvent = new LinkedList<>();
         for (String each : dataList) {
             expectedEvent.add(mppdbDecodingPlugin.decode(ByteBuffer.wrap(each.getBytes()), logSequenceNumber));
@@ -261,7 +261,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"raw"});
         tableData.setColumnsVal(new String[]{"'7D'"});
         List<String> dataList = Arrays.asList("BEGIN CSN: 951909 first_lsn: 5/59825858", JsonUtils.toJsonString(tableData), JsonUtils.toJsonString(tableData), "commit xid: 1006076");
-        MppdbDecodingPlugin mppdbDecodingPlugin = new MppdbDecodingPlugin(null, true, 3);
+        MppdbDecodingPlugin mppdbDecodingPlugin = new MppdbDecodingPlugin(null, true, true);
         List<AbstractWALEvent> actual = new LinkedList<>();
         for (String each : dataList) {
             actual.add(mppdbDecodingPlugin.decode(ByteBuffer.wrap(each.getBytes()), logSequenceNumber));
@@ -284,7 +284,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"tsrange"});
         tableData.setColumnsVal(new String[]{"'[\"2020-01-01 00:00:00\",\"2021-01-01 00:00:00\")'"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber);
         Object byteaObj = actual.getAfterRow().get(0);
         assertThat(byteaObj, instanceOf(PGobject.class));
         assertThat(byteaObj.toString(), is("[\"2020-01-01 00:00:00\",\"2021-01-01 00:00:00\")"));
@@ -299,7 +299,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"daterange"});
         tableData.setColumnsVal(new String[]{"'[2020-01-02,2021-01-02)'"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber);
         Object byteaObj = actual.getAfterRow().get(0);
         assertThat(byteaObj, instanceOf(PGobject.class));
         assertThat(byteaObj.toString(), is("[2020-01-02,2021-01-02)"));
@@ -314,7 +314,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"tsquery"});
         tableData.setColumnsVal(new String[]{"'''fff'' | ''faa'''"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber);
         Object byteaObj = actual.getAfterRow().get(0);
         assertThat(byteaObj.toString(), is("'fff' | 'faa'"));
     }
@@ -328,7 +328,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"tinyint"});
         tableData.setColumnsVal(new String[]{"255"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, false).decode(data, logSequenceNumber);
         Object byteaObj = actual.getAfterRow().get(0);
         assertThat(byteaObj, is(255));
     }

--- a/kernel/data-pipeline/dialect/opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/wal/decode/MppdbDecodingPluginTest.java
+++ b/kernel/data-pipeline/dialect/opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/wal/decode/MppdbDecodingPluginTest.java
@@ -262,15 +262,17 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsVal(new String[]{"'7D'"});
         List<String> dataList = Arrays.asList("BEGIN CSN: 951909 first_lsn: 5/59825858", JsonUtils.toJsonString(tableData), JsonUtils.toJsonString(tableData), "commit xid: 1006076");
         MppdbDecodingPlugin mppdbDecodingPlugin = new MppdbDecodingPlugin(null, true, 3);
-        List<AbstractWALEvent> expectedEvents = new LinkedList<>();
+        List<AbstractWALEvent> actual = new LinkedList<>();
         for (String each : dataList) {
-            expectedEvents.add(mppdbDecodingPlugin.decode(ByteBuffer.wrap(each.getBytes()), logSequenceNumber));
+            actual.add(mppdbDecodingPlugin.decode(ByteBuffer.wrap(each.getBytes()), logSequenceNumber));
         }
-        assertThat(expectedEvents.size(), is(4));
-        assertInstanceOf(BeginTXEvent.class, expectedEvents.get(0));
-        assertThat(((BeginTXEvent) expectedEvents.get(0)).getCsn(), is(951909L));
-        assertThat(((CommitTXEvent) expectedEvents.get(3)).getXid(), is(1006076L));
-        assertNull(((CommitTXEvent) expectedEvents.get(3)).getCsn());
+        assertThat(actual.size(), is(4));
+        assertInstanceOf(BeginTXEvent.class, actual.get(0));
+        assertThat(((BeginTXEvent) actual.get(0)).getCsn(), is(951909L));
+        assertThat(((WriteRowEvent) actual.get(1)).getAfterRow().get(0).toString(), is("7D"));
+        assertThat(((WriteRowEvent) actual.get(2)).getAfterRow().get(0).toString(), is("7D"));
+        assertThat(((CommitTXEvent) actual.get(3)).getXid(), is(1006076L));
+        assertNull(((CommitTXEvent) actual.get(3)).getCsn());
     }
     
     @Test

--- a/kernel/data-pipeline/dialect/opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/wal/decode/MppdbDecodingPluginTest.java
+++ b/kernel/data-pipeline/dialect/opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/wal/decode/MppdbDecodingPluginTest.java
@@ -45,6 +45,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -65,7 +66,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsName(IntStream.range(0, insertTypes.length).mapToObj(idx -> "data" + idx).toArray(String[]::new));
         tableData.setColumnsVal(IntStream.range(0, insertTypes.length).mapToObj(idx -> "'1 2 3'").toArray(String[]::new));
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         IntStream.range(0, insertTypes.length).forEach(each -> assertThat(actual.getAfterRow().get(each), is("1 2 3")));
@@ -80,7 +81,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"character varying"});
         tableData.setColumnsVal(new String[]{"'1 2 3'"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        UpdateRowEvent actual = (UpdateRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        UpdateRowEvent actual = (UpdateRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         assertThat(actual.getAfterRow().get(0), is("1 2 3"));
@@ -97,7 +98,7 @@ class MppdbDecodingPluginTest {
         tableData.setOldKeysName(IntStream.range(0, deleteTypes.length).mapToObj(idx -> "data" + idx).toArray(String[]::new));
         tableData.setOldKeysVal(deleteValues);
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        DeleteRowEvent actual = (DeleteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        DeleteRowEvent actual = (DeleteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         IntStream.range(0, deleteTypes.length).forEach(each -> assertThat(actual.getPrimaryKeys().get(each).toString(), is(deleteValues[each])));
@@ -112,7 +113,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"money"});
         tableData.setColumnsVal(new String[]{"'$1.08'"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         Object byteaObj = actual.getAfterRow().get(0);
@@ -128,7 +129,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"boolean"});
         tableData.setColumnsVal(new String[]{Boolean.TRUE.toString()});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         Object byteaObj = actual.getAfterRow().get(0);
@@ -155,7 +156,7 @@ class MppdbDecodingPluginTest {
         when(timestampUtils.toTimestamp(null, "2010-12-12")).thenReturn(Timestamp.valueOf("2010-12-12 00:00:00.0"));
         when(timestampUtils.toTimestamp(null, "2013-12-11 pst")).thenReturn(Timestamp.valueOf("2013-12-11 16:00:00.0"));
         when(timestampUtils.toTimestamp(null, "2003-04-12 04:05:06")).thenReturn(Timestamp.valueOf("2003-04-12 04:05:00.0"));
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(new OpenGaussTimestampUtils(timestampUtils)).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(new OpenGaussTimestampUtils(timestampUtils), false, 2).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         IntStream.range(0, insertTypes.length).forEach(each -> assertThat(actual.getAfterRow().get(each).toString(), is(compareValues[each])));
@@ -170,7 +171,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"bytea"});
         tableData.setColumnsVal(new String[]{"'\\xff00ab'"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         Object byteaObj = actual.getAfterRow().get(0);
@@ -187,7 +188,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"raw"});
         tableData.setColumnsVal(new String[]{"'7D'"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
         assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
         assertThat(actual.getTableName(), is("test"));
         Object byteaObj = actual.getAfterRow().get(0);
@@ -198,7 +199,7 @@ class MppdbDecodingPluginTest {
     @Test
     void assertDecodeUnknownTableType() {
         ByteBuffer data = ByteBuffer.wrap("unknown".getBytes());
-        assertThat(new MppdbDecodingPlugin(null).decode(data, logSequenceNumber), instanceOf(PlaceholderEvent.class));
+        assertThat(new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber), instanceOf(PlaceholderEvent.class));
     }
     
     @Test
@@ -210,7 +211,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"character varying"});
         tableData.setColumnsVal(new String[]{"1 2 3"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        assertThrows(IngestException.class, () -> new MppdbDecodingPlugin(null).decode(data, logSequenceNumber));
+        assertThrows(IngestException.class, () -> new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber));
     }
     
     @Test
@@ -224,11 +225,11 @@ class MppdbDecodingPluginTest {
         TimestampUtils timestampUtils = mock(TimestampUtils.class);
         when(timestampUtils.toTime(null, "1 2 3")).thenThrow(new SQLException(""));
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        assertThrows(DecodingException.class, () -> new MppdbDecodingPlugin(new OpenGaussTimestampUtils(timestampUtils), true).decode(data, logSequenceNumber));
+        assertThrows(DecodingException.class, () -> new MppdbDecodingPlugin(new OpenGaussTimestampUtils(timestampUtils), true, 2).decode(data, logSequenceNumber));
     }
     
     @Test
-    void assertDecodeWithXid() {
+    void assertDecodeWithTx() {
         MppTableData tableData = new MppTableData();
         tableData.setTableName("public.test");
         tableData.setOpType("INSERT");
@@ -237,7 +238,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsVal(new String[]{"'7D'"});
         List<String> dataList = Arrays.asList("BEGIN 1", JsonUtils.toJsonString(tableData), JsonUtils.toJsonString(tableData),
                 "COMMIT 1 (at 2022-10-27 04:19:39.476261+00) CSN 3468");
-        MppdbDecodingPlugin mppdbDecodingPlugin = new MppdbDecodingPlugin(null, true);
+        MppdbDecodingPlugin mppdbDecodingPlugin = new MppdbDecodingPlugin(null, true, 2);
         List<AbstractWALEvent> expectedEvent = new LinkedList<>();
         for (String each : dataList) {
             expectedEvent.add(mppdbDecodingPlugin.decode(ByteBuffer.wrap(each.getBytes()), logSequenceNumber));
@@ -245,11 +246,31 @@ class MppdbDecodingPluginTest {
         assertThat(expectedEvent.size(), is(4));
         AbstractWALEvent actualFirstEvent = expectedEvent.get(0);
         assertInstanceOf(BeginTXEvent.class, actualFirstEvent);
-        assertThat(((BeginTXEvent) actualFirstEvent).getXid(), is(1L));
         AbstractWALEvent actualLastEvent = expectedEvent.get(expectedEvent.size() - 1);
         assertInstanceOf(CommitTXEvent.class, actualLastEvent);
         assertThat(((CommitTXEvent) actualLastEvent).getCsn(), is(3468L));
         assertThat(((CommitTXEvent) actualLastEvent).getXid(), is(1L));
+    }
+    
+    @Test
+    void assertParallelDecodeWithTx() {
+        MppTableData tableData = new MppTableData();
+        tableData.setTableName("public.test");
+        tableData.setOpType("INSERT");
+        tableData.setColumnsName(new String[]{"data"});
+        tableData.setColumnsType(new String[]{"raw"});
+        tableData.setColumnsVal(new String[]{"'7D'"});
+        List<String> dataList = Arrays.asList("BEGIN CSN: 951909 first_lsn: 5/59825858", JsonUtils.toJsonString(tableData), JsonUtils.toJsonString(tableData), "commit xid: 1006076");
+        MppdbDecodingPlugin mppdbDecodingPlugin = new MppdbDecodingPlugin(null, true, 3);
+        List<AbstractWALEvent> expectedEvents = new LinkedList<>();
+        for (String each : dataList) {
+            expectedEvents.add(mppdbDecodingPlugin.decode(ByteBuffer.wrap(each.getBytes()), logSequenceNumber));
+        }
+        assertThat(expectedEvents.size(), is(4));
+        assertInstanceOf(BeginTXEvent.class, expectedEvents.get(0));
+        assertThat(((BeginTXEvent) expectedEvents.get(0)).getCsn(), is(951909L));
+        assertThat(((CommitTXEvent) expectedEvents.get(3)).getXid(), is(1006076L));
+        assertNull(((CommitTXEvent) expectedEvents.get(3)).getCsn());
     }
     
     @Test
@@ -261,7 +282,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"tsrange"});
         tableData.setColumnsVal(new String[]{"'[\"2020-01-01 00:00:00\",\"2021-01-01 00:00:00\")'"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
         Object byteaObj = actual.getAfterRow().get(0);
         assertThat(byteaObj, instanceOf(PGobject.class));
         assertThat(byteaObj.toString(), is("[\"2020-01-01 00:00:00\",\"2021-01-01 00:00:00\")"));
@@ -276,7 +297,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"daterange"});
         tableData.setColumnsVal(new String[]{"'[2020-01-02,2021-01-02)'"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
         Object byteaObj = actual.getAfterRow().get(0);
         assertThat(byteaObj, instanceOf(PGobject.class));
         assertThat(byteaObj.toString(), is("[2020-01-02,2021-01-02)"));
@@ -291,7 +312,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"tsquery"});
         tableData.setColumnsVal(new String[]{"'''fff'' | ''faa'''"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
         Object byteaObj = actual.getAfterRow().get(0);
         assertThat(byteaObj.toString(), is("'fff' | 'faa'"));
     }
@@ -305,7 +326,7 @@ class MppdbDecodingPluginTest {
         tableData.setColumnsType(new String[]{"tinyint"});
         tableData.setColumnsVal(new String[]{"255"});
         ByteBuffer data = ByteBuffer.wrap(JsonUtils.toJsonString(tableData).getBytes());
-        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null, false, 2).decode(data, logSequenceNumber);
         Object byteaObj = actual.getAfterRow().get(0);
         assertThat(byteaObj, is(255));
     }

--- a/kernel/data-pipeline/dialect/postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/decode/TestDecodingPlugin.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/decode/TestDecodingPlugin.java
@@ -53,7 +53,7 @@ public final class TestDecodingPlugin implements DecodingPlugin {
         AbstractWALEvent result;
         String type = readEventType(data);
         if (type.startsWith("BEGIN")) {
-            result = new BeginTXEvent(Long.parseLong(readNextSegment(data)));
+            result = new BeginTXEvent(Long.parseLong(readNextSegment(data)), null);
         } else if (type.startsWith("COMMIT")) {
             result = new CommitTXEvent(Long.parseLong(readNextSegment(data)), null);
         } else {

--- a/kernel/data-pipeline/dialect/postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/event/BeginTXEvent.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/event/BeginTXEvent.java
@@ -27,5 +27,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public final class BeginTXEvent extends AbstractWALEvent {
     
-    private final long xid;
+    private final Long xid;
+    
+    private final Long csn;
 }

--- a/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/WALEventConverterTest.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/WALEventConverterTest.java
@@ -144,7 +144,7 @@ class WALEventConverterTest {
     
     @Test
     void assertConvertBeginTXEvent() {
-        BeginTXEvent beginTXEvent = new BeginTXEvent(100);
+        BeginTXEvent beginTXEvent = new BeginTXEvent(100L, null);
         beginTXEvent.setLogSequenceNumber(new PostgreSQLLogSequenceNumber(logSequenceNumber));
         Record record = walEventConverter.convert(beginTXEvent);
         assertInstanceOf(PlaceholderRecord.class, record);


### PR DESCRIPTION
Parallel decoder enabled by default after opengauss 3
Fixes: #29554

Changes proposed in this pull request:
  - Pipeline support parallel decoding plugin of opengauss

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
