### PR TITLE
Support parsing MySQL CREATE TABLESPACE/TABLE in Mysql-8

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
@@ -345,30 +345,29 @@ dropView
     ;
 
 createTablespace
-    : createTablespaceInnodb | createTablespaceNdb
+    : CREATE UNDO? TABLESPACE identifier (createTablespaceInnodb | createTablespaceNdb | createTablespaceInnodbAndNdb)*
     ;
 
 createTablespaceInnodb
-    : CREATE (UNDO)? TABLESPACE identifier
-      ADD DATAFILE string_
-      (FILE_BLOCK_SIZE EQ_ fileSizeLiteral)?
-      (ENCRYPTION EQ_ y_or_n=string_)?
-      (ENGINE EQ_? engineRef)?
-      (COMMENT EQ_? string_)?
+    : FILE_BLOCK_SIZE EQ_ fileSizeLiteral
+    | ENCRYPTION EQ_ y_or_n=string_
+    | ENGINE_ATTRIBUTE EQ_? jsonAttribute = string_
     ;
 
 createTablespaceNdb
-    : CREATE ( UNDO )? TABLESPACE identifier
-      ADD DATAFILE string_
-      USE LOGFILE GROUP identifier
-      (EXTENT_SIZE EQ_? fileSizeLiteral)?
-      (INITIAL_SIZE EQ_? fileSizeLiteral)?
-      (AUTOEXTEND_SIZE EQ_? fileSizeLiteral)?
-      (MAX_SIZE EQ_? fileSizeLiteral)?
-      (NODEGROUP EQ_? identifier)?
-      WAIT?
-      (COMMENT EQ_? string_)?
-      (ENGINE EQ_? engineRef)?
+    : USE LOGFILE GROUP identifier
+    | EXTENT_SIZE EQ_? fileSizeLiteral
+    | INITIAL_SIZE EQ_? fileSizeLiteral
+    | MAX_SIZE EQ_? fileSizeLiteral
+    | NODEGROUP EQ_? identifier
+    | WAIT
+    | COMMENT EQ_? string_
+    ;
+
+createTablespaceInnodbAndNdb
+    : ADD DATAFILE string_
+    | AUTOEXTEND_SIZE EQ_? fileSizeLiteral
+    | ENGINE EQ_? engineRef
     ;
 
 alterTablespace
@@ -567,6 +566,7 @@ createTableOption
     | option = KEY_BLOCK_SIZE EQ_? NUMBER_
     | option = ENGINE_ATTRIBUTE EQ_? jsonAttribute = string_
     | option = SECONDARY_ENGINE_ATTRIBUTE EQ_ jsonAttribute = string_
+    | option = AUTOEXTEND_SIZE EQ_? fileSizeLiteral
     ;
 
 createSRSStatement

--- a/test/it/parser/src/main/resources/case/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-table.xml
@@ -2408,4 +2408,11 @@
     <create-table sql-case-id="create_table_with_builtin_function">
         <table name="tab" start-index="13" stop-index="15"/>
     </create-table>
+
+    <create-table sql-case-id="create_table_with_autoextend_size">
+        <table name="t1" start-index="13" stop-index="14"/>
+        <column-definition type="INT" start-index="17" stop-index="22">
+            <column name="c1" start-index="17" stop-index="18"/>
+        </column-definition>
+    </create-table>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/ddl/create-tablespace.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-tablespace.xml
@@ -100,4 +100,7 @@
     <create-tablespace sql-case-id="create_tablespace_with_undo_tablespace_retention_guarantee" />
     <create-tablespace sql-case-id="create_tablespace_with_undo_tablespace_retention_noguarantee" />
     <create-tablespace sql-case-id="create_tablespace_with_relative_location" />
+    <create-tablespace sql-case-id="create_tablespace_with_autoextend_size"/>
+    <create-tablespace sql-case-id="create_tablespace_with_engine_attribute"/>
+    <create-tablespace sql-case-id="create_tablespace_with_extent_size"/>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
@@ -325,4 +325,5 @@
     <sql-case id="create_table_with_edge_constraint" value="CREATE TABLE bought ( PurchaseCount INT ,CONSTRAINT EC_BOUGHT CONNECTION (Customer TO Product) ON DELETE NO ACTION );" db-types="SQLServer"/>
     <sql-case id="create_table_with_enclosed" value="CREATE TABLE emp_load(first_name CHAR(15), last_name CHAR(20), year_of_birth CHAR(4)) ORGANIZATION EXTERNAL (TYPE ORACLE_LOADER DEFAULT DIRECTORY ext_tab_dir ACCESS PARAMETERS FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '(' and ')'LRTRIM LOCATION (info.dat));" db-types="Oracle"/>
     <sql-case id="create_table_with_builtin_function" value="CREATE TABLE tab AS SELECT DBMS_LOB.GETLENGTH@dbs2(clob_col) len FROM tab@dbs2;" db-types="Oracle"/>
+    <sql-case id="create_table_with_autoextend_size" value="CREATE TABLESPACE ts1 AUTOEXTEND_SIZE = 4M" db-types="MySQL"/>
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-tablespace.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-tablespace.xml
@@ -109,4 +109,7 @@
     <sql-case id="create_tablespace_with_undo_tablespace_retention_guarantee" value="CREATE UNDO TABLESPACE tablespaceName RETENTION GUARANTEE" db-types="Oracle" />
     <sql-case id="create_tablespace_with_undo_tablespace_retention_noguarantee" value="CREATE UNDO TABLESPACE tablespaceName RETENTION NOGUARANTEE" db-types="Oracle" />
     <sql-case id="create_tablespace_with_relative_location" value="CREATE TABLESPACE example2 RELATIVE LOCATION 'tablespace2/tablespace_2'" db-types="openGauss" />
+    <sql-case id="create_tablespace_with_extent_size" value="CREATE TABLESPACE TS1 ADD DATAFILE 'data1.dat' EXTENT_SIZE 8M INITIAL_SIZE 2G ENGINE NDBCLUSTER" db-types="MySQL"/>
+    <sql-case id="create_tablespace_with_engine_attribute" value="CREATE TABLESPACE ts1 ENGINE_ATTRIBUTE='{&quot;key&quot;:&quot;value&quot;}'" db-types="MySQL"/>
+    <sql-case id="create_tablespace_with_autoextend_size" value="CREATE TABLESPACE ts1 AUTOEXTEND_SIZE = 4M" db-types="MySQL"/>
 </sql-cases>


### PR DESCRIPTION
Fixes #30963.

Changes proposed in this pull request:
  - Adjust resolution file to support parsing MySQL CREATE TABLESPACE/TABLE in Mysql-8
  - [CREATE TABLESPACE Statement](https://dev.mysql.com/doc/refman/8.0/en/create-tablespace.html)
  - [CREATE TABLE Statement](https://dev.mysql.com/doc/refman/8.0/en/create-table.html)

SQL Case
```sql
CREATE TABLESPACE TS1
    ADD DATAFILE 'data1.dat'
    EXTENT_SIZE 8M
    INITIAL_SIZE 2G
    ENGINE NDBCLUSTER;
```

```sql
CREATE TABLESPACE ts1 ENGINE_ATTRIBUTE='{"key":"value"}';
```

```sql
CREATE TABLE t1 (c1 INT) AUTOEXTEND_SIZE = 4M;
```

```sql
CREATE TABLESPACE ts1 AUTOEXTEND_SIZE = 4M;
```
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
