### PR TITLE
Correct OuterJoinExpression getText logic and add text assertion in sql parse test case

### DIFF
--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
@@ -625,7 +625,7 @@ public abstract class OracleStatementVisitor extends OracleStatementBaseVisitor<
         }
         if (null != ctx.columnName()) {
             return null == ctx.joinOperator() ? visit(ctx.columnName())
-                    : new OuterJoinExpression(startIndex, stopIndex, (ColumnSegment) visitColumnName(ctx.columnName()), ctx.joinOperator().getText());
+                    : new OuterJoinExpression(startIndex, stopIndex, (ColumnSegment) visitColumnName(ctx.columnName()), ctx.joinOperator().getText(), getOriginalText(ctx));
         }
         if (null != ctx.privateExprOfDb()) {
             return visit(ctx.privateExprOfDb());

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/segment/oracle/join/OuterJoinExpression.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/segment/oracle/join/OuterJoinExpression.java
@@ -37,8 +37,10 @@ public class OuterJoinExpression implements ExpressionSegment {
     
     private final String joinOperator;
     
+    private final String text;
+    
     @Override
     public String getText() {
-        return getColumnName().toString();
+        return text;
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/column/OuterJoinExpressionAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/column/OuterJoinExpressionAssert.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.dialect.segment.oracle.join.OuterJoinExpression;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.expr.ExpectedOuterJoinExpression;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -42,6 +43,8 @@ public final class OuterJoinExpressionAssert {
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final OuterJoinExpression actual, final ExpectedOuterJoinExpression expected) {
         ColumnAssert.assertIs(assertContext, actual.getColumnName(), expected.getColumn());
-        assertThat(actual.getJoinOperator(), is(expected.getJoinOperator()));
+        assertThat(assertContext.getText("Outer join expression join operator assertion error: "), actual.getJoinOperator(), is(expected.getJoinOperator()));
+        assertThat(assertContext.getText("Outer join expression text assertion error: "), actual.getText(), is(expected.getText()));
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/expr/ExpectedOuterJoinExpression.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/expr/ExpectedOuterJoinExpression.java
@@ -22,6 +22,7 @@ import lombok.Setter;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.AbstractExpectedSQLSegment;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.column.ExpectedColumn;
 
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
 /**
@@ -37,4 +38,6 @@ public final class ExpectedOuterJoinExpression extends AbstractExpectedSQLSegmen
     @XmlElement(name = "join-operator")
     private String joinOperator;
     
+    @XmlAttribute
+    private String text;
 }

--- a/test/it/parser/src/main/resources/case/ddl/create-view.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-view.xml
@@ -206,7 +206,7 @@
                                     </column>
                                 </left>
                                 <right>
-                                    <outer-join-expression>
+                                    <outer-join-expression start-index="130" stop-index="145" text="m.planet_name(+)">
                                         <column name="planet_name" start-index="130" stop-index="142">
                                             <owner name="m" start-index="130" stop-index="130" />
                                         </column>
@@ -219,7 +219,7 @@
                         <right>
                             <binary-operation-expression start-index="151" stop-index="174">
                                 <left>
-                                    <outer-join-expression>
+                                    <outer-join-expression start-index="151" stop-index="159" text="m.name(+)">
                                         <column name="name" start-index="151" stop-index="156">
                                             <owner name="m" start-index="151" stop-index="151" />
                                         </column>
@@ -583,7 +583,7 @@
                             </column>
                         </left>
                         <right>
-                            <outer-join-expression>
+                            <outer-join-expression start-index="91" stop-index="102" text="d.deptno (+)">
                                 <column name="deptno" start-index="91" stop-index="98">
                                     <owner name="d" start-index="91" stop-index="91" />
                                 </column>
@@ -708,7 +708,7 @@
                 <expr>
                     <binary-operation-expression start-index="103" stop-index="125">
                         <left>
-                            <outer-join-expression>
+                            <outer-join-expression start-index="103" stop-index="114" text="e.deptno (+)">
                                 <column name="deptno" start-index="103" stop-index="110">
                                     <owner name="e" start-index="103" stop-index="103" />
                                 </column>

--- a/test/it/parser/src/main/resources/case/dml/select-join.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-join.xml
@@ -574,7 +574,7 @@
             <expr>
                 <binary-operation-expression start-index="47" stop-index="72">
                     <left>
-                        <outer-join-expression start-index="47" stop-index="48">
+                        <outer-join-expression start-index="47" stop-index="59" text="o.order_id(+)">
                             <column name="order_id" start-index="47" stop-index="56">
                                 <owner name="o" start-index="47" stop-index="47" />
                             </column>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Correct OuterJoinExpression getText logic and add text assertion in sql parse test case

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
