### PR TITLE
Enhance the support for MySQL SQL parsing in ShardingSphere

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DCLStatement.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DCLStatement.g4
@@ -135,7 +135,7 @@ accountLockPasswordExpireOption
     ;
 
 alterUser
-    : ALTER USER ifExists? alterUserList requireClause? connectOptions? accountLockPasswordExpireOptions?
+    : ALTER USER ifExists? alterUserList requireClause? connectOptions? accountLockPasswordExpireOptions? alterOperation?
     | ALTER USER ifExists? USER LP_ RP_ userFuncAuthOption
     | ALTER USER ifExists? username DEFAULT ROLE (NONE | ALL | roleName (COMMA_ roleName)*)
     ;
@@ -146,6 +146,18 @@ alterUserEntry
 
 alterUserList
     : alterUserEntry (COMMA_ alterUserEntry)*
+    ;
+
+alterOperation
+    : (ADD | MODIFY | DROP | SET) factoryOperation
+    ;
+
+factoryOperation
+    : NUMBER_ FACTOR (IDENTIFIED WITH authentication_fido)?
+    ;
+
+authentication_fido
+    : AUTHENTICATION_FIDO
     ;
 
 dropUser

--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/MySQLKeyword.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/MySQLKeyword.g4
@@ -3149,3 +3149,11 @@ ZONE
 TIMESTAMPDIFF
     : T I M E S T A M P D I F F
     ;
+
+AUTHENTICATION_FIDO
+    : A U T H E N T I C A T I O N UL_ F I D O
+    ;
+
+FACTOR
+    : F A C T O R
+    ;

--- a/test/it/parser/src/main/resources/case/dcl/alter-user.xml
+++ b/test/it/parser/src/main/resources/case/dcl/alter-user.xml
@@ -69,4 +69,5 @@
     <alter-user sql-case-id="alter_azure_ad_user_without_login" />
     <alter-user sql-case-id="alter_user_alias_to_existing_azure_id" />
     <alter-user sql-case-id="alter_user_identified_with_single_quoted" />
+    <alter-user sql-case-id="alter_user_with_factor" />
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dcl/alter-user.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dcl/alter-user.xml
@@ -69,4 +69,5 @@
     <sql-case id="alter_azure_ad_user_without_login" value="ALTER USER [westus/joe] FROM EXTERNAL PROVIDER" db-types="SQLServer" />
     <sql-case id="alter_user_alias_to_existing_azure_id" value="ALTER USER [westus/joe] WITH LOGIN = joe@westus.com, name= joe_alias" db-types="SQLServer" />
     <sql-case id="alter_user_identified_with_single_quoted" value="ALTER USER tu1@localhost IDENTIFIED WITH 'sha256_password' REQUIRE CIPHER &quot;DHE-RSA-AES256-SHA&quot;" db-types="MySQL" />
+    <sql-case id="alter_user_with_factor" value="ALTER USER 'alice'@'localhost' MODIFY 2 FACTOR IDENTIFIED WITH authentication_fido" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
Fixes #30950.

Changes proposed in this pull request:
  -Added FIDO authentication support for MySQL, 
   optimized user modifications, and improved keyword definitions.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
