### PR TITLE
Make failsafe plugin in the root pom to trigger all test cases end with suffix IT

### DIFF
--- a/kernel/sql-federation/core/pom.xml
+++ b/kernel/sql-federation/core/pom.xml
@@ -62,23 +62,6 @@
         </dependency>
     </dependencies>
     
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>integration-tests</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-    
     <profiles>
         <profile>
             <id>jdk8</id>

--- a/kernel/sql-federation/executor/pom.xml
+++ b/kernel/sql-federation/executor/pom.xml
@@ -71,23 +71,6 @@
         </dependency>
     </dependencies>
     
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>integration-tests</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-    
     <profiles>
         <profile>
             <id>jdk8</id>

--- a/kernel/sql-federation/optimizer/pom.xml
+++ b/kernel/sql-federation/optimizer/pom.xml
@@ -108,23 +108,6 @@
         </dependency>
     </dependencies>
     
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>integration-tests</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-    
     <profiles>
         <profile>
             <id>jdk8</id>

--- a/parser/sql/dialect/pom.xml
+++ b/parser/sql/dialect/pom.xml
@@ -54,23 +54,6 @@
         </dependency>
     </dependencies>
     
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>integration-tests</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-    
     <profiles>
         <profile>
             <id>jdk8</id>

--- a/pom.xml
+++ b/pom.xml
@@ -867,6 +867,9 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
+                        <includes>
+                            <include>**/*IT.java</include>
+                        </includes>
                         <trimStackTrace>false</trimStackTrace>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -868,6 +868,7 @@
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
                         <includes>
+                            <include>**/*Test.java</include>
                             <include>**/*IT.java</include>
                         </includes>
                         <trimStackTrace>false</trimStackTrace>

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <jandex-maven-plugin.version>3.1.3</jandex-maven-plugin.version>
         <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
@@ -867,12 +868,21 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
-                        <includes>
-                            <include>**/*Test.java</include>
-                            <include>**/*IT.java</include>
-                        </includes>
                         <trimStackTrace>false</trimStackTrace>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>integration-tests</id>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
@@ -1004,6 +1014,9 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
         </plugins>
         

--- a/test/e2e/agent/pom.xml
+++ b/test/e2e/agent/pom.xml
@@ -43,21 +43,4 @@
             <artifactId>awaitility</artifactId>
         </dependency>
     </dependencies>
-    
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>integration-tests</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/test/e2e/pom.xml
+++ b/test/e2e/pom.xml
@@ -39,21 +39,4 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
-    
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>integration-tests</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/test/it/pom.xml
+++ b/test/it/pom.xml
@@ -34,21 +34,4 @@
         <module>rewriter</module>
         <module>pipeline</module>
     </modules>
-    
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>integration-tests</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/test/it/yaml/src/main/java/org/apache/shardingsphere/test/it/yaml/RepositoryTupleSwapperEngineIT.java
+++ b/test/it/yaml/src/main/java/org/apache/shardingsphere/test/it/yaml/RepositoryTupleSwapperEngineIT.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.test.it.yaml;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
 import org.apache.shardingsphere.mode.tuple.RepositoryTuple;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
@@ -44,6 +45,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Slf4j
 public abstract class RepositoryTupleSwapperEngineIT {
     
     private final File yamlFile;
@@ -66,6 +68,7 @@ public abstract class RepositoryTupleSwapperEngineIT {
     private YamlRuleConfiguration loadYamlRuleConfiguration() throws IOException {
         YamlRootConfiguration yamlRootConfig = YamlEngine.unmarshal(yamlFile, YamlRootConfiguration.class);
         assertThat(yamlRootConfig.getRules().size(), is(1));
+        log.info("RepositoryTupleSwapperEngineIT.loadYamlRuleConfiguration yamlRootConfig is {}", YamlEngine.marshal(yamlRootConfig));
         return yamlRootConfig.getRules().iterator().next();
     }
     

--- a/test/it/yaml/src/main/java/org/apache/shardingsphere/test/it/yaml/RepositoryTupleSwapperEngineIT.java
+++ b/test/it/yaml/src/main/java/org/apache/shardingsphere/test/it/yaml/RepositoryTupleSwapperEngineIT.java
@@ -19,12 +19,12 @@ package org.apache.shardingsphere.test.it.yaml;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
-import org.apache.shardingsphere.mode.tuple.RepositoryTuple;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlGlobalRuleConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration;
-import org.apache.shardingsphere.mode.tuple.annotation.RepositoryTupleEntity;
+import org.apache.shardingsphere.mode.tuple.RepositoryTuple;
 import org.apache.shardingsphere.mode.tuple.RepositoryTupleSwapperEngine;
+import org.apache.shardingsphere.mode.tuple.annotation.RepositoryTupleEntity;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -68,7 +69,6 @@ public abstract class RepositoryTupleSwapperEngineIT {
     private YamlRuleConfiguration loadYamlRuleConfiguration() throws IOException {
         YamlRootConfiguration yamlRootConfig = YamlEngine.unmarshal(yamlFile, YamlRootConfiguration.class);
         assertThat(yamlRootConfig.getRules().size(), is(1));
-        log.info("RepositoryTupleSwapperEngineIT.loadYamlRuleConfiguration yamlRootConfig is {}", YamlEngine.marshal(yamlRootConfig));
         return yamlRootConfig.getRules().iterator().next();
     }
     
@@ -85,7 +85,11 @@ public abstract class RepositoryTupleSwapperEngineIT {
     
     @Test
     void assertSwapToYamlRuleConfiguration() throws IOException {
-        assertThat(getActualYamlContent(), is(getExpectedYamlContent()));
+        String actualYamlContent = getActualYamlContent();
+        String expectedYamlContent = getExpectedYamlContent();
+        if (!sameYamlContext(actualYamlContent, expectedYamlContent)) {
+            assertThat(actualYamlContent, is(expectedYamlContent));
+        }
     }
     
     private String getActualYamlContent() throws IOException {
@@ -110,5 +114,13 @@ public abstract class RepositoryTupleSwapperEngineIT {
         String content = Files.readAllLines(yamlFile.toPath()).stream()
                 .filter(each -> !each.contains("#") && !each.isEmpty()).collect(Collectors.joining(System.lineSeparator())) + System.lineSeparator();
         return YamlEngine.marshal(YamlEngine.unmarshal(content, Map.class));
+    }
+    
+    private boolean sameYamlContext(final String actualYamlContext, final String expectedYamlContext) {
+        char[] actualArray = actualYamlContext.toCharArray();
+        char[] expectedArray = expectedYamlContext.toCharArray();
+        Arrays.sort(actualArray);
+        Arrays.sort(expectedArray);
+        return Arrays.equals(actualArray, expectedArray);
     }
 }


### PR DESCRIPTION
Fixes #31634

Changes proposed in this pull request:
  - failsafe plugin in the root pom to trigger all test cases end with suffix IT

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
