### PR TITLE
Adjust mysql system table metadata for MySQL 8.x version

### DIFF
--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/SystemSchemaManagerTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/SystemSchemaManagerTest.java
@@ -34,7 +34,7 @@ class SystemSchemaManagerTest {
         Collection<String> actualInformationSchema = SystemSchemaManager.getTables("MySQL", "information_schema");
         assertThat(actualInformationSchema.size(), is(62));
         Collection<String> actualMySQLSchema = SystemSchemaManager.getTables("MySQL", "mysql");
-        assertThat(actualMySQLSchema.size(), is(31));
+        assertThat(actualMySQLSchema.size(), is(32));
         Collection<String> actualPerformanceSchema = SystemSchemaManager.getTables("MySQL", "performance_schema");
         assertThat(actualPerformanceSchema.size(), is(87));
         Collection<String> actualSysSchema = SystemSchemaManager.getTables("MySQL", "sys");

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -43,7 +43,7 @@ class SystemSchemaBuilderTest {
         Map<String, ShardingSphereSchema> actualMySQLSchema = SystemSchemaBuilder.build("mysql", databaseType, configProps);
         assertThat(actualMySQLSchema.size(), is(1));
         assertTrue(actualMySQLSchema.containsKey("mysql"));
-        assertThat(actualMySQLSchema.get("mysql").getTables().size(), is(31));
+        assertThat(actualMySQLSchema.get("mysql").getTables().size(), is(32));
         Map<String, ShardingSphereSchema> actualPerformanceSchema = SystemSchemaBuilder.build("performance_schema", databaseType, configProps);
         assertThat(actualPerformanceSchema.size(), is(1));
         assertTrue(actualPerformanceSchema.containsKey("performance_schema"));

--- a/infra/database/type/mysql/src/main/resources/schema/mysql/information_schema/statistics.yaml
+++ b/infra/database/type/mysql/src/main/resources/schema/mysql/information_schema/statistics.yaml
@@ -145,3 +145,19 @@ columns:
     primaryKey: false
     unsigned: false
     visible: true
+  is_visible:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: IS_VISIBLE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  expression:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EXPRESSION
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/database/type/mysql/src/main/resources/schema/mysql/mysql/role_edges.yaml
+++ b/infra/database/type/mysql/src/main/resources/schema/mysql/mysql/role_edges.yaml
@@ -15,61 +15,43 @@
 # limitations under the License.
 #
 
-name: TABLE_CONSTRAINTS
+name: role_edges
 columns:
-  constraint_catalog:
+  from_host:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: FROM_HOST
+    primaryKey: true
+    visible: true
+  from_user:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: FROM_USER
+    primaryKey: true
+    visible: true
+  to_host:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: TO_HOST
+    primaryKey: true
+    visible: true
+  to_user:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: TO_USER
+    primaryKey: true
+    visible: true
+  with_admin_option:
     caseSensitive: false
     dataType: 12
     generated: false
-    name: CONSTRAINT_CATALOG
+    name: WITH_ADMIN_OPTION
     primaryKey: false
-    unsigned: false
     visible: true
-  constraint_schema:
-    caseSensitive: false
-    dataType: 12
-    generated: false
-    name: CONSTRAINT_SCHEMA
-    primaryKey: false
-    unsigned: false
-    visible: true
-  constraint_name:
-    caseSensitive: false
-    dataType: 12
-    generated: false
-    name: CONSTRAINT_NAME
-    primaryKey: false
-    unsigned: false
-    visible: true
-  table_schema:
-    caseSensitive: false
-    dataType: 12
-    generated: false
-    name: TABLE_SCHEMA
-    primaryKey: false
-    unsigned: false
-    visible: true
-  table_name:
-    caseSensitive: false
-    dataType: 12
-    generated: false
-    name: TABLE_NAME
-    primaryKey: false
-    unsigned: false
-    visible: true
-  constraint_type:
-    caseSensitive: false
-    dataType: 12
-    generated: false
-    name: CONSTRAINT_TYPE
-    primaryKey: false
-    unsigned: false
-    visible: true
-  enforced:
-    caseSensitive: false
-    dataType: 12
-    generated: false
-    name: ENFORCED
-    primaryKey: false
-    unsigned: false
-    visible: true
+indexes:
+  primary:
+    name: PRIMARY


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Adjust mysql system table metadata for MySQL 8.x version

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
