### PR TITLE
Support Mysql CALL sql with mysql prefix

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DMLStatement.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DMLStatement.g4
@@ -163,7 +163,7 @@ querySpecification
     ;
 
 call
-    : CALL identifier (LP_ (expr (COMMA_ expr)*)? RP_)?
+    : CALL (owner DOT_)? identifier (LP_ (expr (COMMA_ expr)*)? RP_)?
     ;
 
 doStatement

--- a/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/type/MySQLDMLStatementVisitor.java
+++ b/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/type/MySQLDMLStatementVisitor.java
@@ -63,7 +63,11 @@ public final class MySQLDMLStatementVisitor extends MySQLStatementVisitor implem
     public ASTNode visitCall(final CallContext ctx) {
         List<ExpressionSegment> params = new ArrayList<>();
         ctx.expr().forEach(each -> params.add((ExpressionSegment) visit(each)));
-        return new MySQLCallStatement(ctx.identifier().getText(), params);
+        String procedureName = ctx.identifier().getText();
+        if (null != ctx.owner()) {
+            procedureName = ctx.owner().getText().concat(".").concat(procedureName);
+        }
+        return new MySQLCallStatement(procedureName, params);
     }
     
     @Override

--- a/test/it/parser/src/main/resources/case/dml/call.xml
+++ b/test/it/parser/src/main/resources/case/dml/call.xml
@@ -143,4 +143,14 @@
             <common-expression literal-text="1.0/0.1" start-index="7" stop-index="13" />
         </procedure-parameter>
     </call>
+
+    <call sql-case-id="call_with_mysql_firewall_group_enlist">
+        <procedure-name name="mysql.sp_firewall_group_enlist"/>
+        <procedure-parameter>
+            <literal-expression value="fwgrp" start-index="36" stop-index="42"/>
+        </procedure-parameter>
+        <procedure-parameter>
+            <literal-expression value="member2@localhost" start-index="45" stop-index="63"/>
+        </procedure-parameter>
+    </call>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/call.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/call.xml
@@ -29,4 +29,5 @@
     <sql-case id="call_with_mixed_notation_with_apos" value="CALL p(10, b =&gt; &apos;Hello&apos;);" db-types="PostgreSQL" />
     <sql-case id="call_with_named_notation_with_apos" value="CALL p(b =&gt; &apos;Hello&apos;, a =&gt; 10);" db-types="PostgreSQL" />
     <sql-case id="call_with_positional_notation_with_expression" value="CALL p(1.0/0.1);" db-types="PostgreSQL" />
+    <sql-case id="call_with_mysql_firewall_group_enlist" value="CALL mysql.sp_firewall_group_enlist('fwgrp', 'member2@localhost')" db-types="MySQL"/>
 </sql-cases>


### PR DESCRIPTION
Fixes #30951, #30952.

Changes proposed in this pull request:
  - Support Mysql CALL sql with mysql prefix

SQL Case
```sql
CALL mysql.sp_firewall_group_enlist('fwgrp', 'member2@localhost')
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
