### PR TITLE
Adjust SQLFederationDeciderMatchFixture order to 1 to avoid conflict with ShardingOrder

### DIFF
--- a/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/engine/fixture/decider/SQLFederationDeciderMatchFixture.java
+++ b/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/engine/fixture/decider/SQLFederationDeciderMatchFixture.java
@@ -37,7 +37,7 @@ public final class SQLFederationDeciderMatchFixture implements SQLFederationDeci
     
     @Override
     public int getOrder() {
-        return 0;
+        return 1;
     }
     
     @Override


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Adjust SQLFederationDeciderMatchFixture order to 1 to avoid conflict with ShardingOrder

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
