### PR TITLE
Support SQLServer dml encrypt with schema

### DIFF
--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
@@ -514,7 +514,7 @@ class ShardingDQLResultMergerTest {
         return new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME, TypedSPILoader.getService(DatabaseType.class, "MySQL"), mock(ResourceMetaData.class),
                 mock(RuleMetaData.class), Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema));
     }
-
+    
     private ShardingSphereDatabase createSQLServerDatabase() {
         ShardingSphereColumn column1 = new ShardingSphereColumn("col1", 0, false, false, false, true, false, false);
         ShardingSphereColumn column2 = new ShardingSphereColumn("col2", 0, false, false, false, true, false, false);
@@ -524,8 +524,7 @@ class ShardingDQLResultMergerTest {
         return new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME, TypedSPILoader.getService(DatabaseType.class, "MySQL"), mock(ResourceMetaData.class),
                 mock(RuleMetaData.class), Collections.singletonMap("dbo", schema));
     }
-
-
+    
     private SelectStatement buildSelectStatement(final SelectStatement result) {
         result.setFrom(new SimpleTableSegment(new TableNameSegment(10, 13, new IdentifierValue("tbl"))));
         result.setProjections(new ProjectionsSegment(0, 0));

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
@@ -158,7 +158,7 @@ class ShardingDQLResultMergerTest {
         selectStatement.setProjections(new ProjectionsSegment(0, 0));
         selectStatement.setLimit(new LimitSegment(0, 0, new NumberLiteralLimitValueSegment(0, 0, 1), null));
         SelectStatementContext selectStatementContext = new SelectStatementContext(createShardingSphereMetaData(database), Collections.emptyList(), selectStatement, DefaultDatabase.LOGIC_NAME);
-        MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createDatabase(), mock(ConnectionContext.class));
+        MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createSQLServerDatabase(), mock(ConnectionContext.class));
         assertThat(actual, instanceOf(TopAndRowNumberDecoratorMergedResult.class));
         assertThat(((TopAndRowNumberDecoratorMergedResult) actual).getMergedResult(), instanceOf(IteratorStreamMergedResult.class));
     }
@@ -235,7 +235,7 @@ class ShardingDQLResultMergerTest {
         selectStatement.setLimit(new LimitSegment(0, 0, new NumberLiteralRowNumberValueSegment(0, 0, 1, true), null));
         SelectStatementContext selectStatementContext = new SelectStatementContext(createShardingSphereMetaData(database), Collections.emptyList(),
                 selectStatement, DefaultDatabase.LOGIC_NAME);
-        MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createDatabase(), mock(ConnectionContext.class));
+        MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createSQLServerDatabase(), mock(ConnectionContext.class));
         assertThat(actual, instanceOf(TopAndRowNumberDecoratorMergedResult.class));
         assertThat(((TopAndRowNumberDecoratorMergedResult) actual).getMergedResult(), instanceOf(OrderByStreamMergedResult.class));
     }
@@ -316,7 +316,7 @@ class ShardingDQLResultMergerTest {
         selectStatement.setLimit(new LimitSegment(0, 0, new NumberLiteralRowNumberValueSegment(0, 0, 1, true), null));
         SelectStatementContext selectStatementContext = new SelectStatementContext(createShardingSphereMetaData(database), Collections.emptyList(),
                 selectStatement, DefaultDatabase.LOGIC_NAME);
-        MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createDatabase(), mock(ConnectionContext.class));
+        MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createSQLServerDatabase(), mock(ConnectionContext.class));
         assertThat(actual, instanceOf(TopAndRowNumberDecoratorMergedResult.class));
         assertThat(((TopAndRowNumberDecoratorMergedResult) actual).getMergedResult(), instanceOf(GroupByStreamMergedResult.class));
     }
