### PR TITLE
Enhanced support for Oracle SQL parsing.

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/PLSQL.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/PLSQL.g4
@@ -94,6 +94,7 @@ statement
         | forallStatement
         | gotoStatement
         | ifStatement
+        | modifyingStatement
         | nullStatement
         | openStatement
         | openForStatement
@@ -216,6 +217,12 @@ iterationCtlSeq
     : qualIterationCtl (COMMA_ qualIterationCtl)*
     ;
 
+modifyingExpression
+    : INSERTING
+    | DELETING
+    | UPDATING
+    ;
+
 qualIterationCtl
     : REVERSE? iterationCcontrol predClauseSeq
     ;
@@ -310,6 +317,13 @@ gotoStatement
 ifStatement
     : IF booleanExpression THEN statement+
     (ELSIF booleanExpression THEN statement+)*
+    (ELSE statement+)?
+    END IF SEMI_
+    ;
+
+modifyingStatement
+    : IF modifyingExpression THEN statement+
+    (ELSIF modifyingExpression THEN statement+)*
     (ELSE statement+)?
     END IF SEMI_
     ;
@@ -574,7 +588,7 @@ plsqlTriggerSource
     ;
 
 simpleDmlTrigger
-    : (BEFORE | AFTER) dmlEventClause (FOR EACH ROW)? triggerBody
+    : (BEFORE | AFTER) dmlEventClause (FOR EACH ROW)? () ? triggerBody
     ;
 
 dmlEventClause
@@ -582,7 +596,7 @@ dmlEventClause
     ;
 
 dmlEventElement
-    : (DELETE | INSERT | UPDATE) (OF LP_ columnName (COMMA_ columnName)* RP_)?
+    : (DELETE | INSERT | UPDATE) (OF LP_? columnName (COMMA_ columnName)* RP_?)?
     ;
 
 systemTrigger

--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/PLSQL.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/PLSQL.g4
@@ -217,11 +217,7 @@ iterationCtlSeq
     : qualIterationCtl (COMMA_ qualIterationCtl)*
     ;
 
-modifyingExpression
-    : INSERTING
-    | DELETING
-    | UPDATING
-    ;
+modifyingExpression: INSERTING | DELETING | UPDATING;
 
 qualIterationCtl
     : REVERSE? iterationCcontrol predClauseSeq
@@ -321,12 +317,7 @@ ifStatement
     END IF SEMI_
     ;
 
-modifyingStatement
-    : IF modifyingExpression THEN statement+
-    (ELSIF modifyingExpression THEN statement+)*
-    (ELSE statement+)?
-    END IF SEMI_
-    ;
+modifyingStatement: IF modifyingExpression THEN statement+ (ELSIF modifyingExpression THEN statement+)* (ELSE statement+)? END IF SEMI_;
 
 nullStatement
     : NULL SEMI_
@@ -588,7 +579,7 @@ plsqlTriggerSource
     ;
 
 simpleDmlTrigger
-    : (BEFORE | AFTER) dmlEventClause (FOR EACH ROW)? () ? triggerBody
+    : (BEFORE | AFTER) dmlEventClause (FOR EACH ROW)? triggerBody
     ;
 
 dmlEventClause

--- a/test/it/parser/src/main/resources/case/ddl/create-trigger.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-trigger.xml
@@ -27,4 +27,9 @@
     <create-trigger sql-case-id="create_trigger_with_body" />
     <create-trigger sql-case-id="create_trigger_with_execute_immediate_statement" />
     <create-trigger sql-case-id="create_trigger_with_assignment_statement" />
+    <create-trigger sql-case-id="create_trigger_with_logon" />
+    <create-trigger sql-case-id="create_trigger_with_cascade_1" />
+    <create-trigger sql-case-id="create_trigger_with_cascade_2" />
+    <create-trigger sql-case-id="create_trigger_with_cascade_3" />
+    <create-trigger sql-case-id="create_trigger_with_cascade_4" />
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-trigger.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-trigger.xml
@@ -17,37 +17,16 @@
   -->
 
 <sql-cases>
