### PR TITLE
Adjusted support for ENGINE_ATTRIBUTE in ALTER TABLESPACE statement in MySQL

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
@@ -377,10 +377,8 @@ alterTablespace
 
 alterTablespaceNdb
     : ALTER UNDO? TABLESPACE tablespace=identifier
-      ((ADD | DROP) DATAFILE string_)?
+      (ADD | DROP) DATAFILE string_
       (INITIAL_SIZE EQ_? fileSizeLiteral)?
-      (AUTOEXTEND_SIZE EQ_? fileSizeLiteral)?
-      (ENGINE_ATTRIBUTE EQ_? string_)?
       WAIT? (RENAME TO renameTableSpace=identifier)?
       (ENGINE EQ_? identifier)?
     ;
@@ -388,7 +386,9 @@ alterTablespaceNdb
 alterTablespaceInnodb
     : ALTER UNDO? TABLESPACE tablespace=identifier
       (SET (ACTIVE | INACTIVE))?
+      (AUTOEXTEND_SIZE EQ_? fileSizeLiteral)?
       (ENCRYPTION EQ_? y_or_n=string_)?
+      (ENGINE_ATTRIBUTE EQ_? jsonAttribute = string_)?
       (RENAME TO renameTablespace=identifier)?
       (ENGINE EQ_? identifier)?
     ;

--- a/test/it/parser/src/main/resources/case/ddl/alter-tablespace.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-tablespace.xml
@@ -153,4 +153,8 @@
     <alter-tablespace sql-case-id="alter_tablespace_with_initial_size">
         <tablespace start-index="17" stop-index="20" name="ts_1" />
     </alter-tablespace>
+    
+    <alter-tablespace sql-case-id="alter_tablespace_with_engine_attribute">
+        <tablespace start-index="17" stop-index="19" name="ts1" />
+    </alter-tablespace>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-tablespace.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-tablespace.xml
@@ -66,4 +66,5 @@
         ADD DATAFILE 'data_2.dat'
         INITIAL_SIZE 48M
         ENGINE NDB" db-types="MySQL" />
+    <sql-case id="alter_tablespace_with_engine_attribute" value="ALTER TABLESPACE ts1 ENGINE_ATTRIBUTE=&apos;{&quot;key&quot;:&quot;value&quot;}&apos;" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
Fixes #31047 .

Changes proposed in this pull request:
  -Adjusted support for ENGINE_ATTRIBUTE in ALTER TABLESPACE statement to reflect its lack of support in MySQL Cluster. Includes modifications in DDLStatement.g4 file, addition of a new case "alter_tablespace_with_engine_attribute", and corresponding add in the sql.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
