### PR TITLE
Override maxAliasesForCollections at LoaderOptions

### DIFF
--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/yaml/AgentYamlEngine.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/yaml/AgentYamlEngine.java
@@ -54,7 +54,7 @@ public final class AgentYamlEngine {
     
     private static LoaderOptions createLoaderOptions() {
         LoaderOptions result = new LoaderOptions();
-        result.setMaxAliasesForCollections(Integer.MAX_VALUE);
+        result.setMaxAliasesForCollections(1000);
         result.setCodePointLimit(Integer.MAX_VALUE);
         return result;
     }

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/yaml/AgentYamlEngine.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/yaml/AgentYamlEngine.java
@@ -54,6 +54,7 @@ public final class AgentYamlEngine {
     
     private static LoaderOptions createLoaderOptions() {
         LoaderOptions result = new LoaderOptions();
+        result.setMaxAliasesForCollections(Integer.MAX_VALUE);
         result.setCodePointLimit(Integer.MAX_VALUE);
         return result;
     }

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/constructor/ShardingSphereYamlConstructor.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/constructor/ShardingSphereYamlConstructor.java
@@ -49,6 +49,7 @@ public class ShardingSphereYamlConstructor extends Constructor {
     
     private static LoaderOptions createLoaderOptions() {
         LoaderOptions result = new LoaderOptions();
+        result.setMaxAliasesForCollections(Integer.MAX_VALUE);
         result.setCodePointLimit(Integer.MAX_VALUE);
         return result;
     }

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/constructor/ShardingSphereYamlConstructor.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/constructor/ShardingSphereYamlConstructor.java
@@ -49,7 +49,7 @@ public class ShardingSphereYamlConstructor extends Constructor {
     
     private static LoaderOptions createLoaderOptions() {
         LoaderOptions result = new LoaderOptions();
-        result.setMaxAliasesForCollections(Integer.MAX_VALUE);
+        result.setMaxAliasesForCollections(1000);
         result.setCodePointLimit(Integer.MAX_VALUE);
         return result;
     }


### PR DESCRIPTION
Default `maxAliasesForCollections` is 50, if over it, will throw `org.yaml.snakeyaml.error.YAMLException: Number of aliases for non-scalar nodes exceeds the specified max=50`

Changes proposed in this pull request:
  - Set it to Integer.MAX

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