-    <sql-case id="create_trigger" value="CREATE TRIGGER reminder1
-        ON Sales.Customer
-        AFTER INSERT, UPDATE
-        AS INSERT INTO SalesPersonQuotaHistory VALUES(t1, 100)" db-types="SQLServer" />
-    <sql-case id="create_trigger_with_database_scoped" value="CREATE TRIGGER ddl_trig_database
-        ON ALL SERVER
-        AFTER INSERT
-        AS
-            SELECT EVENTDATA()" db-types="SQLServer" />
-
+    <sql-case id="create_trigger" value="CREATE TRIGGER reminder1 ON Sales.Customer AFTER INSERT, UPDATE AS INSERT INTO SalesPersonQuotaHistory VALUES(t1, 100)" db-types="SQLServer" />
+    <sql-case id="create_trigger_with_database_scoped" value="CREATE TRIGGER ddl_trig_database ON ALL SERVER AFTER INSERT AS SELECT EVENTDATA()" db-types="SQLServer" />
     <sql-case id="create_trigger_with_create_view" value="CREATE TRIGGER tr1 BEFORE INSERT ON t1 FOR EACH ROW BEGIN create view v1 as select 1; END" db-types="MySQL" />
     <sql-case id="create_trigger_with_dml_event_clause" value="CREATE TRIGGER scott.emp_permit_changes BEFORE DELETE OR INSERT OR UPDATE ON scott.emp BEGIN IF (IS_SERVERERROR (1017)) THEN NULL; ELSE NULL; END IF; END;" db-types="Oracle" />
-    <sql-case id="create_trigger_with_body" value="CREATE TRIGGER log_errors
-        AFTER SERVERERROR ON DATABASE
-        BEGIN
-        IF (IS_SERVERERROR (1017)) THEN
-          NULL;
-        ELSE
-          NULL;
-        END IF;
-        END;" db-types="Oracle" />
-    <sql-case id="create_trigger_with_execute_immediate_statement" value="CREATE TRIGGER adg_logon_sync_trigger
-        AFTER LOGON ON user.schema
-            begin
-                if (SYS_CONTEXT('USERENV', 'DATABASE_ROLE')  IN ('PHYSICAL STANDBY')) then
-                  execute immediate 'alter session sync with primary';
-            end if;
-        end;" db-types="Oracle" />
-    <sql-case id="create_trigger_with_assignment_statement" value="CREATE TRIGGER Contacts_BI
-            BEFORE INSERT ON Contacts FOR EACH ROW
-        BEGIN
-            :NEW.ID := Contacts_Seq.NEXTVAL;
-        END;" db-types="Oracle" />
+    <sql-case id="create_trigger_with_body" value="CREATE TRIGGER log_errors AFTER SERVERERROR ON DATABASE BEGIN IF (IS_SERVERERROR (1017)) THEN NULL; ELSE NULL; END IF; END;" db-types="Oracle" />
+    <sql-case id="create_trigger_with_execute_immediate_statement" value="CREATE TRIGGER adg_logon_sync_trigger AFTER LOGON ON user.schema begin if (SYS_CONTEXT('USERENV', 'DATABASE_ROLE')  IN ('PHYSICAL STANDBY')) then execute immediate 'alter session sync with primary'; end if; end;" db-types="Oracle" />
+    <sql-case id="create_trigger_with_assignment_statement" value="CREATE TRIGGER Contacts_BI BEFORE INSERT ON Contacts FOR EACH ROW BEGIN :NEW.ID := Contacts_Seq.NEXTVAL; END;" db-types="Oracle" />
+    <sql-case id="create_trigger_with_logon" value="CREATE OR REPLACE TRIGGER check_user AFTER LOGON ON DATABASE BEGIN check_user; EXCEPTION WHEN OTHERS THEN RAISE_APPLICATION_ERROR (-20000, 'Unexpected error: '|| DBMS_Utility.Format_Error_Stack); END;" db-types="Oracle" />
+    <sql-case id="create_trigger_with_cascade_1" value="CREATE OR REPLACE TRIGGER dept_cascade3 AFTER UPDATE OF Deptno ON dept BEGIN UPDATE emp SET Update_id = NULL WHERE Update_id = Integritypackage.Updateseq; END;" db-types="Oracle" />
+    <sql-case id="create_trigger_with_cascade_2" value="CREATE OR REPLACE TRIGGER dept_del_cascade AFTER DELETE ON dept FOR EACH ROW BEGIN DELETE FROM emp WHERE emp.Deptno = :OLD.Deptno; END;" db-types="Oracle" />
+    <sql-case id="create_trigger_with_cascade_3" value="CREATE OR REPLACE TRIGGER dept_cascade2 AFTER DELETE OR UPDATE OF Deptno ON dept FOR EACH ROW BEGIN IF UPDATING THEN UPDATE emp SET Deptno = :NEW.Deptno, Update_id = Integritypackage.Updateseq WHERE emp.Deptno = :OLD.Deptno AND Update_id IS NULL; END IF; IF DELETING THEN DELETE FROM emp WHERE emp.Deptno = :OLD.Deptno; END IF; END;" db-types="Oracle" />
+    <sql-case id="create_trigger_with_cascade_4" value="CREATE OR REPLACE TRIGGER dept_restrict BEFORE DELETE OR UPDATE OF Deptno ON dept FOR EACH ROW DECLARE Dummy INTEGER; Employees_present EXCEPTION; employees_not_present  EXCEPTION; CURSOR Dummy_cursor (Dn NUMBER) IS SELECT Deptno FROM emp WHERE Deptno = Dn; BEGIN OPEN Dummy_cursor (:OLD.Deptno); FETCH Dummy_cursor INTO Dummy; IF Dummy_cursor%FOUND THEN RAISE Employees_present; ELSE RAISE Employees_not_present; END IF; CLOSE Dummy_cursor; EXCEPTION WHEN Employees_present THEN CLOSE Dummy_cursor; Raise_application_error(-20001, 'Employees Present in' || ' Department ' || TO_CHAR(:OLD.DEPTNO)); WHEN Employees_not_present THEN CLOSE Dummy_cursor; END;" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Fixes #27069.

