### PR TITLE
Pass currentDatabaseName to TablesContext constructor to keep schemaNames, databaseNames for all tables

### DIFF
--- a/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/route/BroadcastSqlRouterTest.java
+++ b/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/route/BroadcastSqlRouterTest.java
@@ -132,7 +132,7 @@ class BroadcastSqlRouterTest {
     private QueryContext createQueryContext() {
         CreateTableStatement createTableStatement = new MySQLCreateTableStatement(false);
         createTableStatement.setTable(new SimpleTableSegment(new TableNameSegment(1, 2, new IdentifierValue("t_order"))));
-        return new QueryContext(new CreateTableStatementContext(createTableStatement), "CREATE TABLE", new LinkedList<>(), new HintValueContext());
+        return new QueryContext(new CreateTableStatementContext(createTableStatement, DefaultDatabase.LOGIC_NAME), "CREATE TABLE", new LinkedList<>(), new HintValueContext());
     }
     
     private Map<String, DataSource> createMultiDataSourceMap() throws SQLException {

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptGroupByItemTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptGroupByItemTokenGeneratorTest.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.encrypt.rule.column.EncryptColumn;
 import org.apache.shardingsphere.infra.binder.context.segment.select.orderby.OrderByItem;
 import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
@@ -88,7 +89,7 @@ class EncryptGroupByItemTokenGeneratorTest {
         OrderByItem orderByItem = new OrderByItem(columnOrderByItemSegment);
         when(result.getGroupByContext().getItems()).thenReturn(Collections.singleton(orderByItem));
         when(result.getSubqueryContexts().values()).thenReturn(Collections.emptyList());
-        when(result.getTablesContext()).thenReturn(new TablesContext(Collections.singleton(simpleTableSegment), databaseType));
+        when(result.getTablesContext()).thenReturn(new TablesContext(Collections.singleton(simpleTableSegment), databaseType, DefaultDatabase.LOGIC_NAME));
         return result;
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptOrderByItemTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptOrderByItemTokenGeneratorTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.encrypt.rule.column.EncryptColumn;
 import org.apache.shardingsphere.infra.binder.context.segment.select.orderby.OrderByItem;
 import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
@@ -88,7 +89,7 @@ class EncryptOrderByItemTokenGeneratorTest {
         when(result.getOrderByContext().getItems()).thenReturn(Collections.singleton(orderByItem));
         when(result.getGroupByContext().getItems()).thenReturn(Collections.emptyList());
         when(result.getSubqueryContexts().values()).thenReturn(Collections.emptyList());
-        when(result.getTablesContext()).thenReturn(new TablesContext(Collections.singleton(simpleTableSegment), databaseType));
+        when(result.getTablesContext()).thenReturn(new TablesContext(Collections.singleton(simpleTableSegment), databaseType, DefaultDatabase.LOGIC_NAME));
         return result;
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptProjectionTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptProjectionTokenGeneratorTest.java
@@ -104,7 +104,7 @@ class EncryptProjectionTokenGeneratorTest {
         when(sqlStatementContext.getSqlStatement().getProjections()).thenReturn(projections);
         when(sqlStatementContext.getSubqueryContexts().values()).thenReturn(Collections.emptyList());
         SimpleTableSegment doctorOneTable = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("doctor1")));
-        when(sqlStatementContext.getTablesContext()).thenReturn(new TablesContext(Arrays.asList(doctorTable, doctorOneTable), databaseType));
+        when(sqlStatementContext.getTablesContext()).thenReturn(new TablesContext(Arrays.asList(doctorTable, doctorOneTable), databaseType, DefaultDatabase.LOGIC_NAME));
         when(sqlStatementContext.getProjectionsContext().getProjections()).thenReturn(Collections.singleton(new ColumnProjection("a", "mobile", null, databaseType)));
         Collection<SQLToken> actual = generator.generateSQLTokens(sqlStatementContext);
         assertThat(actual.size(), is(1));
@@ -126,7 +126,7 @@ class EncryptProjectionTokenGeneratorTest {
         when(sqlStatementContext.getSqlStatement().getProjections()).thenReturn(projections);
         when(sqlStatementContext.getSubqueryContexts().values()).thenReturn(Collections.emptyList());
         SimpleTableSegment sameDoctorTable = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("doctor")));
-        when(sqlStatementContext.getTablesContext()).thenReturn(new TablesContext(Arrays.asList(doctorTable, sameDoctorTable), databaseType));
+        when(sqlStatementContext.getTablesContext()).thenReturn(new TablesContext(Arrays.asList(doctorTable, sameDoctorTable), databaseType, DefaultDatabase.LOGIC_NAME));
         when(sqlStatementContext.getProjectionsContext().getProjections()).thenReturn(Collections.singleton(new ColumnProjection("a", "mobile", null, databaseType)));
         Collection<SQLToken> actual = generator.generateSQLTokens(sqlStatementContext);
         assertThat(actual.size(), is(1));
@@ -145,7 +145,7 @@ class EncryptProjectionTokenGeneratorTest {
         when(sqlStatementContext.getSubqueryContexts().values()).thenReturn(Collections.emptyList());
         SimpleTableSegment doctorTable = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("doctor")));
         SimpleTableSegment doctorOneTable = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("doctor1")));
