### PR TITLE
Modify mysql e2e sql mode config to support mysql select column not in aggregate column

### DIFF
--- a/test/e2e/sql/src/test/resources/env/mysql/my.cnf
+++ b/test/e2e/sql/src/test/resources/env/mysql/my.cnf
@@ -23,7 +23,7 @@ binlog-format=row
 binlog-row-image=full
 max_connections=600
 default-authentication-plugin=mysql_native_password
-sql_mode=
+sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
 lower_case_table_names=1
 # for mysql 8.0
 secure_file_priv=/var/lib/mysql


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Modify mysql e2e sql mode config to support mysql select column not in aggregate column

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
