### PR TITLE
Add EqualsAndHashCode for EncryptAlgorithmMetaData to solve encryptor equals wrong

### DIFF
--- a/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/spi/EncryptAlgorithmMetaData.java
+++ b/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/spi/EncryptAlgorithmMetaData.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.encrypt.spi;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -27,6 +28,7 @@ import java.util.Properties;
  */
 @RequiredArgsConstructor
 @Getter
+@EqualsAndHashCode
 public final class EncryptAlgorithmMetaData {
     
     private final boolean supportDecrypt;

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/generator/generic/RemoveTokenGenerator.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/generator/generic/RemoveTokenGenerator.java
@@ -44,15 +44,15 @@ public final class RemoveTokenGenerator implements CollectionSQLTokenGenerator<S
         if (sqlStatementContext instanceof RemoveAvailable) {
             containsRemoveSegment = !((RemoveAvailable) sqlStatementContext).getRemoveSegments().isEmpty();
         }
-        boolean containsSchemaName = false;
+        boolean containsDatabaseName = false;
         if (sqlStatementContext instanceof TableAvailable) {
-            containsSchemaName = ((TableAvailable) sqlStatementContext).getTablesContext().getDatabaseName().isPresent();
+            containsDatabaseName = ((TableAvailable) sqlStatementContext).getTablesContext().getDatabaseName().isPresent();
         }
         boolean containsIndexSegment = false;
         if (sqlStatementContext instanceof IndexAvailable) {
             containsIndexSegment = !((IndexAvailable) sqlStatementContext).getIndexes().isEmpty();
         }
-        return containsRemoveSegment || containsSchemaName || containsIndexSegment;
+        return containsRemoveSegment || containsDatabaseName || containsIndexSegment;
     }
     
     @Override


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Add EqualsAndHashCode for EncryptAlgorithmMetaData to solve encryptor equals wrong

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
