### PR TITLE
Support encrypt column rewrite when combine statement contains same table

### DIFF
--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/SubstitutableColumnNameToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/SubstitutableColumnNameToken.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic;
 
 import com.cedarsoftware.util.CaseInsensitiveMap;
+import com.sphereex.dbplusengine.SphereEx;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/SubstitutableColumnNameToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/SubstitutableColumnNameToken.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic;
 
 import com.cedarsoftware.util.CaseInsensitiveMap;
-import com.sphereex.dbplusengine.SphereEx;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtils.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtils.java
@@ -161,6 +161,8 @@ public final class SubqueryExtractUtils {
     }
     
     private static void extractSubquerySegmentsFromCombine(final List<SubquerySegment> result, final CombineSegment combineSegment) {
+        result.add(combineSegment.getLeft());
+        result.add(combineSegment.getRight());
         extractSubquerySegments(result, combineSegment.getLeft().getSelect());
         extractSubquerySegments(result, combineSegment.getRight().getSelect());
     }

--- a/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtilsTest.java
+++ b/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtilsTest.java
@@ -174,7 +174,7 @@ class SubqueryExtractUtilsTest {
         SubquerySegment left = new SubquerySegment(0, 0, new MySQLSelectStatement(), "");
         selectStatement.setCombine(new CombineSegment(0, 0, left, CombineType.UNION, createSelectStatementForCombineSegment()));
         Collection<SubquerySegment> actual = SubqueryExtractUtils.getSubquerySegments(selectStatement);
-        assertThat(actual.size(), is(1));
+        assertThat(actual.size(), is(3));
     }
     
     private SubquerySegment createSelectStatementForCombineSegment() {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Support encrypt column rewrite when combine statement contains same table

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
