### PR TITLE
Fix shadow moudle throw 'Table does not exist' exception

### DIFF
--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/rule/ShadowRule.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/rule/ShadowRule.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.shadow.api.shadow.ShadowOperationType;
 import org.apache.shardingsphere.shadow.api.shadow.column.ColumnShadowAlgorithm;
 import org.apache.shardingsphere.shadow.api.shadow.hint.HintShadowAlgorithm;
 import org.apache.shardingsphere.shadow.rule.attribute.ShadowDataSourceMapperRuleAttribute;
+import org.apache.shardingsphere.shadow.rule.attribute.ShadowTableMapperRuleAttribute;
 import org.apache.shardingsphere.shadow.spi.ShadowAlgorithm;
 
 import java.util.Collection;
@@ -68,7 +69,8 @@ public final class ShadowRule implements DatabaseRule {
             hintShadowAlgorithmNames.add(ruleConfig.getDefaultShadowAlgorithmName());
         }
         initShadowTableRules(ruleConfig.getTables());
-        attributes = new RuleAttributes(new ShadowDataSourceMapperRuleAttribute(shadowDataSourceMappings));
+        attributes = new RuleAttributes(new ShadowDataSourceMapperRuleAttribute(shadowDataSourceMappings),
+                new ShadowTableMapperRuleAttribute(ruleConfig.getTables().keySet()));
     }
     
     private void initShadowDataSourceMappings(final Collection<ShadowDataSourceConfiguration> dataSources) {

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/rule/attribute/ShadowTableMapperRuleAttribute.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/rule/attribute/ShadowTableMapperRuleAttribute.java
@@ -30,8 +30,8 @@ public class ShadowTableMapperRuleAttribute implements TableMapperRuleAttribute 
     
     private final CaseInsensitiveSet<String> logicalTableMapper;
     
-    public ShadowTableMapperRuleAttribute(final Collection<String> encryptTableNames) {
-        logicalTableMapper = new CaseInsensitiveSet<>(encryptTableNames);
+    public ShadowTableMapperRuleAttribute(final Collection<String> shadowTableNames) {
+        logicalTableMapper = new CaseInsensitiveSet<>(shadowTableNames);
     }
     
     @Override

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/rule/attribute/ShadowTableMapperRuleAttribute.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/rule/attribute/ShadowTableMapperRuleAttribute.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.shadow.rule.attribute;
+
+import com.cedarsoftware.util.CaseInsensitiveSet;
+import org.apache.shardingsphere.infra.rule.attribute.table.TableMapperRuleAttribute;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Shadow table mapper rule attribute.
+ */
+public class ShadowTableMapperRuleAttribute implements TableMapperRuleAttribute {
+    
+    private final CaseInsensitiveSet<String> logicalTableMapper;
+    
+    public ShadowTableMapperRuleAttribute(final Collection<String> encryptTableNames) {
+        logicalTableMapper = new CaseInsensitiveSet<>(encryptTableNames);
+    }
+    
+    @Override
+    public Collection<String> getLogicTableNames() {
+        return logicalTableMapper;
+    }
+    
+    @Override
+    public Collection<String> getDistributedTableNames() {
+        return Collections.emptySet();
+    }
+    
+    @Override
+    public Collection<String> getEnhancedTableNames() {
+        return logicalTableMapper;
+    }
+}


### PR DESCRIPTION
Fixes #31360.

Changes proposed in this pull request:
  - When we have configured the relevant table property configuration for shadow in config.yaml, but our table has been 
created ahead of time and not through ShardingSphereConection, an error is thrown`TableNotFoundException: Table or view ‘t_order’ does not exist.`
 -  we should refer to the tables that are preloaded in the configuration class in shadingRule, which can avoid this problem

For Example 

- **Configuration file**

```yaml
mode:
  type: Standalone
  repository:
    type: JDBC
    props:
      path: demo

dataSources:
  ds_0:
    dataSourceClassName: com.zaxxer.hikari.HikariDataSource
    driverClassName: com.mysql.jdbc.Driver
    jdbcUrl: jdbc:mysql://localhost:3306/demo_ds_0?serverTimezone=UTC&useSSL=false&useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
    username: root
    password: mcycxc19740203
    maxPoolSize: 10
  ds_1:
    dataSourceClassName: com.zaxxer.hikari.HikariDataSource
    driverClassName: com.mysql.jdbc.Driver
    jdbcUrl: jdbc:mysql://localhost:3306/demo_ds_1?serverTimezone=UTC&useSSL=false&useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
    username: root
    password: mcycxc19740203
    maxPoolSize: 10

rules:
- !SHADOW
  tables:
    t_order:
      dataSourceNames:
        - shadow_group
      shadowAlgorithmNames:
        - user_id_insert_match_algorithm
        - user_id_delete_match_algorithm
        - user_id_select_match_algorithm
  dataSources:
    shadow_group:
      productionDataSourceName: ds_0
      shadowDataSourceName: ds_1
  shadowAlgorithms:
    user_id_insert_match_algorithm:
      type: REGEX_MATCH
      props:
        operation: insert
        column: order_type
        regex: "[1]"
    user_id_delete_match_algorithm:
      type: REGEX_MATCH
      props:
        operation: delete
        column: order_type
        regex: "[1]"
    user_id_select_match_algorithm:
      type: REGEX_MATCH
      props:
        operation: select
        column: order_type
        regex: "[1]"
props:
  sql-show: true
```

- **Code**
<img width="481" alt="image" src="https://github.com/apache/shardingsphere/assets/124348939/30af9eb6-7717-48a7-b092-987ebb83bcbb">

- **Exception**
<img width="1333" alt="image" src="https://github.com/apache/shardingsphere/assets/124348939/a4cc803a-903c-471f-a50e-db5a6d3b64f6">

-- **After modification**
<img width="1360" alt="image" src="https://github.com/apache/shardingsphere/assets/124348939/f024a861-b011-4833-99ce-71be30f2faaf">


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
