### PR TITLE
adopt: when the table name is sql keyword

### DIFF
--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/fieldlist/MySQLComFieldListPacketExecutor.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/fieldlist/MySQLComFieldListPacketExecutor.java
@@ -53,7 +53,7 @@ import java.util.LinkedList;
 @RequiredArgsConstructor
 public final class MySQLComFieldListPacketExecutor implements CommandExecutor {
     
-    private static final String SQL = "SHOW COLUMNS FROM %s FROM %s";
+    private static final String SQL = "SHOW COLUMNS FROM `%s` FROM %s";
     
     private final MySQLComFieldListPacket packet;
     


### PR DESCRIPTION
Fixes #30867.

Changes proposed in this pull request:
  -
adopted unstandardized table name. avoid null point error
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
