### PR TITLE
Remove NativeTest's useless TC_DAEMON parameters under Graalvm Native Image

### DIFF
--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
@@ -528,18 +528,18 @@
   "name":"org.apache.shardingsphere.infra.instance.metadata.proxy.ProxyInstanceMetaDataBuilder"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.service.ComputeNodeStatusService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.service.ComputeNodePersistService"},
   "name":"org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeData",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getAttribute","parameterTypes":[] }, {"name":"getVersion","parameterTypes":[] }, {"name":"setAttribute","parameterTypes":["java.lang.String"] }, {"name":"setVersion","parameterTypes":["java.lang.String"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.service.ComputeNodeStatusService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.service.ComputeNodePersistService"},
   "name":"org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeDataBeanInfo"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.service.ComputeNodeStatusService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.service.ComputeNodePersistService"},
   "name":"org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeDataCustomizer"
 },
 {
@@ -572,13 +572,8 @@
   "queryAllDeclaredMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.subsciber.EventSubscriberRegistry$$Lambda/0x00007feecf3840e0"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.subsciber.EventSubscriberRegistry$$Lambda/0x00007f12133825d0"},
   "name":"org.apache.shardingsphere.infra.util.eventbus.EventSubscriber"
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.connection.refresher.type.table.CreateTableStatementSchemaRefresher"},
-  "name":"org.apache.shardingsphere.infra.util.yaml.YamlConfiguration",
-  "queryAllPublicMethods":true
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -591,7 +586,12 @@
   "queryAllPublicMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.service.ComputeNodeStatusService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.refresher.type.table.CreateTableStatementSchemaRefresher"},
+  "name":"org.apache.shardingsphere.infra.util.yaml.YamlConfiguration",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.service.ComputeNodePersistService"},
   "name":"org.apache.shardingsphere.infra.util.yaml.YamlConfiguration",
   "queryAllPublicMethods":true
 },
@@ -695,11 +695,6 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setUnique","parameterTypes":["boolean"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.connection.refresher.type.table.CreateTableStatementSchemaRefresher"},
-  "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
-  "queryAllPublicMethods":true
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
   "methods":[{"name":"setType","parameterTypes":["org.apache.shardingsphere.infra.database.core.metadata.database.enums.TableType"] }]
