### PR TITLE
Fix push down sql execute error when sql contains chinese character with sql federation

### DIFF
--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/sql/SQLDialectFactory.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/sql/SQLDialectFactory.java
@@ -23,8 +23,8 @@ import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.dialect.MssqlSqlDialect;
 import org.apache.calcite.sql.dialect.MysqlSqlDialect;
 import org.apache.calcite.sql.dialect.OracleSqlDialect;
-import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
 import org.apache.shardingsphere.sqlfederation.optimizer.sql.dialect.CustomMySQLSQLDialect;
+import org.apache.shardingsphere.sqlfederation.optimizer.sql.dialect.CustomPostgreSQLSQLDialect;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -43,8 +43,8 @@ public final class SQLDialectFactory {
         SQL_DIALECTS_REGISTRY.put("MariaDB", CustomMySQLSQLDialect.DEFAULT);
         SQL_DIALECTS_REGISTRY.put("Oracle", OracleSqlDialect.DEFAULT);
         SQL_DIALECTS_REGISTRY.put("SQLServer", MssqlSqlDialect.DEFAULT);
-        SQL_DIALECTS_REGISTRY.put("PostgreSQL", PostgresqlSqlDialect.DEFAULT);
-        SQL_DIALECTS_REGISTRY.put("openGauss", PostgresqlSqlDialect.DEFAULT);
+        SQL_DIALECTS_REGISTRY.put("PostgreSQL", CustomPostgreSQLSQLDialect.DEFAULT);
+        SQL_DIALECTS_REGISTRY.put("openGauss", CustomPostgreSQLSQLDialect.DEFAULT);
     }
     
     /**

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/sql/SQLDialectFactory.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/sql/SQLDialectFactory.java
@@ -24,6 +24,7 @@ import org.apache.calcite.sql.dialect.MssqlSqlDialect;
 import org.apache.calcite.sql.dialect.MysqlSqlDialect;
 import org.apache.calcite.sql.dialect.OracleSqlDialect;
 import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
+import org.apache.shardingsphere.sqlfederation.optimizer.sql.dialect.CustomMySQLSQLDialect;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,9 +38,9 @@ public final class SQLDialectFactory {
     private static final Map<String, SqlDialect> SQL_DIALECTS_REGISTRY = new HashMap<>();
     
     static {
-        SQL_DIALECTS_REGISTRY.put("H2", MysqlSqlDialect.DEFAULT);
-        SQL_DIALECTS_REGISTRY.put("MySQL", MysqlSqlDialect.DEFAULT);
-        SQL_DIALECTS_REGISTRY.put("MariaDB", MysqlSqlDialect.DEFAULT);
+        SQL_DIALECTS_REGISTRY.put("H2", CustomMySQLSQLDialect.DEFAULT);
+        SQL_DIALECTS_REGISTRY.put("MySQL", CustomMySQLSQLDialect.DEFAULT);
+        SQL_DIALECTS_REGISTRY.put("MariaDB", CustomMySQLSQLDialect.DEFAULT);
         SQL_DIALECTS_REGISTRY.put("Oracle", OracleSqlDialect.DEFAULT);
         SQL_DIALECTS_REGISTRY.put("SQLServer", MssqlSqlDialect.DEFAULT);
         SQL_DIALECTS_REGISTRY.put("PostgreSQL", PostgresqlSqlDialect.DEFAULT);

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/sql/dialect/CustomMySQLSQLDialect.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/sql/dialect/CustomMySQLSQLDialect.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sqlfederation.optimizer.sql.dialect;
+
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.MysqlSqlDialect;
+
+/**
+ * Custom MySQL SQL dialect.
+ */
+public final class CustomMySQLSQLDialect extends MysqlSqlDialect {
+    
+    public static final SqlDialect DEFAULT = new CustomMySQLSQLDialect(DEFAULT_CONTEXT);
+    
+    public CustomMySQLSQLDialect(final Context context) {
+        super(context);
+    }
+    
+    @Override
+    public void quoteStringLiteral(final StringBuilder builder, final String charsetName, final String value) {
+        builder.append(literalQuoteString);
+        builder.append(value.replace(literalEndQuoteString, literalEscapedQuote));
+        builder.append(literalEndQuoteString);
+    }
+}

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/sql/dialect/CustomPostgreSQLSQLDialect.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/sql/dialect/CustomPostgreSQLSQLDialect.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sqlfederation.optimizer.sql.dialect;
+
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
+
+/**
+ * Custom PostgreSQL SQL dialect.
+ */
+public final class CustomPostgreSQLSQLDialect extends PostgresqlSqlDialect {
+    
+    public static final SqlDialect DEFAULT = new CustomPostgreSQLSQLDialect(DEFAULT_CONTEXT);
+    
+    public CustomPostgreSQLSQLDialect(final Context context) {
+        super(context);
+    }
+    
+    @Override
+    public void quoteStringLiteral(final StringBuilder builder, final String charsetName, final String value) {
+        builder.append(literalQuoteString);
+        builder.append(value.replace(literalEndQuoteString, literalEscapedQuote));
+        builder.append(literalEndQuoteString);
+    }
+}

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select.xml
@@ -32,6 +32,10 @@
     <test-case sql="SELECT 1=1, 1!=1, 1&gt;1, 1&lt;1, 1&gt;=1, 1&lt;=1" db-types="MySQL" scenario-types="db_tbl_sql_federation" >
         <assertion />
     </test-case>
+    
+    <test-case sql="SELECT * FROM t_order WHERE remark LIKE '%张%'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db_tbl_sql_federation" >
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
 
     <test-case sql="SELECT count(*) > 0 from t_order" db-types="MySQL" scenario-types="db_tbl_sql_federation" >
         <assertion expected-data-source-name="read_dataset" />


### PR DESCRIPTION
Fixes #30918.

Changes proposed in this pull request:
  - Fix push down sql execute error when sql contains chinese character with sql federation

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
