### PR TITLE
Fix table not exist exception when bind oracle with statement contains select union all

### DIFF
--- a/mode/type/standalone/repository/provider/jdbc/src/test/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/JDBCRepositoryTest.java
+++ b/mode/type/standalone/repository/provider/jdbc/src/test/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/JDBCRepositoryTest.java
@@ -124,9 +124,10 @@ class JDBCRepositoryTest {
         when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
         when(mockResultSet.next()).thenReturn(true, true, true, false);
         when(mockResultSet.getString("key")).thenReturn("parent1/test1", "parent1/test2", "");
-        List<String> childrenKeys = repository.getChildrenKeys("/testPath");
-        assertThat(childrenKeys.get(0), is("test1"));
-        assertThat(childrenKeys.get(1), is("test2"));
+        List<String> actual = repository.getChildrenKeys("/testPath");
+        assertThat(actual.size(), is(2));
+        assertTrue(actual.contains("test1"));
+        assertTrue(actual.contains("test2"));
     }
     
     @Test

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
@@ -592,6 +592,7 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
             OracleSelectStatement left = (OracleSelectStatement) visit(ctx.selectSubquery(0));
             result.setProjections(left.getProjections());
             left.getFrom().ifPresent(result::setFrom);
+            left.getWithSegment().ifPresent(result::setWithSegment);
             createSelectCombineClause(ctx, result, left);
         } else {
             result = null != ctx.queryBlock() ? (OracleSelectStatement) visit(ctx.queryBlock()) : (OracleSelectStatement) visit(ctx.parenthesisSelectSubquery());


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix table not exist exception when bind oracle with statement contains select union all

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
