### PR TITLE
Revise part of MariaDB E2E

### DIFF
--- a/.github/workflows/e2e-operation.yml
+++ b/.github/workflows/e2e-operation.yml
@@ -62,10 +62,14 @@ jobs:
         operation: [ transaction, pipeline, showprocesslist ]
         image: [ { type: "it.docker.mysql.version", version: "mysql:5.7" }, { type: "it.docker.postgresql.version", version: "postgres:12-alpine" }, { type: "it.docker.opengauss.version", version: "enmotech/opengauss:2.1.0,enmotech/opengauss:3.1.0" }, { type: "it.docker.mariadb.version", version: "mariadb:11" } ]
         exclude:
+          - operation: transaction
+            image: { type: "it.docker.mariadb.version", version: "mariadb:11" }
           - operation: showprocesslist
             image: { type: "it.docker.postgresql.version", version: "postgres:12-alpine" }
           - operation: showprocesslist
             image: { type: "it.docker.opengauss.version", version: "enmotech/opengauss:2.1.0,enmotech/opengauss:3.1.0" }
+          - operation: showprocesslist
+            image: { type: "it.docker.mariadb.version", version: "mariadb:11" }
     steps:
       - env:
           changed_operations: ${{ needs.detect-changed-files.outputs.changed_operations }}

--- a/.github/workflows/nightly-e2e-operation.yml
+++ b/.github/workflows/nightly-e2e-operation.yml
@@ -46,10 +46,14 @@ jobs:
         operation: [ transaction, pipeline, showprocesslist ]
         image: [ { type: "it.docker.mysql.version", version: "mysql:5.7,mysql:8.0" }, { type: "it.docker.postgresql.version", version: "postgres:10-alpine,postgres:11-alpine,postgres:12-alpine,postgres:13-alpine,postgres:14-alpine" }, { type: "it.docker.opengauss.version", version: "enmotech/opengauss:2.1.0,enmotech/opengauss:3.0.0" }, { type: "it.docker.mariadb.version", version: "mariadb:11" } ]
         exclude:
+          - operation: transaction
+            image: { type: "it.docker.mariadb.version", version: "mariadb:11" }
           - operation: showprocesslist
             image: { type: "it.docker.postgresql.version", version: "postgres:10-alpine,postgres:11-alpine,postgres:12-alpine,postgres:13-alpine,postgres:14-alpine" }
           - operation: showprocesslist
             image: { type: "it.docker.opengauss.version", version: "enmotech/opengauss:2.1.0,enmotech/opengauss:3.0.0" }
