### PR TITLE
Add functionSegments to parameter list of cast function in MySQL visitor

### DIFF
--- a/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
+++ b/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
@@ -1035,6 +1035,9 @@ public abstract class MySQLStatementVisitor extends MySQLStatementBaseVisitor<AS
             } else if (expr instanceof LiteralExpressionSegment) {
                 result.getParameters().add((LiteralExpressionSegment) expr);
             }
+            else if (expr instanceof FunctionSegment) {
+                result.getParameters().add((FunctionSegment) expr);
+            }
         }
         if (null != ctx.castType()) {
             result.getParameters().add((DataTypeSegment) visit(ctx.castType()));

--- a/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
+++ b/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
@@ -1034,8 +1034,7 @@ public abstract class MySQLStatementVisitor extends MySQLStatementBaseVisitor<AS
                 result.getParameters().add((ColumnSegment) expr);
             } else if (expr instanceof LiteralExpressionSegment) {
                 result.getParameters().add((LiteralExpressionSegment) expr);
-            }
-            else if (expr instanceof FunctionSegment) {
+            } else if (expr instanceof FunctionSegment) {
                 result.getParameters().add((FunctionSegment) expr);
             }
         }


### PR DESCRIPTION
Changes proposed in this pull request:
  -----------------------------------------------------------------------

> Append functionSegments to parameters list in visitCast of MySQL visitor.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
