### PR TITLE
Refactor ShowTablesExecutor, fix sort without like filter

### DIFF
--- a/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/subscriber/StateChangedSubscriberTest.java
+++ b/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/subscriber/StateChangedSubscriberTest.java
@@ -38,10 +38,10 @@ import org.apache.shardingsphere.mode.manager.ContextManagerBuilderParameter;
 import org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.cluster.event.ClusterLockDeletedEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.cluster.event.ClusterStateEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.event.ComputeNodeInstanceStateChangedEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.event.InstanceOfflineEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.event.InstanceOnlineEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.event.LabelsEvent;
-import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.event.ComputeNodeInstanceStateChangedEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.event.WorkerIdEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.storage.event.StorageNodeChangedEvent;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
@@ -64,6 +64,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -166,14 +167,14 @@ class StateChangedSubscriberTest {
         InstanceOnlineEvent instanceOnlineEvent1 = new InstanceOnlineEvent(instanceMetaData1);
         subscriber.renew(instanceOnlineEvent1);
         assertThat(contextManager.getInstanceContext().getAllClusterComputeNodeInstances().size(), is(1));
-        assertThat(((LinkedList<ComputeNodeInstance>) contextManager.getInstanceContext().getAllClusterComputeNodeInstances()).get(0).getMetaData(), is(instanceMetaData1));
+        assertThat(((CopyOnWriteArrayList<ComputeNodeInstance>) contextManager.getInstanceContext().getAllClusterComputeNodeInstances()).get(0).getMetaData(), is(instanceMetaData1));
         InstanceMetaData instanceMetaData2 = new ProxyInstanceMetaData("foo_instance_3308", 3308);
         InstanceOnlineEvent instanceOnlineEvent2 = new InstanceOnlineEvent(instanceMetaData2);
         subscriber.renew(instanceOnlineEvent2);
         assertThat(contextManager.getInstanceContext().getAllClusterComputeNodeInstances().size(), is(2));
-        assertThat(((LinkedList<ComputeNodeInstance>) contextManager.getInstanceContext().getAllClusterComputeNodeInstances()).get(1).getMetaData(), is(instanceMetaData2));
+        assertThat(((CopyOnWriteArrayList<ComputeNodeInstance>) contextManager.getInstanceContext().getAllClusterComputeNodeInstances()).get(1).getMetaData(), is(instanceMetaData2));
         subscriber.renew(instanceOnlineEvent1);
         assertThat(contextManager.getInstanceContext().getAllClusterComputeNodeInstances().size(), is(2));
-        assertThat(((LinkedList<ComputeNodeInstance>) contextManager.getInstanceContext().getAllClusterComputeNodeInstances()).get(1).getMetaData(), is(instanceMetaData1));
+        assertThat(((CopyOnWriteArrayList<ComputeNodeInstance>) contextManager.getInstanceContext().getAllClusterComputeNodeInstances()).get(1).getMetaData(), is(instanceMetaData1));
     }
 }

--- a/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowTablesExecutor.java
+++ b/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowTablesExecutor.java
@@ -97,10 +97,13 @@ public final class ShowTablesExecutor implements DatabaseAdminQueryExecutor {
     
     private Collection<ShardingSphereTable> getTables(final String databaseName) {
         Collection<ShardingSphereTable> tables = ProxyContext.getInstance().getContextManager().getDatabase(databaseName).getSchema(databaseName).getTables().values();
+        Collection<ShardingSphereTable> filteredTables = filterByLike(tables);
+        return filteredTables.stream().sorted(Comparator.comparing(ShardingSphereTable::getName)).collect(Collectors.toList());
+    }
+    
+    private Collection<ShardingSphereTable> filterByLike(final Collection<ShardingSphereTable> tables) {
         Optional<Pattern> likePattern = getLikePattern();
-        return likePattern.isPresent()
-                ? tables.stream().filter(each -> likePattern.get().matcher(each.getName()).matches()).sorted(Comparator.comparing(ShardingSphereTable::getName)).collect(Collectors.toList())
-                : tables;
+        return likePattern.isPresent() ? tables.stream().filter(each -> likePattern.get().matcher(each.getName()).matches()).collect(Collectors.toList()) : tables;
     }
     
     private Optional<Pattern> getLikePattern() {


### PR DESCRIPTION
Revise #31299

### Before
no order when execute `show tables`
<img width="257" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/c8a7ba87-475b-4937-b509-aeefe1f60ebb">


### After
<img width="282" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/4d404675-f067-4e5d-89f8-4e91cbcd150a">
