### PR TITLE
Fixes the connection of Remote HiveServer2 through HiveServer2 JDBC Driver

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/_index.cn.md
@@ -31,7 +31,6 @@ ShardingSphere 默认情况下仅包含核心 SPI 的实现，在 Git Source 存
 - `org.apache.shardingsphere:shardingsphere-sql-parser-oracle`， SQL 解析的 Oracle 方言解析实现
 - `org.apache.shardingsphere:shardingsphere-sql-parser-sqlserver`， SQL 解析的 SQL Server 方言实现
 - `org.apache.shardingsphere:shardingsphere-sql-parser-doris`， SQL 解析的 Doris 方言实现
-- `org.apache.shardingsphere:shardingsphere-sql-parser-hive`， SQL 解析的 Hive 方言实现
 - `org.apache.shardingsphere:shardingsphere-sql-parser-presto`， SQL 解析的 Presto 方言实现
 - `org.apache.shardingsphere:shardingsphere-sql-parser-sql92`， SQL 解析的 SQL 92 方言实现
 - `org.apache.shardingsphere:shardingsphere-standalone-mode-core`，单机模式配置信息持久化定义核心
@@ -53,6 +52,7 @@ ShardingSphere 默认情况下仅包含核心 SPI 的实现，在 Git Source 存
 - 数据库类型识别
   - `org.apache.shardingsphere:shardingsphere-infra-database-testcontainers`， 对 `testcontainers-java` 的 `JDBC support` 的 jdbcURL 的识别适配
 - SQL 解析
