### PR TITLE
Adjust SubqueryTableSegment start index and stop index visit logic and add test assert

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/from/impl/SubqueryTableSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/from/impl/SubqueryTableSegmentBinder.java
@@ -74,7 +74,7 @@ public final class SubqueryTableSegmentBinder {
         boundedSubquerySegment.setSubqueryType(segment.getSubquery().getSubqueryType());
         IdentifierValue subqueryTableName = segment.getAliasSegment().map(AliasSegment::getIdentifier).orElseGet(() -> new IdentifierValue(""));
         bindParameterMarkerProjection(boundedSubquerySegment, subqueryTableName);
-        SubqueryTableSegment result = new SubqueryTableSegment(boundedSubquerySegment);
+        SubqueryTableSegment result = new SubqueryTableSegment(segment.getStartIndex(), segment.getStopIndex(), boundedSubquerySegment);
         segment.getAliasSegment().ifPresent(result::setAlias);
         tableBinderContexts.put(subqueryTableName.getValue().toLowerCase(),
                 new SimpleTableSegmentBinderContext(createSubqueryProjections(boundedSelect.getProjections().getProjections(), subqueryTableName, statementBinderContext.getDatabaseType())));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionsContextEngineTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionsContextEngineTest.java
@@ -389,7 +389,7 @@ class ProjectionsContextEngineTest {
         projectionsSegment.getProjections().add(projectionSegment);
         selectStatement.setProjections(projectionsSegment);
         subquerySelectStatement.setProjections(new ProjectionsSegment(0, 0));
-        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(new SubquerySegment(0, 0, subquerySelectStatement, ""));
+        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(0, 0, new SubquerySegment(0, 0, subquerySelectStatement, ""));
         subqueryTableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("d")));
         selectStatement.setFrom(subqueryTableSegment);
         ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("name"));
@@ -434,7 +434,7 @@ class ProjectionsContextEngineTest {
         projectionsSegment.getProjections().add(projectionSegment);
         selectStatement.setProjections(projectionsSegment);
         subquerySelectStatement.setProjections(new ProjectionsSegment(0, 0));
-        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(new SubquerySegment(0, 0, subquerySelectStatement, ""));
+        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(0, 0, new SubquerySegment(0, 0, subquerySelectStatement, ""));
         subqueryTableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("TABLE")));
         selectStatement.setFrom(subqueryTableSegment);
         ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("name"));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dml/SelectStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dml/SelectStatementContextTest.java
@@ -632,7 +632,7 @@ class SelectStatementContextTest {
     void assertContainsEnhancedTable() {
         SelectStatement selectStatement = new MySQLSelectStatement();
         selectStatement.setProjections(new ProjectionsSegment(0, 0));
-        selectStatement.setFrom(new SubqueryTableSegment(new SubquerySegment(0, 0, createSubSelectStatement(), "")));
+        selectStatement.setFrom(new SubqueryTableSegment(0, 0, new SubquerySegment(0, 0, createSubSelectStatement(), "")));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singletonMap(DefaultDatabase.LOGIC_NAME, mockDatabase()), mock(ResourceMetaData.class),
                 mock(RuleMetaData.class), mock(ConfigurationProperties.class));
         SelectStatementContext actual = new SelectStatementContext(metaData, Collections.emptyList(), selectStatement, DefaultDatabase.LOGIC_NAME);

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/from/impl/SubqueryTableSegmentBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/from/impl/SubqueryTableSegmentBinderTest.java
@@ -68,7 +68,7 @@ class SubqueryTableSegmentBinderTest {
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
         projectionsSegment.getProjections().add(new ShorthandProjectionSegment(0, 0));
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
-        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(new SubquerySegment(0, 0, selectStatement, ""));
+        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(0, 0, new SubquerySegment(0, 0, selectStatement, ""));
         subqueryTableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("temp")));
         ShardingSphereMetaData metaData = createMetaData();
         Map<String, TableSegmentBinderContext> tableBinderContexts = new LinkedHashMap<>();
@@ -102,7 +102,7 @@ class SubqueryTableSegmentBinderTest {
         columnProjectionSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("order_id_alias")));
         projectionsSegment.getProjections().add(columnProjectionSegment);
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
-        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(new SubquerySegment(0, 0, selectStatement, ""));
+        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(0, 0, new SubquerySegment(0, 0, selectStatement, ""));
         subqueryTableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("temp")));
         ShardingSphereMetaData metaData = createMetaData();
         Map<String, TableSegmentBinderContext> tableBinderContexts = new LinkedHashMap<>();