Changes proposed in this pull request:
  - Enhanced support for Oracle SQL parsing, fixed some issues with SQL parsing failure.
  - Added test cases for these SQL statements, and all tests passed successfully when running the test suite.
  
![image](https://github.com/apache/shardingsphere/assets/165489385/58253d71-750d-4c24-9d4d-78faacffacfa)

### Supported SQL cases are as follows
**case1**

```sql
CREATE OR REPLACE TRIGGER check_user
  AFTER LOGON ON DATABASE
  BEGIN
    check_user;
  EXCEPTION
    WHEN OTHERS THEN
      RAISE_APPLICATION_ERROR
        (-20000, 'Unexpected error: '|| DBMS_Utility.Format_Error_Stack);
 END;
```

**case2**

```sql
CREATE OR REPLACE TRIGGER dept_cascade3
  AFTER UPDATE OF Deptno ON dept
BEGIN UPDATE emp
  SET Update_id = NULL
  WHERE Update_id = Integritypackage.Updateseq;
END;
```

**case3**

```sql
CREATE OR REPLACE TRIGGER dept_del_cascade
  AFTER DELETE ON dept
  FOR EACH ROW

  -- Before row is deleted from dept,
  -- delete all rows from emp table whose DEPTNO is same as
  -- DEPTNO being deleted from dept table:

BEGIN
  DELETE FROM emp
  WHERE emp.Deptno = :OLD.Deptno;
END;
```

**case4**

```sql
CREATE OR REPLACE TRIGGER dept_cascade2
  AFTER DELETE OR UPDATE OF Deptno ON dept
  FOR EACH ROW

  -- For each department number in dept that is updated,
  -- cascade update to dependent foreign keys in emp table.
  -- Cascade update only if child row was not updated by this trigger:
BEGIN
  IF UPDATING THEN
    UPDATE emp
    SET Deptno = :NEW.Deptno,
        Update_id = Integritypackage.Updateseq   --from 1st
    WHERE emp.Deptno = :OLD.Deptno
    AND Update_id IS NULL;

    /* Only NULL if not updated by 3rd trigger
       fired by same triggering statement */
  END IF;
  IF DELETING THEN
    -- After row is deleted from dept,
    -- delete all rows from emp table whose DEPTNO is same as
    -- DEPTNO being deleted from dept table:
    DELETE FROM emp
    WHERE emp.Deptno = :OLD.Deptno;
  END IF;
END;
```

**case5**

```sql
CREATE OR REPLACE TRIGGER dept_restrict
  BEFORE DELETE OR UPDATE OF Deptno ON dept
  FOR EACH ROW

  -- Before row is deleted from dept or primary key (DEPTNO) of dept is updated,
  -- check for dependent foreign key values in emp;
  -- if any are found, roll back.

DECLARE
  Dummy                  INTEGER;  -- Use for cursor fetch
  Employees_present      EXCEPTION;
  employees_not_present  EXCEPTION;

  -- Cursor used to check for dependent foreign key values.
  CURSOR Dummy_cursor (Dn NUMBER) IS
    SELECT Deptno FROM emp WHERE Deptno = Dn;

BEGIN
  OPEN Dummy_cursor (:OLD.Deptno);
  FETCH Dummy_cursor INTO Dummy;

  -- If dependent foreign key is found, raise user-specified
  -- error code and message. If not found, close cursor
  -- before allowing triggering statement to complete.

  IF Dummy_cursor%FOUND THEN
    RAISE Employees_present;     -- Dependent rows exist
  ELSE
    RAISE Employees_not_present; -- No dependent rows exist
  END IF;
  CLOSE Dummy_cursor;

EXCEPTION
  WHEN Employees_present THEN
    CLOSE Dummy_cursor;
    Raise_application_error(-20001, 'Employees Present in'
      || ' Department ' || TO_CHAR(:OLD.DEPTNO));
  WHEN Employees_not_present THEN
    CLOSE Dummy_cursor;
END;
```


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
