### PR TITLE
Add unit test for DataSourcePoolReflection against Alibaba Druid

### DIFF
--- a/infra/data-source-pool/core/pom.xml
+++ b/infra/data-source-pool/core/pom.xml
@@ -54,5 +54,16 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>druid</artifactId>
+            <version>${druid.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/infra/data-source-pool/core/src/test/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourcePoolCreatorTest.java
+++ b/infra/data-source-pool/core/src/test/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourcePoolCreatorTest.java
@@ -17,18 +17,20 @@
 
 package org.apache.shardingsphere.infra.datasource.pool.creator;
 
+import com.alibaba.druid.pool.DruidDataSource;
 import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
 import org.apache.shardingsphere.test.fixture.jdbc.MockedDataSource;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
+import java.sql.SQLException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class DataSourcePoolCreatorTest {
     
@@ -58,5 +60,21 @@ class DataSourcePoolCreatorTest {
         assertThat(actual.getPassword(), is("root"));
         assertThat(actual.getMaxPoolSize(), is(100));
         assertNull(actual.getMinPoolSize());
+    }
+    
+    @Test
+    void assertCreateAlibabaDruidDataSource() throws SQLException {
+        Map<String, Object> props = new LinkedHashMap<>(4, 1F);
+        props.put("url", "jdbc:h2:mem:foo_ds");
+        props.put("driverClassName", "org.h2.Driver");
+        props.put("username", "root");
+        props.put("password", "root");
+        props.put("dbType", "h2");
+        DruidDataSource dataSource = (DruidDataSource) DataSourcePoolCreator.create(new DataSourcePoolProperties(DruidDataSource.class.getName(), props));
+        dataSource.init();
+        assertThat(dataSource.getUrl(), is("jdbc:h2:mem:foo_ds"));
+        assertThat(dataSource.getUsername(), is("root"));
+        assertThat(dataSource.getPassword(), is("root"));
+        dataSource.close();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
         <mariadb-java-client.version>2.4.2</mariadb-java-client.version>
         
         <hikari-cp.version>4.0.3</hikari-cp.version>
+        <druid.version>1.2.22</druid.version>
         
         <prometheus-simpleclient.version>0.11.0</prometheus-simpleclient.version>
         <prometheus-jmx.version>0.16.1</prometheus-jmx.version>


### PR DESCRIPTION
For #30329.

Changes proposed in this pull request:
  - Add unit test for DataSourcePoolReflection against Alibaba Druid.
  - This PR is for testing only and should not be merged.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