@@ -126,7 +126,7 @@ class SubqueryTableSegmentBinderTest {
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
         projectionsSegment.getProjections().add(new ShorthandProjectionSegment(0, 0));
         when(selectStatement.getProjections()).thenReturn(projectionsSegment);
-        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(new SubquerySegment(0, 0, selectStatement, ""));
+        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(0, 0, new SubquerySegment(0, 0, selectStatement, ""));
         ShardingSphereMetaData metaData = createMetaData();
         Map<String, TableSegmentBinderContext> tableBinderContexts = new LinkedHashMap<>();
         SubqueryTableSegment actual = SubqueryTableSegmentBinder.bind(subqueryTableSegment, new SQLStatementBinderContext(metaData, DefaultDatabase.LOGIC_NAME, databaseType, Collections.emptySet()),

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/projection/impl/ShorthandProjectionSegmentBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/projection/impl/ShorthandProjectionSegmentBinderTest.java
@@ -83,7 +83,7 @@ class ShorthandProjectionSegmentBinderTest {
         ColumnProjectionSegment invisibleColumn = new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("status")));
         invisibleColumn.setVisible(false);
         tableBinderContexts.put("o", new SimpleTableSegmentBinderContext(Arrays.asList(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("order_id"))), invisibleColumn)));
-        SubqueryTableSegment boundedTableSegment = new SubqueryTableSegment(new SubquerySegment(0, 0, mock(MySQLSelectStatement.class), ""));
+        SubqueryTableSegment boundedTableSegment = new SubqueryTableSegment(0, 0, new SubquerySegment(0, 0, mock(MySQLSelectStatement.class), ""));
         boundedTableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("o")));
         ShorthandProjectionSegment actual = ShorthandProjectionSegmentBinder.bind(new ShorthandProjectionSegment(0, 0), boundedTableSegment, tableBinderContexts);
         assertThat(actual.getActualProjectionSegments().size(), is(1));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/statement/MergeStatementBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/statement/MergeStatementBinderTest.java
@@ -129,7 +129,7 @@ class MergeStatementBinderTest {
         OracleSelectStatement oracleSelectStatement = new OracleSelectStatement();
         oracleSelectStatement.setProjections(projectionsSegment);
         oracleSelectStatement.setFrom(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order_item"))));
-        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(new SubquerySegment(0, 0, oracleSelectStatement, ""));
+        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(0, 0, new SubquerySegment(0, 0, oracleSelectStatement, ""));
         subqueryTableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("b")));
         mergeStatement.setSource(subqueryTableSegment);
         UpdateStatement updateStatement = new OracleUpdateStatement();

--- a/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
+++ b/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
@@ -1830,7 +1830,7 @@ public abstract class MySQLStatementVisitor extends MySQLStatementBaseVisitor<AS
         if (null != ctx.subquery()) {
             MySQLSelectStatement subquery = (MySQLSelectStatement) visit(ctx.subquery());
             SubquerySegment subquerySegment = new SubquerySegment(ctx.subquery().start.getStartIndex(), ctx.subquery().stop.getStopIndex(), subquery, getOriginalText(ctx.subquery()));
-            SubqueryTableSegment result = new SubqueryTableSegment(subquerySegment);
+            SubqueryTableSegment result = new SubqueryTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), subquerySegment);
             if (null != ctx.alias()) {
                 result.setAlias((AliasSegment) visit(ctx.alias()));
             }

--- a/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/OpenGaussStatementVisitor.java
+++ b/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/OpenGaussStatementVisitor.java
@@ -1207,7 +1207,7 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementBaseVi
     private SubqueryTableSegment getSubqueryTableSegment(final TableReferenceContext ctx) {
         OpenGaussSelectStatement select = (OpenGaussSelectStatement) visit(ctx.selectWithParens());
         SubquerySegment subquery = new SubquerySegment(ctx.selectWithParens().start.getStartIndex(), ctx.selectWithParens().stop.getStopIndex(), select, getOriginalText(ctx.selectWithParens()));
-        SubqueryTableSegment result = new SubqueryTableSegment(subquery);
+        SubqueryTableSegment result = new SubqueryTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), subquery);
         if (null != ctx.aliasClause()) {
             result.setAlias((AliasSegment) visit(ctx.aliasClause()));
         }

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
@@ -226,10 +226,10 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
         }
         if (null != ctx.dmlTableExprClause().dmlSubqueryClause()) {
             SubquerySegment subquerySegment = (SubquerySegment) visit(ctx.dmlTableExprClause().dmlSubqueryClause());
-            return new SubqueryTableSegment(subquerySegment);
+            return new SubqueryTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), subquerySegment);
         }
         SubquerySegment subquerySegment = (SubquerySegment) visit(ctx.dmlTableExprClause().tableCollectionExpr());
-        return new SubqueryTableSegment(subquerySegment);
+        return new SubqueryTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), subquerySegment);
     }
     
     @Override
@@ -421,10 +421,10 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
         }
         if (null != ctx.dmlTableExprClause().dmlSubqueryClause()) {
             SubquerySegment subquerySegment = (SubquerySegment) visit(ctx.dmlTableExprClause().dmlSubqueryClause());
-            return new SubqueryTableSegment(subquerySegment);
+            return new SubqueryTableSegment(ctx.dmlTableExprClause().dmlSubqueryClause().start.getStartIndex(), ctx.dmlTableExprClause().dmlSubqueryClause().stop.getStopIndex(), subquerySegment);
         }
         SubquerySegment subquerySegment = (SubquerySegment) visit(ctx.dmlTableExprClause().tableCollectionExpr());
