### PR TITLE
Extract DCL statement to reduce duplicate logic for MySQL and doris

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/SQLStatementContextFactory.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/SQLStatementContextFactory.java
@@ -77,6 +77,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.ShowIndexSt
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.ShowTableStatusStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.ShowTablesStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DenyUserStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.GrantStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.RevokeStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterIndexStatement;
@@ -111,7 +112,6 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQ
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLLoadXMLStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussCursorStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.dml.OracleMergeStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerDenyUserStatement;
 
 import java.util.Collections;
 import java.util.List;
@@ -254,8 +254,8 @@ public final class SQLStatementContextFactory {
         if (sqlStatement instanceof RevokeStatement) {
             return new RevokeStatementContext((RevokeStatement) sqlStatement);
         }
-        if (sqlStatement instanceof SQLServerDenyUserStatement) {
-            return new DenyUserStatementContext((SQLServerDenyUserStatement) sqlStatement);
+        if (sqlStatement instanceof DenyUserStatement) {
+            return new DenyUserStatementContext((DenyUserStatement) sqlStatement);
         }
         return new UnknownSQLStatementContext(sqlStatement);
     }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/DenyUserStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/DenyUserStatementContext.java
@@ -21,7 +21,7 @@ import lombok.Getter;
 import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.type.TableAvailable;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerDenyUserStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DenyUserStatement;
 
 /**
  * Deny user statement context.
@@ -31,13 +31,13 @@ public final class DenyUserStatementContext extends CommonSQLStatementContext im
     
     private final TablesContext tablesContext;
     
-    public DenyUserStatementContext(final SQLServerDenyUserStatement sqlStatement) {
+    public DenyUserStatementContext(final DenyUserStatement sqlStatement) {
         super(sqlStatement);
         tablesContext = new TablesContext(sqlStatement.getTable(), getDatabaseType());
     }
     
     @Override
-    public SQLServerDenyUserStatement getSqlStatement() {
-        return (SQLServerDenyUserStatement) super.getSqlStatement();
+    public DenyUserStatement getSqlStatement() {
+        return (DenyUserStatement) super.getSqlStatement();
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dal/FlushStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dal/FlushStatement.java
@@ -17,10 +17,22 @@
 
 package org.apache.shardingsphere.sql.parser.sql.common.statement.dal;
 
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+
+import java.util.Collection;
+import java.util.LinkedList;
 
 /**
  * Flush statement.
  */
+@Getter
+@Setter
 public abstract class FlushStatement extends AbstractSQLStatement implements DALStatement {
+    
+    private final Collection<SimpleTableSegment> tables = new LinkedList<>();
+    
+    private boolean flushTable;
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dal/SpoolStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dal/SpoolStatement.java
@@ -17,10 +17,16 @@
 
 package org.apache.shardingsphere.sql.parser.sql.common.statement.dal;
 
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.doris.DorisStatement;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 
 /**
- * Use database statement for Doris.
+ * Spool statement.
  */
-public final class DorisUseStatement extends UseStatement implements DorisStatement {
+@Getter
+@Setter
+public abstract class SpoolStatement extends AbstractSQLStatement implements DALStatement {
+    
+    private String fileName;
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/AlterLoginStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/AlterLoginStatement.java
@@ -15,13 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl;
+package org.apache.shardingsphere.sql.parser.sql.common.statement.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetRoleStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dcl.LoginSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 
 /**
- * MySQL set role statement.
+ * Alter login statement.
  */
-public final class MySQLSetRoleStatement extends SetRoleStatement implements MySQLStatement {
+@Getter
+@Setter
+public abstract class AlterLoginStatement extends AbstractSQLStatement implements DCLStatement {
+    
+    private LoginSegment loginSegment;
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/CreateLoginStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/CreateLoginStatement.java
@@ -15,13 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl;
+package org.apache.shardingsphere.sql.parser.sql.common.statement.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetRoleStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dcl.LoginSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 
 /**
- * MySQL set role statement.
+ * Create login statement.
  */
-public final class MySQLSetRoleStatement extends SetRoleStatement implements MySQLStatement {
+@Getter
+@Setter
+public abstract class CreateLoginStatement extends AbstractSQLStatement implements DCLStatement {
+    
+    private LoginSegment loginSegment;
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/DenyUserStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/DenyUserStatement.java
@@ -15,13 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl;
+package org.apache.shardingsphere.sql.parser.sql.common.statement.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetRoleStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+
+import java.util.Collection;
+import java.util.LinkedList;
 
 /**
- * MySQL set role statement.
+ * Deny user statement.
  */
-public final class MySQLSetRoleStatement extends SetRoleStatement implements MySQLStatement {
+@Getter
+@Setter
+public abstract class DenyUserStatement extends AbstractSQLStatement implements DCLStatement {
+    
+    private SimpleTableSegment table;
+    
+    private final Collection<ColumnSegment> columns = new LinkedList<>();
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/DropLoginStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/DropLoginStatement.java
@@ -15,13 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl;
+package org.apache.shardingsphere.sql.parser.sql.common.statement.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetRoleStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dcl.LoginSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 
 /**
- * MySQL set role statement.
+ * Drop login statement.
  */
-public final class MySQLSetRoleStatement extends SetRoleStatement implements MySQLStatement {
+@Getter
+@Setter
+public abstract class DropLoginStatement extends AbstractSQLStatement implements DCLStatement {
+    
+    private LoginSegment loginSegment;
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/RenameUserStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/RenameUserStatement.java
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl;
+package org.apache.shardingsphere.sql.parser.sql.common.statement.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetRoleStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 
 /**
- * MySQL set role statement.
+ * Rename user statement.
  */
-public final class MySQLSetRoleStatement extends SetRoleStatement implements MySQLStatement {
+public abstract class RenameUserStatement extends AbstractSQLStatement implements DCLStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/SetDefaultRoleStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/SetDefaultRoleStatement.java
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl;
+package org.apache.shardingsphere.sql.parser.sql.common.statement.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetRoleStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 
 /**
- * MySQL set role statement.
+ * Set default role statement.
  */
-public final class MySQLSetRoleStatement extends SetRoleStatement implements MySQLStatement {
+public abstract class SetDefaultRoleStatement extends AbstractSQLStatement implements DCLStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/SetPasswordStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/SetPasswordStatement.java
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl;
+package org.apache.shardingsphere.sql.parser.sql.common.statement.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetRoleStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 
 /**
- * MySQL set role statement.
+ * Set password statement.
  */
-public final class MySQLSetRoleStatement extends SetRoleStatement implements MySQLStatement {
+public abstract class SetPasswordStatement extends AbstractSQLStatement implements DCLStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/SetUserStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dcl/SetUserStatement.java
@@ -15,13 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl;
+package org.apache.shardingsphere.sql.parser.sql.common.statement.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetRoleStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dcl.UserSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 
 /**
- * MySQL set role statement.
+ * Set user statement.
  */
-public final class MySQLSetRoleStatement extends SetRoleStatement implements MySQLStatement {
+@Getter
+@Setter
+public abstract class SetUserStatement extends AbstractSQLStatement implements DCLStatement {
+    
+    private UserSegment user;
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/doris/dal/DorisFlushStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/doris/dal/DorisFlushStatement.java
@@ -17,24 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.doris.dal;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.FlushStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.doris.DorisStatement;
-
-import java.util.Collection;
-import java.util.LinkedList;
 
 /**
  * Doris flush statement.
  */
-@Getter
-@Setter
 public final class DorisFlushStatement extends FlushStatement implements DorisStatement {
-    
-    private final Collection<SimpleTableSegment> tables = new LinkedList<>();
-    
-    private boolean flushTable;
-    
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/doris/dcl/DorisRenameUserStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/doris/dcl/DorisRenameUserStatement.java
@@ -17,12 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.doris.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.RenameUserStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.doris.DorisStatement;
 
 /**
  * Doris rename user statement.
  */
-public final class DorisRenameUserStatement extends AbstractSQLStatement implements DCLStatement, DorisStatement {
+public final class DorisRenameUserStatement extends RenameUserStatement implements DorisStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/doris/dcl/DorisSetDefaultRoleStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/doris/dcl/DorisSetDefaultRoleStatement.java
@@ -17,12 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.doris.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetDefaultRoleStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.doris.DorisStatement;
 
 /**
  * Doris set default role statement.
  */
-public final class DorisSetDefaultRoleStatement extends AbstractSQLStatement implements DCLStatement, DorisStatement {
+public final class DorisSetDefaultRoleStatement extends SetDefaultRoleStatement implements DorisStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/doris/dcl/DorisSetPasswordStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/doris/dcl/DorisSetPasswordStatement.java
@@ -17,12 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.doris.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetPasswordStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.doris.DorisStatement;
 
 /**
  * Doris set password statement.
  */
-public final class DorisSetPasswordStatement extends AbstractSQLStatement implements DCLStatement, DorisStatement {
+public final class DorisSetPasswordStatement extends SetPasswordStatement implements DorisStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/doris/dcl/DorisSetRoleStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/doris/dcl/DorisSetRoleStatement.java
@@ -17,12 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.doris.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetRoleStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.doris.DorisStatement;
 
 /**
  * Doris set role statement.
  */
-public final class DorisSetRoleStatement extends AbstractSQLStatement implements DCLStatement, DorisStatement {
+public final class DorisSetRoleStatement extends SetRoleStatement implements DorisStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/dal/MySQLFlushStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/dal/MySQLFlushStatement.java
@@ -17,24 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.FlushStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
-
-import java.util.Collection;
-import java.util.LinkedList;
 
 /**
  * MySQL flush statement.
  */
-@Getter
-@Setter
 public final class MySQLFlushStatement extends FlushStatement implements MySQLStatement {
-    
-    private final Collection<SimpleTableSegment> tables = new LinkedList<>();
-    
-    private boolean flushTable;
-    
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/dcl/MySQLRenameUserStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/dcl/MySQLRenameUserStatement.java
@@ -17,12 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.RenameUserStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
 
 /**
  * MySQL rename user statement.
  */
-public final class MySQLRenameUserStatement extends AbstractSQLStatement implements DCLStatement, MySQLStatement {
+public final class MySQLRenameUserStatement extends RenameUserStatement implements MySQLStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/dcl/MySQLSetDefaultRoleStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/dcl/MySQLSetDefaultRoleStatement.java
@@ -17,12 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetDefaultRoleStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
 
 /**
  * MySQL set default role statement.
  */
-public final class MySQLSetDefaultRoleStatement extends AbstractSQLStatement implements DCLStatement, MySQLStatement {
+public final class MySQLSetDefaultRoleStatement extends SetDefaultRoleStatement implements MySQLStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/dcl/MySQLSetPasswordStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/dcl/MySQLSetPasswordStatement.java
@@ -17,12 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl;
 
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetPasswordStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
 
 /**
  * MySQL set password statement.
  */
-public final class MySQLSetPasswordStatement extends AbstractSQLStatement implements DCLStatement, MySQLStatement {
+public final class MySQLSetPasswordStatement extends SetPasswordStatement implements MySQLStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/oracle/dal/OracleSpoolStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/oracle/dal/OracleSpoolStatement.java
@@ -17,18 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.dal;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DALStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.SpoolStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.OracleStatement;
 
 /**
  * Oracle Spool statement.
  */
-@Getter
-@Setter
-public final class OracleSpoolStatement extends AbstractSQLStatement implements DALStatement, OracleStatement {
-    
-    private String fileName;
+public final class OracleSpoolStatement extends SpoolStatement implements OracleStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerAlterLoginStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerAlterLoginStatement.java
@@ -17,19 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dcl.LoginSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.AlterLoginStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
 
 /**
  * SQLServer alter login statement.
  */
-@Getter
-@Setter
-public final class SQLServerAlterLoginStatement extends AbstractSQLStatement implements DCLStatement, SQLServerStatement {
-    
-    private LoginSegment loginSegment;
+public final class SQLServerAlterLoginStatement extends AlterLoginStatement implements SQLServerStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerCreateLoginStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerCreateLoginStatement.java
@@ -17,19 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dcl.LoginSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.CreateLoginStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
 
 /**
  * SQLServer create login statement.
  */
-@Getter
-@Setter
-public final class SQLServerCreateLoginStatement extends AbstractSQLStatement implements DCLStatement, SQLServerStatement {
-    
-    private LoginSegment loginSegment;
+public final class SQLServerCreateLoginStatement extends CreateLoginStatement implements SQLServerStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerDenyUserStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerDenyUserStatement.java
@@ -17,25 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DenyUserStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
-
-import java.util.Collection;
-import java.util.LinkedList;
 
 /**
  * SQLServer deny user statement.
  */
-@Getter
-@Setter
-public final class SQLServerDenyUserStatement extends AbstractSQLStatement implements DCLStatement, SQLServerStatement {
-    
-    private SimpleTableSegment table;
-    
-    private final Collection<ColumnSegment> columns = new LinkedList<>();
+public final class SQLServerDenyUserStatement extends DenyUserStatement implements SQLServerStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerDropLoginStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerDropLoginStatement.java
@@ -17,19 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dcl.LoginSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DropLoginStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
 
 /**
  * SQLServer drop login statement.
  */
-@Getter
-@Setter
-public final class SQLServerDropLoginStatement extends AbstractSQLStatement implements DCLStatement, SQLServerStatement {
-    
-    private LoginSegment loginSegment;
+public final class SQLServerDropLoginStatement extends DropLoginStatement implements SQLServerStatement {
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerSetUserStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerSetUserStatement.java
@@ -17,19 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dcl.UserSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetUserStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
 
 /**
  * SQLServer set user statement.
  */
-@Getter
-@Setter
-public final class SQLServerSetUserStatement extends AbstractSQLStatement implements DCLStatement, SQLServerStatement {
-    
-    private UserSegment user;
+public final class SQLServerSetUserStatement extends SetUserStatement implements SQLServerStatement {
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/DALStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/DALStatementAssert.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DelimiterSt
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DropResourceGroupStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.EmptyStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.ExplainStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.FlushStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.InstallComponentStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.InstallPluginStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.KillStatement;
@@ -68,11 +69,10 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.ShowTablesS
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.ShowTriggersStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.ShowVariablesStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.ShutdownStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.SpoolStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.UninstallComponentStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.UninstallPluginStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLFlushStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLUseStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.dal.OracleSpoolStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.UseStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.impl.AlterResourceGroupStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.impl.BinlogStatementAssert;
@@ -124,9 +124,9 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.d
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.impl.SpoolStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.impl.UninstallComponentStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.impl.UninstallPluginStatementAssert;
-import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.impl.mysql.MySQLUseStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.impl.mysql.RepairTableStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.impl.mysql.SetResourceGroupStatementAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.impl.mysql.UseStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.AlterResourceGroupStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.BinlogStatementTestCase;
@@ -196,8 +196,8 @@ public final class DALStatementAssert {
      * @param expected expected DAL statement test case
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final DALStatement actual, final SQLParserTestCase expected) {
-        if (actual instanceof MySQLUseStatement) {
-            MySQLUseStatementAssert.assertIs(assertContext, (MySQLUseStatement) actual, (UseStatementTestCase) expected);
+        if (actual instanceof UseStatement) {
+            UseStatementAssert.assertIs(assertContext, (UseStatement) actual, (UseStatementTestCase) expected);
         } else if (actual instanceof EmptyStatement) {
             EmptyStatementAssert.assertIs(assertContext, (EmptyStatement) actual, (EmptyStatementTestCase) expected);
         } else if (actual instanceof ExplainStatement) {
@@ -228,8 +228,8 @@ public final class DALStatementAssert {
             ResetParameterStatementAssert.assertIs(assertContext, (ResetParameterStatement) actual, (ResetParameterStatementTestCase) expected);
         } else if (actual instanceof InstallComponentStatement) {
             InstallComponentStatementAssert.assertIs(assertContext, (InstallComponentStatement) actual, (InstallComponentStatementTestCase) expected);
-        } else if (actual instanceof MySQLFlushStatement) {
-            FlushStatementAssert.assertIs(assertContext, (MySQLFlushStatement) actual, (FlushStatementTestCase) expected);
+        } else if (actual instanceof FlushStatement) {
+            FlushStatementAssert.assertIs(assertContext, (FlushStatement) actual, (FlushStatementTestCase) expected);
         } else if (actual instanceof InstallPluginStatement) {
             InstallPluginStatementAssert.assertIs(assertContext, (InstallPluginStatement) actual, (InstallPluginStatementTestCase) expected);
         } else if (actual instanceof CloneStatement) {
@@ -300,8 +300,8 @@ public final class DALStatementAssert {
             DelimiterStatementAssert.assertIs(assertContext, (DelimiterStatement) actual, (DelimiterStatementTestCase) expected);
         } else if (actual instanceof ShowBinlogEventsStatement) {
             ShowBinlogEventsStatementAssert.assertIs(assertContext, (ShowBinlogEventsStatement) actual, (ShowBinlogEventsStatementTestCase) expected);
-        } else if (actual instanceof OracleSpoolStatement) {
-            SpoolStatementAssert.assertIs(assertContext, (OracleSpoolStatement) actual, (SpoolStatementTestCase) expected);
+        } else if (actual instanceof SpoolStatement) {
+            SpoolStatementAssert.assertIs(assertContext, (SpoolStatement) actual, (SpoolStatementTestCase) expected);
         }
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/impl/FlushStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/impl/FlushStatementAssert.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLFlushStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.FlushStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.table.TableAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.FlushStatementTestCase;
@@ -40,12 +40,12 @@ public final class FlushStatementAssert {
      * @param actual actual flush statement
      * @param expected expected flush statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final MySQLFlushStatement actual, final FlushStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final FlushStatement actual, final FlushStatementTestCase expected) {
         assertThat(assertContext.getText("Flush statement is flush table assert error: "), actual.isFlushTable(), is(expected.isFlushTable()));
         assertTables(assertContext, actual, expected);
     }
     
-    private static void assertTables(final SQLCaseAssertContext assertContext, final MySQLFlushStatement actual, final FlushStatementTestCase expected) {
+    private static void assertTables(final SQLCaseAssertContext assertContext, final FlushStatement actual, final FlushStatementTestCase expected) {
         TableAssert.assertIs(assertContext, actual.getTables(), expected.getTables());
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/impl/SpoolStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/impl/SpoolStatementAssert.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.dal.OracleSpoolStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.SpoolStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.SpoolStatementTestCase;
 
@@ -39,7 +39,7 @@ public final class SpoolStatementAssert {
      * @param actual actual spool statement
      * @param expected expected spool statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final OracleSpoolStatement actual, final SpoolStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final SpoolStatement actual, final SpoolStatementTestCase expected) {
         if (null != expected.getFilename()) {
             assertThat(assertContext.getText("Actual filename does not match: "), actual.getFileName(), is(expected.getFilename()));
         }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/impl/mysql/UseStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/impl/mysql/UseStatementAssert.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLUseStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.UseStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.UseStatementTestCase;
 
@@ -27,10 +27,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
- * MySQL use statement assert.
+ * Use statement assert.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class MySQLUseStatementAssert {
+public final class UseStatementAssert {
     
     /**
      * Assert use statement is correct with expected parser result.
@@ -39,7 +39,7 @@ public final class MySQLUseStatementAssert {
      * @param actual actual use statement
      * @param expected expected use statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final MySQLUseStatement actual, final UseStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final UseStatement actual, final UseStatementTestCase expected) {
         assertThat(assertContext.getText("Schema name assertion error: "), actual.getSchema(), is(expected.getSchema().getName()));
         // TODO create a new assert class named `SchemaAssert`
         // TODO extract and assert start index, stop index, start delimiter and end delimiter

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/DCLStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/DCLStatementAssert.java
@@ -19,25 +19,25 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.AlterLoginStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.AlterRoleStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.AlterUserStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.CreateLoginStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.CreateRoleStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.CreateUserStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DenyUserStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DropLoginStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DropRoleStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DropUserStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.GrantStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.ReassignOwnedStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.RenameUserStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.RevokeStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetDefaultRoleStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetPasswordStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetRoleStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl.MySQLRenameUserStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl.MySQLSetDefaultRoleStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl.MySQLSetPasswordStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerAlterLoginStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerCreateLoginStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerDenyUserStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerDropLoginStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerSetUserStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetUserStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dcl.impl.AlterLoginStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dcl.impl.AlterRoleStatementAssert;
@@ -101,16 +101,16 @@ public final class DCLStatementAssert {
             AlterUserStatementAssert.assertIs(assertContext, (AlterUserStatement) actual, (AlterUserStatementTestCase) expected);
         } else if (actual instanceof DropUserStatement) {
             DropUserStatementAssert.assertIs(assertContext, (DropUserStatement) actual, (DropUserStatementTestCase) expected);
-        } else if (actual instanceof MySQLRenameUserStatement) {
-            RenameUserStatementAssert.assertIs(assertContext, (MySQLRenameUserStatement) actual, (RenameUserStatementTestCase) expected);
-        } else if (actual instanceof SQLServerDenyUserStatement) {
-            DenyUserStatementAssert.assertIs(assertContext, (SQLServerDenyUserStatement) actual, (DenyUserStatementTestCase) expected);
-        } else if (actual instanceof SQLServerCreateLoginStatement) {
-            CreateLoginStatementAssert.assertIs(assertContext, (SQLServerCreateLoginStatement) actual, (CreateLoginStatementTestCase) expected);
-        } else if (actual instanceof SQLServerAlterLoginStatement) {
-            AlterLoginStatementAssert.assertIs(assertContext, (SQLServerAlterLoginStatement) actual, (AlterLoginStatementTestCase) expected);
-        } else if (actual instanceof SQLServerDropLoginStatement) {
-            DropLoginStatementAssert.assertIs(assertContext, (SQLServerDropLoginStatement) actual, (DropLoginStatementTestCase) expected);
+        } else if (actual instanceof RenameUserStatement) {
+            RenameUserStatementAssert.assertIs(assertContext, (RenameUserStatement) actual, (RenameUserStatementTestCase) expected);
+        } else if (actual instanceof DenyUserStatement) {
+            DenyUserStatementAssert.assertIs(assertContext, (DenyUserStatement) actual, (DenyUserStatementTestCase) expected);
+        } else if (actual instanceof CreateLoginStatement) {
+            CreateLoginStatementAssert.assertIs(assertContext, (CreateLoginStatement) actual, (CreateLoginStatementTestCase) expected);
+        } else if (actual instanceof AlterLoginStatement) {
+            AlterLoginStatementAssert.assertIs(assertContext, (AlterLoginStatement) actual, (AlterLoginStatementTestCase) expected);
+        } else if (actual instanceof DropLoginStatement) {
+            DropLoginStatementAssert.assertIs(assertContext, (DropLoginStatement) actual, (DropLoginStatementTestCase) expected);
         } else if (actual instanceof CreateRoleStatement) {
             CreateRoleStatementAssert.assertIs(assertContext, (CreateRoleStatement) actual, (CreateRoleStatementTestCase) expected);
         } else if (actual instanceof AlterRoleStatement) {
@@ -119,12 +119,12 @@ public final class DCLStatementAssert {
             DropRoleStatementAssert.assertIs(assertContext, (DropRoleStatement) actual, (DropRoleStatementTestCase) expected);
         } else if (actual instanceof SetRoleStatement) {
             SetRoleStatementAssert.assertIs(assertContext, (SetRoleStatement) actual, (SetRoleStatementTestCase) expected);
-        } else if (actual instanceof MySQLSetDefaultRoleStatement) {
-            SetDefaultRoleStatementAssert.assertIs(assertContext, (MySQLSetDefaultRoleStatement) actual, (SetDefaultRoleStatementTestCase) expected);
-        } else if (actual instanceof MySQLSetPasswordStatement) {
-            SetPasswordStatementAssert.assertIs(assertContext, (MySQLSetPasswordStatement) actual, (SetPasswordStatementTestCase) expected);
-        } else if (actual instanceof SQLServerSetUserStatement) {
-            SQLServerSetUserStatementAssert.assertIs(assertContext, (SQLServerSetUserStatement) actual, (SetUserStatementTestCase) expected);
+        } else if (actual instanceof SetDefaultRoleStatement) {
+            SetDefaultRoleStatementAssert.assertIs(assertContext, (SetDefaultRoleStatement) actual, (SetDefaultRoleStatementTestCase) expected);
+        } else if (actual instanceof SetPasswordStatement) {
+            SetPasswordStatementAssert.assertIs(assertContext, (SetPasswordStatement) actual, (SetPasswordStatementTestCase) expected);
+        } else if (actual instanceof SetUserStatement) {
+            SQLServerSetUserStatementAssert.assertIs(assertContext, (SetUserStatement) actual, (SetUserStatementTestCase) expected);
         } else if (actual instanceof ReassignOwnedStatement) {
             ReassignOwnedStatementAssert.assertIs(assertContext, (ReassignOwnedStatement) actual, (ReassignOwnedStatementTestCase) expected);
         }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/AlterLoginStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/AlterLoginStatementAssert.java
@@ -19,15 +19,15 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerAlterLoginStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.AlterLoginStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dcl.AlterLoginStatementTestCase;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Alter login statement assert.
@@ -42,7 +42,7 @@ public final class AlterLoginStatementAssert {
      * @param actual actual alter login statement
      * @param expected expected alter login statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final SQLServerAlterLoginStatement actual, final AlterLoginStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final AlterLoginStatement actual, final AlterLoginStatementTestCase expected) {
         if (null == expected.getLogin()) {
             assertNull(actual.getLoginSegment(), assertContext.getText("Actual login should not exist."));
         } else {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/CreateLoginStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/CreateLoginStatementAssert.java
@@ -19,15 +19,15 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerCreateLoginStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.CreateLoginStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dcl.CreateLoginStatementTestCase;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Create login statement assert.
@@ -42,7 +42,7 @@ public final class CreateLoginStatementAssert {
      * @param actual actual create login statement
      * @param expected expected create login statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final SQLServerCreateLoginStatement actual, final CreateLoginStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final CreateLoginStatement actual, final CreateLoginStatementTestCase expected) {
         if (null == expected.getLogin()) {
             assertNull(actual.getLoginSegment(), assertContext.getText("Actual login should not exist."));
         } else {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/DenyUserStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/DenyUserStatementAssert.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerDenyUserStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DenyUserStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.column.ColumnAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.table.TableAssert;
@@ -42,12 +42,12 @@ public final class DenyUserStatementAssert {
      * @param actual actual deny user statement
      * @param expected expected deny user statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final SQLServerDenyUserStatement actual, final DenyUserStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final DenyUserStatement actual, final DenyUserStatementTestCase expected) {
         assertTable(assertContext, actual, expected);
         assertColumns(assertContext, actual, expected);
     }
     
-    private static void assertTable(final SQLCaseAssertContext assertContext, final SQLServerDenyUserStatement actual, final DenyUserStatementTestCase expected) {
+    private static void assertTable(final SQLCaseAssertContext assertContext, final DenyUserStatement actual, final DenyUserStatementTestCase expected) {
         if (null == expected.getTable()) {
             assertNull(actual.getTable(), assertContext.getText("Actual table segment should not exist."));
         } else {
@@ -56,7 +56,7 @@ public final class DenyUserStatementAssert {
         }
     }
     
-    private static void assertColumns(final SQLCaseAssertContext assertContext, final SQLServerDenyUserStatement actual, final DenyUserStatementTestCase expected) {
+    private static void assertColumns(final SQLCaseAssertContext assertContext, final DenyUserStatement actual, final DenyUserStatementTestCase expected) {
         if (expected.getColumns().isEmpty()) {
             assertTrue(actual.getColumns().isEmpty(), assertContext.getText("Actual columns segments should not exist."));
         } else {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/DropLoginStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/DropLoginStatementAssert.java
@@ -19,15 +19,15 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerDropLoginStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DropLoginStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dcl.DropLoginStatementTestCase;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Drop login statement assert.
@@ -42,7 +42,7 @@ public final class DropLoginStatementAssert {
      * @param actual actual drop login statement
      * @param expected expected drop login statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final SQLServerDropLoginStatement actual, final DropLoginStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final DropLoginStatement actual, final DropLoginStatementTestCase expected) {
         if (null == expected.getLogin()) {
             assertNull(actual.getLoginSegment(), assertContext.getText("Actual login should not exist."));
         } else {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/RenameUserStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/RenameUserStatementAssert.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl.MySQLRenameUserStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.RenameUserStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dcl.RenameUserStatementTestCase;
 
@@ -36,6 +36,6 @@ public final class RenameUserStatementAssert {
      * @param actual actual rename user statement
      * @param expected expected rename user statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final MySQLRenameUserStatement actual, final RenameUserStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final RenameUserStatement actual, final RenameUserStatementTestCase expected) {
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/SetDefaultRoleStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/SetDefaultRoleStatementAssert.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl.MySQLSetDefaultRoleStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetDefaultRoleStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dcl.SetDefaultRoleStatementTestCase;
 
@@ -36,6 +36,6 @@ public final class SetDefaultRoleStatementAssert {
      * @param actual actual set role statement
      * @param expected expected set role statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final MySQLSetDefaultRoleStatement actual, final SetDefaultRoleStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final SetDefaultRoleStatement actual, final SetDefaultRoleStatementTestCase expected) {
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/SetPasswordStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/SetPasswordStatementAssert.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl.MySQLSetPasswordStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetPasswordStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dcl.SetPasswordStatementTestCase;
 
@@ -36,6 +36,6 @@ public final class SetPasswordStatementAssert {
      * @param actual actual set password statement
      * @param expected expected set password statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final MySQLSetPasswordStatement actual, final SetPasswordStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final SetPasswordStatement actual, final SetPasswordStatementTestCase expected) {
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/sqlserver/SQLServerSetUserStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dcl/impl/sqlserver/SQLServerSetUserStatementAssert.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerSetUserStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.SetUserStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dcl.SetUserStatementTestCase;
@@ -40,7 +40,7 @@ public final class SQLServerSetUserStatementAssert {
      * @param actual actual SQLServer set user statement
      * @param expected expected set user statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final SQLServerSetUserStatement actual, final SetUserStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final SetUserStatement actual, final SetUserStatementTestCase expected) {
         if (null != expected.getUser()) {
             assertThat(assertContext.getText("Actual user name does not match: "), actual.getUser().getUser(), is(expected.getUser().getName()));
             SQLSegmentAssert.assertIs(assertContext, actual.getUser(), expected.getUser());


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Extract DCL statement to reduce duplicate logic for MySQL and doris

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
