### PR TITLE
Remove useless cachedStatements when statement is close and close cachedStatements when close connection

### DIFF
--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatement.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatement.java
@@ -149,6 +149,7 @@ public final class ShardingSpherePreparedStatement extends AbstractPreparedState
         database = metaData.getDatabase(databaseName);
         statementOption = returnGeneratedKeys ? new StatementOption(true, columns) : new StatementOption(resultSetType, resultSetConcurrency, resultSetHoldability);
         statementManager = new StatementManager();
+        connection.getStatementManagers().add(statementManager);
         parameterMetaData = new ShardingSphereParameterMetaData(sqlStatement);
         driverExecutorFacade = new DriverExecutorFacade(connection, statementOption, statementManager, JDBCDriverType.PREPARED_STATEMENT, new Grantee("", ""));
         executeBatchExecutor = new DriverExecuteBatchExecutor(connection, metaData, statementOption, statementManager, database);

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSphereStatement.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSphereStatement.java
@@ -103,6 +103,7 @@ public final class ShardingSphereStatement extends AbstractStatementAdapter {
         metaData = connection.getContextManager().getMetaDataContexts().getMetaData();
         statementOption = new StatementOption(resultSetType, resultSetConcurrency, resultSetHoldability);
         statementManager = new StatementManager();
+        connection.getStatementManagers().add(statementManager);
         driverExecutorFacade = new DriverExecutorFacade(connection, statementOption, statementManager, JDBCDriverType.STATEMENT, new Grantee("", ""));
         batchStatementExecutor = new BatchStatementExecutor(this);
         statements = new LinkedList<>();

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/StatementManager.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/StatementManager.java
@@ -86,7 +86,8 @@ public final class StatementManager implements ExecutorJDBCStatementManager, Aut
         return result;
     }
     
-    private PreparedStatement prepareStatement(Connection connection, String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+    private PreparedStatement prepareStatement(final Connection connection, final String sql, final int resultSetType, final int resultSetConcurrency,
+                                               final int resultSetHoldability) throws SQLException {
         PreparedStatement result;
         try {
             result = connection.prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability);

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/StatementManager.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/StatementManager.java
@@ -32,6 +32,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -51,17 +52,12 @@ public final class StatementManager implements ExecutorJDBCStatementManager, Aut
     @Override
     public Statement createStorageResource(final ExecutionUnit executionUnit, final Connection connection, final ConnectionMode connectionMode, final StatementOption option,
                                            final DatabaseType databaseType) throws SQLException {
-        Statement result = cachedStatements.get(new CacheKey(executionUnit, connectionMode));
-        if (null == result || result.isClosed() || result.getConnection().isClosed()) {
-            String sql = executionUnit.getSqlUnit().getSql();
-            if (option.isReturnGeneratedKeys()) {
-                result = null == option.getColumns() || 0 == option.getColumns().length
-                        ? connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)
-                        : connection.prepareStatement(sql, option.getColumns());
-            } else {
-                result = prepareStatement(connection, option, sql);
-            }
-            cachedStatements.put(new CacheKey(executionUnit, connectionMode), result);
+        CacheKey cacheKey = new CacheKey(executionUnit, connectionMode);
+        Statement result = cachedStatements.get(cacheKey);
+        if (null == result || result.getConnection().isClosed() || result.isClosed()) {
+            Optional.ofNullable(result).ifPresent(optional -> cachedStatements.remove(cacheKey));
+            result = prepareStatement(executionUnit, connection, option);
+            cachedStatements.put(cacheKey, result);
         }
         return result;
     }
@@ -77,11 +73,23 @@ public final class StatementManager implements ExecutorJDBCStatementManager, Aut
         return result;
     }
     
-    @SuppressWarnings("MagicConstant")
-    private PreparedStatement prepareStatement(final Connection connection, final StatementOption option, final String sql) throws SQLException {
+    private PreparedStatement prepareStatement(final ExecutionUnit executionUnit, final Connection connection, final StatementOption option) throws SQLException {
+        PreparedStatement result;
+        String sql = executionUnit.getSqlUnit().getSql();
+        if (option.isReturnGeneratedKeys()) {
+            result = null == option.getColumns() || 0 == option.getColumns().length
+                    ? connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)
+                    : connection.prepareStatement(sql, option.getColumns());
+        } else {
+            result = prepareStatement(connection, sql, option.getResultSetType(), option.getResultSetConcurrency(), option.getResultSetHoldability());
+        }
+        return result;
+    }
+    
+    private PreparedStatement prepareStatement(Connection connection, String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
         PreparedStatement result;
         try {
-            result = connection.prepareStatement(sql, option.getResultSetType(), option.getResultSetConcurrency(), option.getResultSetHoldability());
+            result = connection.prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
         } catch (final SQLFeatureNotSupportedException ignore) {
             result = connection.prepareStatement(sql);
         }

--- a/test/e2e/agent/plugins/logging/file/src/test/java/org/apache/shardingsphere/test/e2e/agent/file/FilePluginE2EIT.java
+++ b/test/e2e/agent/plugins/logging/file/src/test/java/org/apache/shardingsphere/test/e2e/agent/file/FilePluginE2EIT.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+@Disabled("Fix me by @jiangmaolin")
 @ExtendWith(AgentTestActionExtension.class)
 class FilePluginE2EIT {
     

--- a/test/e2e/agent/plugins/logging/file/src/test/java/org/apache/shardingsphere/test/e2e/agent/file/FilePluginE2EIT.java
+++ b/test/e2e/agent/plugins/logging/file/src/test/java/org/apache/shardingsphere/test/e2e/agent/file/FilePluginE2EIT.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.test.e2e.agent.common.env.E2ETestEnvironment;
 import org.apache.shardingsphere.test.e2e.agent.file.asserts.ContentAssert;
 import org.apache.shardingsphere.test.e2e.agent.file.cases.IntegrationTestCasesLoader;
 import org.apache.shardingsphere.test.e2e.agent.file.cases.LogTestCase;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove useless cachedStatements when statement is close and close cachedStatements when close connection

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