-        return new SubqueryTableSegment(subquerySegment);
+        return new SubqueryTableSegment(ctx.dmlTableExprClause().tableCollectionExpr().start.getStartIndex(), ctx.dmlTableExprClause().tableCollectionExpr().stop.getStopIndex(), subquerySegment);
     }
     
     @Override
@@ -1093,7 +1093,7 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
             result = (TableSegment) visit(ctx.selectTableReference());
         } else {
             SubquerySegment subquerySegment = (SubquerySegment) visit(ctx.collectionExpr());
-            result = new SubqueryTableSegment(subquerySegment);
+            result = new SubqueryTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), subquerySegment);
         }
         return result;
     }
@@ -1163,11 +1163,11 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
             OracleSelectStatement subquery = (OracleSelectStatement) visit(ctx.lateralClause().selectSubquery());
             SubquerySegment subquerySegment = new SubquerySegment(ctx.lateralClause().selectSubquery().start.getStartIndex(), ctx.lateralClause().selectSubquery().stop.getStopIndex(), subquery,
                     getOriginalText(ctx.lateralClause().selectSubquery()));
-            result = new SubqueryTableSegment(subquerySegment);
+            result = new SubqueryTableSegment(ctx.lateralClause().LP_().getSymbol().getStartIndex(), ctx.lateralClause().RP_().getSymbol().getStopIndex(), subquerySegment);
         } else {
             if (null != ctx.tableCollectionExpr().collectionExpr().selectSubquery()) {
                 SubquerySegment subquerySegment = (SubquerySegment) visit(ctx.tableCollectionExpr());
-                result = new SubqueryTableSegment(subquerySegment);
+                result = new SubqueryTableSegment(ctx.tableCollectionExpr().start.getStartIndex(), ctx.tableCollectionExpr().stop.getStopIndex(), subquerySegment);
             } else {
                 result = new CollectionTableSegment((ExpressionSegment) visit(ctx.tableCollectionExpr()));
             }
@@ -1376,7 +1376,7 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
         }
         OracleSelectStatement subquery = (OracleSelectStatement) visit(ctx.subquery());
         SubquerySegment subquerySegment = new SubquerySegment(ctx.subquery().start.getStartIndex(), ctx.subquery().stop.getStopIndex(), subquery, getOriginalText(ctx.subquery()));
-        SubqueryTableSegment result = new SubqueryTableSegment(subquerySegment);
+        SubqueryTableSegment result = new SubqueryTableSegment(ctx.subquery().start.getStartIndex(), ctx.subquery().stop.getStopIndex(), subquerySegment);
         if (null != ctx.alias()) {
             result.setAlias((AliasSegment) visit(ctx.alias()));
         }
@@ -1402,7 +1402,7 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
         OracleSelectStatement subquery = (OracleSelectStatement) visit(ctx.subquery());
         SubquerySegment subquerySegment = new SubquerySegment(ctx.subquery().start.getStartIndex(), ctx.subquery().stop.getStopIndex(), subquery, getOriginalText(ctx.subquery()));
         subquerySegment.getSelect().getParameterMarkerSegments().addAll(popAllStatementParameterMarkerSegments());
-        SubqueryTableSegment result = new SubqueryTableSegment(subquerySegment);
+        SubqueryTableSegment result = new SubqueryTableSegment(ctx.subquery().start.getStartIndex(), ctx.subquery().stop.getStopIndex(), subquerySegment);
         if (null != ctx.alias()) {
             result.setAlias((AliasSegment) visit(ctx.alias()));
         }

--- a/parser/sql/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/PostgreSQLStatementVisitor.java
+++ b/parser/sql/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/PostgreSQLStatementVisitor.java
@@ -1161,7 +1161,7 @@ public abstract class PostgreSQLStatementVisitor extends PostgreSQLStatementPars
             PostgreSQLSelectStatement select = (PostgreSQLSelectStatement) visit(ctx.selectWithParens());
             SubquerySegment subquery = new SubquerySegment(ctx.selectWithParens().start.getStartIndex(), ctx.selectWithParens().stop.getStopIndex(), select, getOriginalText(ctx.selectWithParens()));
             AliasSegment alias = null == ctx.aliasClause() ? null : (AliasSegment) visit(ctx.aliasClause());
-            SubqueryTableSegment result = new SubqueryTableSegment(subquery);
+            SubqueryTableSegment result = new SubqueryTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), subquery);
             result.setAlias(alias);
             return result;
         }

