### PR TITLE
Adjust outdated PARSE ENGINE documents.

### DIFF
--- a/docs/document/content/reference/sharding/parse.cn.md
+++ b/docs/document/content/reference/sharding/parse.cn.md
@@ -67,13 +67,13 @@ ShardingSphere 的 SQL 解析器经历了 3 代产品的更新迭代。
 ```xml
 <dependency>
     <groupId>org.apache.shardingsphere</groupId>
-    <artifactId>shardingsphere-sql-parser-engine</artifactId>
+    <artifactId>shardingsphere-parser-sql-engine</artifactId>
     <version>${project.version}</version>
 </dependency>
 <!-- 根据需要引入指定方言的解析模块（以 MySQL 为例），可以添加所有支持的方言，也可以只添加使用到的 -->
 <dependency>
     <groupId>org.apache.shardingsphere</groupId>
-    <artifactId>shardingsphere-sql-parser-mysql</artifactId>
+    <artifactId>shardingsphere-parser-sql-mysql</artifactId>
     <version>${project.version}</version>
 </dependency>
 ```
@@ -99,7 +99,8 @@ SQLStatement sqlStatement = sqlVisitorEngine.visit(parseASTNode);
 - SQL 格式化
 
 ```java
-new SQLFormatEngine(databaseType, cacheOption).format(sql, useCache, props);
+new SQLFormatEngine(TypedSPILoader.getService(DatabaseType.class, "Mysql"), cacheOption)
+        .format(sql, false, null);
 ```
 
 例子：

--- a/docs/document/content/reference/sharding/parse.en.md
+++ b/docs/document/content/reference/sharding/parse.en.md
@@ -64,13 +64,13 @@ Since V5.0.x, the architecture of the parsing engine has been restructured and a
 ```xml
 <dependency>
     <groupId>org.apache.shardingsphere</groupId>
-    <artifactId>shardingsphere-sql-parser-engine</artifactId>
+    <artifactId>shardingsphere-parser-sql-engine</artifactId>
     <version>${project.version}</version>
 </dependency>
 <!-- According to the needs, introduce the parsing module of the specified dialect (take MySQL as an example), you can add all the supported dialects, or just what you need -->
 <dependency>
     <groupId>org.apache.shardingsphere</groupId>
-    <artifactId>shardingsphere-sql-parser-mysql</artifactId>
+    <artifactId>shardingsphere-parser-sql-mysql</artifactId>
     <version>${project.version}</version>
 </dependency>
 ```
@@ -96,7 +96,8 @@ SQLStatement sqlStatement = sqlVisitorEngine.visit(parseASTNode);
 - SQL Formatting
 
 ```java
-new SQLFormatEngine(databaseType, cacheOption).format(sql, useCache, props);
+new SQLFormatEngine(TypedSPILoader.getService(DatabaseType.class, "Mysql"), cacheOption)
+        .format(sql, false, null);
 ```
 
 Example：


### PR DESCRIPTION
Changes proposed in this pull request:
  - Adjust outdated PARSE ENGINE documents.
  - shardingsphere-sql-parser-mysql, The module has been adjusted to shardingsphere-parser-sql-engine
  - shardingsphere-sql-parser-engine. The module has been adjusted to shardingsphere-parser-sql-engine

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
