### PR TITLE
Fix SqlFederation data type converter NullPointerException

### DIFF
--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/projection/impl/DataTypeConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/projection/impl/DataTypeConverter.java
@@ -45,7 +45,12 @@ public final class DataTypeConverter {
         if (null == segment) {
             return Optional.empty();
         }
-        return Optional.of(new SqlDataTypeSpec(new SqlBasicTypeNameSpec(Objects.requireNonNull(SqlTypeName.get(segment.getDataTypeName())), segment.getDataLength().getPrecision(), SqlParserPos.ZERO),
-                SqlParserPos.ZERO));
+        return Optional.of(new SqlDataTypeSpec(getSqlBasicTypeNameSpec(segment), SqlParserPos.ZERO));
+    }
+    
+    private static SqlBasicTypeNameSpec getSqlBasicTypeNameSpec(final DataTypeSegment segment) {
+        SqlTypeName sqlTypeName = Objects.requireNonNull(SqlTypeName.get(segment.getDataTypeName().toUpperCase()));
+        return segment.getDataTypeLength().isPresent() ? new SqlBasicTypeNameSpec(sqlTypeName, segment.getDataLength().getPrecision(), SqlParserPos.ZERO)
+                : new SqlBasicTypeNameSpec(sqlTypeName, SqlParserPos.ZERO);
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/DataTypeLengthSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/DataTypeLengthSegment.java
@@ -36,7 +36,7 @@ public final class DataTypeLengthSegment implements SQLSegment {
     private int scale;
     
     /**
-     * Get second number.
+     * Get scale.
      * 
      * @return scale
      */

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/DataTypeLengthSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/DataTypeLengthSegment.java
@@ -36,8 +36,9 @@ public final class DataTypeLengthSegment implements SQLSegment {
     private int scale;
     
     /**
-     * get secondNumber.
-     * @return Optional.
+     * Get second number.
+     * 
+     * @return scale
      */
     public Optional<Integer> getScale() {
         return Optional.of(scale);

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/DataTypeSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/DataTypeSegment.java
@@ -21,6 +21,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
 
+import java.util.Optional;
+
 @Getter
 @Setter
 public final class DataTypeSegment implements ExpressionSegment {
@@ -36,5 +38,14 @@ public final class DataTypeSegment implements ExpressionSegment {
     @Override
     public String getText() {
         return dataTypeName;
+    }
+    
+    /**
+     * Get data type length.
+     * 
+     * @return data type length segment
+     */
+    public Optional<DataTypeLengthSegment> getDataTypeLength() {
+        return Optional.ofNullable(dataLength);
     }
 }


### PR DESCRIPTION
Fixes #30669.

Changes proposed in this pull request:
  - Fix null pointer exception caused by obtaining DataLength
  - Adjust data type name to uppercase

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