--- a/parser/sql/dialect/sql92/src/main/java/org/apache/shardingsphere/sql/parser/sql92/visitor/statement/type/SQL92DMLStatementVisitor.java
+++ b/parser/sql/dialect/sql92/src/main/java/org/apache/shardingsphere/sql/parser/sql92/visitor/statement/type/SQL92DMLStatementVisitor.java
@@ -406,7 +406,7 @@ public final class SQL92DMLStatementVisitor extends SQL92StatementVisitor implem
         if (null != ctx.subquery()) {
             SQL92SelectStatement subquery = (SQL92SelectStatement) visit(ctx.subquery());
             SubquerySegment subquerySegment = new SubquerySegment(ctx.subquery().start.getStartIndex(), ctx.subquery().stop.getStopIndex(), subquery, getOriginalText(ctx.subquery()));
-            SubqueryTableSegment result = new SubqueryTableSegment(subquerySegment);
+            SubqueryTableSegment result = new SubqueryTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), subquerySegment);
             if (null != ctx.alias()) {
                 result.setAlias((AliasSegment) visit(ctx.alias()));
             }

--- a/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
+++ b/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
@@ -1595,7 +1595,7 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
             } else {
                 subquerySegment.setSelect((SQLServerSelectStatement) visit(ctx.subquery()));
             }
-            SubqueryTableSegment result = new SubqueryTableSegment(subquerySegment);
+            SubqueryTableSegment result = new SubqueryTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), subquerySegment);
             if (null != ctx.alias()) {
                 result.setAlias((AliasSegment) visit(ctx.alias()));
             }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/SubqueryTableSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/SubqueryTableSegment.java
