### PR TITLE
Remove useless null check and use checkNotEmpty to replace checkState in ShardingRuleBuilder

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/builder/ShardingRuleBuilder.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/builder/ShardingRuleBuilder.java
@@ -39,7 +39,7 @@ public final class ShardingRuleBuilder implements DatabaseRuleBuilder<ShardingRu
     @Override
     public ShardingRule build(final ShardingRuleConfiguration config, final String databaseName, final DatabaseType protocolType,
                               final Map<String, DataSource> dataSources, final Collection<ShardingSphereRule> builtRules, final InstanceContext instanceContext) {
-        ShardingSpherePreconditions.checkState(null != dataSources && !dataSources.isEmpty(), () -> new MissingRequiredShardingConfigurationException("Data source", databaseName));
+        ShardingSpherePreconditions.checkNotEmpty(dataSources, () -> new MissingRequiredShardingConfigurationException("Data source", databaseName));
         return new ShardingRule(config, dataSources, instanceContext);
     }
     

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/builder/ShardingRuleBuilderTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/builder/ShardingRuleBuilderTest.java
@@ -55,14 +55,7 @@ class ShardingRuleBuilderTest {
         assertThat(builder.build(ruleConfig, "sharding_db", new MySQLDatabaseType(),
                 Collections.singletonMap("name", mock(DataSource.class, RETURNS_DEEP_STUBS)), Collections.emptyList(), mock(InstanceContext.class)), instanceOf(ShardingRule.class));
     }
-    
-    @SuppressWarnings("unchecked")
-    @Test
-    void assertBuildWithNullDataSourceMap() {
-        assertThrows(MissingRequiredShardingConfigurationException.class,
-                () -> builder.build(ruleConfig, "sharding_db", new MySQLDatabaseType(), null, Collections.emptyList(), mock(InstanceContext.class)));
-    }
-    
+    les
     @SuppressWarnings("unchecked")
     @Test
     void assertBuildWithEmptyDataSourceMap() {

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/builder/ShardingRuleBuilderTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/builder/ShardingRuleBuilderTest.java
@@ -55,7 +55,7 @@ class ShardingRuleBuilderTest {
         assertThat(builder.build(ruleConfig, "sharding_db", new MySQLDatabaseType(),
                 Collections.singletonMap("name", mock(DataSource.class, RETURNS_DEEP_STUBS)), Collections.emptyList(), mock(InstanceContext.class)), instanceOf(ShardingRule.class));
     }
-    les
+    
     @SuppressWarnings("unchecked")
     @Test
     void assertBuildWithEmptyDataSourceMap() {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove useless null check and use checkNotEmpty to replace checkState in ShardingRuleBuilder

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
