### PR TITLE
Remove useless getTrunkDataBaseType method in SQLParserRule

### DIFF
--- a/kernel/sql-parser/core/src/main/java/org/apache/shardingsphere/parser/rule/SQLParserRule.java
+++ b/kernel/sql-parser/core/src/main/java/org/apache/shardingsphere/parser/rule/SQLParserRule.java
@@ -22,8 +22,8 @@ import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.parser.SQLParserEngine;
 import org.apache.shardingsphere.infra.parser.ShardingSphereSQLParserEngine;
 import org.apache.shardingsphere.infra.parser.SimpleSQLParserEngine;
-import org.apache.shardingsphere.infra.rule.scope.GlobalRule;
 import org.apache.shardingsphere.infra.rule.attribute.RuleAttributes;
+import org.apache.shardingsphere.infra.rule.scope.GlobalRule;
 import org.apache.shardingsphere.parser.config.SQLParserRuleConfiguration;
 import org.apache.shardingsphere.sql.parser.api.CacheOption;
 
@@ -56,7 +56,7 @@ public final class SQLParserRule implements GlobalRule {
      */
     public SQLParserEngine getSQLParserEngine(final DatabaseType databaseType) {
         return "Standard".equals(engineType)
-                ? new ShardingSphereSQLParserEngine(databaseType.getTrunkDatabaseType().orElse(databaseType), sqlStatementCache, parseTreeCache)
+                ? new ShardingSphereSQLParserEngine(databaseType, sqlStatementCache, parseTreeCache)
                 : new SimpleSQLParserEngine();
     }
     


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove useless getTrunkDataBaseType method in SQLParserRule

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