@@ -34,6 +34,10 @@ import java.util.Optional;
 @Getter
 public final class SubqueryTableSegment implements TableSegment {
     
+    private final int startIndex;
+    
+    private final int stopIndex;
+    
     private final SubquerySegment subquery;
     
     @Setter
@@ -63,12 +67,12 @@ public final class SubqueryTableSegment implements TableSegment {
     
     @Override
     public int getStartIndex() {
-        return subquery.getStartIndex();
+        return startIndex;
     }
     
     @Override
     public int getStopIndex() {
-        return subquery.getStopIndex();
+        return null == alias ? stopIndex : alias.getStopIndex();
     }
     
     /**

--- a/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtilsTest.java
+++ b/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtilsTest.java
@@ -102,7 +102,7 @@ class SubqueryExtractUtilsTest {
         MySQLSelectStatement selectStatement = new MySQLSelectStatement();
         selectStatement.setProjections(new ProjectionsSegment(7, 16));
         selectStatement.getProjections().getProjections().add(new ColumnProjectionSegment(new ColumnSegment(7, 16, new IdentifierValue("order_id"))));
-        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(new SubquerySegment(23, 71, subquery, ""));
+        SubqueryTableSegment subqueryTableSegment = new SubqueryTableSegment(0, 0, new SubquerySegment(23, 71, subquery, ""));
         selectStatement.setFrom(subqueryTableSegment);
         Collection<SubquerySegment> result = SubqueryExtractUtils.getSubquerySegments(selectStatement);
         assertThat(result.size(), is(1));
@@ -140,8 +140,8 @@ class SubqueryExtractUtilsTest {
         ColumnSegment columnSegment2 = new ColumnSegment(203, 213, new IdentifierValue("order_id"));
         BinaryOperationExpression orderIdCondition = new BinaryOperationExpression(190, 213, columnSegment1, columnSegment2, "=", "o.order_id = oi.order_id");
         from.setCondition(orderIdCondition);
-        SubqueryTableSegment leftSubquerySegment = new SubqueryTableSegment(new SubquerySegment(26, 92, subqueryLeftSelectStatement, ""));
-        SubqueryTableSegment rightSubquerySegment = new SubqueryTableSegment(new SubquerySegment(104, 175, subqueryRightSelectStatement, ""));
+        SubqueryTableSegment leftSubquerySegment = new SubqueryTableSegment(0, 0, new SubquerySegment(26, 92, subqueryLeftSelectStatement, ""));
+        SubqueryTableSegment rightSubquerySegment = new SubqueryTableSegment(0, 0, new SubquerySegment(104, 175, subqueryRightSelectStatement, ""));
         from.setLeft(leftSubquerySegment);
         from.setRight(rightSubquerySegment);
         selectStatement.setFrom(from);
@@ -155,7 +155,7 @@ class SubqueryExtractUtilsTest {
     @Test
     void assertGetSubquerySegmentsWithMultiNestedSubquery() {
         SelectStatement selectStatement = new MySQLSelectStatement();
-        selectStatement.setFrom(new SubqueryTableSegment(createSubquerySegmentForFrom()));
+        selectStatement.setFrom(new SubqueryTableSegment(0, 0, createSubquerySegmentForFrom()));
         Collection<SubquerySegment> result = SubqueryExtractUtils.getSubquerySegments(selectStatement);
         assertThat(result.size(), is(2));
     }

--- a/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/WhereExtractUtilsTest.java
+++ b/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/WhereExtractUtilsTest.java
@@ -88,7 +88,7 @@ class WhereExtractUtilsTest {
         MySQLSelectStatement subQuerySelectStatement = new MySQLSelectStatement();
         subQuerySelectStatement.setFrom(joinTableSegment);
         MySQLSelectStatement selectStatement = new MySQLSelectStatement();
-        selectStatement.setFrom(new SubqueryTableSegment(new SubquerySegment(20, 84, subQuerySelectStatement, "")));
+        selectStatement.setFrom(new SubqueryTableSegment(0, 0, new SubquerySegment(20, 84, subQuerySelectStatement, "")));
         Collection<WhereSegment> subqueryWhereSegments = WhereExtractUtils.getSubqueryWhereSegments(selectStatement);
         WhereSegment actual = subqueryWhereSegments.iterator().next();
         assertThat(actual.getExpr(), is(joinTableSegment.getCondition()));

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/table/TableAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/table/TableAssert.java
@@ -167,6 +167,7 @@ public final class TableAssert {
      * @param expected expected subquery expression
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final SubqueryTableSegment actual, final ExpectedSubqueryTable expected) {
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
         if (null != actual.getSubquery().getSelect()) {
             SelectStatementAssert.assertIs(assertContext, actual.getSubquery().getSelect(), expected.getSubquery().getSelectTestCases());
         }

--- a/test/it/parser/src/main/resources/case/dml/delete.xml
+++ b/test/it/parser/src/main/resources/case/dml/delete.xml
@@ -527,7 +527,7 @@
     </delete>
 
     <delete sql-case-id="delete_with_simple_subquery">
-        <subquery-table>
+        <subquery-table start-index="12" stop-index="36">
             <subquery>
                 <select>
                     <from start-index="27" stop-index="35">
@@ -571,7 +571,7 @@
     </delete>
 
     <delete sql-case-id="delete_with_simple_subquery_without_from">
-        <subquery-table>
+        <subquery-table start-index="7" stop-index="43">
             <subquery>
                 <select>
                     <from start-index="27" stop-index="35">

--- a/test/it/parser/src/main/resources/case/dml/insert.xml
+++ b/test/it/parser/src/main/resources/case/dml/insert.xml
@@ -3959,11 +3959,11 @@
                 </expression-projection>
             </projections>
             <from>
-                <subquery-table alias="Changes">
+                <subquery-table alias="Changes" start-index="104" stop-index="582">
                    <subquery>
                        <merge>
                            <source>
-                               <subquery-table alias="src">
+                               <subquery-table alias="src" start-index="151" stop-index="349">
                                    <subquery>
                                        <select>
                                            <projections start-index="159" stop-index="182">

--- a/test/it/parser/src/main/resources/case/dml/merge.xml
+++ b/test/it/parser/src/main/resources/case/dml/merge.xml
@@ -46,7 +46,7 @@
             <simple-table name="bonuses" alias="D" start-index="11" stop-index="19" />
         </target>
         <source>
-            <subquery-table alias="S">
+            <subquery-table alias="S" start-index="27" stop-index="111">
                 <subquery>
                     <select>
                         <from>
@@ -152,7 +152,7 @@
             <simple-table name="bonuses" alias="D" start-index="11" stop-index="19" />
         </target>
         <source>
-            <subquery-table alias="S">
+            <subquery-table alias="S" start-index="27" stop-index="111">
                 <subquery>
                     <select>
                         <from>
@@ -250,7 +250,7 @@
             <simple-table alias="D" name="bonuses" start-index="11" stop-index="19" literal-start-index="11" literal-stop-index="19" />
         </target>
         <source>
-            <subquery-table alias="S">
+            <subquery-table alias="S" start-index="30" stop-index="120">
                 <subquery>
                     <select>
                         <projections start-index="38" stop-index="71" literal-start-index="38" literal-stop-index="71">
@@ -338,7 +338,7 @@
             <simple-table alias="t1" name="t_order" start-index="11" stop-index="20" />
         </target>
         <source>
-            <subquery-table alias="t2">
+            <subquery-table alias="t2" start-index="84" stop-index="193">
                 <subquery>
                     <select>
                         <projections start-index="92" stop-index="116">
@@ -458,7 +458,7 @@
     </merge>
     <merge sql-case-id="merge_into_select">
         <target>
-            <subquery-table alias="D">
+            <subquery-table alias="D" start-index="11" stop-index="60">
                 <subquery>
                     <select>
                         <projections start-index="19" stop-index="19" >
@@ -485,7 +485,7 @@
             </subquery-table>
         </target>
         <source>
-            <subquery-table alias="S">
+            <subquery-table alias="S" start-index="68" stop-index="152">
                 <subquery>
                     <select>
                         <from>

--- a/test/it/parser/src/main/resources/case/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-expression.xml
@@ -2964,7 +2964,7 @@
             <expression-projection start-index="7" stop-index="56" text="PREDICT BY point_kmeans (FEATURES position)" alias="pos" />
         </projections>
         <from>
-            <subquery-table>
+            <subquery-table start-index="63" stop-index="96">
                 <subquery>
                     <select>
                         <projections start-index="71" stop-index="71">

--- a/test/it/parser/src/main/resources/case/dml/select-join.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-join.xml
@@ -318,7 +318,7 @@
                     <simple-table name="departments" alias="d" start-index="58" stop-index="70" />
                 </left>
                 <right>
-                    <subquery-table alias="v">
+                    <subquery-table alias="v" start-index="84" stop-index="152" >
                         <subquery>
                             <select>
                                 <projections start-index="92" stop-index="92">
@@ -1908,7 +1908,7 @@
                     <simple-table name="user" start-index="64" stop-index="67"/>
                 </left>
                 <right>
-                    <subquery-table alias="ms">
+                    <subquery-table alias="ms" start-index="80" stop-index="147">
                         <subquery>
                             <select>
                                 <projections start-index="88" stop-index="88">
@@ -2364,7 +2364,7 @@
                 <left>
                     <join-table join-type="LEFT">
                         <left>
-                            <subquery-table alias="t1">
+                            <subquery-table alias="t1" start-index="82" stop-index="502">
                                 <subquery>
                                     <select>
                                         <projections start-index="90" stop-index="248">
@@ -2518,7 +2518,7 @@
                             </subquery-table>
                         </left>
                         <right>
-                            <subquery-table alias="t2">
+                            <subquery-table alias="t2" start-index="514" stop-index="633">
                                 <subquery>
                                     <select>
                                         <projections start-index="522" stop-index="550">
@@ -2565,7 +2565,7 @@
                     </join-table>
                 </left>
                 <right>
-                    <subquery-table alias="t3">
+                    <subquery-table alias="t3" start-index="675" stop-index="809">
                         <subquery>
                             <select>
                                 <projections start-index="683" stop-index="700">
@@ -3023,7 +3023,7 @@
                     <simple-table name="user" start-index="64" stop-index="67" />
                 </left>
                 <right>
-                    <subquery-table alias="ms">
+                    <subquery-table alias="ms" start-index="80" stop-index="147">
                         <subquery>
                             <select>
                                 <projections start-index="88" stop-index="88">

--- a/test/it/parser/src/main/resources/case/dml/select-pagination-group-by-order-by.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-pagination-group-by-order-by.xml
@@ -249,7 +249,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="331" literal-start-index="14" literal-stop-index="332">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="158">
@@ -393,7 +393,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="349" literal-start-index="14" literal-stop-index="350">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="176">
@@ -537,7 +537,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="333" literal-start-index="14" literal-stop-index="334">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="160">
@@ -681,7 +681,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="351" literal-start-index="14" literal-stop-index="352">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="178">
@@ -825,7 +825,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="331" literal-start-index="14" literal-stop-index="332">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="158">
@@ -969,7 +969,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="349" literal-start-index="14" literal-stop-index="350">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="176">
@@ -1113,7 +1113,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="333" literal-start-index="14" literal-stop-index="334" >
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="160">
@@ -1257,7 +1257,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="351" literal-start-index="14" literal-stop-index="352">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="178">
@@ -1401,7 +1401,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table start-index="14" stop-index="382" alias="t">
+            <subquery-table alias="t" start-index="14" stop-index="384">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="43">
@@ -1411,7 +1411,7 @@
                             <column-projection start-index="30" stop-index="43" name="rownum" alias="rownum_" />
                         </projections>
                         <from>
-                            <subquery-table alias="row_">
+                            <subquery-table alias="row_" start-index="50" stop-index="363">
                                 <subquery>
                                     <select>
                                         <projections start-index="58" stop-index="139">
@@ -1572,7 +1572,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table start-index="14" stop-index="382" alias="t">
+            <subquery-table start-index="14" stop-index="384" alias="t">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="43">
@@ -1582,7 +1582,7 @@
                             <column-projection start-index="30" stop-index="43" name="rownum" alias="rownum_" />
                         </projections>
                         <from>
-                            <subquery-table alias="row_">
+                            <subquery-table alias="row_" start-index="50" stop-index="363">
                                 <subquery>
                                     <select>
                                         <projections start-index="58" stop-index="139">
@@ -1743,7 +1743,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table start-index="14" stop-index="382" alias="tt">
+            <subquery-table alias="tt" start-index="14" stop-index="385">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="43">
@@ -1753,7 +1753,7 @@
                             <column-projection start-index="30" stop-index="43" name="rownum" alias="rownum_" />
                         </projections>
                         <from>
-                            <subquery-table alias="row_">
+                            <subquery-table alias="row_" start-index="50" stop-index="363">
                                 <subquery>
                                     <select>
                                         <projections start-index="58" stop-index="139">
@@ -1914,7 +1914,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table start-index="14" stop-index="382" alias="t">
+            <subquery-table alias="t" start-index="14" stop-index="384" >
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="43">
@@ -1924,7 +1924,7 @@
                             <column-projection start-index="30" stop-index="43" name="rownum" alias="rownum_" />
                         </projections>
                         <from>
-                            <subquery-table alias="row_">
+                            <subquery-table alias="row_" start-index="50" stop-index="363">
                                 <subquery>
                                     <select>
                                         <projections start-index="58" stop-index="139">

--- a/test/it/parser/src/main/resources/case/dml/select-pagination.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-pagination.xml
@@ -456,7 +456,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="314" literal-start-index="14" literal-stop-index="315">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="160">
@@ -579,7 +579,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="332" literal-start-index="14" literal-stop-index="333">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="178">
@@ -919,7 +919,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="314" literal-start-index="14" literal-stop-index="315">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="160">
@@ -1058,7 +1058,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="332" literal-start-index="14" literal-stop-index="333">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="178">
@@ -1197,7 +1197,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="314" literal-start-index="14" literal-stop-index="315">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="160">
@@ -1336,7 +1336,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="row_">
+            <subquery-table alias="row_" start-index="14" stop-index="332" literal-start-index="14" literal-stop-index="333">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="178">
@@ -1475,7 +1475,7 @@
             <shorthand-projection stop-index="7" start-index="7" />
         </projections>
         <from>
-            <subquery-table>
+            <subquery-table start-index="14" stop-index="363">
                 <subquery start-index="14" stop_index="363">
                     <select>
                         <projections start-index="22" stop-index="43">
@@ -1485,7 +1485,7 @@
                             <column-projection start-index="30" stop-index="43" name="rownum" alias="rownum_" />
                         </projections>
                         <from>
-                            <subquery-table start-index="50" stop-index="339" alias="row_">
+                            <subquery-table alias="row_" start-index="50" stop-index="344" >
                                 <subquery>
                                     <select>
                                         <projections start-index="58" stop-index="139" >
@@ -1625,7 +1625,7 @@
             <shorthand-projection stop-index="7" start-index="7" />
         </projections>
         <from>
-            <subquery-table alias="tt">
+            <subquery-table alias="tt" start-index="14" stop-index="366">
                 <subquery start-index="14" stop_index="363">
                     <select parameters="7">
                         <projections start-index="22" stop-index="43">
@@ -1635,7 +1635,7 @@
                             <column-projection start-index="30" stop-index="43" name="rownum" alias="rownum_" />
                         </projections>
                         <from>
-                            <subquery-table start-index="50" stop-index="339" alias="row_">
+                            <subquery-table alias="row_" start-index="50" stop-index="344" >
                                 <subquery>
                                     <select parameters="1, 2, 9">
                                         <projections start-index="58" stop-index="139" >
@@ -1791,7 +1791,7 @@
             <shorthand-projection stop-index="7" start-index="7" />
         </projections>
         <from>
-            <subquery-table alias="tt">
+            <subquery-table alias="tt" start-index="14" stop-index="366">
                 <subquery start-index="14" stop_index="363">
                     <select>
                         <projections start-index="22" stop-index="43">
@@ -1801,7 +1801,7 @@
                             <column-projection start-index="30" stop-index="43" name="rownum" alias="rownum_" />
                         </projections>
                         <from>
-                            <subquery-table start-index="50" stop-index="339" alias="row_">
+                            <subquery-table alias="row_" start-index="50" stop-index="344" >
                                 <subquery>
                                     <select>
                                         <projections start-index="58" stop-index="139" >

--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -573,7 +573,7 @@
             <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
         <from>
-            <subquery-table>
+            <subquery-table start-index="14" stop-index="34" >
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="22">

--- a/test/it/parser/src/main/resources/case/dml/select-start-with-connect-by.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-start-with-connect-by.xml
@@ -22,7 +22,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="temp">
+            <subquery-table alias="temp" start-index="14" stop-index="148" >
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="31">

--- a/test/it/parser/src/main/resources/case/dml/select-sub-query.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-sub-query.xml
@@ -26,7 +26,7 @@
                             <simple-table start-index="14" stop-index="15" name="t1" />
                         </left>
                         <right>
-                            <subquery-table alias="dt1">
+                            <subquery-table alias="dt1" start-index="18" stop-index="54">
                                 <subquery start-index="26" stop-index="47">
                                     <select>
                                         <projections distinct-row="true" start-index="43" stop-index="46">
@@ -41,7 +41,7 @@
                     </join-table>
                 </left>
                 <right>
-                    <subquery-table alias="dt2">
+                    <subquery-table alias="dt2" start-index="57" stop-index="94">
                         <subquery start-index="65" stop-index="87">
                             <select>
                                 <projections distinct-row="true" start-index="82" stop-index="86">
@@ -106,7 +106,7 @@
             </shorthand-projection>
         </projections>
         <from>
-            <subquery-table alias="t">
+            <subquery-table alias="t" start-index="16" stop-index="65">
                 <subquery>
                     <select parameters="3, 4">
                         <projections start-index="24" stop-index="24">
@@ -368,7 +368,7 @@
                     <simple-table name="t_order_federate" start-index="75" stop-index="90" />
                 </left>
                 <right>
-                    <subquery-table alias="u">
+                    <subquery-table alias="u" start-index="93" stop-index="124">
                         <subquery>
                             <select>
                                 <projections start-index="101" stop-index="101">
@@ -716,7 +716,7 @@
             </column-projection>
         </projections>
         <from start-index="133" stop-index="378">
-            <subquery-table alias="T1_1">
+            <subquery-table alias="T1_1" start-index="133" stop-index="386">
                 <subquery start-index="133" stop-index="378">
                     <select>
                         <projections start-index="141" stop-index="259">
@@ -775,7 +775,7 @@
             </column-projection>
          </projections>
         <from>
-            <subquery-table alias="T1_1">
+            <subquery-table alias="T1_1" start-index="95" stop-index="385">
                 <subquery start-index="95" stop-index="377">
                     <select>
                         <projections start-index="103" stop-index="184">
@@ -832,7 +832,7 @@
             </column-projection>
         </projections>
         <from>
-            <subquery-table alias="T1_1">
+            <subquery-table alias="T1_1" start-index="34" stop-index="147">
                 <subquery>
                     <select>
                         <projections start-index="42" stop-index="72">

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -173,7 +173,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="a">
+            <subquery-table alias="a" start-index="14" stop-index="69">
                 <subquery start-index="14" stop-index="67">
                     <select>
                         <projections start-index="22" stop-index="22">
@@ -380,7 +380,7 @@
                                         </expression-projection>
                                     </projections>
                                     <from>
-                                        <subquery-table alias="dt">
+                                        <subquery-table alias="dt" start-index="48" stop-index="93">
                                             <subquery>
                                                 <select>
                                                     <projections start-index="56" stop-index="57">
@@ -4457,7 +4457,7 @@
         <from>
             <join-table join-type="COMMA">
                 <left>
-                    <subquery-table alias="a">
+                    <subquery-table alias="a" start-index="119" stop-index="219">
                         <subquery>
                             <select>
                                 <projections start-index="127" stop-index="178">
@@ -4476,7 +4476,7 @@
                     </subquery-table>
                 </left>
                 <right>
-                    <subquery-table alias="b">
+                    <subquery-table alias="b" start-index="222" stop-index="290">
                         <subquery>
                             <select>
                                 <projections start-index="230" stop-index="272">
@@ -4584,7 +4584,7 @@
                     <simple-table name="employees" alias="e" start-index="14" stop-index="24" />
                 </left>
                 <right>
-                    <subquery-table>
+                    <subquery-table start-index="34" stop-index="102">
                         <subquery>
                             <select>
                                 <projections start-index="42" stop-index="42">
@@ -4755,7 +4755,7 @@
 
     <select sql-case-id="select_with_model_dimension">
         <from>
-            <subquery-table>
+            <subquery-table start-index="38" stop-index="118">
                 <subquery>
                     <select>
                         <from start-index="81" stop-index="94">
@@ -5035,7 +5035,7 @@
 
     <select sql-case-id="select_with_model_in">
         <from>
-            <subquery-table>
+            <subquery-table start-index="47" stop-index="118">
                 <subquery>
                     <select>
                         <projections start-index="55" stop-index="107" literal-start-index="55" literal-stop-index="107">
@@ -6778,7 +6778,7 @@
             <column-projection name="salary" start-index="45" stop-index="50" literal-start-index="45" literal-stop-index="50" />
         </projections>
         <from>
-            <subquery-table>
+            <subquery-table start-index="57" stop-index="197">
                 <subquery>
                     <select>
                         <projections start-index="65" stop-index="180" literal-start-index="65" literal-stop-index="180">
@@ -9115,7 +9115,7 @@
             <column-projection name="Friends" start-index="19" stop-index="25"/>
         </projections>
         <from start-index="32" stop-index="356">
-            <subquery-table alias="Q">
+            <subquery-table alias="Q" start-index="32" stop-index="361">
                 <subquery start-index="32" stop-index="356">
                     <select>
                         <projections start-index="40" stop-index="198">

--- a/test/it/parser/src/main/resources/case/dml/table.xml
+++ b/test/it/parser/src/main/resources/case/dml/table.xml
@@ -74,7 +74,7 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <from>
-            <subquery-table alias="dt">
+            <subquery-table alias="dt" start-index="14" stop-index="29">
                 <subquery>
                     <select>
                         <projections start-index="15" stop-index="15">

--- a/test/it/parser/src/main/resources/case/dml/values.xml
+++ b/test/it/parser/src/main/resources/case/dml/values.xml
@@ -37,7 +37,8 @@
             </expression-projection>
         </projections>
         <from>
-            <subquery-table alias="v">
+            <!-- TODO check the visitor result when alias contains column -->
+            <subquery-table alias="v" start-index="47" stop-index="111">
                 <subquery>
                     <select>
                         <projections start-index="48" stop-index="105">


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Adjust SubqueryTableSegment start index and stop index visit logic and add test assert

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
