### PR TITLE
Prevent SystemSchemaManager from parsing wrong folders

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/manager/SystemSchemaManager.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/manager/SystemSchemaManager.java
@@ -49,7 +49,7 @@ public final class SystemSchemaManager {
     
     static {
         List<String> resourceNames;
-        try (Stream<String> resourceNameStream = ClasspathResourceDirectoryReader.read("schema")) {
+        try (Stream<String> resourceNameStream = ClasspathResourceDirectoryReader.read(SystemSchemaManager.class.getClassLoader(), "schema")) {
             resourceNames = resourceNameStream.filter(each -> each.endsWith(".yaml")).collect(Collectors.toList());
         }
         DATABASE_TYPE_SCHEMA_TABLE_MAP = resourceNames.stream().map(resourceName -> resourceName.split("/")).filter(each -> each.length == 4)


### PR DESCRIPTION
For #30945.

Changes proposed in this pull request:
  - Prevent SystemSchemaManager from parsing wrong folders.
  - This is the simplest process. It may be necessary to completely change the location of all `schema/` folders to the `shardingsphere-metadata/schema/` folder. But this required changes to more than 800 files.
  - ~`./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e` started to force the existence of a Docker environment, not sure what happened.~ Fixed by #30978.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
