### PR TITLE
Support Mysql create loadable function returns int/dec

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DALStatement.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DALStatement.g4
@@ -268,7 +268,7 @@ cloneAction
     ;
 
 createLoadableFunction
-    : CREATE AGGREGATE? FUNCTION functionName RETURNS (STRING | INTEGER | REAL | DECIMAL) SONAME shardLibraryName
+    : CREATE AGGREGATE? FUNCTION functionName RETURNS (STRING | INTEGER | INT | REAL | DECIMAL | DEC) SONAME shardLibraryName
     ;
 
 install

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.CheckTableStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.ChecksumTableStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.CloneStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.CreateLoadableFunctionTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.CreateResourceGroupStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.DelimiterStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.DropResourceGroupStatementTestCase;
@@ -1744,6 +1745,9 @@ public final class RootSQLParserTestCases {
     
     @XmlElement(name = "spool")
     private final List<SpoolStatementTestCase> oracleSpoolStatementTestCases = new LinkedList<>();
+
+    @XmlElement(name = "create-loadable-function")
+    private final List<CreateLoadableFunctionTestCase> createLoadableFunctionTestCases = new LinkedList<>();
     
     /**
      * Get all SQL parser test cases.

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
@@ -1745,7 +1745,7 @@ public final class RootSQLParserTestCases {
     
     @XmlElement(name = "spool")
     private final List<SpoolStatementTestCase> oracleSpoolStatementTestCases = new LinkedList<>();
-
+    
     @XmlElement(name = "create-loadable-function")
     private final List<CreateLoadableFunctionTestCase> createLoadableFunctionTestCases = new LinkedList<>();
     

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/CreateLoadableFunctionTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/CreateLoadableFunctionTestCase.java
@@ -22,5 +22,5 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.S
 /**
  * Create loadable function test case.
  */
-public class CreateLoadableFunctionTestCase extends SQLParserTestCase {
+public final class CreateLoadableFunctionTestCase extends SQLParserTestCase {
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/CreateLoadableFunctionTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/CreateLoadableFunctionTestCase.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal;
+
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+
+/**
+ * Create loadable function test case.
+ */
+public class CreateLoadableFunctionTestCase extends SQLParserTestCase {
+}

--- a/test/it/parser/src/main/resources/case/dal/create-loadable-function.xml
+++ b/test/it/parser/src/main/resources/case/dal/create-loadable-function.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <create-loadable-function sql-case-id="create_loadable_function_return_int"/>
+    <create-loadable-function sql-case-id="create_loadable_function_return_dec"/>
+</sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dal/create-loadable-function.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/create-loadable-function.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="create_loadable_function_return_int" value="CREATE FUNCTION service_get_read_locks RETURNS INT SONAME 'locking_service.so'" db-types="MySQL" />
+    <sql-case id="create_loadable_function_return_dec" value="CREATE FUNCTION version_tokens_lock_exclusive RETURNS DEC SONAME 'version_token.so'" db-types="MySQL"/>
+</sql-cases>


### PR DESCRIPTION
Fixes #30961.

Changes proposed in this pull request:
  - Support Mysql create loadable function returns int/dec
  - In the official MySQL syntax documentation, there is no mention of the usage of RETURNS INT/DEC. However, through testing, it was found that this notation can be executed normally. [CREATE FUNCTION Statement for Loadable Functions](https://dev.mysql.com/doc/refman/8.0/en/create-function-loadable.html)
<img width="734" alt="image" src="https://github.com/apache/shardingsphere/assets/124348939/52489ed1-77ae-4eb8-a075-70f0d553eb5b">

<img width="747" alt="image" src="https://github.com/apache/shardingsphere/assets/124348939/faaaeb1d-8ca1-4010-b8e9-d12f52a3bd58">

  - When searching the official documentation, it is found that in MySQL, INT and INTEGER are defined as synonyms, and DEC and DECIMAL are defined as synonyms. [Numeric Data Types](https://dev.mysql.com/doc/refman/8.0/en/numeric-types.html)
<img width="1144" alt="image" src="https://github.com/apache/shardingsphere/assets/124348939/b4116e3f-5669-4c71-bece-347747b1c2fe">


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
