### PR TITLE
Revert #15409 to save driverClassName related properties

### DIFF
--- a/infra/data-source-pool/core/src/main/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourcePoolReflection.java
+++ b/infra/data-source-pool/core/src/main/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourcePoolReflection.java
@@ -32,6 +32,7 @@ import javax.sql.DataSource;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -62,7 +63,7 @@ public final class DataSourcePoolReflection {
     static {
         GENERAL_CLASS_TYPES = new HashSet<>(
                 Arrays.asList(boolean.class, Boolean.class, int.class, Integer.class, long.class, Long.class, String.class, Collection.class, List.class, Properties.class));
-        SKIPPED_PROPERTY_KEYS = new HashSet<>(Arrays.asList("loginTimeout", "driverClassName"));
+        SKIPPED_PROPERTY_KEYS = new HashSet<>(Collections.singletonList("loginTimeout"));
     }
     
     public DataSourcePoolReflection(final DataSource dataSource) {

--- a/infra/data-source-pool/core/src/test/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourcePoolCreatorTest.java
+++ b/infra/data-source-pool/core/src/test/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourcePoolCreatorTest.java
@@ -49,6 +49,7 @@ class DataSourcePoolCreatorTest {
         result.put("url", "jdbc:mock://127.0.0.1/foo_ds");
         result.put("username", "root");
         result.put("password", "root");
+        result.put("driverClassName", MockedDataSource.class.getName());
         return result;
     }
     
@@ -58,5 +59,6 @@ class DataSourcePoolCreatorTest {
         assertThat(actual.getPassword(), is("root"));
         assertThat(actual.getMaxPoolSize(), is(100));
         assertNull(actual.getMinPoolSize());
+        assertThat(actual.getDriverClassName(), is(MockedDataSource.class.getName()));
     }
 }

--- a/infra/data-source-pool/core/src/test/java/org/apache/shardingsphere/infra/datasource/pool/props/domain/DataSourcePoolPropertiesTest.java
+++ b/infra/data-source-pool/core/src/test/java/org/apache/shardingsphere/infra/datasource/pool/props/domain/DataSourcePoolPropertiesTest.java
@@ -50,6 +50,7 @@ class DataSourcePoolPropertiesTest {
         actualDataSource.setConnectionInitSqls(Arrays.asList("set names utf8mb4;", "set names utf8;"));
         DataSourcePoolProperties actual = DataSourcePoolPropertiesCreator.create(actualDataSource);
         assertThat(actual.getPoolClassName(), is(MockedDataSource.class.getName()));
+        assertThat(actual.getAllLocalProperties().get("driverClassName").toString(), is(MockedDataSource.class.getName()));
         assertThat(actual.getAllLocalProperties().get("url").toString(), is("jdbc:mock://127.0.0.1/foo_ds"));
         assertThat(actual.getAllLocalProperties().get("username").toString(), is("root"));
         assertThat(actual.getAllLocalProperties().get("password").toString(), is("root"));

--- a/infra/data-source-pool/type/hikari/src/test/java/org/apache/shardingsphere/infra/datasource/pool/hikari/creator/HikariDataSourcePoolCreatorTest.java
+++ b/infra/data-source-pool/type/hikari/src/test/java/org/apache/shardingsphere/infra/datasource/pool/hikari/creator/HikariDataSourcePoolCreatorTest.java
@@ -37,6 +37,7 @@ class HikariDataSourcePoolCreatorTest {
     void assertCreateDataSource() {
         HikariDataSource actual = (HikariDataSource) DataSourcePoolCreator.create(new DataSourcePoolProperties(HikariDataSource.class.getName(), createDataSourcePoolProperties()));
         assertThat(actual.getJdbcUrl(), is("jdbc:mock://127.0.0.1/foo_ds"));
+        assertThat(actual.getDriverClassName(), is(MockedDataSource.class.getName()));
         assertThat(actual.getUsername(), is("root"));
         assertThat(actual.getPassword(), is("root"));
         assertThat(actual.getDataSourceProperties(), is(PropertiesBuilder.build(new Property("foo", "foo_value"), new Property("bar", "bar_value"))));

--- a/kernel/metadata/core/src/test/resources/yaml/persist/data-source-foo.yaml
+++ b/kernel/metadata/core/src/test/resources/yaml/persist/data-source-foo.yaml
@@ -18,6 +18,7 @@
 foo_ds:
   password: root
   closed: false
+  driverClassName: com.mysql.cj.jdbc.Driver
   dataSourceClassName: org.apache.shardingsphere.test.fixture.jdbc.MockedDataSource
   connectionInitSqls:
 # No spaces after conversion


### PR DESCRIPTION
For #31618.

Changes proposed in this pull request:
  - Revert #15409 to save driverClassName related properties. Also fixes #27921 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
