### PR TITLE
Support encrypt rewriter test with custom databaseName config

### DIFF
--- a/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewrite/engine/SQLRewriterIT.java
+++ b/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewrite/engine/SQLRewriterIT.java
@@ -145,7 +145,7 @@ public abstract class SQLRewriterIT {
             ((ParameterAware) sqlStatementContext).setUpParameters(testParams.getInputParameters());
         }
         if (sqlStatementContext instanceof CursorDefinitionAware) {
-            ((CursorDefinitionAware) sqlStatementContext).setUpCursorDefinition(createCursorDefinition(schemaName, metaData, sqlStatementParserEngine));
+            ((CursorDefinitionAware) sqlStatementContext).setUpCursorDefinition(createCursorDefinition(databaseName, metaData, sqlStatementParserEngine));
         }
         QueryContext queryContext = new QueryContext(sqlStatementContext, sql, testParams.getInputParameters(), hintValueContext);
         ConfigurationProperties props = new ConfigurationProperties(rootConfig.getProps());

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/delete/delete.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/delete/delete.xml
@@ -63,7 +63,7 @@
     </rewrite-assertion>
     
     <rewrite-assertion id="delete_user_with_database_and_schema_and_alias_for_literals" db-types="SQLServer">
-        <input sql="DELETE t FROM logic_db.dbo.t_user as t WHERE t.user_id = 4 and t.user_name = 'test_user' and t.user_name like 'test_%' and t.password = 'admin123'  and t.email = 'admin@gmail.com'" />
+        <input sql="DELETE t FROM encrypt.dbo.t_user as t WHERE t.user_id = 4 and t.user_name = 'test_user' and t.user_name like 'test_%' and t.password = 'admin123'  and t.email = 'admin@gmail.com'" />
         <output sql="DELETE t FROM dbo.t_user as t WHERE t.user_id = 4 and t.user_name_cipher = 'o07WOpLlazifLKU747nd8w==' and t.user_name_like like 'udtu_%' and t.password_cipher = 'beO6rTHBW9jmVeSPPb62QA=='  and t.email_cipher = 'zclI1Wk2uaVYHyNckTRYzA=='" />
     </rewrite-assertion>
 </rewrite-assertions>

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-projection.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-projection.xml
@@ -63,22 +63,22 @@
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_schema_name_in_shorthand_projection_for_parameters" db-types="MySQL">
-        <input sql="SELECT logic_db.t_account.* FROM t_account WHERE account_id = ? AND certificate_number = ? AND certificate_number LIKE ?" parameters="100, 200, 300" />
+        <input sql="SELECT encrypt.t_account.* FROM t_account WHERE account_id = ? AND certificate_number = ? AND certificate_number LIKE ?" parameters="100, 200, 300" />
         <output sql="SELECT t_account.`account_id`, t_account.`cipher_certificate_number` AS `certificate_number`, t_account.`cipher_password` AS `password`, t_account.`cipher_amount` AS `amount` FROM t_account WHERE account_id = ? AND assisted_query_certificate_number = ? AND like_query_certificate_number LIKE ?" parameters="100, assisted_query_200, like_query_300" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_schema_name_in_shorthand_projection_for_literals" db-types="MySQL">
-        <input sql="SELECT logic_db.t_account.* FROM t_account WHERE account_id = 100 AND certificate_number = 200 AND certificate_number LIKE 300" />
+        <input sql="SELECT encrypt.t_account.* FROM t_account WHERE account_id = 100 AND certificate_number = 200 AND certificate_number LIKE 300" />
         <output sql="SELECT t_account.`account_id`, t_account.`cipher_certificate_number` AS `certificate_number`, t_account.`cipher_password` AS `password`, t_account.`cipher_amount` AS `amount` FROM t_account WHERE account_id = 100 AND assisted_query_certificate_number = 'assisted_query_200' AND like_query_certificate_number LIKE 'like_query_300'" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_schema_name_in_column_projection_for_parameters" db-types="MySQL">
-        <input sql="SELECT logic_db.t_account.account_id FROM t_account WHERE account_id = ?" parameters="100" />
+        <input sql="SELECT encrypt.t_account.account_id FROM t_account WHERE account_id = ?" parameters="100" />
         <output sql="SELECT t_account.account_id FROM t_account WHERE account_id = ?" parameters="100" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_schema_name_in_column_projection_for_literals" db-types="MySQL">
-        <input sql="SELECT logic_db.t_account.account_id FROM t_account WHERE account_id = 100" />
+        <input sql="SELECT encrypt.t_account.account_id FROM t_account WHERE account_id = 100" />
         <output sql="SELECT t_account.account_id FROM t_account WHERE account_id = 100" />
     </rewrite-assertion>
 

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-where.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-where.xml
@@ -103,4 +103,9 @@
         <input sql="SELECT * FROM dbo.t_user"/>
         <output sql="SELECT t_user.[user_id], t_user.[user_name_cipher] AS [user_name], t_user.[password_cipher] AS [password], t_user.[email_cipher] AS [email], t_user.[user_telephone_cipher] AS [telephone], t_user.[creation_date] FROM dbo.t_user"/>
     </rewrite-assertion>
+
+    <rewrite-assertion id="select_from_user_with_schema_and_database" db-types="SQLServer">
+        <input sql="SELECT * FROM encrypt.dbo.t_user"/>
+        <output sql="SELECT t_user.[user_id], t_user.[user_name_cipher] AS [user_name], t_user.[password_cipher] AS [password], t_user.[email_cipher] AS [email], t_user.[user_telephone_cipher] AS [telephone], t_user.[creation_date] FROM dbo.t_user"/>
+    </rewrite-assertion>
 </rewrite-assertions>

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/config/query-with-cipher.yaml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/config/query-with-cipher.yaml
@@ -19,6 +19,8 @@ dataSources:
   encrypt_ds:
     dataSourceClassName: org.apache.shardingsphere.test.fixture.jdbc.MockedDataSource
 
+databaseName: encrypt
+
 rules:
 - !ENCRYPT
   tables:

--- a/test/it/rewriter/src/test/resources/scenario/sharding/case/dml/select.xml
+++ b/test/it/rewriter/src/test/resources/scenario/sharding/case/dml/select.xml
@@ -543,7 +543,7 @@
     </rewrite-assertion>
 
     <rewrite-assertion id="select_with_database_name_and_schema_name_in_table" db-types="PostgreSQL,openGauss">
-        <input sql="SELECT account_id FROM public.public.t_account WHERE account_id = ?" parameters="100" />
+        <input sql="SELECT account_id FROM logic_db.public.t_account WHERE account_id = ?" parameters="100" />
         <output sql="SELECT account_id FROM public.t_account_0 WHERE account_id = ?" parameters="100" />
     </rewrite-assertion>
 


### PR DESCRIPTION
link #30227.

Changes proposed in this pull request:
  - Support encrypt rewriter test with custom databaseName config
  - When the user has specified databaseName in the configuration file, there is no need to use the default databasaeName.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
