### PR TITLE
Add getReadWriteSplitReplicaRoute and return optional in TransactionConnectionContext

### DIFF
--- a/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/route/qualified/type/QualifiedReadwriteSplittingTransactionalDataSourceRouter.java
+++ b/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/route/qualified/type/QualifiedReadwriteSplittingTransactionalDataSourceRouter.java
@@ -44,10 +44,10 @@ public final class QualifiedReadwriteSplittingTransactionalDataSourceRouter impl
     public String route(final ReadwriteSplittingDataSourceGroupRule rule) {
         switch (rule.getTransactionalReadQueryStrategy()) {
             case FIXED:
-                if (null == connectionContext.getTransactionContext().getReadWriteSplitReplicaRoute()) {
+                if (!connectionContext.getTransactionContext().getReadWriteSplitReplicaRoute().isPresent()) {
                     connectionContext.getTransactionContext().setReadWriteSplitReplicaRoute(standardRouter.route(rule));
                 }
-                return connectionContext.getTransactionContext().getReadWriteSplitReplicaRoute();
+                return connectionContext.getTransactionContext().getReadWriteSplitReplicaRoute().get();
             case DYNAMIC:
                 return standardRouter.route(rule);
             case PRIMARY:

--- a/infra/session/src/main/java/org/apache/shardingsphere/infra/session/connection/transaction/TransactionConnectionContext.java
+++ b/infra/session/src/main/java/org/apache/shardingsphere/infra/session/connection/transaction/TransactionConnectionContext.java
@@ -69,6 +69,15 @@ public final class TransactionConnectionContext implements AutoCloseable {
         return Optional.ofNullable(transactionType);
     }
     
+    /**
+     * Get read write split replica route. 
+     *
+     * @return read write split replica route
+     */
+    public Optional<String> getReadWriteSplitReplicaRoute() {
+        return Optional.ofNullable(readWriteSplitReplicaRoute);
+    }
+    
     @Override
     public void close() {
         transactionType = null;


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Add getReadWriteSplitReplicaRoute and return optional in TransactionConnectionContext

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
