### PR TITLE
Remove wrong unit test when ShardingSphereRule has been refactored

### DIFF
--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/rule/RuleMetaDataTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/rule/RuleMetaDataTest.java
@@ -17,27 +17,17 @@
 
 package org.apache.shardingsphere.infra.metadata.database.rule;
 
-import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
-import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
-import org.apache.shardingsphere.infra.rule.identifier.type.DataNodeContainedRule;
-import org.apache.shardingsphere.infra.rule.identifier.type.DataSourceContainedRule;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class RuleMetaDataTest {
     
@@ -60,80 +50,8 @@ class RuleMetaDataTest {
     
     @Test
     void assertGetInUsedStorageUnitNameAndRulesMapWhenRulesAreEmpty() {
-        Collection<ShardingSphereRule> rules = new ArrayList<>();
-        RuleMetaData ruleMetaData = new RuleMetaData(rules);
+        RuleMetaData ruleMetaData = new RuleMetaData(Collections.emptyList());
         Map<String, Collection<Class<? extends ShardingSphereRule>>> actual = ruleMetaData.getInUsedStorageUnitNameAndRulesMap();
         assertThat(actual.size(), is(0));
-    }
-    
-    @Test
-    void assertGetInUsedStorageUnitNameAndRulesMapWhenRulesContainDataNodeContainedRule() {
-        Collection<ShardingSphereRule> rules = new ArrayList<>();
-        DataNodeContainedRule rule = new MockDataNodeContainedRule();
-        rules.add(rule);
-        RuleMetaData ruleMetaData = new RuleMetaData(rules);
-        Map<String, Collection<Class<? extends ShardingSphereRule>>> actual = ruleMetaData.getInUsedStorageUnitNameAndRulesMap();
-        assertThat(actual.size(), is(1));
-        assertTrue(actual.containsKey("testDataNodeSourceName"));
-        assertThat(actual.get("testDataNodeSourceName").size(), is(1));
-        assertThat(actual.get("testDataNodeSourceName").size(), is(1));
-        assertTrue(actual.get("testDataNodeSourceName").contains(MockDataNodeContainedRule.class));
-    }
-    
-    @Test
-    void assertGetInUsedStorageUnitNameAndRulesMapWhenRulesContainBothDataSourceContainedRuleAndDataNodeContainedRule() {
-        Collection<ShardingSphereRule> rules = new ArrayList<>();
-        DataSourceContainedRule dataSourceContainedRule = mock(DataSourceContainedRule.class);
-        when(dataSourceContainedRule.getDataSourceMapper()).thenReturn(Collections.singletonMap("test", Arrays.asList("testDataSourceName")));
-        DataNodeContainedRule dataNodeContainedRule = new MockDataNodeContainedRule();
-        rules.add(dataSourceContainedRule);
-        rules.add(dataNodeContainedRule);
-        RuleMetaData ruleMetaData = new RuleMetaData(rules);
-        Map<String, Collection<Class<? extends ShardingSphereRule>>> actual = ruleMetaData.getInUsedStorageUnitNameAndRulesMap();
-        assertThat(actual.size(), is(2));
-        assertTrue(actual.containsKey("testDataSourceName"));
-        assertTrue(actual.containsKey("testDataNodeSourceName"));
-        assertTrue(actual.get("testDataSourceName").contains(dataSourceContainedRule.getClass()));
-        assertTrue(actual.get("testDataNodeSourceName").contains(MockDataNodeContainedRule.class));
-    }
-    
-    private static class MockDataNodeContainedRule implements DataNodeContainedRule {
-        
-        @Override
-        public RuleConfiguration getConfiguration() {
-            return mock(RuleConfiguration.class);
-        }
-        
-        @Override
-        public Map<String, Collection<DataNode>> getAllDataNodes() {
-            Map<String, Collection<DataNode>> result = new LinkedHashMap<>();
-            result.put("test", Arrays.asList(new DataNode("testDataNodeSourceName", "testTableName")));
-            return result;
-        }
-        
-        @Override
-        public boolean isNeedAccumulate(final Collection<String> tableNames) {
-            return false;
-        }
-        
-        @Override
-        public Optional<String> findLogicTableByActualTable(final String actualTable) {
-            return Optional.empty();
-        }
-        
-        @Override
-        public Optional<String> findFirstActualTable(final String logicTable) {
-            return Optional.empty();
-        }
-        
-        @Override
-        public Collection<DataNode> getDataNodesByTableName(final String tableName) {
-            return null;
-        }
-        
-        @Override
-        public Optional<String> findActualTableByCatalog(final String catalog, final String logicTable) {
-            return Optional.empty();
-        }
     }
 }


### PR DESCRIPTION
Ref #28724.

Changes proposed in this pull request:
  - Remove wrong unit test when ShardingSphereRule has been refactored

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