@@ -395,7 +395,7 @@ class ShardingDQLResultMergerTest {
         selectStatement.setLimit(new LimitSegment(0, 0, new NumberLiteralRowNumberValueSegment(0, 0, 1, true), null));
         SelectStatementContext selectStatementContext = new SelectStatementContext(createShardingSphereMetaData(database), Collections.emptyList(),
                 selectStatement, DefaultDatabase.LOGIC_NAME);
-        MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createDatabase(), mock(ConnectionContext.class));
+        MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createSQLServerDatabase(), mock(ConnectionContext.class));
         assertThat(actual, instanceOf(TopAndRowNumberDecoratorMergedResult.class));
         assertThat(((TopAndRowNumberDecoratorMergedResult) actual).getMergedResult(), instanceOf(GroupByMemoryMergedResult.class));
     }
@@ -477,7 +477,7 @@ class ShardingDQLResultMergerTest {
         selectStatement.setLimit(new LimitSegment(0, 0, new NumberLiteralRowNumberValueSegment(0, 0, 1, true), null));
         SelectStatementContext selectStatementContext = new SelectStatementContext(createShardingSphereMetaData(database), Collections.emptyList(),
                 selectStatement, DefaultDatabase.LOGIC_NAME);
-        MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createDatabase(), mock(ConnectionContext.class));
+        MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createSQLServerDatabase(), mock(ConnectionContext.class));
         assertThat(actual, instanceOf(TopAndRowNumberDecoratorMergedResult.class));
         assertThat(((TopAndRowNumberDecoratorMergedResult) actual).getMergedResult(), instanceOf(GroupByMemoryMergedResult.class));
     }
@@ -514,7 +514,18 @@ class ShardingDQLResultMergerTest {
         return new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME, TypedSPILoader.getService(DatabaseType.class, "MySQL"), mock(ResourceMetaData.class),
                 mock(RuleMetaData.class), Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema));
     }
