### PR TITLE
Fix transaction context not cleaned up when xa transaction is committed

### DIFF
--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnection.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnection.java
@@ -198,15 +198,13 @@ public final class ShardingSphereConnection extends AbstractConnectionAdapter {
     
     private void processLocalTransaction() throws SQLException {
         databaseConnectionManager.setAutoCommit(autoCommit);
-        if (autoCommit) {
-            if (databaseConnectionManager.getConnectionContext().getTransactionContext().isInTransaction()) {
-                databaseConnectionManager.getConnectionContext().getTransactionContext().close();
-            }
-        } else {
-            if (!databaseConnectionManager.getConnectionContext().getTransactionContext().isInTransaction()) {
-                databaseConnectionManager.getConnectionContext().getTransactionContext()
-                        .beginTransaction(String.valueOf(contextManager.getMetaDataContexts().getMetaData().getGlobalRuleMetaData().getSingleRule(TransactionRule.class).getDefaultType()));
-            }
+        if (autoCommit && databaseConnectionManager.getConnectionContext().getTransactionContext().isInTransaction()) {
+            databaseConnectionManager.getConnectionContext().getTransactionContext().close();
+            return;
+        }
+        if (!autoCommit && !databaseConnectionManager.getConnectionContext().getTransactionContext().isInTransaction()) {
+            databaseConnectionManager.getConnectionContext().getTransactionContext()
+                    .beginTransaction(String.valueOf(contextManager.getMetaDataContexts().getMetaData().getGlobalRuleMetaData().getSingleRule(TransactionRule.class).getDefaultType()));
         }
     }
     
@@ -216,7 +214,7 @@ public final class ShardingSphereConnection extends AbstractConnectionAdapter {
                 beginDistributedTransaction();
                 break;
             case COMMIT:
-                databaseConnectionManager.getConnectionTransaction().commit();
+                commit();
                 break;
             default:
                 break;

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnectionTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnectionTest.java
@@ -70,11 +70,11 @@ class ShardingSphereConnectionTest {
         when(connectionTransaction.getDistributedTransactionOperationType(true)).thenReturn(DistributedTransactionOperationType.COMMIT);
         when(connectionTransaction.getTransactionType()).thenReturn(TransactionType.XA);
         try (ShardingSphereConnection connection = new ShardingSphereConnection(DefaultDatabase.LOGIC_NAME, mockContextManager())) {
-            mockConnectionManager(connection, connectionTransaction);
+            DriverDatabaseConnectionManager connectionManager = mockConnectionManager(connection, connectionTransaction);
             connection.setAutoCommit(true);
             assertTrue(connection.getAutoCommit());
+            verify(connectionManager).commit();
         }
-        verify(connectionTransaction).commit();
     }
     
     @Test


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
