### PR TITLE
disable agent e2e test when mvn clean install

### DIFF
--- a/test/e2e/agent/plugins/common/src/test/java/org/apache/shardingsphere/test/e2e/agent/common/env/E2ETestEnvironment.java
+++ b/test/e2e/agent/plugins/common/src/test/java/org/apache/shardingsphere/test/e2e/agent/common/env/E2ETestEnvironment.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.test.e2e.agent.common.env;
 
+import com.google.common.base.Strings;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.test.e2e.agent.common.container.ITContainers;
@@ -83,8 +84,8 @@ public final class E2ETestEnvironment {
     
     private E2ETestEnvironment() {
         Properties props = EnvironmentProperties.loadProperties("env/engine-env.properties");
-        adapter = props.getProperty("it.env.adapter", "proxy");
-        plugin = props.getProperty("it.env.plugin", "file");
+        adapter = props.getProperty("it.env.adapter");
+        plugin = props.getProperty("it.env.plugin");
         collectDataWaitSeconds = Long.parseLong(props.getProperty("it.env.collect.data.wait.seconds", "0"));
     }
     
@@ -101,6 +102,9 @@ public final class E2ETestEnvironment {
      * Init environment.
      */
     public void init() {
+        if (!containsTestParameter()) {
+            return;
+        }
         if (AdapterType.PROXY.getValue().equalsIgnoreCase(adapter)) {
             createProxyEnvironment();
         } else if (AdapterType.JDBC.getValue().equalsIgnoreCase(adapter)) {
@@ -180,11 +184,23 @@ public final class E2ETestEnvironment {
      * Destroy environment.
      */
     public void destroy() {
+        if (!containsTestParameter()) {
+            return;
+        }
         if (null != proxyRequestExecutor) {
             proxyRequestExecutor.stop();
         }
         if (null != containers) {
             containers.stop();
         }
+    }
+    
+    /**
+     * Judge whether contains test parameter.
+     *
+     * @return contains or not
+     */
+    public boolean containsTestParameter() {
+        return !Strings.isNullOrEmpty(adapter) && !Strings.isNullOrEmpty(plugin);
     }
 }

--- a/test/e2e/agent/plugins/logging/file/src/test/java/org/apache/shardingsphere/test/e2e/agent/file/FilePluginE2EIT.java
+++ b/test/e2e/agent/plugins/logging/file/src/test/java/org/apache/shardingsphere/test/e2e/agent/file/FilePluginE2EIT.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.test.e2e.agent.common.enums.AdapterType;
 import org.apache.shardingsphere.test.e2e.agent.common.env.E2ETestEnvironment;
 import org.apache.shardingsphere.test.e2e.agent.file.asserts.ContentAssert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collection;
@@ -33,10 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 @Slf4j
 class FilePluginE2EIT {
     
+    @EnabledIf("isEnabled")
     @Test
     void assertWithAgent() {
         Collection<String> actualLogLines = E2ETestEnvironment.getInstance().getActualLogs();
-        log.info("actualLogLines size:{}", actualLogLines.size());
         assertFalse(actualLogLines.isEmpty(), "Actual log is empty");
         if (AdapterType.PROXY.getValue().equalsIgnoreCase(E2ETestEnvironment.getInstance().getAdapter())) {
             assertProxyWithAgent(actualLogLines);
@@ -51,5 +52,9 @@ class FilePluginE2EIT {
     
     private void assertJdbcWithAgent(final Collection<String> actualLogLines) {
         ContentAssert.assertIs(actualLogLines, "Build meta data contexts finished, cost\\s(?=[1-9]+\\d*)");
+    }
+    
+    private static boolean isEnabled() {
+        return E2ETestEnvironment.getInstance().containsTestParameter();
     }
 }

--- a/test/e2e/agent/plugins/logging/file/src/test/resources/env/engine-env.properties
+++ b/test/e2e/agent/plugins/logging/file/src/test/resources/env/engine-env.properties
@@ -16,6 +16,6 @@
 #
 
 # The value of it.env.adapter is proxy or jdbc
-it.env.adapter=proxy
+it.env.adapter=
 it.env.plugin=file
 it.env.collect.data.wait.seconds=15

--- a/test/e2e/agent/plugins/metrics/prometheus/src/test/java/org/apache/shardingsphere/test/e2e/agent/metrics/MetricsPluginE2EIT.java
+++ b/test/e2e/agent/plugins/metrics/prometheus/src/test/java/org/apache/shardingsphere/test/e2e/agent/metrics/MetricsPluginE2EIT.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.test.e2e.agent.metrics.cases.MetricQueryAsserti
 import org.apache.shardingsphere.test.e2e.agent.metrics.cases.MetricTestCase;
 import org.apache.shardingsphere.test.e2e.agent.metrics.result.MetricsMetaDataResult;
 import org.apache.shardingsphere.test.e2e.agent.metrics.result.MetricsQueryResult;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,6 +44,7 @@ import java.util.stream.Stream;
 @Slf4j
 class MetricsPluginE2EIT {
     
+    @EnabledIf("isEnabled")
     @ParameterizedTest
     @ArgumentsSource(TestCaseArgumentsProvider.class)
     void assertWithAgent(final MetricTestCase metricTestCase) {
@@ -73,6 +75,10 @@ class MetricsPluginE2EIT {
                 log.info("Access prometheus HTTP RESTFul API error: ", ex);
             }
         }
+    }
+    
+    private static boolean isEnabled() {
+        return E2ETestEnvironment.getInstance().containsTestParameter();
     }
     
     private static class TestCaseArgumentsProvider implements ArgumentsProvider {

--- a/test/e2e/agent/plugins/metrics/prometheus/src/test/resources/env/engine-env.properties
+++ b/test/e2e/agent/plugins/metrics/prometheus/src/test/resources/env/engine-env.properties
@@ -16,6 +16,6 @@
 #
 
 # The value of it.env.adapter is proxy or jdbc
-it.env.adapter=jdbc
+it.env.adapter=
 it.env.plugin=prometheus
 it.env.collect.data.wait.seconds=35

--- a/test/e2e/agent/plugins/tracing/jaeger/src/test/java/org/apache/shardingsphere/test/e2e/agent/jaeger/JaegerPluginE2EIT.java
+++ b/test/e2e/agent/plugins/tracing/jaeger/src/test/java/org/apache/shardingsphere/test/e2e/agent/jaeger/JaegerPluginE2EIT.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.test.e2e.agent.common.env.E2ETestEnvironment;
 import org.apache.shardingsphere.test.e2e.agent.jaeger.asserts.SpanAssert;
 import org.apache.shardingsphere.test.e2e.agent.jaeger.cases.IntegrationTestCasesLoader;
 import org.apache.shardingsphere.test.e2e.agent.jaeger.cases.SpanTestCase;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -34,10 +35,15 @@ import java.util.stream.Stream;
 @ExtendWith(AgentTestActionExtension.class)
 class JaegerPluginE2EIT {
     
+    @EnabledIf("isEnabled")
     @ParameterizedTest
     @ArgumentsSource(TestCaseArgumentsProvider.class)
     void assertWithAgent(final SpanTestCase spanTestCase) {
         SpanAssert.assertIs(E2ETestEnvironment.getInstance().getJaegerHttpUrl(), spanTestCase);
+    }
+    
+    private static boolean isEnabled() {
+        return E2ETestEnvironment.getInstance().containsTestParameter();
     }
     
     private static class TestCaseArgumentsProvider implements ArgumentsProvider {

--- a/test/e2e/agent/plugins/tracing/jaeger/src/test/java/org/apache/shardingsphere/test/e2e/agent/jaeger/asserts/SpanAssert.java
+++ b/test/e2e/agent/plugins/tracing/jaeger/src/test/java/org/apache/shardingsphere/test/e2e/agent/jaeger/asserts/SpanAssert.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.test.e2e.agent.jaeger.asserts;
 
 import com.google.common.collect.ImmutableMap;
 import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.util.json.JsonUtils;
 import org.apache.shardingsphere.test.e2e.agent.common.util.OkHttpUtils;
 import org.apache.shardingsphere.test.e2e.agent.jaeger.cases.SpanTestCase;
@@ -42,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Span assert.
  */
-@Slf4j
 public final class SpanAssert {
     
     /**
@@ -52,7 +50,6 @@ public final class SpanAssert {
      * @param expected expected span
      */
     public static void assertIs(final String baseUrl, final SpanTestCase expected) {
-        log.info("SpanAssert baseUrl:{}", baseUrl);
         assertTagKey(baseUrl, expected);
         expected.getTagCases().stream().filter(TagAssertion::isNeedAssertValue).forEach(each -> assertTagValue(baseUrl, expected, each));
     }

--- a/test/e2e/agent/plugins/tracing/jaeger/src/test/resources/env/engine-env.properties
+++ b/test/e2e/agent/plugins/tracing/jaeger/src/test/resources/env/engine-env.properties
@@ -16,6 +16,6 @@
 #
 
 # The value of it.env.adapter is proxy or jdbc
-it.env.adapter=proxy
+it.env.adapter=
 it.env.plugin=jaeger
 it.env.collect.data.wait.seconds=15

--- a/test/e2e/agent/plugins/tracing/zipkin/src/test/java/org/apache/shardingsphere/test/e2e/agent/zipkin/ZipkinPluginE2EIT.java
+++ b/test/e2e/agent/plugins/tracing/zipkin/src/test/java/org/apache/shardingsphere/test/e2e/agent/zipkin/ZipkinPluginE2EIT.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.test.e2e.agent.common.env.E2ETestEnvironment;
 import org.apache.shardingsphere.test.e2e.agent.zipkin.asserts.SpanAssert;
 import org.apache.shardingsphere.test.e2e.agent.zipkin.cases.IntegrationTestCasesLoader;
 import org.apache.shardingsphere.test.e2e.agent.zipkin.cases.SpanTestCase;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -34,10 +35,15 @@ import java.util.stream.Stream;
 @ExtendWith(AgentTestActionExtension.class)
 class ZipkinPluginE2EIT {
     
+    @EnabledIf("isEnabled")
     @ParameterizedTest
     @ArgumentsSource(TestCaseArgumentsProvider.class)
     void assertWithAgent(final SpanTestCase spanTestCase) {
         SpanAssert.assertIs(E2ETestEnvironment.getInstance().getZipKinHttpUrl(), spanTestCase);
+    }
+    
+    private static boolean isEnabled() {
+        return E2ETestEnvironment.getInstance().containsTestParameter();
     }
     
     private static class TestCaseArgumentsProvider implements ArgumentsProvider {

--- a/test/e2e/agent/plugins/tracing/zipkin/src/test/resources/env/engine-env.properties
+++ b/test/e2e/agent/plugins/tracing/zipkin/src/test/resources/env/engine-env.properties
@@ -16,6 +16,6 @@
 #
 
 # The value of it.env.adapter is proxy or jdbc
-it.env.adapter=proxy
+it.env.adapter=
 it.env.plugin=zipkin
 it.env.collect.data.wait.seconds=15


### PR DESCRIPTION
Fixes #30897.

Changes proposed in this pull request:
  - Default disable agent e2e test

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