-    
+
+    private ShardingSphereDatabase createSQLServerDatabase() {
+        ShardingSphereColumn column1 = new ShardingSphereColumn("col1", 0, false, false, false, true, false, false);
+        ShardingSphereColumn column2 = new ShardingSphereColumn("col2", 0, false, false, false, true, false, false);
+        ShardingSphereColumn column3 = new ShardingSphereColumn("col3", 0, false, false, false, true, false, false);
+        ShardingSphereTable table = new ShardingSphereTable("tbl", Arrays.asList(column1, column2, column3), Collections.emptyList(), Collections.emptyList());
+        ShardingSphereSchema schema = new ShardingSphereSchema(Collections.singletonMap("tbl", table), Collections.emptyMap());
+        return new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME, TypedSPILoader.getService(DatabaseType.class, "MySQL"), mock(ResourceMetaData.class),
+                mock(RuleMetaData.class), Collections.singletonMap("dbo", schema));
+    }
+
+
     private SelectStatement buildSelectStatement(final SelectStatement result) {
         result.setFrom(new SimpleTableSegment(new TableNameSegment(10, 13, new IdentifierValue("tbl"))));
         result.setProjections(new ProjectionsSegment(0, 0));

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
@@ -521,7 +521,7 @@ class ShardingDQLResultMergerTest {
         ShardingSphereColumn column3 = new ShardingSphereColumn("col3", 0, false, false, false, true, false, false);
         ShardingSphereTable table = new ShardingSphereTable("tbl", Arrays.asList(column1, column2, column3), Collections.emptyList(), Collections.emptyList());
         ShardingSphereSchema schema = new ShardingSphereSchema(Collections.singletonMap("tbl", table), Collections.emptyMap());
-        return new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME, TypedSPILoader.getService(DatabaseType.class, "MySQL"), mock(ResourceMetaData.class),
+        return new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME, TypedSPILoader.getService(DatabaseType.class, "SQLServer"), mock(ResourceMetaData.class),
                 mock(RuleMetaData.class), Collections.singletonMap("dbo", schema));
     }
     

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateTableStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateTableStatementValidatorTest.java
@@ -100,7 +100,7 @@ class ShardingCreateTableStatementValidatorTest {
     void assertPreValidateCreateTableForSQLServer() {
         SQLServerCreateTableStatement sqlStatement = new SQLServerCreateTableStatement();
         sqlStatement.setTable(new SimpleTableSegment(new TableNameSegment(1, 2, new IdentifierValue("t_order"))));
-        assertThrows(TableExistsException.class, () -> assertPreValidateCreateTable(sqlStatement, "sharding_db"));
+        assertThrows(TableExistsException.class, () -> assertPreValidateCreateTable(sqlStatement, "dbo"));
     }
     
     private void assertPreValidateCreateTable(final CreateTableStatement sqlStatement, final String schemaName) {

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/SQLStatementContextFactoryTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/SQLStatementContextFactoryTest.java
@@ -154,6 +154,8 @@ class SQLStatementContextFactoryTest {
         when(database.containsSchema("public")).thenReturn(true);
         when(database.getSchema(DefaultDatabase.LOGIC_NAME).containsTable("tbl")).thenReturn(true);
         when(database.getSchema("public").containsTable("tbl")).thenReturn(true);
+        when(database.containsSchema("dbo")).thenReturn(true);
+        when(database.getSchema("dbo").containsTable("tbl")).thenReturn(true);
         Map<String, ShardingSphereDatabase> databases = Collections.singletonMap(DefaultDatabase.LOGIC_NAME, database);
         return new ShardingSphereMetaData(databases, mock(ResourceMetaData.class), mock(RuleMetaData.class), mock(ConfigurationProperties.class));
     }

--- a/infra/database/type/sqlserver/src/main/java/org/apache/shardingsphere/infra/database/sqlserver/metadata/database/SQLServerDatabaseMetaData.java
+++ b/infra/database/type/sqlserver/src/main/java/org/apache/shardingsphere/infra/database/sqlserver/metadata/database/SQLServerDatabaseMetaData.java
@@ -21,6 +21,8 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.DialectDa
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
 
+import java.util.Optional;
+
 /**
  * Database meta data of SQLServer.
  */
@@ -39,5 +41,10 @@ public final class SQLServerDatabaseMetaData implements DialectDatabaseMetaData 
     @Override
     public String getDatabaseType() {
         return "SQLServer";
+    }
+    
+    @Override
+    public Optional<String> getDefaultSchema() {
+        return Optional.of("dbo");
     }
 }

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-where.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-where.xml
@@ -98,4 +98,9 @@
         <input sql="SELECT * FROM t_user where user_name like '%an%'"/>
         <output sql="SELECT t_user.[user_id], t_user.[user_name_cipher] AS [user_name], t_user.[password_cipher] AS [password], t_user.[email_cipher] AS [email], t_user.[user_telephone_cipher] AS [telephone], t_user.[creation_date] FROM t_user where user_name_like like '%`m%'"/>
     </rewrite-assertion>
+
+    <rewrite-assertion id="select_from_user_with_schema" db-types="SQLServer">
+        <input sql="SELECT * FROM dbo.t_user"/>
+        <output sql="SELECT t_user.[user_id], t_user.[user_name_cipher] AS [user_name], t_user.[password_cipher] AS [password], t_user.[email_cipher] AS [email], t_user.[user_telephone_cipher] AS [telephone], t_user.[creation_date] FROM dbo.t_user"/>
+    </rewrite-assertion>
 </rewrite-assertions>

--- a/test/it/rewriter/src/test/resources/scenario/sharding/case/dml/delete.xml
+++ b/test/it/rewriter/src/test/resources/scenario/sharding/case/dml/delete.xml
@@ -27,13 +27,13 @@
         <output sql="DELETE FROM t_account_0 WHERE account_id = 100" />
     </rewrite-assertion>
     
-    <rewrite-assertion id="delete_without_sharding_value_for_parameters" db-types="MySQL,Oracle,SQLServer,SQL92">
+    <rewrite-assertion id="delete_without_sharding_value_for_parameters" db-types="MySQL,Oracle,SQL92">
         <input sql="DELETE FROM logic_db.t_account WHERE status = ?" parameters="OK" />
         <output sql="DELETE FROM t_account_0 WHERE status = ?" parameters="OK" />
         <output sql="DELETE FROM t_account_1 WHERE status = ?" parameters="OK" />
     </rewrite-assertion>
     
-    <rewrite-assertion id="delete_without_sharding_value_for_literals" db-types="MySQL,Oracle,SQLServer,SQL92">
+    <rewrite-assertion id="delete_without_sharding_value_for_literals" db-types="MySQL,Oracle,SQL92">
         <input sql="DELETE FROM logic_db.t_account WHERE status = 'OK'" />
         <output sql="DELETE FROM t_account_0 WHERE status = 'OK'" />
         <output sql="DELETE FROM t_account_1 WHERE status = 'OK'" />

--- a/test/it/rewriter/src/test/resources/scenario/sharding/case/dml/select.xml
+++ b/test/it/rewriter/src/test/resources/scenario/sharding/case/dml/select.xml
@@ -58,7 +58,7 @@
         <output sql="SELECT DISTINCT amount AS AGGREGATION_DISTINCT_DERIVED_0, account_id FROM t_account_1  ORDER BY account_id ASC " />
     </rewrite-assertion>
 
-    <rewrite-assertion id="select_with_schema" db-types="MySQL,Oracle,SQLServer,SQL92">
+    <rewrite-assertion id="select_with_schema" db-types="MySQL,Oracle,SQL92">
         <input sql="SELECT * FROM logic_db.t_account" />
         <output sql="SELECT * FROM t_account_0 UNION ALL SELECT * FROM t_account_1" />
     </rewrite-assertion>
@@ -78,12 +78,12 @@
         <output sql="SELECT * FROM t_account_0 WHERE account_id = ? AND amount BETWEEN (SELECT amount FROM t_account_0 WHERE account_id = ?) AND ?"  parameters="100, 100, 1500" />
     </rewrite-assertion>
     
-    <rewrite-assertion id="select_without_sharding_value_for_parameters" db-types="MySQL,Oracle,SQLServer,SQL92">
+    <rewrite-assertion id="select_without_sharding_value_for_parameters" db-types="MySQL,Oracle,SQL92">
         <input sql="SELECT * FROM logic_db.t_account WHERE amount = ?" parameters="1000" />
         <output sql="SELECT * FROM t_account_0 WHERE amount = ? UNION ALL SELECT * FROM t_account_1 WHERE amount = ?" parameters="1000, 1000" />
     </rewrite-assertion>
     
-    <rewrite-assertion id="select_without_sharding_value_for_literals" db-types="MySQL,Oracle,SQLServer,SQL92">
+    <rewrite-assertion id="select_without_sharding_value_for_literals" db-types="MySQL,Oracle,SQL92">
         <input sql="SELECT * FROM logic_db.t_account WHERE amount = 1000" />
         <output sql="SELECT * FROM t_account_0 WHERE amount = 1000 UNION ALL SELECT * FROM t_account_1 WHERE amount = 1000" />
     </rewrite-assertion>


### PR DESCRIPTION
Fixes #30342.
Linked #30227.

Changes proposed in this pull request:
  - Support SQLServer dml encrypt rewrite with schema
  - If a schema is added to the SQL Server statement before, an error will occur and the corresponding table cannot be found.
![image](https://github.com/apache/shardingsphere/assets/124348939/84360410-71bd-4593-a15e-f6e4c41ff458)

  - According to the official rules of SQL Server, dbo is the default schema. [Ownership and user-schema separation in SQL Server](https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/ownership-and-user-schema-separation?view=sql-server-ver16)
  - After completion, rerun the previous SQL to obtain the correct result.
![image](https://github.com/apache/shardingsphere/assets/124348939/270f60ba-f126-4d81-a626-c6a58bc5dbef)


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