+          - operation: showprocesslist
+            image: { type: "it.docker.mariadb.version", version: "mariadb:11" }
     timeout-minutes: 40
     steps:
       - name: Checkout Project

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/runtime/DataSourceEnvironment.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/runtime/DataSourceEnvironment.java
@@ -65,7 +65,7 @@ public final class DataSourceEnvironment {
                 return String.format("jdbc:mysql://%s:%s?useSSL=true&requireSSL=true&enabledTLSProtocols=TLSv1.2,TLSv1.3&verifyServerCertificate=false"
                         + "&useServerPrepStmts=true&useLocalSessionState=true&characterEncoding=utf-8&allowMultiQueries=true&rewriteBatchedStatements=true", host, port);
             case "MariaDB":
-                return String.format("jdbc:mariadb://%s:%s?useSSL=false&useServerPrepStmts=true&useLocalSessionState=true&characterEncoding=utf-8&allowMultiQueries=true&rewriteBatchedStatements=true",
+                return String.format("jdbc:mysql://%s:%s?useSSL=false&useServerPrepStmts=true&useLocalSessionState=true&characterEncoding=utf-8&allowMultiQueries=true&rewriteBatchedStatements=true",
                         host, port);
             case "PostgreSQL":
                 return String.format("jdbc:postgresql://%s:%s/?ssl=on&sslmode=prefer", host, port);
@@ -96,7 +96,7 @@ public final class DataSourceEnvironment {
                                 + "&useServerPrepStmts=true&useLocalSessionState=true&characterEncoding=utf-8&allowPublicKeyRetrieval=true&allowMultiQueries=true&rewriteBatchedStatements=true",
                         host, port, dataSourceName);
             case "MariaDB":
-                return String.format("jdbc:mariadb://%s:%s/%s?useSSL=false&useServerPrepStmts=true&useLocalSessionState=true&characterEncoding=utf-8&allowMultiQueries=true"
+                return String.format("jdbc:mysql://%s:%s/%s?useSSL=false&useServerPrepStmts=true&useLocalSessionState=true&characterEncoding=utf-8&allowMultiQueries=true"
                         + "&rewriteBatchedStatements=true", host, port, dataSourceName);
             case "PostgreSQL":
                 return String.format("jdbc:postgresql://%s:%s/%s?ssl=on&sslmode=prefer", host, port, dataSourceName);

--- a/test/e2e/fixture/pom.xml
+++ b/test/e2e/fixture/pom.xml
@@ -59,11 +59,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.mariadb.jdbc</groupId>
-            <artifactId>mariadb-java-client</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.opengauss</groupId>
             <artifactId>opengauss-jdbc</artifactId>
             <scope>runtime</scope>

--- a/test/e2e/operation/pipeline/pom.xml
+++ b/test/e2e/operation/pipeline/pom.xml
@@ -80,12 +80,6 @@
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
         </dependency>
-        
-        <dependency>
-            <groupId>org.mariadb.jdbc</groupId>
-            <artifactId>mariadb-java-client</artifactId>
-        </dependency>
-        
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLMigrationGeneralE2EIT.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLMigrationGeneralE2EIT.java
@@ -50,10 +50,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@PipelineE2ESettings(database = {
-        @PipelineE2EDatabaseSettings(type = "MySQL", scenarioFiles = "env/scenario/general/mysql.xml"),
-        @PipelineE2EDatabaseSettings(type = "MariaDB", scenarioFiles = "env/scenario/general/mysql.xml")
-})
+@PipelineE2ESettings(database = @PipelineE2EDatabaseSettings(type = "MySQL", scenarioFiles = "env/scenario/general/mysql.xml"))
 @Slf4j
 class MySQLMigrationGeneralE2EIT extends AbstractMigrationE2EIT {
     
@@ -118,6 +115,6 @@ class MySQLMigrationGeneralE2EIT extends AbstractMigrationE2EIT {
     }
     
     private static boolean isEnabled() {
-        return PipelineE2ECondition.isEnabled(TypedSPILoader.getService(DatabaseType.class, "MySQL"), TypedSPILoader.getService(DatabaseType.class, "MariaDB"));
+        return PipelineE2ECondition.isEnabled(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
     }
 }

--- a/test/e2e/operation/pipeline/src/test/resources/env/mysql/mysql8/my.cnf
+++ b/test/e2e/operation/pipeline/src/test/resources/env/mysql/mysql8/my.cnf
@@ -18,6 +18,8 @@
 [mysql]
 
 [mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_general_ci
 log-bin=mysql-bin
 binlog-format=row
 binlog-row-image=full

--- a/test/e2e/operation/pipeline/src/test/resources/env/scenario/general/mysql.xml
+++ b/test/e2e/operation/pipeline/src/test/resources/env/scenario/general/mysql.xml
@@ -49,7 +49,7 @@
         PRIMARY KEY ( `order_id` ),
         KEY `idx_user_id` (`user_id`),
         KEY `idx_mulit` (`t_mediumint`,`t_unsigned_mediumint`)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
     </create-table-order>
     
     <create-table-order-item>
@@ -59,7 +59,7 @@
         user_id int NOT NULL,
         status varchar(50) DEFAULT NULL,
         PRIMARY KEY (item_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
     </create-table-order-item>
     
     <full-insert-order>

--- a/test/e2e/operation/pipeline/src/test/resources/env/scenario/primary_key/text_primary_key/mysql.xml
+++ b/test/e2e/operation/pipeline/src/test/resources/env/scenario/primary_key/text_primary_key/mysql.xml
@@ -23,6 +23,6 @@
         `t_unsigned_int` int UNSIGNED NULL,
         PRIMARY KEY ( `order_id` ),
         INDEX ( `user_id` )
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
     </create-table-order>
 </command>


### PR DESCRIPTION
Related to #30535

Since get connection of `jdbc:mysql://host:port/xxx` might from mariadb-java-client, it might cause other issues.

Changes proposed in this pull request:
  - Remove mariadb-java-client dependency in E2E; Replace jdbc:mariadb to jdbc:mysql
  - Exclude mariadb in transaction and processlist operation E2E. Only keep MariaDB test for pipeline

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