-  - `org.apache.shardingsphere:shardingsphere-sql-parser-clickhouse`， SQL 解析的 ClickHouse 方言实现
+  - `org.apache.shardingsphere:shardingsphere-parser-sql-clickhouse`， SQL 解析的 ClickHouse 方言实现
+  - `org.apache.shardingsphere:shardingsphere-parser-sql-hive`， SQL 解析的 Hive 方言实现
 
 除了以上可选插件外，ShardingSphere 社区开发者还贡献了大量的插件实现，可以在 [ShardingSphere Plugin](https://github.com/apache/shardingsphere-plugin) 仓库中查看插件的使用说明，ShardingSphere Plugin 仓库中的插件会和 ShardingSphere 保持相同的发布节奏，可以在 https://central.sonatype.com/ 进行检索，并安装到 ShardingSphere 中。

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/_index.en.md
@@ -31,7 +31,6 @@ All the built-in plugins for ShardingSphere-JDBC are listed below in the form of
 - `org.apache.shardingsphere:shardingsphere-sql-parser-oracle`, Oracle dialect implementation of SQL parsing
 - `org.apache.shardingsphere:shardingsphere-sql-parser-sqlserver`, SQL Server dialect implementation of SQL parsing
 - `org.apache.shardingsphere:shardingsphere-sql-parser-doris`， Doris dialect implementation of SQL parsing
-- `org.apache.shardingsphere:shardingsphere-sql-parser-hive`， Hive dialect implementation of SQL parsing
 - `org.apache.shardingsphere:shardingsphere-sql-parser-presto`， Presto dialect implementation of SQL parsing
 - `org.apache.shardingsphere:shardingsphere-sql-parser-sql92`,the SQL 92 dialect implementation of SQL parsing
 - `org.apache.shardingsphere:shardingsphere-standalone-mode-core`, the persistence definition core of single-machine mode configuration information
@@ -53,6 +52,7 @@ All optional plugins are listed below in the form of `groupId:artifactId`.
 - Database type identification
   - `org.apache.shardingsphere:shardingsphere-infra-database-testcontainers`, Adaptation of jdbcURL for `JDBC support` of `testcontainers-java`
 - SQL parsing
-  - `org.apache.shardingsphere:shardingsphere-sql-parser-clickhouse`, ClickHouse dialect implementation of SQL parsing
+  - `org.apache.shardingsphere:shardingsphere-parser-sql-clickhouse`, ClickHouse dialect implementation of SQL parsing
+  - `org.apache.shardingsphere:shardingsphere-parser-sql-hive`， Hive dialect implementation of SQL parsing
 
 In addition to the above optional plugins, ShardingSphere community developers have contributed a number of plugin implementations. These plugins can be found in [ShardingSphere Plugins] (https://github.com/apache/shardingsphere-plugin) repository. Plugins in ShardingSphere Plugin repository would remain the same release plan with ShardingSphere, they can be retrieved at https://central.sonatype.com/, and install into ShardingSphere.

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.cn.md
@@ -97,7 +97,7 @@ client {
 }
 ```
 
-根据实际场景修改 Seata 的 `file.conf` 和 `registry.conf` 文件。
+根据实际场景修改 Seata 的 `registry.conf` 文件。
 
 ## 使用限制
 
@@ -180,7 +180,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class ExampleApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(ShardingsphereSeataSpringBootTestApplication.class, args);
+        SpringApplication.run(ExampleApplication.class, args);
     }
 
 }

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.en.md
@@ -98,7 +98,7 @@ client {
 }
 ```
 
-Modify the `file.conf` and `registry.conf` files of Seata as required.
+Modify the `registry.conf` file of Seata as required.
 
 ## Usage restrictions
 
@@ -184,7 +184,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class ExampleApplication {
 
      public static void main(String[] args) {
-         SpringApplication.run(ShardingsphereSeataSpringBootTestApplication.class, args);
+         SpringApplication.run(ExampleApplication.class, args);
      }
 
 }

--- a/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/_index.cn.md
@@ -38,5 +38,8 @@ ShardingSphere 默认情况下仅包含核心 SPI 的实现，在 Git Source 存
   - `org.apache.shardingsphere:shardingsphere-infra-expr-espresso`，基于 GraalVM Truffle 的 Espresso 实现的使用 Groovy 语法的行表达式
 - 数据库类型识别
   - `org.apache.shardingsphere:shardingsphere-infra-database-testcontainers`， 对 `testcontainers-java` 的 `JDBC support` 的 jdbcURL 的识别适配
+- SQL 解析
+  - `org.apache.shardingsphere:shardingsphere-parser-sql-clickhouse`， SQL 解析的 ClickHouse 方言实现
+  - `org.apache.shardingsphere:shardingsphere-parser-sql-hive`， SQL 解析的 Hive 方言实现
 
 除了以上可选插件外，ShardingSphere 社区开发者还贡献了大量的插件实现，可以在 [ShardingSphere Plugin](https://github.com/apache/shardingsphere-plugin) 仓库中查看插件的使用说明，ShardingSphere Plugin 仓库中的插件会和 ShardingSphere 保持相同的发布节奏，可以在 https://central.sonatype.com/ 进行检索，并安装到 ShardingSphere 中。

--- a/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/_index.en.md
@@ -38,5 +38,8 @@ All optional plugins are listed below in the form of `groupId:artifactId`.
   - `org.apache.shardingsphere:shardingsphere-infra-expr-espresso`，Row Value Expressions that uses the Groovy syntax based on GraalVM Truffle's Espresso implementation
 - Database type identification
   - `org.apache.shardingsphere:shardingsphere-infra-database-testcontainers`, Adaptation of jdbcURL for `JDBC support` of `testcontainers-java` 
+- SQL parsing
+  - `org.apache.shardingsphere:shardingsphere-parser-sql-clickhouse`, ClickHouse dialect implementation of SQL parsing
+  - `org.apache.shardingsphere:shardingsphere-parser-sql-hive`， Hive dialect implementation of SQL parsing
 
 In addition to the above optional plugins, ShardingSphere community developers have contributed a number of plugin implementations. These plugins can be found in [ShardingSphere Plugins](https://github.com/apache/shardingsphere-plugin) repository. Plugins in ShardingSphere Plugin repository would remain the same release plan with ShardingSphere, they can be retrieved at https://central.sonatype.com/, and install into ShardingSphere.

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/database/DatabaseTypeEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/database/DatabaseTypeEngine.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory;
+import org.apache.shardingsphere.infra.datasource.pool.CatalogSwitchableDataSource;
 import org.apache.shardingsphere.infra.exception.core.external.sql.type.wrapper.SQLWrapperException;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.infra.state.datasource.DataSourceStateManager;
@@ -31,6 +32,7 @@ import org.apache.shardingsphere.infra.state.datasource.DataSourceStateManager;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -47,10 +49,10 @@ public final class DatabaseTypeEngine {
     
     /**
      * Get protocol type.
-     * 
-     * @param databaseName database name
+     *
+     * @param databaseName   database name
      * @param databaseConfig database configuration
-     * @param props configuration properties
+     * @param props          configuration properties
      * @return protocol type
      */
     public static DatabaseType getProtocolType(final String databaseName, final DatabaseConfiguration databaseConfig, final ConfigurationProperties props) {
@@ -66,7 +68,7 @@ public final class DatabaseTypeEngine {
      * Get protocol type.
      *
      * @param databaseConfigs database configurations
-     * @param props configuration properties
+     * @param props           configuration properties
      * @return protocol type
      */
     public static DatabaseType getProtocolType(final Map<String, ? extends DatabaseConfiguration> databaseConfigs, final ConfigurationProperties props) {
@@ -94,7 +96,7 @@ public final class DatabaseTypeEngine {
     /**
      * Get storage types.
      *
-     * @param databaseName database name
+     * @param databaseName   database name
      * @param databaseConfig database configuration
      * @return storage types
      */
@@ -109,6 +111,8 @@ public final class DatabaseTypeEngine {
     
     /**
      * Get storage type.
+     * Similar to apache/hive 4.0.0's `org.apache.hive.jdbc.HiveDatabaseMetaData`, it does not implement {@link java.sql.DatabaseMetaData#getURL()}.
+     * So use {@link CatalogSwitchableDataSource#getUrl()} to try fuzzy matching.
      *
      * @param dataSource data source
      * @return storage type
@@ -117,6 +121,11 @@ public final class DatabaseTypeEngine {
     public static DatabaseType getStorageType(final DataSource dataSource) {
         try (Connection connection = dataSource.getConnection()) {
             return DatabaseTypeFactory.get(connection.getMetaData().getURL());
+        } catch (final SQLFeatureNotSupportedException sqlFeatureNotSupportedException) {
+            if (dataSource instanceof CatalogSwitchableDataSource) {
+                return DatabaseTypeFactory.get(((CatalogSwitchableDataSource) dataSource).getUrl());
+            }
+            throw new SQLWrapperException(sqlFeatureNotSupportedException);
         } catch (final SQLException ex) {
             throw new SQLWrapperException(ex);
         }

--- a/infra/database/type/clickhouse/src/test/java/org/apache/shardingsphere/infra/database/clickhouse/connector/ClickHouseConnectionPropertiesTest.java
+++ b/infra/database/type/clickhouse/src/test/java/org/apache/shardingsphere/infra/database/clickhouse/connector/ClickHouseConnectionPropertiesTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.clickhouse.connector;
+
+import org.apache.shardingsphere.infra.database.core.connector.ConnectionProperties;
+import org.apache.shardingsphere.infra.database.core.connector.ConnectionPropertiesParser;
+import org.apache.shardingsphere.infra.database.core.exception.UnrecognizedDatabaseURLException;
+import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.test.util.PropertiesBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ClickHouseConnectionPropertiesTest {
+    
+    private final ConnectionPropertiesParser parser = DatabaseTypedSPILoader.getService(ConnectionPropertiesParser.class, TypedSPILoader.getService(DatabaseType.class, "ClickHouse"));
+    
+    @ParameterizedTest(name = "{0}")
+    @ArgumentsSource(NewConstructorTestCaseArgumentsProvider.class)
+    void assertNewConstructor(final String name, final String url, final String hostname, final int port, final String catalog, final String schema, final Properties queryProps) {
+        ConnectionProperties actual = parser.parse(url, null, null);
+        assertThat(actual.getHostname(), is(hostname));
+        assertThat(actual.getPort(), is(port));
+        assertThat(actual.getCatalog(), is(catalog));
+        assertThat(actual.getSchema(), is(schema));
+        assertThat(actual.getQueryProperties(), is(queryProps));
+    }
+    
+    @Test
+    void assertNewConstructorFailure() {
+        assertThrows(UnrecognizedDatabaseURLException.class, () -> parser.parse("jdbc:ch:xxxxxxxx", null, null));
+    }
+    
+    private static class NewConstructorTestCaseArgumentsProvider implements ArgumentsProvider {
+        
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    Arguments.of("simple", "jdbc:ch://127.0.0.1/foo_ds", "127.0.0.1", 8123, "foo_ds", null, new Properties()),
+                    Arguments.of("complex", "jdbc:clickhouse:http://127.0.0.1:9999/foo_ds?continueBatchOnError=true", "127.0.0.1", 9999, "foo_ds", null,
+                            PropertiesBuilder.build(new PropertiesBuilder.Property("continueBatchOnError", "true"))));
+        }
+    }
+}

--- a/infra/database/type/clickhouse/src/test/java/org/apache/shardingsphere/infra/database/clickhouse/metadata/database/ClickHouseDatabaseMetaDataTest.java
+++ b/infra/database/type/clickhouse/src/test/java/org/apache/shardingsphere/infra/database/clickhouse/metadata/database/ClickHouseDatabaseMetaDataTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.clickhouse.metadata.database;
+
+import org.apache.shardingsphere.infra.database.core.metadata.database.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
+import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ClickHouseDatabaseMetaDataTest {
+    
+    private final DialectDatabaseMetaData dialectDatabaseMetaData = DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, TypedSPILoader.getService(DatabaseType.class, "ClickHouse"));
+    
+    @Test
+    void assertGetQuoteCharacter() {
+        assertThat(dialectDatabaseMetaData.getQuoteCharacter(), is(QuoteCharacter.QUOTE));
+    }
+    
+    @Test
+    void assertGetDefaultNullsOrderType() {
+        assertThat(dialectDatabaseMetaData.getDefaultNullsOrderType(), is(NullsOrderType.FIRST));
+    }
+}

--- a/infra/database/type/hive/src/main/java/org/apache/shardingsphere/infra/database/hive/connector/HiveConnectionPropertiesParser.java
+++ b/infra/database/type/hive/src/main/java/org/apache/shardingsphere/infra/database/hive/connector/HiveConnectionPropertiesParser.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.hive.connector;
+
+import org.apache.shardingsphere.infra.database.core.connector.ConnectionProperties;
+import org.apache.shardingsphere.infra.database.core.connector.ConnectionPropertiesParser;
+import org.apache.shardingsphere.infra.database.core.connector.StandardConnectionProperties;
+import org.apache.shardingsphere.infra.database.core.connector.url.JdbcUrl;
+import org.apache.shardingsphere.infra.database.core.connector.url.StandardJdbcUrlParser;
+
+import java.util.Properties;
+
+/**
+ * Connection properties parser of Hive.
+ */
+public final class HiveConnectionPropertiesParser implements ConnectionPropertiesParser {
+    
+    private static final int DEFAULT_PORT = 10000;
+    
+    private static final String DEFAULT_HOSTNAME = "localhost";
+    
+    @Override
+    public ConnectionProperties parse(final String url, final String username, final String catalog) {
+        JdbcUrl jdbcUrl = new StandardJdbcUrlParser().parse(url);
+        return jdbcUrl.getHostname().isEmpty()
+                ? new StandardConnectionProperties(DEFAULT_HOSTNAME, jdbcUrl.getPort(DEFAULT_PORT), jdbcUrl.getDatabase(), null, jdbcUrl.getQueryProperties(), new Properties())
+                : new StandardConnectionProperties(jdbcUrl.getHostname(), jdbcUrl.getPort(DEFAULT_PORT), jdbcUrl.getDatabase(), null, jdbcUrl.getQueryProperties(), new Properties());
+    }
+    
+    @Override
+    public String getDatabaseType() {
+        return "Hive";
+    }
+}

--- a/infra/database/type/hive/src/main/java/org/apache/shardingsphere/infra/database/hive/metadata/database/HiveDatabaseMetaData.java
+++ b/infra/database/type/hive/src/main/java/org/apache/shardingsphere/infra/database/hive/metadata/database/HiveDatabaseMetaData.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.hive.metadata.database;
+
+import org.apache.shardingsphere.infra.database.core.metadata.database.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
+import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
+
+/**
+ * Database metadata of Hive.
+ */
+public final class HiveDatabaseMetaData implements DialectDatabaseMetaData {
+    
+    @Override
+    public QuoteCharacter getQuoteCharacter() {
+        return QuoteCharacter.QUOTE;
+    }
+    
+    @Override
+    public NullsOrderType getDefaultNullsOrderType() {
+        return NullsOrderType.FIRST;
+    }
+    
+    @Override
+    public String getDatabaseType() {
+        return "Hive";
+    }
+}

--- a/infra/database/type/hive/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.database.core.connector.ConnectionPropertiesParser
+++ b/infra/database/type/hive/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.database.core.connector.ConnectionPropertiesParser
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.infra.database.hive.connector.HiveConnectionPropertiesParser

--- a/infra/database/type/hive/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.database.core.metadata.database.DialectDatabaseMetaData
+++ b/infra/database/type/hive/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.database.core.metadata.database.DialectDatabaseMetaData
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.infra.database.hive.metadata.database.HiveDatabaseMetaData

--- a/infra/database/type/hive/src/test/java/org/apache/shardingsphere/infra/database/hive/connector/HiveConnectionPropertiesTest.java
+++ b/infra/database/type/hive/src/test/java/org/apache/shardingsphere/infra/database/hive/connector/HiveConnectionPropertiesTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.hive.connector;
+
+import org.apache.shardingsphere.infra.database.core.connector.ConnectionProperties;
+import org.apache.shardingsphere.infra.database.core.connector.ConnectionPropertiesParser;
+import org.apache.shardingsphere.infra.database.core.exception.UnrecognizedDatabaseURLException;
+import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.test.util.PropertiesBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HiveConnectionPropertiesTest {
+    
+    private final ConnectionPropertiesParser parser = DatabaseTypedSPILoader.getService(ConnectionPropertiesParser.class, TypedSPILoader.getService(DatabaseType.class, "Hive"));
+    
+    @ParameterizedTest(name = "{0}")
+    @ArgumentsSource(NewConstructorTestCaseArgumentsProvider.class)
+    void assertNewConstructor(final String name, final String url, final String hostname, final int port, final String catalog, final String schema, final Properties queryProps) {
+        ConnectionProperties actual = parser.parse(url, null, null);
+        assertThat(actual.getHostname(), is(hostname));
+        assertThat(actual.getPort(), is(port));
+        assertThat(actual.getCatalog(), is(catalog));
+        assertThat(actual.getSchema(), is(schema));
+        assertThat(actual.getQueryProperties(), is(queryProps));
+    }
+    
+    @Test
+    void assertNewConstructorFailure() {
+        assertThrows(UnrecognizedDatabaseURLException.class, () -> parser.parse("jdbc:hive2:xxxxxxxx", null, null));
+    }
+    
+    private static class NewConstructorTestCaseArgumentsProvider implements ArgumentsProvider {
+        
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
+            return Stream.of(
+                    Arguments.of("simple", "jdbc:hive2:///foo_ds", "localhost", 10000, "foo_ds", null, new Properties()),
+                    Arguments.of("complex", "jdbc:hive2://127.0.0.1:9999/foo_ds?transportMode=http", "127.0.0.1", 9999, "foo_ds", null,
+                            PropertiesBuilder.build(new PropertiesBuilder.Property("transportMode", "http"))));
+        }
+    }
+}

--- a/infra/database/type/hive/src/test/java/org/apache/shardingsphere/infra/database/hive/metadata/database/HiveDatabaseMetaDataTest.java
+++ b/infra/database/type/hive/src/test/java/org/apache/shardingsphere/infra/database/hive/metadata/database/HiveDatabaseMetaDataTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.hive.metadata.database;
+
+import org.apache.shardingsphere.infra.database.core.metadata.database.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
+import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class HiveDatabaseMetaDataTest {
+    
+    private final DialectDatabaseMetaData dialectDatabaseMetaData = DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, TypedSPILoader.getService(DatabaseType.class, "Hive"));
+    
+    @Test
+    void assertGetQuoteCharacter() {
+        assertThat(dialectDatabaseMetaData.getQuoteCharacter(), is(QuoteCharacter.QUOTE));
+    }
+    
+    @Test
+    void assertGetDefaultNullsOrderType() {
+        assertThat(dialectDatabaseMetaData.getDefaultNullsOrderType(), is(NullsOrderType.FIRST));
+    }
+}


### PR DESCRIPTION
For #31526.

Changes proposed in this pull request:
  - Fixes the connection of Remote HiveServer2 through HiveServer2 JDBC Driver. HiveServer2 JDBC Driver did not implement the `java.sql.dataBasemetadata#getUrl()`, which caused us to deal with additional processing.
  - This PR is the split of #31526 to expose the core logic.
  - Supplement the Clickhouse unit test.
  - Fix the document of seata and optional modules.
  - **Note that this PR only addresses the `?hive_conf_list` part of `jdbc:hive2://<host1>:<port1>,<host2>:<port2>/dbName;initFile=<file>;sess_var_list?hive_conf_list#hive_var_list`.** `sess_var_list` and `hive_var_list` in https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Clients#HiveServer2Clients-JDBC are not considered and parsed yet. This actually brings up a new issue of how to reuse regular expression logic as much as possible.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
