### PR TITLE
Support parsing MySQL CREATE INDEX with ENGINE_ATTRIBUTE

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DALStatement.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DALStatement.g4
@@ -335,7 +335,7 @@ vcpuSpec
 
 createResourceGroup
     : CREATE RESOURCE GROUP groupName TYPE EQ_ (SYSTEM | USER) (VCPU EQ_? vcpuSpec (COMMA_ vcpuSpec)*)?
-    (THREAD_PRIORITY EQ_? NUMBER_)? (ENABLE | DISABLE)?
+    (THREAD_PRIORITY EQ_? numberLiterals)? (ENABLE | DISABLE)?
     ;
 
 dropResourceGroup

--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
@@ -462,6 +462,7 @@ columnAttribute
     | constraintClause? checkConstraint
     | constraintEnforcement
     | visibility
+    | value = ENGINE_ATTRIBUTE EQ_? jsonAttribute = string_
     ;
 
 checkConstraint
@@ -521,6 +522,7 @@ commonIndexOption
     : KEY_BLOCK_SIZE EQ_? NUMBER_
     | COMMENT stringLiterals
     | visibility
+    | ENGINE_ATTRIBUTE EQ_? jsonAttribute = string_
     ;
 
 visibility

--- a/test/it/parser/src/main/resources/case/dal/create.xml
+++ b/test/it/parser/src/main/resources/case/dal/create.xml
@@ -20,4 +20,7 @@
     <create-resource-group sql-case-id="create_resource_group">
         <group name="rg" start-index="23" stop-index="24" />
     </create-resource-group>
+    <create-resource-group sql-case-id="create_resource_group_with_system_type_and_thread_priority">
+        <group name="rg2" start-index="23" stop-index="25"/>
+    </create-resource-group>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/ddl/create-index.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-index.xml
@@ -269,4 +269,12 @@
         </table>
         <column start-index="58" stop-index="66" name="is_active" />
     </create-index>
+
+    <create-index sql-case-id="create_index_with_engine_attribute">
+        <index name="i1" start-index="13" stop-index="14"/>
+        <table>
+            <simple-table name="t1" start-index="19" stop-index="20"/>
+        </table>
+        <column name="c1" start-index="23" stop-index="24"/>
+    </create-index>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dal/create.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/create.xml
@@ -18,4 +18,5 @@
 
 <sql-cases>
     <sql-case id="create_resource_group" value="CREATE RESOURCE GROUP rg type = user" db-types="MySQL" />
+    <sql-case id="create_resource_group_with_system_type_and_thread_priority" value="CREATE RESOURCE GROUP rg2 TYPE = SYSTEM THREAD_PRIORITY = -20 DISABLE" db-types="MySQL"/>
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-index.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-index.xml
@@ -54,4 +54,5 @@
         WITH (FILLFACTOR = 80, PAD_INDEX = ON, DROP_EXISTING = ON);" db-types="SQLServer" />
     <sql-case id="create_index_on_local_parallel_nologging" value="CREATE INDEX from_number_ix ON call_detail_records(from_number) LOCAL PARALLEL NOLOGGING" db-types="Oracle" />
     <sql-case id="create_bitmap_index_on_local_parallel_nologging" value="CREATE BITMAP INDEX is_active_bix ON credit_card_accounts(is_active) LOCAL PARALLEL NOLOGGING" db-types="Oracle" />
+    <sql-case id="create_index_with_engine_attribute" value="CREATE INDEX i1 ON t1 (c1) ENGINE_ATTRIBUTE='{&quot;key&quot;:&quot;value&quot;}';" db-types="MySQL"/>
 </sql-cases>


### PR DESCRIPTION
Fixes #30962.

Changes proposed in this pull request:
  - Support parsing MySQL CREATE INDEX with ENGINE_ATTRIBUTE

SQL Case
```sql
CREATE INDEX i1 ON t1 (c1) ENGINE_ATTRIBUTE='{"key":"value"}';
```

```sql
CREATE RESOURCE GROUP rg2
  TYPE = SYSTEM
  THREAD_PRIORITY = -20
  DISABLE;
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
