### PR TITLE
Allow not setting username and password in datasource config to use DistSQL with testcontainers-java DataSource

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/node/StorageNodeAggregator.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/node/StorageNodeAggregator.java
@@ -62,7 +62,7 @@ public final class StorageNodeAggregator {
             Map<String, Object> standardProps = entry.getValue().getConnectionPropertySynonyms().getStandardProperties();
             String url = standardProps.get("url").toString();
             boolean isInstanceConnectionAvailable = new DatabaseTypeRegistry(DatabaseTypeFactory.get(url)).getDialectDatabaseMetaData().isInstanceConnectionAvailable();
-            StorageNode storageNode = getStorageNode(entry.getKey(), url, standardProps.get("username").toString(), isInstanceConnectionAvailable);
+            StorageNode storageNode = getStorageNode(entry.getKey(), url, standardProps.getOrDefault("username", "").toString(), isInstanceConnectionAvailable);
             result.putIfAbsent(storageNode, entry.getValue());
         }
         return result;

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/unit/StorageUnit.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/unit/StorageUnit.java
@@ -51,8 +51,7 @@ public final class StorageUnit {
         this.storageNode = storageNode;
         Map<String, Object> standardProps = dataSourcePoolProps.getConnectionPropertySynonyms().getStandardProperties();
         String url = standardProps.get("url").toString();
-        Object originUsername = standardProps.get("username");
-        String username = null != originUsername ? originUsername.toString() : "";
+        String username = standardProps.getOrDefault("username", "").toString();
         storageType = DatabaseTypeFactory.get(url);
         boolean isInstanceConnectionAvailable = new DatabaseTypeRegistry(storageType).getDialectDatabaseMetaData().isInstanceConnectionAvailable();
         String catalog = isInstanceConnectionAvailable ? DatabaseTypedSPILoader.getService(ConnectionPropertiesParser.class, storageType).parse(url, username, null).getCatalog() : null;

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/unit/StorageUnitNodeMapCreator.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/unit/StorageUnitNodeMapCreator.java
@@ -51,7 +51,7 @@ public final class StorageUnitNodeMapCreator {
     
     private static StorageNode create(final String storageUnitName, final DataSourcePoolProperties props) {
         Map<String, Object> standardProps = props.getConnectionPropertySynonyms().getStandardProperties();
-        return create(storageUnitName, standardProps.get("url").toString(), standardProps.get("username").toString());
+        return create(storageUnitName, standardProps.get("url").toString(), standardProps.getOrDefault("username", "").toString());
     }
     
     private static StorageNode create(final String storageUnitName, final String url, final String username) {

--- a/infra/data-source-pool/core/src/main/java/org/apache/shardingsphere/infra/datasource/pool/props/creator/DataSourcePoolPropertiesCreator.java
+++ b/infra/data-source-pool/core/src/main/java/org/apache/shardingsphere/infra/datasource/pool/props/creator/DataSourcePoolPropertiesCreator.java
@@ -115,7 +115,8 @@ public final class DataSourcePoolPropertiesCreator {
     private static ConnectionConfiguration getConnectionConfiguration(final ConnectionPropertySynonyms connectionPropSynonyms) {
         Map<String, Object> standardProps = connectionPropSynonyms.getStandardProperties();
         return new ConnectionConfiguration(
-                (String) standardProps.get("dataSourceClassName"), (String) standardProps.get("url"), (String) standardProps.get("username"), (String) standardProps.get("password"));
+                (String) standardProps.get("dataSourceClassName"), (String) standardProps.get("url"), (String) standardProps.getOrDefault("username", ""),
+                (String) standardProps.getOrDefault("password", ""));
     }
     
     private static PoolConfiguration getPoolConfiguration(final PoolPropertySynonyms poolPropSynonyms, final CustomDataSourcePoolProperties customProps) {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/swapper/DataSourceSwapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/swapper/DataSourceSwapper.java
@@ -81,8 +81,8 @@ public final class DataSourceSwapper {
         Map<String, Object> standardProps = DataSourcePoolPropertiesCreator.create(
                 dataSource instanceof CatalogSwitchableDataSource ? ((CatalogSwitchableDataSource) dataSource).getDataSource() : dataSource).getAllStandardProperties();
         result.put("url", dataSource instanceof CatalogSwitchableDataSource ? ((CatalogSwitchableDataSource) dataSource).getUrl() : standardProps.get("url"));
-        result.put("user", standardProps.get("username"));
-        result.put("password", standardProps.get("password"));
+        result.put("user", standardProps.getOrDefault("username", ""));
+        result.put("password", standardProps.getOrDefault("password", ""));
         return result;
     }
     

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ExportStorageNodesExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ExportStorageNodesExecutor.java
@@ -98,7 +98,7 @@ public final class ExportStorageNodesExecutor implements DistSQLQueryExecutor<Ex
             }
             Map<String, Object> standardProps = DataSourcePoolPropertiesCreator.create(entry.getValue().getDataSource()).getConnectionPropertySynonyms().getStandardProperties();
             ExportedStorageNode exportedStorageNode = new ExportedStorageNode(connectionProps.getHostname(), String.valueOf(connectionProps.getPort()),
-                    String.valueOf(standardProps.get("username")), String.valueOf(standardProps.get("password")), connectionProps.getCatalog());
+                    String.valueOf(standardProps.getOrDefault("username", "")), String.valueOf(standardProps.getOrDefault("password", "")), connectionProps.getCatalog());
             storageNodes.put(databaseInstanceIp, exportedStorageNode);
         }
         return Collections.singletonMap(database.getName(), storageNodes.values());


### PR DESCRIPTION
For https://github.com/apache/shardingsphere/pull/31817#issuecomment-2184410345 .

Changes proposed in this pull request:
  - Allow not setting username and password in datasource config to use DistSQL with testcontainers-java DataSource. This type of testcontainers module hides the real username and password of the data source in the SPI implementation of `org.testcontainers.containers.JdbcDatabaseContainerProvider`, and it seems intuitive to simply assign empty strings to them.
  - Actually, there is currently no integration test for DistSQL for the following scenario about `org.testcontainers:postgresql:1.19.8`. So it is hard to say whether this requires any additional changes.
```yaml
dataSources:
  ds_0:
    dataSourceClassName: com.zaxxer.hikari.HikariDataSource
    driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
    jdbcUrl: jdbc:tc:postgresql:16.3-bookworm://test-native-databases-postgres/demo_ds_0
  ds_1:
    dataSourceClassName: com.zaxxer.hikari.HikariDataSource
    driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
    jdbcUrl: jdbc:tc:postgresql:16.3-bookworm://test-native-databases-postgres/demo_ds_1
  ds_2:
    dataSourceClassName: com.zaxxer.hikari.HikariDataSource
    driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
    jdbcUrl: jdbc:tc:postgresql:16.3-bookworm://test-native-databases-postgres/demo_ds_2
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
