### PR TITLE
Support sql federation bit_count function for mysql

### DIFF
--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/converter/impl/MySQLColumnTypeConverter.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/converter/impl/MySQLColumnTypeConverter.java
@@ -35,7 +35,7 @@ public final class MySQLColumnTypeConverter implements SQLFederationColumnTypeCo
     
     @Override
     public int convertColumnType(final int columnType) {
-        if (SqlTypeName.BOOLEAN.getJdbcOrdinal() == columnType) {
+        if (SqlTypeName.BOOLEAN.getJdbcOrdinal() == columnType || SqlTypeName.ANY.getJdbcOrdinal() == columnType) {
             return SqlTypeName.VARCHAR.getJdbcOrdinal();
         }
         return columnType;

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/function/mysql/MySQLBitCountFunction.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/function/mysql/MySQLBitCountFunction.java
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.math.BigInteger;
 
 /**
- * MySQL bitCount function.
+ * MySQL bit count function.
  */
 public final class MySQLBitCountFunction {
     

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/function/mysql/MySQLBitCountFunction.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/function/mysql/MySQLBitCountFunction.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sqlfederation.optimizer.function.mysql;
+
+import org.apache.calcite.util.BitString;
+import org.apache.commons.lang3.StringUtils;
+
+import java.math.BigInteger;
+
+/**
+ * MySQL bitCount function.
+ */
+public final class MySQLBitCountFunction {
+    
+    /**
+     * Bit count.
+     *
+     * @param value value
+     * @return bit count
+     */
+    public static Object bitCount(final Object value) {
+        if (null == value) {
+            return 0;
+        }
+        if (value instanceof byte[]) {
+            return bitCount((byte[]) value);
+        }
+        if (value instanceof String) {
+            return StringUtils.isNumeric((String) value) ? Long.bitCount(Long.parseLong((String) value)) : 0;
+        }
+        if (value instanceof BigInteger) {
+            return ((BigInteger) value).bitCount();
+        }
+        if (value instanceof Integer) {
+            return Integer.bitCount((Integer) value);
+        }
+        if (value instanceof Long) {
+            return Long.bitCount((Long) value);
+        }
+        return 0;
+    }
+    
+    private static long bitCount(final byte[] byteValue) {
+        long result = 0;
+        for (char each : BitString.createFromBytes(byteValue).toBitString().toCharArray()) {
+            if ('1' == each) {
+                result++;
+            }
+        }
+        return result;
+    }
+}

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/planner/util/SQLFederationFunctionUtils.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/planner/util/SQLFederationFunctionUtils.java
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.impl.ScalarFunctionImpl;
 import org.apache.shardingsphere.infra.autogen.version.ShardingSphereVersion;
+import org.apache.shardingsphere.sqlfederation.optimizer.function.mysql.MySQLBitCountFunction;
 
 /**
  * SQL federation function utility class.
@@ -48,6 +49,7 @@ public final class SQLFederationFunctionUtils {
         schemaPlus.add("pg_catalog.gs_password_deadline", ScalarFunctionImpl.create(SQLFederationFunctionUtils.class, "gsPasswordDeadline"));
         schemaPlus.add("pg_catalog.intervaltonum", ScalarFunctionImpl.create(SQLFederationFunctionUtils.class, "intervalToNum"));
         schemaPlus.add("pg_catalog.gs_password_notifyTime", ScalarFunctionImpl.create(SQLFederationFunctionUtils.class, "gsPasswordNotifyTime"));
+        schemaPlus.add("bit_count", ScalarFunctionImpl.create(MySQLBitCountFunction.class, "bitCount"));
         if ("pg_catalog".equalsIgnoreCase(schemaName)) {
             schemaPlus.add("pg_catalog.pg_table_is_visible", ScalarFunctionImpl.create(SQLFederationFunctionUtils.class, "pgTableIsVisible"));
             schemaPlus.add("pg_catalog.pg_get_userbyid", ScalarFunctionImpl.create(SQLFederationFunctionUtils.class, "pgGetUserById"));

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select.xml
@@ -304,4 +304,32 @@
     <test-case sql="SELECT type_bit, type_blob, type_mediumblob, type_longblob, type_binary, type_varbinary FROM t_product_extend" db-types="MySQL" scenario-types="db_tbl_sql_federation">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
+    
+    <test-case sql="SELECT bit_count(123456), bit_count('123456'), bit_count('abcdefg'), BIT_COUNT('abcdef1234'), bit_count(''), bit_count(1 + 1)" db-types="MySQL" scenario-types="db_tbl_sql_federation">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
+    <test-case sql="SELECT bit_count(type_int), bit_count(type_smallint), bit_count(type_decimal), bit_count(type_float), bit_count(type_double), bit_count(type_bit),
+                    bit_count(type_tinyint), bit_count(type_mediumint), bit_count(type_bigint), bit_count(type_date), bit_count(type_time), bit_count(type_datetime),
+                    bit_count(type_timestamp), bit_count(type_year), bit_count(type_char), bit_count(type_text), bit_count(type_varchar), bit_count(type_longtext),
+                    bit_count(type_longblob), bit_count(type_mediumtext), bit_count(type_mediumblob), bit_count(type_binary), bit_count(type_varbinary), bit_count(type_blob),
+                    bit_count(type_enum), bit_count(type_set), bit_count(type_json), bit_count(type_unsigned_int), bit_count(type_unsigned_bigint), bit_count(type_unsigned_tinyint),
+                    bit_count(type_unsigned_smallint), bit_count(type_unsigned_float), bit_count(type_unsigned_double), bit_count(type_unsigned_decimal) FROM t_product_extend" db-types="MySQL" scenario-types="db_tbl_sql_federation">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
+    <test-case sql="SELECT t4.order_id, t3.item_id, bit_count(t4.order_id), bit_count(t3.item_id), t2.* FROM t_product t1
+                    INNER JOIN (
+                                SELECT product_id, bit_count(type_int), bit_count(type_smallint), bit_count(type_decimal), bit_count(type_float),
+                                bit_count(type_double), bit_count(type_bit), bit_count(type_tinyint), bit_count(type_mediumint), bit_count(type_bigint),
+                                bit_count(type_date), bit_count(type_time), bit_count(type_datetime), bit_count(type_timestamp), bit_count(type_year),
+                                bit_count(type_char), bit_count(type_text), bit_count(type_varchar), bit_count(type_longtext), bit_count(type_longblob),
+                                bit_count(type_mediumtext), bit_count(type_mediumblob), bit_count(type_binary), bit_count(type_varbinary),
+                                bit_count(type_blob), bit_count(type_enum), bit_count(type_set), bit_count(type_json), bit_count(type_unsigned_int),
+                                bit_count(type_unsigned_bigint), bit_count(type_unsigned_tinyint), bit_count(type_unsigned_smallint), bit_count(type_unsigned_float),
+                                bit_count(type_unsigned_double), bit_count(type_unsigned_decimal) FROM t_product_extend
+                               ) t2 ON t1.product_id = t2.product_id
+                    INNER JOIN t_order_item t3 ON t2.product_id = t3.product_id INNER JOIN t_order t4 ON t4.order_id = t3.order_id order by t1.product_id" db-types="MySQL" scenario-types="db_tbl_sql_federation">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
 </integration-test-cases>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Support sql federation bit_count function for mysql
  - ref: https://github.com/mysql/mysql-server/blob/trunk/sql/item_func.cc#L4441

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