@@ -717,11 +712,16 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getColumns","parameterTypes":[] }, {"name":"getConstraints","parameterTypes":[] }, {"name":"getIndexes","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }, {"name":"getType","parameterTypes":[] }, {"name":"setColumns","parameterTypes":["java.util.Map"] }, {"name":"setIndexes","parameterTypes":["java.util.Map"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setType","parameterTypes":["org.apache.shardingsphere.infra.database.core.metadata.database.enums.TableType"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.connection.refresher.type.table.CreateTableStatementSchemaRefresher"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.refresher.type.table.CreateTableStatementSchemaRefresher"},
+  "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.refresher.type.table.CreateTableStatementSchemaRefresher"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTableBeanInfo"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.connection.refresher.type.table.CreateTableStatementSchemaRefresher"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.refresher.type.table.CreateTableStatementSchemaRefresher"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTableCustomizer"
 },
 {
@@ -911,18 +911,8 @@
   "queryAllDeclaredMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.cluster.subscriber.ClusterStateSubscriber",
-  "queryAllDeclaredMethods":true
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceWatcherFactory"},
   "name":"org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.cluster.watcher.ClusterStateChangedWatcher"
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.subscriber.ComputeNodeStatusSubscriber",
-  "queryAllDeclaredMethods":true
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceWatcherFactory"},
@@ -961,12 +951,22 @@
   "methods":[{"name":"renew","parameterTypes":["org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.cluster.event.ClusterStateEvent"] }]
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.service.PersistServiceFacade"},
+  "name":"org.apache.shardingsphere.mode.manager.cluster.service.ClusterMetaDataManagerPersistServiceBuilder",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.swapper.mode.YamlModeConfigurationSwapper"},
   "name":"org.apache.shardingsphere.mode.manager.cluster.yaml.ClusterYamlPersistRepositoryConfigurationSwapper"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
   "name":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.service.PersistServiceFacade"},
+  "name":"org.apache.shardingsphere.mode.manager.standalone.service.StandaloneMetaDataManagerPersistServiceBuilder",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.swapper.mode.YamlModeConfigurationSwapper"},

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/resource-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/resource-config.json
@@ -259,6 +259,9 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.repository.standalone.StandalonePersistRepository\\E"
   }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.service.MetaDataManagerPersistServiceBuilder\\E"
+  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.MetaDataContextsFactory"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.spi.RuleNodePathProvider\\E"
   }, {

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/MySQLTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/MySQLTest.java
@@ -61,7 +61,7 @@ class MySQLTest {
     @EnabledInNativeImage
     void assertShardingInLocalTransactions() throws SQLException {
         try (
-                GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("mysql:8.2.0-oracle"))
+                GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("mysql:8.4.0-oracle"))
                         .withEnv("MYSQL_DATABASE", DATABASE)
                         .withEnv("MYSQL_ROOT_PASSWORD", PASSWORD)
                         .withExposedPorts(3306)) {

--- a/test/native/src/test/resources/test-native/yaml/databases/postgresql.yaml
+++ b/test/native/src/test/resources/test-native/yaml/databases/postgresql.yaml
@@ -24,15 +24,15 @@ dataSources:
   ds_0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:16.1-bookworm://test-native-databases-postgres/demo_ds_0?TC_DAEMON=true
+    jdbcUrl: jdbc:tc:postgresql:16.3-bookworm://test-native-databases-postgres/demo_ds_0
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:16.1-bookworm://test-native-databases-postgres/demo_ds_1?TC_DAEMON=true
+    jdbcUrl: jdbc:tc:postgresql:16.3-bookworm://test-native-databases-postgres/demo_ds_1
   ds_2:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:16.1-bookworm://test-native-databases-postgres/demo_ds_2?TC_DAEMON=true
+    jdbcUrl: jdbc:tc:postgresql:16.3-bookworm://test-native-databases-postgres/demo_ds_2
 
 rules:
 - !SHARDING

--- a/test/native/src/test/resources/test-native/yaml/databases/sqlserver.yaml
+++ b/test/native/src/test/resources/test-native/yaml/databases/sqlserver.yaml
@@ -24,15 +24,15 @@ dataSources:
   ds_0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:sqlserver:2022-CU10-ubuntu-22.04://test-native-databases-mssqlserver;databaseName=demo_ds_0;TC_DAEMON=true;
+    jdbcUrl: jdbc:tc:sqlserver:2022-CU10-ubuntu-22.04://test-native-databases-mssqlserver;databaseName=demo_ds_0;
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:sqlserver:2022-CU10-ubuntu-22.04://test-native-databases-mssqlserver;databaseName=demo_ds_1;TC_DAEMON=true;
+    jdbcUrl: jdbc:tc:sqlserver:2022-CU10-ubuntu-22.04://test-native-databases-mssqlserver;databaseName=demo_ds_1;
   ds_2:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:sqlserver:2022-CU10-ubuntu-22.04://test-native-databases-mssqlserver;databaseName=demo_ds_2;TC_DAEMON=true;
+    jdbcUrl: jdbc:tc:sqlserver:2022-CU10-ubuntu-22.04://test-native-databases-mssqlserver;databaseName=demo_ds_2;
 
 rules:
 - !SHARDING

--- a/test/native/src/test/resources/test-native/yaml/transactions/base/seata.yaml
+++ b/test/native/src/test/resources/test-native/yaml/transactions/base/seata.yaml
@@ -24,15 +24,15 @@ dataSources:
   ds_0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:16.2-bookworm://test-native-transactions-base/demo_ds_0?TC_DAEMON=true?TC_INITSCRIPT=test-native/sql/seata-script-client-at-postgresql.sql
+    jdbcUrl: jdbc:tc:postgresql:16.3-bookworm://test-native-transactions-base/demo_ds_0?TC_INITSCRIPT=test-native/sql/seata-script-client-at-postgresql.sql
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:16.2-bookworm://test-native-transactions-base/demo_ds_1?TC_DAEMON=true?TC_INITSCRIPT=test-native/sql/seata-script-client-at-postgresql.sql
+    jdbcUrl: jdbc:tc:postgresql:16.3-bookworm://test-native-transactions-base/demo_ds_1?TC_INITSCRIPT=test-native/sql/seata-script-client-at-postgresql.sql
   ds_2:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:16.2-bookworm://test-native-transactions-base/demo_ds_2?TC_DAEMON=true?TC_INITSCRIPT=test-native/sql/seata-script-client-at-postgresql.sql
+    jdbcUrl: jdbc:tc:postgresql:16.3-bookworm://test-native-transactions-base/demo_ds_2?TC_INITSCRIPT=test-native/sql/seata-script-client-at-postgresql.sql
 
 rules:
 - !SHARDING


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Remove NativeTest's useless TC_DAEMON parameters under Graalvm Native Image.
  - Fixes nativeTest failure under GraalVM Native Image due to class information changes. For https://github.com/apache/shardingsphere/actions/runs/9196231415/job/25293863433 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
