### PR TITLE
Refactor : remove opengauss from e2e-operation, only keep it in nightly

### DIFF
--- a/.github/workflows/e2e-operation.yml
+++ b/.github/workflows/e2e-operation.yml
@@ -60,14 +60,12 @@ jobs:
       fail-fast: false
       matrix:
         operation: [ transaction, pipeline, showprocesslist ]
-        image: [ { type: "it.docker.mysql.version", version: "mysql:5.7" }, { type: "it.docker.postgresql.version", version: "postgres:12-alpine" }, { type: "it.docker.opengauss.version", version: "enmotech/opengauss:2.1.0,enmotech/opengauss:3.1.0" }, { type: "it.docker.mariadb.version", version: "mariadb:11" } ]
+        image: [ { type: "it.docker.mysql.version", version: "mysql:5.7" }, { type: "it.docker.postgresql.version", version: "postgres:12-alpine" }, { type: "it.docker.mariadb.version", version: "mariadb:11" } ]
         exclude:
           - operation: transaction
             image: { type: "it.docker.mariadb.version", version: "mariadb:11" }
           - operation: showprocesslist
             image: { type: "it.docker.postgresql.version", version: "postgres:12-alpine" }
-          - operation: showprocesslist
-            image: { type: "it.docker.opengauss.version", version: "enmotech/opengauss:2.1.0,enmotech/opengauss:3.1.0" }
           - operation: showprocesslist
             image: { type: "it.docker.mariadb.version", version: "mariadb:11" }
     steps:


### PR DESCRIPTION
Changes proposed in this pull request:
  - remove opengauss from e2e-operation, only keep it in nightly e2e-operation

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
