### PR TITLE
Revert "Fixed link jump 404 error in documentation：The error part of the Chinese document is modified."

### DIFF
--- a/docs/community/content/involved/_index.cn.md
+++ b/docs/community/content/involved/_index.cn.md
@@ -7,14 +7,14 @@ chapter = true
 
 Apache ShardingSphere 是一个开放且活跃的社区，非常欢迎高质量的参与者与我们共建开源之路。
 
-您可以从[订阅官方邮件列表](/docs/community/content/involved/subscribe.cn.md)开始参与社区。
+您可以从[订阅官方邮件列表](/cn/involved/subscribe/)开始参与社区。
 
-如果您想参与 Apache ShardingSphere 的贡献，请先阅读[贡献指南](/docs/community/content/involved/contribute/_index.cn.md)。
+如果您想参与 Apache ShardingSphere 的贡献，请先阅读[贡献指南](/cn/involved/contribute/)。
 
-在成为一个贡献者之前，请您阅读[贡献规范](/docs/community/content/involved/conduct/code.cn.md)。
+在成为一个贡献者之前，请您阅读[贡献规范](/cn/involved/conduct/)。
 
-如果您想成为官方提交者，请您阅读[提交者指南](/docs/community/content/involved/committer/_index.cn.md)。
+如果您想成为官方提交者，请您阅读[提交者指南](/cn/involved/committer/)。
 
-如果您想成为官方版本发布经理，请您阅读[发布指南](/docs/community/content/involved/release/_index.cn.md)。
+如果您想成为官方版本发布经理，请您阅读[发布指南](/cn/involved/release/)。
 
 感谢您关注 Apache ShardingSphere。


### PR DESCRIPTION
Reverts apache/shardingsphere#31127

The original link in website is correct. The md files are serviced for website, so please do not care about link on md files.