### PR TITLE
Support parsing MySQL LOAD DATA with @ variable

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -442,7 +442,7 @@ identifierKeywordsUnambiguous
     | SERVER
     | SHARE
     | SIMPLE
-//    | SKIP
+    | SKIP_SYMBOL
     | SLOW
     | SNAPSHOT
     | SOCKET
@@ -1334,7 +1334,7 @@ collateClause
     ;
     
 fieldOrVarSpec
-    : LP_ (identifier (COMMA_ identifier)*)? RP_
+    : LP_ (userVariable (COMMA_ userVariable)*)? RP_
     ;
     
 ifNotExists

--- a/test/it/parser/src/main/resources/case/ddl/prepared.xml
+++ b/test/it/parser/src/main/resources/case/ddl/prepared.xml
@@ -24,4 +24,5 @@
     <prepared sql-case-id="execute_with_statement_and_using" />
     <prepared sql-case-id="deallocate_statement" />
     <prepared sql-case-id="drop_statement" />
+    <prepared sql-case-id="execute_stmt_with_using"/>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dml/load-data.xml
+++ b/test/it/parser/src/main/resources/case/dml/load-data.xml
@@ -34,4 +34,10 @@
     <load-data sql-case-id="load_data_into_table_with_ignore_lines">
         <table name="t_order" start-index="44" stop-index="50" />
     </load-data>
+    <load-data sql-case-id="load_data_into_table_with_at_01">
+        <table name="t1" start-index="39" stop-index="40"/>
+    </load-data>
+    <load-data sql-case-id="load_data_into_table_with_at_02">
+        <table name="t1" start-index="39" stop-index="40"/>
+    </load-data>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/prepared.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/prepared.xml
@@ -24,4 +24,5 @@
     <sql-case id="execute_with_statement_and_using" value="EXECUTE stmt USING @a, @b" db-types="MySQL" />
     <sql-case id="deallocate_statement" value="DEALLOCATE PREPARE stmt1" db-types="MySQL" />
     <sql-case id="drop_statement" value="DROP PREPARE stmt1" db-types="MySQL" />
+    <sql-case id="execute_stmt_with_using" value="EXECUTE STMT USING @skip, @numrows" db-types="MySQL"/>
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/load-data.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/load-data.xml
@@ -22,4 +22,6 @@
     <sql-case id="load_data_into_table_with_schema_name" value="LOAD DATA INFILE '/temp/test.txt' INTO TABLE sharding_db.t_order" db-types="MySQL" />
     <sql-case id="load_data_into_table_with_lines_starting" value="LOAD DATA INFILE '/tmp/test.txt' INTO TABLE t_order FIELDS TERMINATED BY ','  LINES STARTING BY 'xxx'" db-types="MySQL" />
     <sql-case id="load_data_into_table_with_ignore_lines" value="LOAD DATA INFILE '/tmp/test.txt' INTO TABLE t_order IGNORE 1 LINES" db-types="MySQL" />
+    <sql-case id="load_data_into_table_with_at_01" value="LOAD DATA INFILE 'file.txt' INTO TABLE t1 (column1, @var1) SET column2 = @var1/100;" db-types="MySQL"/>
+    <sql-case id="load_data_into_table_with_at_02" value="LOAD DATA INFILE 'file.txt' INTO TABLE t1 (column1, @dummy, column2, @dummy, column3);" db-types="MySQL"/>
 </sql-cases>


### PR DESCRIPTION
Fixes #30973.

Changes proposed in this pull request:
  - Support parsing MySQL LOAD DATA with @ variable

SQL Case
```sql
LOAD DATA INFILE 'file.txt'
  INTO TABLE t1
  (column1, @var1)
  SET column2 = @var1/100;
```

```sql
LOAD DATA INFILE 'file.txt'
  INTO TABLE t1
  (column1, @dummy, column2, @dummy, column3);
```

```sql
EXECUTE STMT USING @skip, @numrows;
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
