### PR TITLE
add `role_edges` schema table for `mysql` database.

### DIFF
--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/SystemSchemaManagerTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/SystemSchemaManagerTest.java
@@ -34,7 +34,7 @@ class SystemSchemaManagerTest {
         Collection<String> actualInformationSchema = SystemSchemaManager.getTables("MySQL", "information_schema");
         assertThat(actualInformationSchema.size(), is(61));
         Collection<String> actualMySQLSchema = SystemSchemaManager.getTables("MySQL", "mysql");
-        assertThat(actualMySQLSchema.size(), is(31));
+        assertThat(actualMySQLSchema.size(), is(32));
         Collection<String> actualPerformanceSchema = SystemSchemaManager.getTables("MySQL", "performance_schema");
         assertThat(actualPerformanceSchema.size(), is(87));
         Collection<String> actualSysSchema = SystemSchemaManager.getTables("MySQL", "sys");

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -43,7 +43,7 @@ class SystemSchemaBuilderTest {
         Map<String, ShardingSphereSchema> actualMySQLSchema = SystemSchemaBuilder.build("mysql", databaseType, configProps);
         assertThat(actualMySQLSchema.size(), is(1));
         assertTrue(actualMySQLSchema.containsKey("mysql"));
-        assertThat(actualMySQLSchema.get("mysql").getTables().size(), is(31));
+        assertThat(actualMySQLSchema.get("mysql").getTables().size(), is(32));
         Map<String, ShardingSphereSchema> actualPerformanceSchema = SystemSchemaBuilder.build("performance_schema", databaseType, configProps);
         assertThat(actualPerformanceSchema.size(), is(1));
         assertTrue(actualPerformanceSchema.containsKey("performance_schema"));

--- a/infra/database/type/mysql/src/main/resources/schema/mysql/mysql/role_edges.yaml
+++ b/infra/database/type/mysql/src/main/resources/schema/mysql/mysql/role_edges.yaml
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: role_edges
+columns:
+  from_host:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: FROM_HOST
+    primaryKey: true
+    visible: true
+  from_user:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: FROM_USER
+    primaryKey: true
+    visible: true
+  to_host:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: TO_HOST
+    primaryKey: true
+    visible: true
+  to_user:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: TO_USER
+    primaryKey: true
+    visible: true
+  with_admin_option:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: WITH_ADMIN_OPTION
+    primaryKey: false
+    visible: true
+indexes:
+  primary:
+    name: PRIMARY

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/MySQLContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/MySQLContainer.java
@@ -41,7 +41,7 @@ public final class MySQLContainer extends DockerStorageContainer {
     private final StorageContainerConfiguration storageContainerConfig;
     
     public MySQLContainer(final String containerImage, final StorageContainerConfiguration storageContainerConfig) {
-        super(TypedSPILoader.getService(DatabaseType.class, "MySQL"), Strings.isNullOrEmpty(containerImage) ? "mysql:5.7" : containerImage);
+        super(TypedSPILoader.getService(DatabaseType.class, "MySQL"), Strings.isNullOrEmpty(containerImage) ? "mysql:8.0" : containerImage);
         this.storageContainerConfig = storageContainerConfig;
     }
     

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_mysql_role_edges.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_mysql_role_edges.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="from_host" />
+        <column name="from_user" />
+        <column name="to_host" />
+        <column name="to_user" />
+        <column name="with_admin_option" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema-mysql.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema-mysql.xml
@@ -277,6 +277,10 @@
     <test-case sql="SELECT * FROM mysql.procs_priv limit 1" db-types="MySQL" scenario-types="tbl" adapters="proxy">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
+
+    <test-case sql="SELECT * FROM mysql.role_edges limit 1" db-types="MySQL" scenario-types="tbl" adapters="proxy">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
     
     <test-case sql="SELECT * FROM mysql.server_cost limit 1" db-types="MySQL" scenario-types="tbl" adapters="proxy">
         <assertion expected-data-source-name="read_dataset" />


### PR DESCRIPTION
For #30483 

Changes proposed in this pull request:
  - add `role_edges` schema table for `mysql` database.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
