### PR TITLE
#28513 add unit tests for where segment binder

### DIFF
--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/where/WhereSegmentBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/where/WhereSegmentBinderTest.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.Expressi
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.predicate.WhereSegment;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/where/WhereSegmentBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/where/WhereSegmentBinderTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.segment.where;
+
+import org.apache.shardingsphere.infra.binder.segment.from.TableSegmentBinderContext;
+import org.apache.shardingsphere.infra.binder.statement.SQLStatementBinderContext;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.predicate.WhereSegment;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+class WhereSegmentBinderTest {
+    
+    @Test
+    void assertBind() {
+        SQLStatementBinderContext sqlStatementBinderContext = mock(SQLStatementBinderContext.class);
+        WhereSegment expectedWhereSegment = new WhereSegment(1, 2, mock(ExpressionSegment.class));
+        Map<String, TableSegmentBinderContext> tableBinderContexts = new HashMap<>();
+        Map<String, TableSegmentBinderContext> outerTableBinderContexts = new HashMap<>();
+        WhereSegment actualWhereSegment = WhereSegmentBinder.bind(expectedWhereSegment, sqlStatementBinderContext, tableBinderContexts, outerTableBinderContexts);
+        Assertions.assertEquals(expectedWhereSegment.getStopIndex(), actualWhereSegment.getStopIndex());
+        Assertions.assertEquals(expectedWhereSegment.getStartIndex(), actualWhereSegment.getStartIndex());
+        Assertions.assertEquals(expectedWhereSegment.getExpr(), actualWhereSegment.getExpr());
+    }
+}


### PR DESCRIPTION
Fixes #28513 .

Changes proposed in this pull request:
  -
Added unit test to test the methods of WhereSegmentBinder class. 
---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