-        when(sqlStatementContext.getTablesContext()).thenReturn(new TablesContext(Arrays.asList(doctorTable, doctorOneTable), databaseType));
+        when(sqlStatementContext.getTablesContext()).thenReturn(new TablesContext(Arrays.asList(doctorTable, doctorOneTable), databaseType, DefaultDatabase.LOGIC_NAME));
         when(sqlStatementContext.getProjectionsContext().getProjections()).thenReturn(Collections.singleton(new ColumnProjection("doctor", "mobile", null, databaseType)));
         Collection<SQLToken> actual = generator.generateSQLTokens(sqlStatementContext);
         assertThat(actual.size(), is(1));

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/fixture/EncryptGeneratorFixtureBuilder.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/fixture/EncryptGeneratorFixtureBuilder.java
@@ -168,7 +168,7 @@ public final class EncryptGeneratorFixtureBuilder {
         updateStatement.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_user"))));
         updateStatement.setWhere(createWhereSegment());
         updateStatement.setSetAssignment(createSetAssignmentSegment());
-        return new UpdateStatementContext(updateStatement);
+        return new UpdateStatementContext(updateStatement, DefaultDatabase.LOGIC_NAME);
     }
     
     private static WhereSegment createWhereSegment() {

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/ddl/ShardingDDLResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/ddl/ShardingDDLResultMergerTest.java
@@ -83,7 +83,7 @@ class ShardingDDLResultMergerTest {
     
     private FetchStatementContext createFetchStatementContext(final ShardingSphereDatabase database) {
         OpenGaussFetchStatement fetchStatement = createFetchStatement();
-        FetchStatementContext result = new FetchStatementContext(fetchStatement);
+        FetchStatementContext result = new FetchStatementContext(fetchStatement, DefaultDatabase.LOGIC_NAME);
         CursorStatementContext cursorStatementContext = createCursorStatementContext(database);
         result.setUpCursorDefinition(cursorStatementContext);
         return result;

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/ddl/fetch/FetchStreamMergedResultTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/ddl/fetch/FetchStreamMergedResultTest.java
@@ -86,7 +86,7 @@ class FetchStreamMergedResultTest {
     }
     
     private static FetchStatementContext createFetchStatementContext(final boolean containsAllDirectionType) {
-        FetchStatementContext result = new FetchStatementContext(createFetchStatement(containsAllDirectionType));
+        FetchStatementContext result = new FetchStatementContext(createFetchStatement(containsAllDirectionType), DefaultDatabase.LOGIC_NAME);
         result.setUpCursorDefinition(createCursorStatementContext());
         return result;
     }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/ShardingRouteEngineFactoryTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/ShardingRouteEngineFactoryTest.java
@@ -219,7 +219,7 @@ class ShardingRouteEngineFactoryTest {
     
     private void assertNewInstanceForDCLForSingleTableWithShardingRule(final GrantStatement grantStatement) {
         grantStatement.getTables().add(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl"))));
-        GrantStatementContext sqlStatementContext = new GrantStatementContext(grantStatement);
+        GrantStatementContext sqlStatementContext = new GrantStatementContext(grantStatement, DefaultDatabase.LOGIC_NAME);
         QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext());
         ShardingRouteEngine actual =
                 ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props, new ConnectionContext(Collections::emptySet));
@@ -228,7 +228,7 @@ class ShardingRouteEngineFactoryTest {
     
     private void assertNewInstanceForDCLForSingleTableWithoutShardingRule(final GrantStatement grantStatement) {
         grantStatement.getTables().add(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl"))));
-        GrantStatementContext sqlStatementContext = new GrantStatementContext(grantStatement);
+        GrantStatementContext sqlStatementContext = new GrantStatementContext(grantStatement, DefaultDatabase.LOGIC_NAME);
         QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext());
         ShardingRouteEngine actual =
                 ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props, new ConnectionContext(Collections::emptySet));

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingAlterIndexStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingAlterIndexStatementValidatorTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.route.engine.validator.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.AlterIndexStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.sharding.exception.metadata.DuplicateIndexException;
@@ -62,7 +63,7 @@ class ShardingAlterIndexStatementValidatorTest {
         when(table.containsIndex("t_order_index")).thenReturn(true);
         when(table.containsIndex("t_order_index_new")).thenReturn(false);
         assertDoesNotThrow(() -> new ShardingAlterIndexStatementValidator().preValidate(
-                shardingRule, new AlterIndexStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                shardingRule, new AlterIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
@@ -76,7 +77,7 @@ class ShardingAlterIndexStatementValidatorTest {
         when(table.containsIndex("t_order_index")).thenReturn(false);
         assertThrows(IndexNotExistedException.class,
                 () -> new ShardingAlterIndexStatementValidator().preValidate(
-                        shardingRule, new AlterIndexStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                        shardingRule, new AlterIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
@@ -91,6 +92,6 @@ class ShardingAlterIndexStatementValidatorTest {
         when(table.containsIndex("t_order_index_new")).thenReturn(true);
         assertThrows(DuplicateIndexException.class,
                 () -> new ShardingAlterIndexStatementValidator().preValidate(
-                        shardingRule, new AlterIndexStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                        shardingRule, new AlterIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingAlterTableStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingAlterTableStatementValidatorTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sharding.route.engine.validator.ddl;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.AlterTableStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
@@ -67,7 +68,7 @@ class ShardingAlterTableStatementValidatorTest {
         PostgreSQLAlterTableStatement sqlStatement = new PostgreSQLAlterTableStatement();
         sqlStatement.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         sqlStatement.setRenameTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order_new"))));
-        SQLStatementContext sqlStatementContext = new AlterTableStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new AlterTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         when(shardingRule.containsShardingTable(Arrays.asList("t_order", "t_order_new"))).thenReturn(true);
         assertThrows(UnsupportedShardingOperationException.class,
                 () -> new ShardingAlterTableStatementValidator().preValidate(shardingRule, sqlStatementContext, Collections.emptyList(), database, mock(ConfigurationProperties.class)));
@@ -84,7 +85,8 @@ class ShardingAlterTableStatementValidatorTest {
         routeUnits.add(new RouteUnit(new RouteMapper("ds_1", "ds_1"), Collections.singletonList(new RouteMapper("t_order", "t_order_0"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertDoesNotThrow(() -> new ShardingAlterTableStatementValidator().postValidate(
-                shardingRule, new AlterTableStatementContext(sqlStatement), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class), routeContext));
+                shardingRule, new AlterTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class),
+                routeContext));
     }
     
     @Test
@@ -97,7 +99,7 @@ class ShardingAlterTableStatementValidatorTest {
         routeUnits.add(new RouteUnit(new RouteMapper("ds_0", "ds_0"), Collections.singletonList(new RouteMapper("t_order", "t_order_0"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertThrows(ShardingDDLRouteException.class,
-                () -> new ShardingAlterTableStatementValidator().postValidate(shardingRule, new AlterTableStatementContext(sqlStatement),
+                () -> new ShardingAlterTableStatementValidator().postValidate(shardingRule, new AlterTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME),
                         new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class), routeContext));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingAlterViewStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingAlterViewStatementValidatorTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sharding.route.engine.validator.ddl;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.AlterViewStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.sharding.exception.syntax.UnsupportedShardingOperationException;
 import org.apache.shardingsphere.sharding.route.engine.validator.ddl.impl.ShardingAlterViewStatementValidator;
@@ -54,7 +55,7 @@ class ShardingAlterViewStatementValidatorTest {
         selectStatement.setFrom(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         MySQLAlterViewStatement sqlStatement = new MySQLAlterViewStatement();
         sqlStatement.setSelect(selectStatement);
-        SQLStatementContext sqlStatementContext = new AlterViewStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new AlterViewStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
         when(shardingRule.isShardingTable("t_order")).thenReturn(false);
         assertDoesNotThrow(() -> new ShardingAlterViewStatementValidator().preValidate(shardingRule, sqlStatementContext, Collections.emptyList(), database, mock(ConfigurationProperties.class)));
@@ -67,7 +68,7 @@ class ShardingAlterViewStatementValidatorTest {
         MySQLAlterViewStatement sqlStatement = new MySQLAlterViewStatement();
         sqlStatement.setSelect(selectStatement);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
-        SQLStatementContext sqlStatementContext = new AlterViewStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new AlterViewStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         when(shardingRule.isShardingTable("t_order")).thenReturn(true);
         assertThrows(UnsupportedShardingOperationException.class,
                 () -> new ShardingAlterViewStatementValidator().preValidate(shardingRule, sqlStatementContext, Collections.emptyList(), database, mock(ConfigurationProperties.class)));
@@ -78,7 +79,7 @@ class ShardingAlterViewStatementValidatorTest {
         OpenGaussAlterViewStatement selectStatement = new OpenGaussAlterViewStatement();
         selectStatement.setView(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         selectStatement.setRenameView(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order_new"))));
-        SQLStatementContext sqlStatementContext = new AlterViewStatementContext(selectStatement);
+        SQLStatementContext sqlStatementContext = new AlterViewStatementContext(selectStatement, DefaultDatabase.LOGIC_NAME);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
         assertDoesNotThrow(() -> new ShardingAlterViewStatementValidator().preValidate(shardingRule, sqlStatementContext, Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateFunctionStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateFunctionStatementValidatorTest.java
@@ -68,7 +68,7 @@ class ShardingCreateFunctionStatementValidatorTest {
         routineBody.getValidStatements().add(selectValidStatementSegment);
         MySQLCreateFunctionStatement sqlStatement = new MySQLCreateFunctionStatement();
         sqlStatement.setRoutineBody(routineBody);
-        SQLStatementContext sqlStatementContext = new CreateFunctionStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new CreateFunctionStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn(DefaultDatabase.LOGIC_NAME);
         when(database.getSchema(DefaultDatabase.LOGIC_NAME).containsTable("t_order_item")).thenReturn(true);
@@ -86,7 +86,7 @@ class ShardingCreateFunctionStatementValidatorTest {
         routineBody.getValidStatements().add(validStatementSegment);
         MySQLCreateFunctionStatement sqlStatement = new MySQLCreateFunctionStatement();
         sqlStatement.setRoutineBody(routineBody);
-        SQLStatementContext sqlStatementContext = new CreateFunctionStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new CreateFunctionStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("db_schema");
         assertThrows(NoSuchTableException.class,
@@ -103,7 +103,7 @@ class ShardingCreateFunctionStatementValidatorTest {
         routineBody.getValidStatements().add(validStatementSegment);
         MySQLCreateFunctionStatement sqlStatement = new MySQLCreateFunctionStatement();
         sqlStatement.setRoutineBody(routineBody);
-        SQLStatementContext sqlStatementContext = new CreateFunctionStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new CreateFunctionStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("db_schema");
         assertThrows(NoSuchTableException.class,
@@ -120,7 +120,7 @@ class ShardingCreateFunctionStatementValidatorTest {
         routineBody.getValidStatements().add(validStatementSegment);
         MySQLCreateFunctionStatement sqlStatement = new MySQLCreateFunctionStatement();
         sqlStatement.setRoutineBody(routineBody);
-        SQLStatementContext sqlStatementContext = new CreateFunctionStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new CreateFunctionStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn(DefaultDatabase.LOGIC_NAME);
         when(database.getSchema(DefaultDatabase.LOGIC_NAME).containsTable("t_order")).thenReturn(true);

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateIndexStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateIndexStatementValidatorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sharding.route.engine.validator.ddl;
 
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.table.NoSuchTableException;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.CreateIndexStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
@@ -63,7 +64,7 @@ class ShardingCreateIndexStatementValidatorTest {
         ShardingSphereTable table = mock(ShardingSphereTable.class);
         when(database.getSchema("public").getTable("t_order")).thenReturn(table);
         assertDoesNotThrow(() -> new ShardingCreateIndexStatementValidator().preValidate(
-                shardingRule, new CreateIndexStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                shardingRule, new CreateIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
@@ -74,7 +75,7 @@ class ShardingCreateIndexStatementValidatorTest {
         when(database.getSchema("public").containsTable("t_order")).thenReturn(false);
         assertThrows(NoSuchTableException.class,
                 () -> new ShardingCreateIndexStatementValidator().preValidate(
-                        shardingRule, new CreateIndexStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                        shardingRule, new CreateIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
@@ -88,7 +89,7 @@ class ShardingCreateIndexStatementValidatorTest {
         when(database.getSchema("public").containsIndex("t_order", "t_order_index")).thenReturn(true);
         assertThrows(DuplicateIndexException.class,
                 () -> new ShardingCreateIndexStatementValidator().preValidate(
-                        shardingRule, new CreateIndexStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                        shardingRule, new CreateIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
@@ -101,7 +102,7 @@ class ShardingCreateIndexStatementValidatorTest {
         ShardingSphereTable table = mock(ShardingSphereTable.class);
         when(database.getSchema("public").getTable("t_order")).thenReturn(table);
         assertDoesNotThrow(() -> new ShardingCreateIndexStatementValidator().preValidate(
-                shardingRule, new CreateIndexStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                shardingRule, new CreateIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
@@ -113,7 +114,7 @@ class ShardingCreateIndexStatementValidatorTest {
         when(database.getSchema("public").containsTable("t_order")).thenReturn(false);
         assertThrows(NoSuchTableException.class,
                 () -> new ShardingCreateIndexStatementValidator().preValidate(
-                        shardingRule, new CreateIndexStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                        shardingRule, new CreateIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
@@ -128,6 +129,6 @@ class ShardingCreateIndexStatementValidatorTest {
         when(database.getSchema("public").containsIndex("t_order", "content_idx")).thenReturn(true);
         assertThrows(DuplicateIndexException.class,
                 () -> new ShardingCreateIndexStatementValidator().preValidate(
-                        shardingRule, new CreateIndexStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                        shardingRule, new CreateIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateProcedureStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateProcedureStatementValidatorTest.java
@@ -72,7 +72,7 @@ class ShardingCreateProcedureStatementValidatorTest {
         when(database.getName()).thenReturn(DefaultDatabase.LOGIC_NAME);
         when(database.getSchema(DefaultDatabase.LOGIC_NAME).containsTable("t_order_item")).thenReturn(true);
         when(shardingRule.isShardingTable("t_order_item")).thenReturn(false);
-        SQLStatementContext sqlStatementContext = new CreateProcedureStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new CreateProcedureStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         assertDoesNotThrow(() -> new ShardingCreateProcedureStatementValidator().preValidate(
                 shardingRule, sqlStatementContext, Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
@@ -87,7 +87,7 @@ class ShardingCreateProcedureStatementValidatorTest {
         routineBody.getValidStatements().add(validStatementSegment);
         MySQLCreateProcedureStatement sqlStatement = new MySQLCreateProcedureStatement();
         sqlStatement.setRoutineBody(routineBody);
-        SQLStatementContext sqlStatementContext = new CreateProcedureStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new CreateProcedureStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("db_schema");
         assertThrows(NoSuchTableException.class,
@@ -104,7 +104,7 @@ class ShardingCreateProcedureStatementValidatorTest {
         routineBody.getValidStatements().add(validStatementSegment);
         MySQLCreateProcedureStatement sqlStatement = new MySQLCreateProcedureStatement();
         sqlStatement.setRoutineBody(routineBody);
-        SQLStatementContext sqlStatementContext = new CreateProcedureStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new CreateProcedureStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("db_schema");
         assertThrows(NoSuchTableException.class,
@@ -121,7 +121,7 @@ class ShardingCreateProcedureStatementValidatorTest {
         routineBody.getValidStatements().add(validStatementSegment);
         MySQLCreateProcedureStatement sqlStatement = new MySQLCreateProcedureStatement();
         sqlStatement.setRoutineBody(routineBody);
-        SQLStatementContext sqlStatementContext = new CreateProcedureStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new CreateProcedureStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn(DefaultDatabase.LOGIC_NAME);
         when(database.getSchema(DefaultDatabase.LOGIC_NAME).containsTable("t_order")).thenReturn(true);

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateTableStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateTableStatementValidatorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sharding.route.engine.validator.ddl;
 
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.table.TableExistsException;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.CreateTableStatementContext;
@@ -104,7 +105,7 @@ class ShardingCreateTableStatementValidatorTest {
     }
     
     private void assertPreValidateCreateTable(final CreateTableStatement sqlStatement, final String schemaName) {
-        SQLStatementContext sqlStatementContext = new CreateTableStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new CreateTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("sharding_db");
         when(database.getSchema(schemaName).containsTable("t_order")).thenReturn(true);
@@ -126,7 +127,7 @@ class ShardingCreateTableStatementValidatorTest {
     }
     
     private void assertPreValidateCreateTableIfNotExists(final CreateTableStatement sqlStatement) {
-        SQLStatementContext sqlStatementContext = new CreateTableStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new CreateTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         new ShardingCreateTableStatementValidator().preValidate(shardingRule, sqlStatementContext, Collections.emptyList(), database, mock(ConfigurationProperties.class));
     }
@@ -142,7 +143,8 @@ class ShardingCreateTableStatementValidatorTest {
         routeUnits.add(new RouteUnit(new RouteMapper("ds_1", "ds_1"), Collections.singletonList(new RouteMapper("t_order", "t_order_0"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertDoesNotThrow(() -> new ShardingCreateTableStatementValidator().postValidate(
-                shardingRule, new CreateTableStatementContext(sqlStatement), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class), routeContext));
+                shardingRule, new CreateTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class),
+                routeContext));
     }
     
     @Test
@@ -155,7 +157,8 @@ class ShardingCreateTableStatementValidatorTest {
         routeUnits.add(new RouteUnit(new RouteMapper("ds_0", "ds_0"), Collections.singletonList(new RouteMapper("t_order", "t_order_0"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertThrows(ShardingDDLRouteException.class, () -> new ShardingCreateTableStatementValidator().postValidate(shardingRule,
-                new CreateTableStatementContext(sqlStatement), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class), routeContext));
+                new CreateTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class),
+                routeContext));
     }
     
     @Test
@@ -163,6 +166,7 @@ class ShardingCreateTableStatementValidatorTest {
         PostgreSQLCreateTableStatement sqlStatement = new PostgreSQLCreateTableStatement(false);
         sqlStatement.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_config"))));
         assertDoesNotThrow(() -> new ShardingCreateTableStatementValidator().postValidate(
-                shardingRule, new CreateTableStatementContext(sqlStatement), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class), routeContext));
+                shardingRule, new CreateTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class),
+                routeContext));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateTableStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateTableStatementValidatorTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.shardingsphere.sharding.route.engine.validator.ddl;
 
-import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
-import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.table.TableExistsException;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.CreateTableStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
+import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.table.TableExistsException;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
@@ -105,7 +105,7 @@ class ShardingCreateTableStatementValidatorTest {
     }
     
     private void assertPreValidateCreateTable(final CreateTableStatement sqlStatement, final String schemaName) {
-        SQLStatementContext sqlStatementContext = new CreateTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
+        SQLStatementContext sqlStatementContext = new CreateTableStatementContext(sqlStatement, "sharding_db");
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("sharding_db");
         when(database.getSchema(schemaName).containsTable("t_order")).thenReturn(true);

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingDropIndexStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingDropIndexStatementValidatorTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.route.engine.validator.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.DropIndexStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
@@ -73,7 +74,7 @@ class ShardingDropIndexStatementValidatorTest {
         when(table.containsIndex("t_order_index")).thenReturn(true);
         when(table.containsIndex("t_order_index_new")).thenReturn(true);
         assertDoesNotThrow(() -> new ShardingDropIndexStatementValidator().preValidate(
-                shardingRule, new DropIndexStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                shardingRule, new DropIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
@@ -87,7 +88,7 @@ class ShardingDropIndexStatementValidatorTest {
         when(table.containsIndex("t_order_index")).thenReturn(false);
         assertThrows(IndexNotExistedException.class,
                 () -> new ShardingDropIndexStatementValidator().preValidate(
-                        shardingRule, new DropIndexStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                        shardingRule, new DropIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
@@ -106,7 +107,8 @@ class ShardingDropIndexStatementValidatorTest {
         routeUnits.add(new RouteUnit(new RouteMapper("ds_1", "ds_1"), Collections.singletonList(new RouteMapper("t_order", "t_order_0"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertDoesNotThrow(() -> new ShardingDropIndexStatementValidator().postValidate(
-                shardingRule, new DropIndexStatementContext(sqlStatement), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class), routeContext));
+                shardingRule, new DropIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class),
+                routeContext));
     }
     
     @Test
@@ -123,7 +125,8 @@ class ShardingDropIndexStatementValidatorTest {
         Collection<RouteUnit> routeUnits = new LinkedList<>();
         routeUnits.add(new RouteUnit(new RouteMapper("ds_0", "ds_0"), Collections.singletonList(new RouteMapper("t_order", "t_order_0"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
-        assertThrows(ShardingDDLRouteException.class, () -> new ShardingDropIndexStatementValidator().postValidate(shardingRule, new DropIndexStatementContext(sqlStatement), new HintValueContext(),
-                Collections.emptyList(), database, mock(ConfigurationProperties.class), routeContext));
+        assertThrows(ShardingDDLRouteException.class,
+                () -> new ShardingDropIndexStatementValidator().postValidate(shardingRule, new DropIndexStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(),
+                        Collections.emptyList(), database, mock(ConfigurationProperties.class), routeContext));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingDropTableStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingDropTableStatementValidatorTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sharding.route.engine.validator.ddl;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.DropTableStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -81,7 +82,7 @@ class ShardingDropTableStatementValidatorTest {
     void assertPreValidateDropTableForMySQL() {
         MySQLDropTableStatement sqlStatement = new MySQLDropTableStatement(false);
         sqlStatement.getTables().add(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order_item"))));
-        SQLStatementContext sqlStatementContext = new DropTableStatementContext(sqlStatement);
+        SQLStatementContext sqlStatementContext = new DropTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("db_schema");
         when(database.getSchema("db_schema").containsTable("t_order_item")).thenReturn(true);
@@ -97,7 +98,7 @@ class ShardingDropTableStatementValidatorTest {
         RouteContext routeContext = mock(RouteContext.class);
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertThrows(InUsedTablesException.class,
-                () -> validator.postValidate(shardingRule, new DropTableStatementContext(sqlStatement), new HintValueContext(), Collections.emptyList(), database,
+                () -> validator.postValidate(shardingRule, new DropTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(), Collections.emptyList(), database,
                         mock(ConfigurationProperties.class), routeContext));
     }
     
@@ -131,7 +132,7 @@ class ShardingDropTableStatementValidatorTest {
         routeUnits.add(new RouteUnit(new RouteMapper("ds_1", "ds_1"), Collections.singleton(new RouteMapper("t_order", "t_order_0"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertDoesNotThrow(() -> new ShardingDropTableStatementValidator().postValidate(
-                shardingRule, new DropTableStatementContext(sqlStatement), new HintValueContext(), Collections.emptyList(),
+                shardingRule, new DropTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(), Collections.emptyList(),
                 mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS), mock(ConfigurationProperties.class), routeContext));
     }
     
@@ -145,7 +146,7 @@ class ShardingDropTableStatementValidatorTest {
         routeUnits.add(new RouteUnit(new RouteMapper("ds_0", "ds_0"), Collections.singleton(new RouteMapper("t_order", "t_order_0"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertThrows(ShardingDDLRouteException.class,
-                () -> new ShardingDropTableStatementValidator().postValidate(shardingRule, new DropTableStatementContext(sqlStatement), new HintValueContext(),
+                () -> new ShardingDropTableStatementValidator().postValidate(shardingRule, new DropTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(),
                         Collections.emptyList(), mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS), mock(ConfigurationProperties.class), routeContext));
     }
     
@@ -159,7 +160,7 @@ class ShardingDropTableStatementValidatorTest {
         routeUnits.add(new RouteUnit(new RouteMapper("ds_1", "ds_1"), Collections.singleton(new RouteMapper("t_config", "t_config"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertDoesNotThrow(() -> new ShardingDropTableStatementValidator().postValidate(
-                shardingRule, new DropTableStatementContext(sqlStatement), new HintValueContext(),
+                shardingRule, new DropTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(),
                 Collections.emptyList(), mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS), mock(ConfigurationProperties.class), routeContext));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingDropTableStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingDropTableStatementValidatorTest.java
@@ -82,7 +82,7 @@ class ShardingDropTableStatementValidatorTest {
     void assertPreValidateDropTableForMySQL() {
         MySQLDropTableStatement sqlStatement = new MySQLDropTableStatement(false);
         sqlStatement.getTables().add(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order_item"))));
-        SQLStatementContext sqlStatementContext = new DropTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
+        SQLStatementContext sqlStatementContext = new DropTableStatementContext(sqlStatement, "db_schema");
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("db_schema");
         when(database.getSchema("db_schema").containsTable("t_order_item")).thenReturn(true);

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingPrepareStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingPrepareStatementValidatorTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.route.engine.validator.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.PrepareStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
@@ -62,7 +63,7 @@ class ShardingPrepareStatementValidatorTest {
         PrepareStatement sqlStatement = new PostgreSQLPrepareStatement();
         when(routeContext.getRouteUnits()).thenReturn(Collections.emptyList());
         assertThrows(EmptyShardingRouteResultException.class,
-                () -> new ShardingPrepareStatementValidator().postValidate(shardingRule, new PrepareStatementContext(sqlStatement), new HintValueContext(),
+                () -> new ShardingPrepareStatementValidator().postValidate(shardingRule, new PrepareStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(),
                         Collections.emptyList(), database, mock(ConfigurationProperties.class), routeContext));
     }
     
@@ -74,7 +75,8 @@ class ShardingPrepareStatementValidatorTest {
                 Arrays.asList(new RouteMapper("t_order", "t_order_0"), new RouteMapper("t_order_item", "t_order_item_0"))));
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         assertDoesNotThrow(() -> new ShardingPrepareStatementValidator().postValidate(
-                shardingRule, new PrepareStatementContext(sqlStatement), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class), routeContext));
+                shardingRule, new PrepareStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class),
+                routeContext));
     }
     
     @Test
@@ -87,6 +89,7 @@ class ShardingPrepareStatementValidatorTest {
         when(routeContext.getRouteUnits()).thenReturn(routeUnits);
         PrepareStatement sqlStatement = new PostgreSQLPrepareStatement();
         assertThrows(UnsupportedPrepareRouteToSameDataSourceException.class, () -> new ShardingPrepareStatementValidator().postValidate(
-                shardingRule, new PrepareStatementContext(sqlStatement), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class), routeContext));
+                shardingRule, new PrepareStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class),
+                routeContext));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingRenameTableStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingRenameTableStatementValidatorTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sharding.route.engine.validator.ddl;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.RenameTableStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -107,6 +108,6 @@ class ShardingRenameTableStatementValidatorTest {
         renameTableDefinitionSegment.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue(originTableName))));
         renameTableDefinitionSegment.setRenameTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue(newTableName))));
         sqlStatement.getRenameTables().add(renameTableDefinitionSegment);
-        return new RenameTableStatementContext(sqlStatement);
+        return new RenameTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/ShardingCopyStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/ShardingCopyStatementValidatorTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.route.engine.validator.dml;
 
 import org.apache.shardingsphere.infra.binder.context.statement.dml.CopyStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.sharding.exception.syntax.UnsupportedShardingOperationException;
 import org.apache.shardingsphere.sharding.route.engine.validator.dml.impl.ShardingCopyStatementValidator;
@@ -56,7 +57,7 @@ class ShardingCopyStatementValidatorTest {
         PostgreSQLCopyStatement sqlStatement = new PostgreSQLCopyStatement();
         sqlStatement.setTableSegment(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         assertDoesNotThrow(() -> new ShardingCopyStatementValidator().preValidate(
-                shardingRule, new CopyStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                shardingRule, new CopyStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
@@ -64,7 +65,7 @@ class ShardingCopyStatementValidatorTest {
         OpenGaussCopyStatement sqlStatement = new OpenGaussCopyStatement();
         sqlStatement.setTableSegment(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         assertDoesNotThrow(() -> new ShardingCopyStatementValidator().preValidate(
-                shardingRule, new CopyStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                shardingRule, new CopyStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
@@ -79,7 +80,7 @@ class ShardingCopyStatementValidatorTest {
     
     private void assertPreValidateCopyTable(final CopyStatement sqlStatement) {
         sqlStatement.setTableSegment(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
-        CopyStatementContext sqlStatementContext = new CopyStatementContext(sqlStatement);
+        CopyStatementContext sqlStatementContext = new CopyStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         String tableName = "t_order";
         when(shardingRule.isShardingTable(tableName)).thenReturn(true);
         new ShardingCopyStatementValidator().preValidate(

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/ShardingDeleteStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/ShardingDeleteStatementValidatorTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.route.engine.validator.dml;
 
 import org.apache.shardingsphere.infra.binder.context.statement.dml.DeleteStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.sharding.exception.syntax.DMLWithMultipleShardingTablesException;
 import org.apache.shardingsphere.sharding.route.engine.validator.dml.impl.ShardingDeleteStatementValidator;
@@ -88,7 +89,7 @@ class ShardingDeleteStatementValidatorTest {
         when(shardingRule.isAllShardingTables(tableNames)).thenReturn(false);
         when(shardingRule.containsShardingTable(tableNames)).thenReturn(true);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
-        DeleteStatementContext sqlStatementContext = new DeleteStatementContext(sqlStatement);
+        DeleteStatementContext sqlStatementContext = new DeleteStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
         new ShardingDeleteStatementValidator().preValidate(shardingRule, sqlStatementContext, Collections.emptyList(), database, mock(ConfigurationProperties.class));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/ShardingInsertStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/ShardingInsertStatementValidatorTest.java
@@ -292,13 +292,13 @@ class ShardingInsertStatementValidatorTest {
     private TablesContext createSingleTablesContext() {
         List<SimpleTableSegment> result = new LinkedList<>();
         result.add(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("user"))));
-        return new TablesContext(result, TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+        return new TablesContext(result, TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME);
     }
     
     private TablesContext createMultiTablesContext() {
         List<SimpleTableSegment> result = new LinkedList<>();
         result.add(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("user"))));
         result.add(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("order"))));
-        return new TablesContext(result, TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+        return new TablesContext(result, TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME);
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/ShardingLoadDataStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/ShardingLoadDataStatementValidatorTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.route.engine.validator.dml;
 
 import org.apache.shardingsphere.infra.binder.context.statement.dml.LoadDataStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.sharding.exception.syntax.UnsupportedShardingOperationException;
 import org.apache.shardingsphere.sharding.route.engine.validator.dml.impl.ShardingLoadDataStatementValidator;
@@ -53,14 +54,15 @@ class ShardingLoadDataStatementValidatorTest {
     void assertPreValidateLoadDataWithSingleTable() {
         MySQLLoadDataStatement sqlStatement = new MySQLLoadDataStatement(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         assertDoesNotThrow(() -> new ShardingLoadDataStatementValidator().preValidate(
-                shardingRule, new LoadDataStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                shardingRule, new LoadDataStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
     void assertPreValidateLoadDataWithShardingTable() {
         MySQLLoadDataStatement sqlStatement = new MySQLLoadDataStatement(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         when(shardingRule.isShardingTable("t_order")).thenReturn(true);
-        assertThrows(UnsupportedShardingOperationException.class, () -> new ShardingLoadDataStatementValidator().preValidate(shardingRule, new LoadDataStatementContext(sqlStatement),
-                Collections.emptyList(), mock(ShardingSphereDatabase.class), mock(ConfigurationProperties.class)));
+        assertThrows(UnsupportedShardingOperationException.class,
+                () -> new ShardingLoadDataStatementValidator().preValidate(shardingRule, new LoadDataStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME),
+                        Collections.emptyList(), mock(ShardingSphereDatabase.class), mock(ConfigurationProperties.class)));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/ShardingLoadXMLStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/ShardingLoadXMLStatementValidatorTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.route.engine.validator.dml;
 
 import org.apache.shardingsphere.infra.binder.context.statement.dml.LoadXMLStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.sharding.exception.syntax.UnsupportedShardingOperationException;
 import org.apache.shardingsphere.sharding.route.engine.validator.dml.impl.ShardingLoadXMLStatementValidator;
@@ -53,14 +54,15 @@ class ShardingLoadXMLStatementValidatorTest {
     void assertPreValidateLoadXMLWithSingleTable() {
         MySQLLoadXMLStatement sqlStatement = new MySQLLoadXMLStatement(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         assertDoesNotThrow(() -> new ShardingLoadXMLStatementValidator().preValidate(
-                shardingRule, new LoadXMLStatementContext(sqlStatement), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
+                shardingRule, new LoadXMLStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME), Collections.emptyList(), database, mock(ConfigurationProperties.class)));
     }
     
     @Test
     void assertPreValidateLoadXMLWithShardingTable() {
         MySQLLoadXMLStatement sqlStatement = new MySQLLoadXMLStatement(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         when(shardingRule.isShardingTable("t_order")).thenReturn(true);
-        assertThrows(UnsupportedShardingOperationException.class, () -> new ShardingLoadXMLStatementValidator().preValidate(shardingRule, new LoadXMLStatementContext(sqlStatement),
-                Collections.emptyList(), mock(ShardingSphereDatabase.class), mock(ConfigurationProperties.class)));
+        assertThrows(UnsupportedShardingOperationException.class,
+                () -> new ShardingLoadXMLStatementValidator().preValidate(shardingRule, new LoadXMLStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME),
+                        Collections.emptyList(), mock(ShardingSphereDatabase.class), mock(ConfigurationProperties.class)));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/ShardingUpdateStatementValidatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/ShardingUpdateStatementValidatorTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.route.engine.validator.dml;
 
 import org.apache.shardingsphere.infra.binder.context.statement.dml.UpdateStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
@@ -75,7 +76,7 @@ class ShardingUpdateStatementValidatorTest {
     void assertPreValidateWhenUpdateSingleTable() {
         UpdateStatement updateStatement = createUpdateStatement();
         updateStatement.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("user"))));
-        UpdateStatementContext sqlStatementContext = new UpdateStatementContext(updateStatement);
+        UpdateStatementContext sqlStatementContext = new UpdateStatementContext(updateStatement, DefaultDatabase.LOGIC_NAME);
         Collection<String> tableNames = sqlStatementContext.getTablesContext().getTableNames();
         when(shardingRule.isAllShardingTables(tableNames)).thenReturn(true);
         when(shardingRule.containsShardingTable(tableNames)).thenReturn(true);
@@ -90,7 +91,7 @@ class ShardingUpdateStatementValidatorTest {
         joinTableSegment.setLeft(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("user"))));
         joinTableSegment.setRight(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("order"))));
         updateStatement.setTable(joinTableSegment);
-        UpdateStatementContext sqlStatementContext = new UpdateStatementContext(updateStatement);
+        UpdateStatementContext sqlStatementContext = new UpdateStatementContext(updateStatement, DefaultDatabase.LOGIC_NAME);
         Collection<String> tableNames = sqlStatementContext.getTablesContext().getTableNames();
         when(shardingRule.isAllShardingTables(tableNames)).thenReturn(false);
         when(shardingRule.containsShardingTable(tableNames)).thenReturn(true);
@@ -100,7 +101,7 @@ class ShardingUpdateStatementValidatorTest {
     
     @Test
     void assertPostValidateWhenNotUpdateShardingColumn() {
-        UpdateStatementContext sqlStatementContext = new UpdateStatementContext(createUpdateStatement());
+        UpdateStatementContext sqlStatementContext = new UpdateStatementContext(createUpdateStatement(), DefaultDatabase.LOGIC_NAME);
         assertDoesNotThrow(() -> new ShardingUpdateStatementValidator().postValidate(shardingRule,
                 sqlStatementContext, new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class), mock(RouteContext.class)));
     }
@@ -108,14 +109,14 @@ class ShardingUpdateStatementValidatorTest {
     @Test
     void assertPostValidateWhenUpdateShardingColumnWithSameRouteContext() {
         mockShardingRuleForUpdateShardingColumn();
-        assertDoesNotThrow(() -> new ShardingUpdateStatementValidator().postValidate(shardingRule, new UpdateStatementContext(createUpdateStatement()),
+        assertDoesNotThrow(() -> new ShardingUpdateStatementValidator().postValidate(shardingRule, new UpdateStatementContext(createUpdateStatement(), DefaultDatabase.LOGIC_NAME),
                 new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class), createSingleRouteContext()));
     }
     
     @Test
     void assertPostValidateWhenTableNameIsBroadcastTable() {
         mockShardingRuleForUpdateShardingColumn();
-        assertDoesNotThrow(() -> new ShardingUpdateStatementValidator().postValidate(shardingRule, new UpdateStatementContext(createUpdateStatement()),
+        assertDoesNotThrow(() -> new ShardingUpdateStatementValidator().postValidate(shardingRule, new UpdateStatementContext(createUpdateStatement(), DefaultDatabase.LOGIC_NAME),
                 new HintValueContext(), Collections.emptyList(), database, mock(ConfigurationProperties.class), createSingleRouteContext()));
     }
     
@@ -123,7 +124,7 @@ class ShardingUpdateStatementValidatorTest {
     void assertPostValidateWhenUpdateShardingColumnWithDifferentRouteContext() {
         mockShardingRuleForUpdateShardingColumn();
         assertThrows(UnsupportedUpdatingShardingValueException.class,
-                () -> new ShardingUpdateStatementValidator().postValidate(shardingRule, new UpdateStatementContext(createUpdateStatement()), new HintValueContext(),
+                () -> new ShardingUpdateStatementValidator().postValidate(shardingRule, new UpdateStatementContext(createUpdateStatement(), DefaultDatabase.LOGIC_NAME), new HintValueContext(),
                         Collections.emptyList(), database, mock(ConfigurationProperties.class), createFullRouteContext()));
     }
     

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
@@ -668,7 +668,7 @@ class ShardingRuleTest {
         Collection<SimpleTableSegment> tableSegments = Arrays.asList(
                 new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("LOGIC_TABLE"))),
                 new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("SUB_LOGIC_TABLE"))));
-        TablesContext tablesContext = new TablesContext(tableSegments, Collections.emptyMap(), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+        TablesContext tablesContext = new TablesContext(tableSegments, Collections.emptyMap(), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME);
         when(sqlStatementContext.getTablesContext()).thenReturn(tablesContext);
         when(sqlStatementContext.getDatabaseType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/table/TablesContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/table/TablesContext.java
@@ -88,7 +88,8 @@ public final class TablesContext {
                 SimpleTableSegment simpleTableSegment = (SimpleTableSegment) each;
                 simpleTables.add(simpleTableSegment);
                 tableNames.add(simpleTableSegment.getTableName().getIdentifier().getValue());
-                schemaNames.add(simpleTableSegment.getOwner().map(optional -> optional.getIdentifier().getValue()).orElse(getDefaultSchemaName(databaseType, currentDatabaseName)));
+                // TODO use sql binder result when statement which contains tables support bind logic
+                simpleTableSegment.getOwner().ifPresent(optional -> schemaNames.add(optional.getIdentifier().getValue()));
                 databaseNames.add(findDatabaseName(simpleTableSegment, databaseType).orElse(currentDatabaseName));
                 tableNameAliasMap.put(simpleTableSegment.getTableName().getIdentifier().getValue().toLowerCase(), each.getAlias().orElse(simpleTableSegment.getTableName().getIdentifier()));
             }
@@ -96,11 +97,6 @@ public final class TablesContext {
                 subqueryTables.putAll(createSubqueryTables(subqueryContexts, (SubqueryTableSegment) each));
             }
         }
-    }
-    
-    private String getDefaultSchemaName(final DatabaseType databaseType, final String currentDatabaseName) {
-        DialectDatabaseMetaData dialectDatabaseMetaData = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData();
-        return dialectDatabaseMetaData.getDefaultSchema().orElse(currentDatabaseName);
     }
     
     private Optional<String> findDatabaseName(final SimpleTableSegment tableSegment, final DatabaseType databaseType) {

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/SQLStatementContextFactory.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/SQLStatementContextFactory.java
@@ -139,10 +139,10 @@ public final class SQLStatementContextFactory {
             return getDDLStatementContext(metaData, params, (DDLStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof DCLStatement) {
-            return getDCLStatementContext((DCLStatement) sqlStatement);
+            return getDCLStatementContext((DCLStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof DALStatement) {
-            return getDALStatementContext((DALStatement) sqlStatement);
+            return getDALStatementContext((DALStatement) sqlStatement, currentDatabaseName);
         }
         return new UnknownSQLStatementContext(sqlStatement);
     }
@@ -153,10 +153,10 @@ public final class SQLStatementContextFactory {
             return new SelectStatementContext(metaData, params, (SelectStatement) sqlStatement, currentDatabaseName, Collections.emptyList());
         }
         if (sqlStatement instanceof UpdateStatement) {
-            return new UpdateStatementContext((UpdateStatement) sqlStatement);
+            return new UpdateStatementContext((UpdateStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof DeleteStatement) {
-            return new DeleteStatementContext((DeleteStatement) sqlStatement);
+            return new DeleteStatementContext((DeleteStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof InsertStatement) {
             return new InsertStatementContext(metaData, params, (InsertStatement) sqlStatement, currentDatabaseName);
@@ -165,16 +165,16 @@ public final class SQLStatementContextFactory {
             return new CallStatementContext((CallStatement) sqlStatement);
         }
         if (sqlStatement instanceof CopyStatement) {
-            return new CopyStatementContext((CopyStatement) sqlStatement);
+            return new CopyStatementContext((CopyStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof DoStatement) {
             return new DoStatementContext((DoStatement) sqlStatement);
         }
         if (sqlStatement instanceof LoadDataStatement) {
-            return new LoadDataStatementContext((LoadDataStatement) sqlStatement);
+            return new LoadDataStatementContext((LoadDataStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof LoadXMLStatement) {
-            return new LoadXMLStatementContext((LoadXMLStatement) sqlStatement);
+            return new LoadXMLStatementContext((LoadXMLStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof MergeStatement) {
             return new MergeStatementContext((MergeStatement) sqlStatement);
@@ -188,87 +188,87 @@ public final class SQLStatementContextFactory {
             return new CreateSchemaStatementContext((CreateSchemaStatement) sqlStatement);
         }
         if (sqlStatement instanceof CreateTableStatement) {
-            return new CreateTableStatementContext((CreateTableStatement) sqlStatement);
+            return new CreateTableStatementContext((CreateTableStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof AlterTableStatement) {
-            return new AlterTableStatementContext((AlterTableStatement) sqlStatement);
+            return new AlterTableStatementContext((AlterTableStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof RenameTableStatement) {
-            return new RenameTableStatementContext((RenameTableStatement) sqlStatement);
+            return new RenameTableStatementContext((RenameTableStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof DropTableStatement) {
-            return new DropTableStatementContext((DropTableStatement) sqlStatement);
+            return new DropTableStatementContext((DropTableStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof CreateIndexStatement) {
-            return new CreateIndexStatementContext((CreateIndexStatement) sqlStatement);
+            return new CreateIndexStatementContext((CreateIndexStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof AlterIndexStatement) {
-            return new AlterIndexStatementContext((AlterIndexStatement) sqlStatement);
+            return new AlterIndexStatementContext((AlterIndexStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof DropIndexStatement) {
-            return new DropIndexStatementContext((DropIndexStatement) sqlStatement);
+            return new DropIndexStatementContext((DropIndexStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof TruncateStatement) {
-            return new TruncateStatementContext((TruncateStatement) sqlStatement);
+            return new TruncateStatementContext((TruncateStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof CreateFunctionStatement) {
-            return new CreateFunctionStatementContext((CreateFunctionStatement) sqlStatement);
+            return new CreateFunctionStatementContext((CreateFunctionStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof CreateProcedureStatement) {
-            return new CreateProcedureStatementContext((CreateProcedureStatement) sqlStatement);
+            return new CreateProcedureStatementContext((CreateProcedureStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof CreateViewStatement) {
-            return new CreateViewStatementContext((CreateViewStatement) sqlStatement);
+            return new CreateViewStatementContext((CreateViewStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof AlterViewStatement) {
-            return new AlterViewStatementContext((AlterViewStatement) sqlStatement);
+            return new AlterViewStatementContext((AlterViewStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof DropViewStatement) {
-            return new DropViewStatementContext((DropViewStatement) sqlStatement);
+            return new DropViewStatementContext((DropViewStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof PrepareStatement) {
-            return new PrepareStatementContext((PrepareStatement) sqlStatement);
+            return new PrepareStatementContext((PrepareStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof CommentStatement) {
-            return new CommentStatementContext((CommentStatement) sqlStatement);
+            return new CommentStatementContext((CommentStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof CursorStatement) {
             return new CursorStatementContext(metaData, params, (CursorStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof CloseStatement) {
-            return new CloseStatementContext((CloseStatement) sqlStatement);
+            return new CloseStatementContext((CloseStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof MoveStatement) {
-            return new MoveStatementContext((MoveStatement) sqlStatement);
+            return new MoveStatementContext((MoveStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof FetchStatement) {
-            return new FetchStatementContext((FetchStatement) sqlStatement);
+            return new FetchStatementContext((FetchStatement) sqlStatement, currentDatabaseName);
         }
         return new UnknownSQLStatementContext(sqlStatement);
     }
     
-    private static SQLStatementContext getDCLStatementContext(final DCLStatement sqlStatement) {
+    private static SQLStatementContext getDCLStatementContext(final DCLStatement sqlStatement, final String currentDatabaseName) {
         if (sqlStatement instanceof GrantStatement) {
-            return new GrantStatementContext((GrantStatement) sqlStatement);
+            return new GrantStatementContext((GrantStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof RevokeStatement) {
-            return new RevokeStatementContext((RevokeStatement) sqlStatement);
+            return new RevokeStatementContext((RevokeStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof DenyUserStatement) {
-            return new DenyUserStatementContext((DenyUserStatement) sqlStatement);
+            return new DenyUserStatementContext((DenyUserStatement) sqlStatement, currentDatabaseName);
         }
         return new UnknownSQLStatementContext(sqlStatement);
     }
     
-    private static SQLStatementContext getDALStatementContext(final DALStatement sqlStatement) {
+    private static SQLStatementContext getDALStatementContext(final DALStatement sqlStatement, final String currentDatabaseName) {
         if (sqlStatement instanceof ExplainStatement) {
-            return new ExplainStatementContext((ExplainStatement) sqlStatement);
+            return new ExplainStatementContext((ExplainStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof ShowCreateTableStatement) {
-            return new ShowCreateTableStatementContext((ShowCreateTableStatement) sqlStatement);
+            return new ShowCreateTableStatementContext((ShowCreateTableStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof ShowColumnsStatement) {
-            return new ShowColumnsStatementContext((ShowColumnsStatement) sqlStatement);
+            return new ShowColumnsStatementContext((ShowColumnsStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof ShowTablesStatement) {
             return new ShowTablesStatementContext((ShowTablesStatement) sqlStatement);
@@ -277,16 +277,16 @@ public final class SQLStatementContextFactory {
             return new ShowTableStatusStatementContext((ShowTableStatusStatement) sqlStatement);
         }
         if (sqlStatement instanceof ShowIndexStatement) {
-            return new ShowIndexStatementContext((ShowIndexStatement) sqlStatement);
+            return new ShowIndexStatementContext((ShowIndexStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof AnalyzeTableStatement) {
-            return new AnalyzeTableStatementContext((AnalyzeTableStatement) sqlStatement);
+            return new AnalyzeTableStatementContext((AnalyzeTableStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof FlushStatement) {
-            return new FlushStatementContext((FlushStatement) sqlStatement);
+            return new FlushStatementContext((FlushStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof OptimizeTableStatement) {
-            return new OptimizeTableStatementContext((OptimizeTableStatement) sqlStatement);
+            return new OptimizeTableStatementContext((OptimizeTableStatement) sqlStatement, currentDatabaseName);
         }
         if (sqlStatement instanceof KillStatement) {
             return new KillStatementContext((KillStatement) sqlStatement);

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/AnalyzeTableStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/AnalyzeTableStatementContext.java
@@ -31,9 +31,9 @@ public final class AnalyzeTableStatementContext extends CommonSQLStatementContex
     
     private final TablesContext tablesContext;
     
-    public AnalyzeTableStatementContext(final AnalyzeTableStatement sqlStatement) {
+    public AnalyzeTableStatementContext(final AnalyzeTableStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ExplainStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ExplainStatementContext.java
@@ -37,9 +37,9 @@ public final class ExplainStatementContext extends CommonSQLStatementContext imp
     
     private final TablesContext tablesContext;
     
-    public ExplainStatementContext(final ExplainStatement sqlStatement) {
+    public ExplainStatementContext(final ExplainStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(extractTablesFromExplain(sqlStatement), getDatabaseType());
+        tablesContext = new TablesContext(extractTablesFromExplain(sqlStatement), getDatabaseType(), currentDatabaseName);
     }
     
     private Collection<SimpleTableSegment> extractTablesFromExplain(final ExplainStatement sqlStatement) {

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/FlushStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/FlushStatementContext.java
@@ -31,9 +31,9 @@ public final class FlushStatementContext extends CommonSQLStatementContext imple
     
     private final TablesContext tablesContext;
     
-    public FlushStatementContext(final FlushStatement sqlStatement) {
+    public FlushStatementContext(final FlushStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/OptimizeTableStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/OptimizeTableStatementContext.java
@@ -31,9 +31,9 @@ public final class OptimizeTableStatementContext extends CommonSQLStatementConte
     
     private final TablesContext tablesContext;
     
-    public OptimizeTableStatementContext(final OptimizeTableStatement sqlStatement) {
+    public OptimizeTableStatementContext(final OptimizeTableStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ShowColumnsStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ShowColumnsStatementContext.java
@@ -36,9 +36,9 @@ public final class ShowColumnsStatementContext extends CommonSQLStatementContext
     
     private final TablesContext tablesContext;
     
-    public ShowColumnsStatementContext(final ShowColumnsStatement sqlStatement) {
+    public ShowColumnsStatementContext(final ShowColumnsStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTable(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTable(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ShowCreateTableStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ShowCreateTableStatementContext.java
@@ -31,9 +31,9 @@ public final class ShowCreateTableStatementContext extends CommonSQLStatementCon
     
     private final TablesContext tablesContext;
     
-    public ShowCreateTableStatementContext(final ShowCreateTableStatement sqlStatement) {
+    public ShowCreateTableStatementContext(final ShowCreateTableStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTable(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTable(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ShowIndexStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ShowIndexStatementContext.java
@@ -36,9 +36,9 @@ public final class ShowIndexStatementContext extends CommonSQLStatementContext i
     
     private final TablesContext tablesContext;
     
-    public ShowIndexStatementContext(final ShowIndexStatement sqlStatement) {
+    public ShowIndexStatementContext(final ShowIndexStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTable(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTable(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/DenyUserStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/DenyUserStatementContext.java
@@ -31,9 +31,9 @@ public final class DenyUserStatementContext extends CommonSQLStatementContext im
     
     private final TablesContext tablesContext;
     
-    public DenyUserStatementContext(final DenyUserStatement sqlStatement) {
+    public DenyUserStatementContext(final DenyUserStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTable(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTable(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/GrantStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/GrantStatementContext.java
@@ -31,9 +31,9 @@ public final class GrantStatementContext extends CommonSQLStatementContext imple
     
     private final TablesContext tablesContext;
     
-    public GrantStatementContext(final GrantStatement sqlStatement) {
+    public GrantStatementContext(final GrantStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/RevokeStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/RevokeStatementContext.java
@@ -31,9 +31,9 @@ public final class RevokeStatementContext extends CommonSQLStatementContext impl
     
     private final TablesContext tablesContext;
     
-    public RevokeStatementContext(final RevokeStatement sqlStatement) {
+    public RevokeStatementContext(final RevokeStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/AlterIndexStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/AlterIndexStatementContext.java
@@ -39,10 +39,10 @@ public final class AlterIndexStatementContext extends CommonSQLStatementContext 
     
     private final TablesContext tablesContext;
     
-    public AlterIndexStatementContext(final AlterIndexStatement sqlStatement) {
+    public AlterIndexStatementContext(final AlterIndexStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
         SimpleTableSegment simpleTableSegment = sqlStatement.getSimpleTable().orElse(null);
-        tablesContext = new TablesContext(simpleTableSegment, getDatabaseType());
+        tablesContext = new TablesContext(simpleTableSegment, getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/AlterTableStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/AlterTableStatementContext.java
@@ -48,9 +48,9 @@ public final class AlterTableStatementContext extends CommonSQLStatementContext 
     
     private final TablesContext tablesContext;
     
-    public AlterTableStatementContext(final AlterTableStatement sqlStatement) {
+    public AlterTableStatementContext(final AlterTableStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(getTables(sqlStatement), getDatabaseType());
+        tablesContext = new TablesContext(getTables(sqlStatement), getDatabaseType(), currentDatabaseName);
     }
     
     private Collection<SimpleTableSegment> getTables(final AlterTableStatement sqlStatement) {

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/AlterViewStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/AlterViewStatementContext.java
@@ -38,7 +38,7 @@ public final class AlterViewStatementContext extends CommonSQLStatementContext i
     
     private final TablesContext tablesContext;
     
-    public AlterViewStatementContext(final AlterViewStatement sqlStatement) {
+    public AlterViewStatementContext(final AlterViewStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
         Collection<SimpleTableSegment> tables = new LinkedList<>();
         tables.add(sqlStatement.getView());
@@ -49,7 +49,7 @@ public final class AlterViewStatementContext extends CommonSQLStatementContext i
             tables.addAll(extractor.getRewriteTables());
         });
         sqlStatement.getRenameView().ifPresent(tables::add);
-        tablesContext = new TablesContext(tables, getDatabaseType());
+        tablesContext = new TablesContext(tables, getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CloseStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CloseStatementContext.java
@@ -44,9 +44,9 @@ public final class CloseStatementContext extends CommonSQLStatementContext imple
     
     private TablesContext tablesContext;
     
-    public CloseStatementContext(final CloseStatement sqlStatement) {
+    public CloseStatementContext(final CloseStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(Collections.emptyList(), getDatabaseType());
+        tablesContext = new TablesContext(Collections.emptyList(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CommentStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CommentStatementContext.java
@@ -33,9 +33,9 @@ public final class CommentStatementContext extends CommonSQLStatementContext imp
     
     private final TablesContext tablesContext;
     
-    public CommentStatementContext(final CommentStatement sqlStatement) {
+    public CommentStatementContext(final CommentStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(null == sqlStatement.getTable() ? Collections.emptyList() : Collections.singletonList(sqlStatement.getTable()), getDatabaseType());
+        tablesContext = new TablesContext(null == sqlStatement.getTable() ? Collections.emptyList() : Collections.singletonList(sqlStatement.getTable()), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateFunctionStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateFunctionStatementContext.java
@@ -37,11 +37,11 @@ public final class CreateFunctionStatementContext extends CommonSQLStatementCont
     
     private final TablesContext tablesContext;
     
-    public CreateFunctionStatementContext(final CreateFunctionStatement sqlStatement) {
+    public CreateFunctionStatementContext(final CreateFunctionStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
         Optional<RoutineBodySegment> routineBodySegment = sqlStatement.getRoutineBody();
         Collection<SimpleTableSegment> tables = routineBodySegment.map(optional -> new TableExtractor().extractExistTableFromRoutineBody(optional)).orElseGet(Collections::emptyList);
-        tablesContext = new TablesContext(tables, getDatabaseType());
+        tablesContext = new TablesContext(tables, getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateIndexStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateIndexStatementContext.java
@@ -42,9 +42,9 @@ public final class CreateIndexStatementContext extends CommonSQLStatementContext
     
     private final boolean generatedIndex;
     
-    public CreateIndexStatementContext(final CreateIndexStatement sqlStatement) {
+    public CreateIndexStatementContext(final CreateIndexStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTable(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTable(), getDatabaseType(), currentDatabaseName);
         generatedIndex = null == sqlStatement.getIndex();
     }
     

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateProcedureStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateProcedureStatementContext.java
@@ -37,11 +37,11 @@ public final class CreateProcedureStatementContext extends CommonSQLStatementCon
     
     private final TablesContext tablesContext;
     
-    public CreateProcedureStatementContext(final CreateProcedureStatement sqlStatement) {
+    public CreateProcedureStatementContext(final CreateProcedureStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
         Optional<RoutineBodySegment> routineBodySegment = sqlStatement.getRoutineBody();
         Collection<SimpleTableSegment> tables = routineBodySegment.map(optional -> new TableExtractor().extractExistTableFromRoutineBody(optional)).orElseGet(Collections::emptyList);
-        tablesContext = new TablesContext(tables, getDatabaseType());
+        tablesContext = new TablesContext(tables, getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateTableStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateTableStatementContext.java
@@ -42,9 +42,9 @@ public final class CreateTableStatementContext extends CommonSQLStatementContext
     
     private final TablesContext tablesContext;
     
-    public CreateTableStatementContext(final CreateTableStatement sqlStatement) {
+    public CreateTableStatementContext(final CreateTableStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(getTables(sqlStatement), getDatabaseType());
+        tablesContext = new TablesContext(getTables(sqlStatement), getDatabaseType(), currentDatabaseName);
     }
     
     private Collection<SimpleTableSegment> getTables(final CreateTableStatement sqlStatement) {

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateViewStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateViewStatementContext.java
@@ -32,11 +32,11 @@ public final class CreateViewStatementContext extends CommonSQLStatementContext 
     
     private final TablesContext tablesContext;
     
-    public CreateViewStatementContext(final CreateViewStatement sqlStatement) {
+    public CreateViewStatementContext(final CreateViewStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
         TableExtractor extractor = new TableExtractor();
         extractor.extractTablesFromCreateViewStatement(sqlStatement);
-        tablesContext = new TablesContext(extractor.getRewriteTables(), getDatabaseType());
+        tablesContext = new TablesContext(extractor.getRewriteTables(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CursorStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CursorStatementContext.java
@@ -59,7 +59,7 @@ public final class CursorStatementContext extends CommonSQLStatementContext impl
     public CursorStatementContext(final ShardingSphereMetaData metaData, final List<Object> params,
                                   final CursorStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(getSimpleTableSegments(), getDatabaseType());
+        tablesContext = new TablesContext(getSimpleTableSegments(), getDatabaseType(), currentDatabaseName);
         selectStatementContext = new SelectStatementContext(metaData, params, sqlStatement.getSelect(), currentDatabaseName, Collections.emptyList());
         whereSegments.addAll(selectStatementContext.getWhereSegments());
         columnSegments.addAll(selectStatementContext.getColumnSegments());

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/DropIndexStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/DropIndexStatementContext.java
@@ -38,10 +38,10 @@ public final class DropIndexStatementContext extends CommonSQLStatementContext i
     
     private final TablesContext tablesContext;
     
-    public DropIndexStatementContext(final DropIndexStatement sqlStatement) {
+    public DropIndexStatementContext(final DropIndexStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
         SimpleTableSegment simpleTableSegment = sqlStatement.getSimpleTable().orElse(null);
-        tablesContext = new TablesContext(simpleTableSegment, getDatabaseType());
+        tablesContext = new TablesContext(simpleTableSegment, getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/DropTableStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/DropTableStatementContext.java
@@ -31,9 +31,9 @@ public final class DropTableStatementContext extends CommonSQLStatementContext i
     
     private final TablesContext tablesContext;
     
-    public DropTableStatementContext(final DropTableStatement sqlStatement) {
+    public DropTableStatementContext(final DropTableStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/DropViewStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/DropViewStatementContext.java
@@ -31,9 +31,9 @@ public final class DropViewStatementContext extends CommonSQLStatementContext im
     
     private final TablesContext tablesContext;
     
-    public DropViewStatementContext(final DropViewStatement sqlStatement) {
+    public DropViewStatementContext(final DropViewStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getViews(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getViews(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/FetchStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/FetchStatementContext.java
@@ -44,9 +44,9 @@ public final class FetchStatementContext extends CommonSQLStatementContext imple
     
     private TablesContext tablesContext;
     
-    public FetchStatementContext(final FetchStatement sqlStatement) {
+    public FetchStatementContext(final FetchStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(Collections.emptyList(), getDatabaseType());
+        tablesContext = new TablesContext(Collections.emptyList(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/MoveStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/MoveStatementContext.java
@@ -44,9 +44,9 @@ public final class MoveStatementContext extends CommonSQLStatementContext implem
     
     private TablesContext tablesContext;
     
-    public MoveStatementContext(final MoveStatement sqlStatement) {
+    public MoveStatementContext(final MoveStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(Collections.emptyList(), getDatabaseType());
+        tablesContext = new TablesContext(Collections.emptyList(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/PrepareStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/PrepareStatementContext.java
@@ -36,9 +36,9 @@ public final class PrepareStatementContext extends CommonSQLStatementContext imp
     
     private final TablesContext tablesContext;
     
-    public PrepareStatementContext(final PrepareStatement sqlStatement) {
+    public PrepareStatementContext(final PrepareStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(extractTablesFromPreparedStatement(sqlStatement), getDatabaseType());
+        tablesContext = new TablesContext(extractTablesFromPreparedStatement(sqlStatement), getDatabaseType(), currentDatabaseName);
     }
     
     private Collection<SimpleTableSegment> extractTablesFromPreparedStatement(final PrepareStatement sqlStatement) {

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/RenameTableStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/RenameTableStatementContext.java
@@ -36,9 +36,9 @@ public final class RenameTableStatementContext extends CommonSQLStatementContext
     
     private final TablesContext tablesContext;
     
-    public RenameTableStatementContext(final RenameTableStatement sqlStatement) {
+    public RenameTableStatementContext(final RenameTableStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(getTables(sqlStatement), getDatabaseType());
+        tablesContext = new TablesContext(getTables(sqlStatement), getDatabaseType(), currentDatabaseName);
     }
     
     private Collection<SimpleTableSegment> getTables(final RenameTableStatement sqlStatement) {

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/TruncateStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/TruncateStatementContext.java
@@ -31,9 +31,9 @@ public final class TruncateStatementContext extends CommonSQLStatementContext im
     
     private final TablesContext tablesContext;
     
-    public TruncateStatementContext(final TruncateStatement sqlStatement) {
+    public TruncateStatementContext(final TruncateStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTables(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/CopyStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/CopyStatementContext.java
@@ -31,9 +31,9 @@ public final class CopyStatementContext extends CommonSQLStatementContext implem
     
     private final TablesContext tablesContext;
     
-    public CopyStatementContext(final CopyStatement sqlStatement) {
+    public CopyStatementContext(final CopyStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTableSegment(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTableSegment(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/DeleteStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/DeleteStatementContext.java
@@ -50,9 +50,9 @@ public final class DeleteStatementContext extends CommonSQLStatementContext impl
     
     private final Collection<BinaryOperationExpression> joinConditions = new LinkedList<>();
     
-    public DeleteStatementContext(final DeleteStatement sqlStatement) {
+    public DeleteStatementContext(final DeleteStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(getAllSimpleTableSegments(), getDatabaseType());
+        tablesContext = new TablesContext(getAllSimpleTableSegments(), getDatabaseType(), currentDatabaseName);
         getSqlStatement().getWhere().ifPresent(whereSegments::add);
         ColumnExtractUtils.extractColumnSegments(columnSegments, whereSegments);
         ExpressionExtractUtils.extractJoinConditions(joinConditions, whereSegments);

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/InsertStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/InsertStatementContext.java
@@ -91,7 +91,7 @@ public final class InsertStatementContext extends CommonSQLStatementContext impl
         insertValueContexts = getInsertValueContexts(params, parametersOffset, valueExpressions);
         insertSelectContext = getInsertSelectContext(metaData, params, parametersOffset, currentDatabaseName).orElse(null);
         onDuplicateKeyUpdateValueContext = getOnDuplicateKeyUpdateValueContext(params, parametersOffset).orElse(null);
-        tablesContext = new TablesContext(getAllSimpleTableSegments(), getDatabaseType());
+        tablesContext = new TablesContext(getAllSimpleTableSegments(), getDatabaseType(), currentDatabaseName);
         ShardingSphereSchema schema = getSchema(metaData, currentDatabaseName);
         columnNames = containsInsertColumns() ? insertColumnNames
                 : Optional.ofNullable(sqlStatement.getTable()).map(optional -> schema.getVisibleColumnNames(optional.getTableName().getIdentifier().getValue())).orElseGet(Collections::emptyList);

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/LoadDataStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/LoadDataStatementContext.java
@@ -31,9 +31,9 @@ public final class LoadDataStatementContext extends CommonSQLStatementContext im
     
     private final TablesContext tablesContext;
     
-    public LoadDataStatementContext(final LoadDataStatement sqlStatement) {
+    public LoadDataStatementContext(final LoadDataStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTableSegment(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTableSegment(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/LoadXMLStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/LoadXMLStatementContext.java
@@ -31,9 +31,9 @@ public final class LoadXMLStatementContext extends CommonSQLStatementContext imp
     
     private final TablesContext tablesContext;
     
-    public LoadXMLStatementContext(final LoadXMLStatement sqlStatement) {
+    public LoadXMLStatementContext(final LoadXMLStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(sqlStatement.getTableSegment(), getDatabaseType());
+        tablesContext = new TablesContext(sqlStatement.getTableSegment(), getDatabaseType(), currentDatabaseName);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/SelectStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/SelectStatementContext.java
@@ -112,15 +112,15 @@ public final class SelectStatementContext extends CommonSQLStatementContext impl
     
     private PaginationContext paginationContext;
     
-    public SelectStatementContext(final ShardingSphereMetaData metaData, final List<Object> params, final SelectStatement sqlStatement, final String currentDatabaseName,
-                                  final Collection<TableSegment> inheritedTables) {
+    public SelectStatementContext(final ShardingSphereMetaData metaData, final List<Object> params, final SelectStatement sqlStatement,
+                                  final String currentDatabaseName, final Collection<TableSegment> inheritedTables) {
         super(sqlStatement);
         extractWhereSegments(whereSegments, sqlStatement);
         ColumnExtractUtils.extractColumnSegments(columnSegments, whereSegments);
         Collection<TableSegment> tableSegments = getAllTableSegments(inheritedTables);
         ExpressionExtractUtils.extractJoinConditions(joinConditions, whereSegments);
         subqueryContexts = createSubqueryContexts(metaData, params, currentDatabaseName, tableSegments);
-        tablesContext = new TablesContext(tableSegments, subqueryContexts, getDatabaseType());
+        tablesContext = new TablesContext(tableSegments, subqueryContexts, getDatabaseType(), currentDatabaseName);
         groupByContext = new GroupByContextEngine().createGroupByContext(sqlStatement);
         orderByContext = new OrderByContextEngine().createOrderBy(sqlStatement, groupByContext);
         projectionsContext = new ProjectionsContextEngine(getDatabaseType()).createProjectionsContext(getSqlStatement().getProjections(), groupByContext, orderByContext);

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/UpdateStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/UpdateStatementContext.java
@@ -48,9 +48,9 @@ public final class UpdateStatementContext extends CommonSQLStatementContext impl
     
     private final Collection<BinaryOperationExpression> joinConditions = new LinkedList<>();
     
-    public UpdateStatementContext(final UpdateStatement sqlStatement) {
+    public UpdateStatementContext(final UpdateStatement sqlStatement, final String currentDatabaseName) {
         super(sqlStatement);
-        tablesContext = new TablesContext(getAllSimpleTableSegments(), getDatabaseType());
+        tablesContext = new TablesContext(getAllSimpleTableSegments(), getDatabaseType(), currentDatabaseName);
         getSqlStatement().getWhere().ifPresent(whereSegments::add);
         ColumnExtractUtils.extractColumnSegments(columnSegments, whereSegments);
         ExpressionExtractUtils.extractJoinConditions(joinConditions, whereSegments);

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/table/TablesContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/table/TablesContextTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.binder.context.segment.table;
 
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
@@ -51,7 +52,7 @@ class TablesContextTest {
     @Test
     void assertGetTableNames() {
         TablesContext tablesContext = new TablesContext(Arrays.asList(createTableSegment("table_1", "tbl_1"),
-                createTableSegment("table_2", "tbl_2")), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+                createTableSegment("table_2", "tbl_2")), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME);
         assertThat(tablesContext.getTableNames(), is(new HashSet<>(Arrays.asList("table_1", "table_2"))));
     }
     
@@ -59,7 +60,7 @@ class TablesContextTest {
     void assertInstanceCreatedWhenNoExceptionThrown() {
         SimpleTableSegment tableSegment = new SimpleTableSegment(new TableNameSegment(0, 10, new IdentifierValue("tbl")));
         tableSegment.setOwner(new OwnerSegment(0, 0, new IdentifierValue("schema")));
-        TablesContext tablesContext = new TablesContext(Collections.singleton(tableSegment), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+        TablesContext tablesContext = new TablesContext(Collections.singleton(tableSegment), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME);
         assertThat(tablesContext.getDatabaseName(), is(Optional.of("schema")));
         assertThat(tablesContext.getSchemaName(), is(Optional.of("schema")));
         assertThat(tablesContext.getTableNames(), is(Collections.singleton("tbl")));
@@ -69,7 +70,7 @@ class TablesContextTest {
     void assertFindTableNameWhenSingleTable() {
         SimpleTableSegment tableSegment = createTableSegment("table_1", "tbl_1");
         ColumnSegment columnSegment = createColumnSegment(null, "col");
-        Map<String, String> actual = new TablesContext(Collections.singletonList(tableSegment), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"))
+        Map<String, String> actual = new TablesContext(Collections.singletonList(tableSegment), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME)
                 .findTableNames(Collections.singletonList(columnSegment), mock(ShardingSphereSchema.class));
         assertFalse(actual.isEmpty());
         assertThat(actual.get("col"), is("table_1"));
@@ -80,7 +81,7 @@ class TablesContextTest {
         SimpleTableSegment tableSegment1 = createTableSegment("table_1", "tbl_1");
         SimpleTableSegment tableSegment2 = createTableSegment("table_2", "tbl_2");
         ColumnSegment columnSegment = createColumnSegment("table_1", "col");
-        Map<String, String> actual = new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"))
+        Map<String, String> actual = new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME)
                 .findTableNames(Collections.singletonList(columnSegment), mock(ShardingSphereSchema.class));
         assertFalse(actual.isEmpty());
         assertThat(actual.get("table_1.col"), is("table_1"));
@@ -91,7 +92,7 @@ class TablesContextTest {
         SimpleTableSegment tableSegment1 = createTableSegment("table_1", "tbl_1");
         SimpleTableSegment tableSegment2 = createTableSegment("table_2", "tbl_2");
         ColumnSegment columnSegment = createColumnSegment(null, "col");
-        Map<String, String> actual = new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"))
+        Map<String, String> actual = new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME)
                 .findTableNames(Collections.singletonList(columnSegment), mock(ShardingSphereSchema.class));
         assertTrue(actual.isEmpty());
     }
@@ -104,7 +105,7 @@ class TablesContextTest {
         when(schema.getAllColumnNames("table_1")).thenReturn(Collections.singletonList("col"));
         ColumnSegment columnSegment = createColumnSegment(null, "col");
         Map<String, String> actual = new TablesContext(Arrays.asList(tableSegment1, tableSegment2),
-                TypedSPILoader.getService(DatabaseType.class, "FIXTURE")).findTableNames(Collections.singletonList(columnSegment), schema);
+                TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME).findTableNames(Collections.singletonList(columnSegment), schema);
         assertFalse(actual.isEmpty());
         assertThat(actual.get("col"), is("table_1"));
     }
@@ -118,7 +119,7 @@ class TablesContextTest {
         ShardingSphereSchema schema = new ShardingSphereSchema(Stream.of(table).collect(Collectors.toMap(ShardingSphereTable::getName, value -> value)), Collections.emptyMap());
         ColumnSegment columnSegment = createColumnSegment(null, "COL");
         Map<String, String> actual = new TablesContext(Arrays.asList(tableSegment1, tableSegment2),
-                TypedSPILoader.getService(DatabaseType.class, "FIXTURE")).findTableNames(Collections.singletonList(columnSegment), schema);
+                TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME).findTableNames(Collections.singletonList(columnSegment), schema);
         assertFalse(actual.isEmpty());
         assertThat(actual.get("col"), is("TABLE_1"));
     }
@@ -144,7 +145,7 @@ class TablesContextTest {
         tableSegment1.setOwner(new OwnerSegment(0, 0, new IdentifierValue("sharding_db_1")));
         SimpleTableSegment tableSegment2 = createTableSegment("table_1", "tbl_1");
         tableSegment2.setOwner(new OwnerSegment(0, 0, new IdentifierValue("sharding_db_1")));
-        TablesContext tablesContext = new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+        TablesContext tablesContext = new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME);
         assertTrue(tablesContext.getDatabaseName().isPresent());
         assertThat(tablesContext.getDatabaseName().get(), is("sharding_db_1"));
     }
@@ -155,7 +156,7 @@ class TablesContextTest {
         tableSegment1.setOwner(new OwnerSegment(0, 0, new IdentifierValue("sharding_db_1")));
         SimpleTableSegment tableSegment2 = createTableSegment("table_2", "tbl_2");
         tableSegment2.setOwner(new OwnerSegment(0, 0, new IdentifierValue("sharding_db_1")));
-        TablesContext tablesContext = new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+        TablesContext tablesContext = new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME);
         assertTrue(tablesContext.getDatabaseName().isPresent());
         assertThat(tablesContext.getDatabaseName().get(), is("sharding_db_1"));
     }
@@ -166,7 +167,8 @@ class TablesContextTest {
         tableSegment1.setOwner(new OwnerSegment(0, 0, new IdentifierValue("sharding_db_1")));
         SimpleTableSegment tableSegment2 = createTableSegment("table_1", "tbl_1");
         tableSegment2.setOwner(new OwnerSegment(0, 0, new IdentifierValue("sharding_db_2")));
-        assertThrows(IllegalStateException.class, () -> new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE")).getDatabaseName());
+        assertThrows(IllegalStateException.class,
+                () -> new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME).getDatabaseName());
     }
     
     @Test
@@ -175,7 +177,8 @@ class TablesContextTest {
         tableSegment1.setOwner(new OwnerSegment(0, 0, new IdentifierValue("sharding_db_1")));
         SimpleTableSegment tableSegment2 = createTableSegment("table_2", "tbl_2");
         tableSegment2.setOwner(new OwnerSegment(0, 0, new IdentifierValue("sharding_db_2")));
-        assertThrows(IllegalStateException.class, () -> new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE")).getDatabaseName());
+        assertThrows(IllegalStateException.class,
+                () -> new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME).getDatabaseName());
     }
     
     @Test
@@ -184,7 +187,7 @@ class TablesContextTest {
         tableSegment1.setOwner(new OwnerSegment(0, 0, new IdentifierValue("sharding_db_1")));
         SimpleTableSegment tableSegment2 = createTableSegment("table_2", "tbl_2");
         tableSegment2.setOwner(new OwnerSegment(0, 0, new IdentifierValue("sharding_db_1")));
-        TablesContext tablesContext = new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+        TablesContext tablesContext = new TablesContext(Arrays.asList(tableSegment1, tableSegment2), TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), DefaultDatabase.LOGIC_NAME);
         assertTrue(tablesContext.getSchemaName().isPresent());
         assertThat(tablesContext.getSchemaName().get(), is("sharding_db_1"));
     }

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dal/AnalyzeTableStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dal/AnalyzeTableStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.dal;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.AnalyzeTableStatement;
@@ -56,7 +57,7 @@ class AnalyzeTableStatementContextTest {
         tables.add(table1);
         tables.add(table2);
         when(analyzeTableStatement.getTables()).thenReturn(tables);
-        AnalyzeTableStatementContext actual = new AnalyzeTableStatementContext(analyzeTableStatement);
+        AnalyzeTableStatementContext actual = new AnalyzeTableStatementContext(analyzeTableStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(analyzeTableStatement));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()), is(Arrays.asList("tbl_1", "tbl_2")));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ExplainStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ExplainStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.dal;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.ExplainStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLExplainStatement;
@@ -48,7 +49,7 @@ class ExplainStatementContextTest {
     private void assertNewInstance(final ExplainStatement explainStatement) {
         SQLStatement statement = () -> 0;
         when(explainStatement.getSqlStatement()).thenReturn(Optional.of(statement));
-        ExplainStatementContext actual = new ExplainStatementContext(explainStatement);
+        ExplainStatementContext actual = new ExplainStatementContext(explainStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(explainStatement));
         assertThat(actual.getSqlStatement().getSqlStatement().orElse(null), is(statement));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dal/OptimizeTableStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dal/OptimizeTableStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.dal;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
@@ -41,7 +42,7 @@ class OptimizeTableStatementContextTest {
         MySQLOptimizeTableStatement optimizeTableStatement = mock(MySQLOptimizeTableStatement.class);
         Collection<SimpleTableSegment> tables = Collections.singletonList(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl_1"))));
         when(optimizeTableStatement.getTables()).thenReturn(tables);
-        OptimizeTableStatementContext actual = new OptimizeTableStatementContext(optimizeTableStatement);
+        OptimizeTableStatementContext actual = new OptimizeTableStatementContext(optimizeTableStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(optimizeTableStatement));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()),

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ShowColumnsStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ShowColumnsStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.dal;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.FromDatabaseSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.DatabaseSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
@@ -47,7 +48,7 @@ class ShowColumnsStatementContextTest {
         FromDatabaseSegment fromDatabase = new FromDatabaseSegment(0, 0, new DatabaseSegment(0, 0, new IdentifierValue(databaseName)));
         when(showColumnsStatement.getTable()).thenReturn(table);
         when(showColumnsStatement.getFromDatabase()).thenReturn(Optional.of(fromDatabase));
-        ShowColumnsStatementContext actual = new ShowColumnsStatementContext(showColumnsStatement);
+        ShowColumnsStatementContext actual = new ShowColumnsStatementContext(showColumnsStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(showColumnsStatement));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()),

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ShowCreateTableStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ShowCreateTableStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.dal;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
@@ -40,7 +41,7 @@ class ShowCreateTableStatementContextTest {
         MySQLShowCreateTableStatement showCreateTableStatement = mock(MySQLShowCreateTableStatement.class);
         SimpleTableSegment table = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl_1")));
         when(showCreateTableStatement.getTable()).thenReturn(table);
-        ShowCreateTableStatementContext actual = new ShowCreateTableStatementContext(showCreateTableStatement);
+        ShowCreateTableStatementContext actual = new ShowCreateTableStatementContext(showCreateTableStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(showCreateTableStatement));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()),

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ShowIndexStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dal/ShowIndexStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.dal;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
@@ -40,7 +41,7 @@ class ShowIndexStatementContextTest {
         MySQLShowIndexStatement showIndexStatement = mock(MySQLShowIndexStatement.class);
         SimpleTableSegment table = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl_1")));
         when(showIndexStatement.getTable()).thenReturn(table);
-        ShowIndexStatementContext actual = new ShowIndexStatementContext(showIndexStatement);
+        ShowIndexStatementContext actual = new ShowIndexStatementContext(showIndexStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(showIndexStatement));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()),

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/DenyUserStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/DenyUserStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.dcl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
@@ -40,7 +41,7 @@ class DenyUserStatementContextTest {
         SQLServerDenyUserStatement sqlServerDenyUserStatement = mock(SQLServerDenyUserStatement.class);
         SimpleTableSegment table = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl_1")));
         when(sqlServerDenyUserStatement.getTable()).thenReturn(table);
-        DenyUserStatementContext actual = new DenyUserStatementContext(sqlServerDenyUserStatement);
+        DenyUserStatementContext actual = new DenyUserStatementContext(sqlServerDenyUserStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(sqlServerDenyUserStatement));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()),

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/GrantStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/GrantStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.dcl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dcl.GrantStatement;
@@ -74,7 +75,7 @@ class GrantStatementContextTest {
         tables.add(table1);
         tables.add(table2);
         when(grantStatement.getTables()).thenReturn(tables);
-        GrantStatementContext actual = new GrantStatementContext(grantStatement);
+        GrantStatementContext actual = new GrantStatementContext(grantStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(grantStatement));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()), is(Arrays.asList("tbl_1", "tbl_2")));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/RevokeStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dcl/RevokeStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.dcl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dcl.RevokeStatement;
@@ -74,7 +75,7 @@ class RevokeStatementContextTest {
         tables.add(table1);
         tables.add(table2);
         when(revokeStatement.getTables()).thenReturn(tables);
-        RevokeStatementContext actual = new RevokeStatementContext(revokeStatement);
+        RevokeStatementContext actual = new RevokeStatementContext(revokeStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(revokeStatement));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()), is(Arrays.asList("tbl_1", "tbl_2")));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/AlterIndexStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/AlterIndexStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.index.IndexNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.index.IndexSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.AlterIndexStatement;
@@ -57,7 +58,7 @@ class AlterIndexStatementContextTest {
     private void assertNewInstance(final AlterIndexStatement alterIndexStatement) {
         IndexSegment indexSegment = new IndexSegment(0, 0, new IndexNameSegment(0, 0, new IdentifierValue("index_1")));
         when(alterIndexStatement.getIndex()).thenReturn(Optional.of(indexSegment));
-        AlterIndexStatementContext actual = new AlterIndexStatementContext(alterIndexStatement);
+        AlterIndexStatementContext actual = new AlterIndexStatementContext(alterIndexStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(alterIndexStatement));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()), is(Collections.emptyList()));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/AlterTableStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/AlterTableStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.column.ColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.column.alter.AddColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.column.alter.ModifyColumnDefinitionSegment;
@@ -110,7 +111,7 @@ class AlterTableStatementContextTest {
         DropIndexDefinitionSegment dropIndexDefinitionSegment = mock(DropIndexDefinitionSegment.class);
         when(dropIndexDefinitionSegment.getIndexSegment()).thenReturn(new IndexSegment(0, 0, new IndexNameSegment(0, 0, new IdentifierValue("drop_index"))));
         when(alterTableStatement.getDropIndexDefinitions()).thenReturn(Collections.singletonList(dropIndexDefinitionSegment));
-        AlterTableStatementContext actual = new AlterTableStatementContext(alterTableStatement);
+        AlterTableStatementContext actual = new AlterTableStatementContext(alterTableStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(alterTableStatement));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()),

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/AlterViewStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/AlterViewStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.AlterViewStatement;
@@ -65,7 +66,7 @@ class AlterViewStatementContextTest {
     }
     
     private void assertNewInstance(final AlterViewStatement alterViewStatement) {
-        AlterViewStatementContext actual = new AlterViewStatementContext(alterViewStatement);
+        AlterViewStatementContext actual = new AlterViewStatementContext(alterViewStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(alterViewStatement));
         assertThat(actual.getTablesContext().getSimpleTables().size(), is(2));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateFunctionStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateFunctionStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.CreateFunctionStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.ddl.MySQLCreateFunctionStatement;
 import org.apache.shardingsphere.sql.parser.statement.postgresql.ddl.PostgreSQLCreateFunctionStatement;
@@ -47,7 +48,7 @@ class CreateFunctionStatementContextTest {
     }
     
     private void assertNewInstance(final CreateFunctionStatement createDatabaseStatement) {
-        CreateFunctionStatementContext actual = new CreateFunctionStatementContext(createDatabaseStatement);
+        CreateFunctionStatementContext actual = new CreateFunctionStatementContext(createDatabaseStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(createDatabaseStatement));
     }

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateIndexStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateIndexStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.index.IndexNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.index.IndexSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.CreateIndexStatement;
@@ -61,14 +62,14 @@ class CreateIndexStatementContextTest {
     }
     
     private void assertNewInstance(final CreateIndexStatement createIndexStatement) {
-        CreateIndexStatementContext actual = new CreateIndexStatementContext(createIndexStatement);
+        CreateIndexStatementContext actual = new CreateIndexStatementContext(createIndexStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(createIndexStatement));
         assertTrue(actual.isGeneratedIndex());
         assertThat(actual.getTablesContext().getSimpleTables(), is(Collections.emptyList()));
         assertThat(actual.getIndexes(), is(Collections.emptyList()));
         when(createIndexStatement.getIndex()).thenReturn(new IndexSegment(0, 0, new IndexNameSegment(0, 0, new IdentifierValue("index_2"))));
-        CreateIndexStatementContext actual2 = new CreateIndexStatementContext(createIndexStatement);
+        CreateIndexStatementContext actual2 = new CreateIndexStatementContext(createIndexStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual2.getIndexes().stream().map(each -> each.getIndexName().getIdentifier().getValue()).collect(Collectors.toList()), is(Collections.singletonList("index_2")));
     }
 }

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateProcedureStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateProcedureStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.CreateProcedureStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.ddl.MySQLCreateProcedureStatement;
 import org.apache.shardingsphere.sql.parser.statement.postgresql.ddl.PostgreSQLCreateProcedureStatement;
@@ -41,7 +42,7 @@ class CreateProcedureStatementContextTest {
     }
     
     private void assertNewInstance(final CreateProcedureStatement createProcedureStatement) {
-        CreateProcedureStatementContext actual = new CreateProcedureStatementContext(createProcedureStatement);
+        CreateProcedureStatementContext actual = new CreateProcedureStatementContext(createProcedureStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(createProcedureStatement));
     }

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateTableStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateTableStatementContextTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.type.ConstraintAvailable;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.column.ColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.constraint.ConstraintDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.constraint.ConstraintSegment;
@@ -73,7 +74,7 @@ class CreateTableStatementContextTest {
     }
     
     private void assertNewInstance(final CreateTableStatement createTableStatement) {
-        CreateTableStatementContext actual = new CreateTableStatementContext(createTableStatement);
+        CreateTableStatementContext actual = new CreateTableStatementContext(createTableStatement, DefaultDatabase.LOGIC_NAME);
         SimpleTableSegment table = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl_1")));
         when(createTableStatement.getTable()).thenReturn(table);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateViewStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/CreateViewStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.CreateViewStatement;
@@ -49,7 +50,7 @@ class CreateViewStatementContextTest {
         SimpleTableSegment view = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("view")));
         when(createViewStatement.getView()).thenReturn(view);
         when(createViewStatement.getSelect()).thenReturn(mock(SelectStatement.class));
-        CreateViewStatementContext actual = new CreateViewStatementContext(createViewStatement);
+        CreateViewStatementContext actual = new CreateViewStatementContext(createViewStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(createViewStatement));
     }

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/DropIndexStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/DropIndexStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.index.IndexNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.index.IndexSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DropIndexStatement;
@@ -69,7 +70,7 @@ class DropIndexStatementContextTest {
         indexes.add(index1);
         indexes.add(index2);
         when(dropIndexStatement.getIndexes()).thenReturn(indexes);
-        DropIndexStatementContext actual = new DropIndexStatementContext(dropIndexStatement);
+        DropIndexStatementContext actual = new DropIndexStatementContext(dropIndexStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(dropIndexStatement));
         assertThat(actual.getTablesContext().getSimpleTables(), is(Collections.emptyList()));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/DropTableStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/DropTableStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DropTableStatement;
@@ -65,7 +66,7 @@ class DropTableStatementContextTest {
     }
     
     private void assertNewInstance(final DropTableStatement dropTableStatement) {
-        DropTableStatementContext actual = new DropTableStatementContext(dropTableStatement);
+        DropTableStatementContext actual = new DropTableStatementContext(dropTableStatement, DefaultDatabase.LOGIC_NAME);
         SimpleTableSegment table1 = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl_1")));
         SimpleTableSegment table2 = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl_2")));
         when(dropTableStatement.getTables()).thenReturn(Arrays.asList(table1, table2));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/DropViewStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/DropViewStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DropViewStatement;
@@ -50,7 +51,7 @@ class DropViewStatementContextTest {
         SimpleTableSegment table1 = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl_1")));
         SimpleTableSegment table2 = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl_2")));
         when(dropViewStatement.getViews()).thenReturn(Arrays.asList(table1, table2));
-        DropViewStatementContext actual = new DropViewStatementContext(dropViewStatement);
+        DropViewStatementContext actual = new DropViewStatementContext(dropViewStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(dropViewStatement));
     }

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/PrepareStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/PrepareStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.ColumnAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.SetAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
@@ -66,7 +67,7 @@ class PrepareStatementContextTest {
         when(prepareStatement.getInsert()).thenReturn(Optional.of(getInsert()));
         when(prepareStatement.getUpdate()).thenReturn(Optional.of(getUpdate()));
         when(prepareStatement.getDelete()).thenReturn(Optional.of(getDelete()));
-        PrepareStatementContext actual = new PrepareStatementContext(prepareStatement);
+        PrepareStatementContext actual = new PrepareStatementContext(prepareStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(prepareStatement));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()),

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/TruncateStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/ddl/TruncateStatementContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.context.statement.ddl;
 
 import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.TruncateStatement;
@@ -63,7 +64,7 @@ class TruncateStatementContextTest {
         SimpleTableSegment table1 = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl_1")));
         SimpleTableSegment table2 = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("tbl_2")));
         when(truncateStatement.getTables()).thenReturn(Arrays.asList(table1, table2));
-        TruncateStatementContext actual = new TruncateStatementContext(truncateStatement);
+        TruncateStatementContext actual = new TruncateStatementContext(truncateStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual, instanceOf(CommonSQLStatementContext.class));
         assertThat(actual.getSqlStatement(), is(truncateStatement));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()), is(Arrays.asList("tbl_1", "tbl_2")));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dml/DeleteStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dml/DeleteStatementContextTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.binder.context.statement.dml;
 
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.JoinTableSegment;
@@ -84,7 +85,7 @@ class DeleteStatementContextTest {
         tableSegment.setRight(table2);
         deleteStatement.setWhere(whereSegment);
         deleteStatement.setTable(tableSegment);
-        DeleteStatementContext actual = new DeleteStatementContext(deleteStatement);
+        DeleteStatementContext actual = new DeleteStatementContext(deleteStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual.getTablesContext().getTableNames(), is(new HashSet<>(Arrays.asList("tbl_1", "tbl_2"))));
         assertThat(actual.getWhereSegments(), is(Collections.singletonList(whereSegment)));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()), is(Arrays.asList("tbl_1", "tbl_2")));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dml/UpdateStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dml/UpdateStatementContextTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.binder.context.statement.dml;
 
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.SetAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
@@ -66,7 +67,7 @@ class UpdateStatementContextTest {
         updateStatement.setWhere(whereSegment);
         updateStatement.setTable(joinTableSegment);
         updateStatement.setSetAssignment(new SetAssignmentSegment(0, 0, Collections.emptyList()));
-        UpdateStatementContext actual = new UpdateStatementContext(updateStatement);
+        UpdateStatementContext actual = new UpdateStatementContext(updateStatement, DefaultDatabase.LOGIC_NAME);
         assertThat(actual.getTablesContext().getTableNames(), is(new HashSet<>(Arrays.asList("tbl_1", "tbl_2"))));
         assertThat(actual.getWhereSegments(), is(Collections.singletonList(whereSegment)));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()),

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/process/ProcessEngineTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/process/ProcessEngineTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.executor.sql.process;
 
 import org.apache.shardingsphere.infra.binder.context.statement.dml.UpdateStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroupContext;
 import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroupReportContext;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.SQLExecutionUnit;
@@ -58,7 +59,7 @@ class ProcessEngineTest {
     @Test
     void assertExecuteSQL() {
         ExecutionGroupContext<? extends SQLExecutionUnit> executionGroupContext = mockExecutionGroupContext();
-        new ProcessEngine().executeSQL(executionGroupContext, new QueryContext(new UpdateStatementContext(getSQLStatement()), null, null, new HintValueContext()));
+        new ProcessEngine().executeSQL(executionGroupContext, new QueryContext(new UpdateStatementContext(getSQLStatement(), DefaultDatabase.LOGIC_NAME), null, null, new HintValueContext()));
         verify(processRegistry).add(any());
     }
     

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/SingleSQLRouterTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/SingleSQLRouterTest.java
@@ -215,6 +215,6 @@ class SingleSQLRouterTest {
     private QueryContext createQueryContext() {
         CreateTableStatement createTableStatement = new MySQLCreateTableStatement(false);
         createTableStatement.setTable(new SimpleTableSegment(new TableNameSegment(1, 2, new IdentifierValue("t_order"))));
-        return new QueryContext(new CreateTableStatementContext(createTableStatement), "CREATE TABLE", new LinkedList<>(), new HintValueContext());
+        return new QueryContext(new CreateTableStatementContext(createTableStatement, DefaultDatabase.LOGIC_NAME), "CREATE TABLE", new LinkedList<>(), new HintValueContext());
     }
 }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/engine/SQLFederationEngine.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/engine/SQLFederationEngine.java
@@ -34,6 +34,8 @@ import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;
+import org.apache.shardingsphere.infra.database.core.metadata.database.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.table.NoSuchTableException;
@@ -191,7 +193,7 @@ public final class SQLFederationEngine implements AutoCloseable {
         try {
             SelectStatementContext selectStatementContext = (SelectStatementContext) federationContext.getQueryContext().getSqlStatementContext();
             String databaseName = selectStatementContext.getTablesContext().getDatabaseNames().stream().findFirst().orElse(currentDatabaseName);
-            String schemaName = selectStatementContext.getTablesContext().getSchemaName().orElse(currentSchemaName);
+            String schemaName = getSchemaName(selectStatementContext);
             OptimizerMetaData optimizerMetaData = sqlFederationRule.getOptimizerContext().getMetaData(databaseName);
             CalciteConnectionConfig connectionConfig = new CalciteConnectionConfigImpl(sqlFederationRule.getOptimizerContext().getParserContext(databaseName).getDialectProps());
             CalciteCatalogReader catalogReader = SQLFederationPlannerUtils.createCatalogReader(schemaName, optimizerMetaData.getSchema(schemaName), DEFAULT_DATA_TYPE_FACTORY, connectionConfig);
@@ -209,6 +211,11 @@ public final class SQLFederationEngine implements AutoCloseable {
             // CHECKSTYLE:ON
             throw new SQLFederationUnsupportedSQLException(federationContext.getQueryContext().getSql(), ex);
         }
+    }
+    
+    private String getSchemaName(final SelectStatementContext selectStatementContext) {
+        DialectDatabaseMetaData dialectDatabaseMetaData = new DatabaseTypeRegistry(selectStatementContext.getDatabaseType()).getDialectDatabaseMetaData();
+        return dialectDatabaseMetaData.getDefaultSchema().isPresent() ? currentSchemaName : selectStatementContext.getTablesContext().getSchemaName().orElse(currentSchemaName);
     }
     
     private SQLFederationExecutionPlan compileQuery(final DriverExecutionPrepareEngine<JDBCExecutionUnit, Connection> prepareEngine, final JDBCExecutorCallback<? extends ExecuteResult> callback,

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxySQLExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxySQLExecutorTest.java
@@ -228,19 +228,19 @@ class ProxySQLExecutorTest {
     private CreateTableStatementContext createMySQLCreateTableStatementContext() {
         MySQLCreateTableStatement sqlStatement = new MySQLCreateTableStatement(false);
         sqlStatement.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
-        return new CreateTableStatementContext(sqlStatement);
+        return new CreateTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
     }
     
     private TruncateStatementContext createMySQLTruncateStatementContext() {
         MySQLTruncateStatement sqlStatement = new MySQLTruncateStatement();
         sqlStatement.getTables().add(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
-        return new TruncateStatementContext(sqlStatement);
+        return new TruncateStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
     }
     
     private SQLStatementContext createPostgreSQLTruncateStatementContext() {
         PostgreSQLTruncateStatement sqlStatement = new PostgreSQLTruncateStatement();
         sqlStatement.getTables().add(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
-        return new TruncateStatementContext(sqlStatement);
+        return new TruncateStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
     }
     
     private CursorStatementContext createCursorStatementContext() {
@@ -280,7 +280,7 @@ class ProxySQLExecutorTest {
     private CreateTableStatementContext createPostgreSQLCreateTableStatementContext() {
         PostgreSQLCreateTableStatement sqlStatement = new PostgreSQLCreateTableStatement(false);
         sqlStatement.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
-        return new CreateTableStatementContext(sqlStatement);
+        return new CreateTableStatementContext(sqlStatement, DefaultDatabase.LOGIC_NAME);
     }
     
     private InsertStatementContext createPostgreSQLInsertStatementContext() {

--- a/proxy/backend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/PostgreSQLAdminExecutorCreatorTest.java
+++ b/proxy/backend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/PostgreSQLAdminExecutorCreatorTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.proxy.backend.postgresql.handler.admin;
 import org.apache.shardingsphere.infra.binder.context.statement.UnknownSQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.DeleteStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.parser.config.SQLParserRuleConfiguration;
@@ -163,7 +164,7 @@ class PostgreSQLAdminExecutorCreatorTest {
     
     @Test
     void assertCreateWithDMLStatement() {
-        DeleteStatementContext sqlStatementContext = new DeleteStatementContext(new PostgreSQLDeleteStatement());
+        DeleteStatementContext sqlStatementContext = new DeleteStatementContext(new PostgreSQLDeleteStatement(), DefaultDatabase.LOGIC_NAME);
         assertThat(new PostgreSQLAdminExecutorCreator().create(sqlStatementContext, "delete from t where id = 1", "", Collections.emptyList()), is(Optional.empty()));
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Pass currentDatabaseName to TablesContext constructor to keep schemaNames, databaseNames for all tables

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
