### PR TITLE
Allow `InlineExpressionParser#handlePlaceHolder` to be an optional implementation

### DIFF
--- a/infra/expr/core/src/test/java/org/apache/shardingsphere/infra/expr/core/InlineExpressionParserFactoryTest.java
+++ b/infra/expr/core/src/test/java/org/apache/shardingsphere/infra/expr/core/InlineExpressionParserFactoryTest.java
@@ -35,7 +35,7 @@ class InlineExpressionParserFactoryTest {
         assertThat(InlineExpressionParserFactory.newInstance("<GROOVY>t_order_0, t_order_1").getType(), is("GROOVY"));
         assertThat(InlineExpressionParserFactory.newInstance("<GROOVY>t_order_0, t_order_1").handlePlaceHolder(), is("t_order_0, t_order_1"));
         assertThat(InlineExpressionParserFactory.newInstance("<LITERAL>t_order_0, t_order_1").getType(), is("LITERAL"));
-        assertThat(InlineExpressionParserFactory.newInstance("<LITERAL>t_order_0, t_order_1").handlePlaceHolder(), is("t_order_0, t_order_1"));
+        assertThrows(UnsupportedOperationException.class, () -> InlineExpressionParserFactory.newInstance("<LITERAL>t_order_0, t_order_1").handlePlaceHolder());
     }
     
     @Test
@@ -46,6 +46,7 @@ class InlineExpressionParserFactoryTest {
     
     @Test
     void assertFixtureInstance() {
+        assertThat(InlineExpressionParserFactory.newInstance("<CUSTOM.FIXTURE>spring").handlePlaceHolder(), is("spring"));
         assertThat(InlineExpressionParserFactory.newInstance("<CUSTOM.FIXTURE>spring").splitAndEvaluate(),
                 is(Arrays.asList("t_order_2023_03", "t_order_2023_04", "t_order_2023_05")));
         assertThat(InlineExpressionParserFactory.newInstance("<CUSTOM.FIXTURE>summer").splitAndEvaluate(),

--- a/infra/expr/spi/src/main/java/org/apache/shardingsphere/infra/expr/spi/InlineExpressionParser.java
+++ b/infra/expr/spi/src/main/java/org/apache/shardingsphere/infra/expr/spi/InlineExpressionParser.java
@@ -33,19 +33,29 @@ public interface InlineExpressionParser extends TypedSPI {
     String INLINE_EXPRESSION_KEY = "inlineExpression";
     
     /**
-     * This method is used to return the inlineExpression String itself. In some cases, you may want to do
-     * additional processing on inlineExpression to return a specific value, in which case you need to override this method.
-     *
-     * @return result processed inline expression defined by the SPI implementation
-     */
-    String handlePlaceHolder();
-    
-    /**
      * Split and evaluate inline expression.
      *
      * @return result list
      */
     List<String> splitAndEvaluate();
+    
+    /**
+     * This method is used to return the inlineExpression String itself. In some cases, you may want to do
+     * additional processing on inlineExpression to return a specific value, in which case you need to override this method.
+     * Normally there is no need to use this method downstream, because this method only encapsulates the use of Groovy syntax
+     * by ShardingSphere's existing algorithm classes.
+     * An {@link org.apache.shardingsphere.infra.expr.spi.InlineExpressionParser} implementation that implements this method
+     * will provide the following algorithm classes with the ability to convert original expressions.
+     * 1. `org.apache.shardingsphere.sharding.algorithm.sharding.hint.HintInlineShardingAlgorithm`
+     * 2. `org.apache.shardingsphere.sharding.algorithm.sharding.inline.ComplexInlineShardingAlgorithm`
+     * 3. `org.apache.shardingsphere.sharding.algorithm.sharding.inline.InlineShardingAlgorithm`
+     *
+     * @return result processed inline expression defined by the SPI implementation
+     * @throws UnsupportedOperationException Thrown to indicate that the requested operation is not supported.
+     */
+    default String handlePlaceHolder() {
+        throw new UnsupportedOperationException("This SPI implementation does not support the use of this method.");
+    }
     
     /**
      * Evaluate with arguments.

--- a/infra/expr/type/interval/src/main/java/org/apache/shardingsphere/infra/expr/interval/IntervalInlineExpressionParser.java
+++ b/infra/expr/type/interval/src/main/java/org/apache/shardingsphere/infra/expr/interval/IntervalInlineExpressionParser.java
@@ -110,11 +110,6 @@ public class IntervalInlineExpressionParser implements InlineExpressionParser {
     }
     
     @Override
-    public String handlePlaceHolder() {
-        return inlineExpression;
-    }
-    
-    @Override
     public List<String> splitAndEvaluate() {
         return Strings.isNullOrEmpty(inlineExpression) ? Collections.emptyList() : split();
     }

--- a/infra/expr/type/literal/src/main/java/org/apache/shardingsphere/infra/expr/literal/LiteralInlineExpressionParser.java
+++ b/infra/expr/type/literal/src/main/java/org/apache/shardingsphere/infra/expr/literal/LiteralInlineExpressionParser.java
@@ -40,11 +40,6 @@ public final class LiteralInlineExpressionParser implements InlineExpressionPars
     }
     
     @Override
-    public String handlePlaceHolder() {
-        return inlineExpression;
-    }
-    
-    @Override
     public List<String> splitAndEvaluate() {
         return Strings.isNullOrEmpty(inlineExpression) ? Collections.emptyList() : split(inlineExpression);
     }

--- a/infra/expr/type/literal/src/test/java/org/apache/shardingsphere/infra/expr/literal/LiteralInlineExpressionParserTest.java
+++ b/infra/expr/type/literal/src/test/java/org/apache/shardingsphere/infra/expr/literal/LiteralInlineExpressionParserTest.java
@@ -69,10 +69,12 @@ class LiteralInlineExpressionParserTest {
     
     @Test
     void assertHandlePlaceHolder() {
-        assertThat(TypedSPILoader.getService(InlineExpressionParser.class, "LITERAL", PropertiesBuilder.build(
-                new PropertiesBuilder.Property(InlineExpressionParser.INLINE_EXPRESSION_KEY, "t_$->{[\"new$->{1+2}\"]}"))).handlePlaceHolder(), is("t_$->{[\"new$->{1+2}\"]}"));
-        assertThat(TypedSPILoader.getService(InlineExpressionParser.class, "LITERAL", PropertiesBuilder.build(
-                new PropertiesBuilder.Property(InlineExpressionParser.INLINE_EXPRESSION_KEY, "t_${[\"new$->{1+2}\"]}"))).handlePlaceHolder(), is("t_${[\"new$->{1+2}\"]}"));
+        assertThrows(UnsupportedOperationException.class, () -> {
+            TypedSPILoader.getService(InlineExpressionParser.class, "LITERAL", PropertiesBuilder.build(
+                    new PropertiesBuilder.Property(InlineExpressionParser.INLINE_EXPRESSION_KEY, "t_$->{[\"new$->{1+2}\"]}"))).handlePlaceHolder();
+            TypedSPILoader.getService(InlineExpressionParser.class, "LITERAL", PropertiesBuilder.build(
+                    new PropertiesBuilder.Property(InlineExpressionParser.INLINE_EXPRESSION_KEY, "t_${[\"new$->{1+2}\"]}"))).handlePlaceHolder();
+        });
     }
     
     @Test


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Allow `InlineExpressionParser#handlePlaceHolder` to be an optional implementation.
  - This method is currently only used in several algorithm classes in the shardingsphere git. Further transformation of the algorithm classes has not yet been completed. In this case, implementing this method is unnecessary.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
