### PR TITLE
Improve atan and anan2 sql function for mysql

### DIFF
--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/planner/util/SQLFederationFunctionUtils.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/planner/util/SQLFederationFunctionUtils.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sqlfederation.optimizer.planner.util;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.impl.ScalarFunctionImpl;
 import org.apache.shardingsphere.infra.autogen.version.ShardingSphereVersion;
@@ -50,6 +51,8 @@ public final class SQLFederationFunctionUtils {
         schemaPlus.add("pg_catalog.intervaltonum", ScalarFunctionImpl.create(SQLFederationFunctionUtils.class, "intervalToNum"));
         schemaPlus.add("pg_catalog.gs_password_notifyTime", ScalarFunctionImpl.create(SQLFederationFunctionUtils.class, "gsPasswordNotifyTime"));
         schemaPlus.add("bit_count", ScalarFunctionImpl.create(MySQLBitCountFunction.class, "bitCount"));
+        schemaPlus.add("atan", ScalarFunctionImpl.create(SqlFunctions.class, "atan2"));
+        schemaPlus.add("atan2", ScalarFunctionImpl.create(SqlFunctions.class, "atan"));
         if ("pg_catalog".equalsIgnoreCase(schemaName)) {
             schemaPlus.add("pg_catalog.pg_table_is_visible", ScalarFunctionImpl.create(SQLFederationFunctionUtils.class, "pgTableIsVisible"));
             schemaPlus.add("pg_catalog.pg_get_userbyid", ScalarFunctionImpl.create(SQLFederationFunctionUtils.class, "pgGetUserById"));

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select.xml
@@ -333,4 +333,18 @@
                     INNER JOIN t_order_item t3 ON t2.product_id = t3.product_id INNER JOIN t_order t4 ON t4.order_id = t3.order_id order by t1.product_id" db-types="MySQL" scenario-types="db_tbl_sql_federation">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
+    
+    <test-case sql="SELECT ATAN(1.0), ATAN(1), ATAN('1'), ATAN(1.0, 2.0), ATAN(1, 2), ATAN(1, 2.0), ATAN(-2, 2)" db-types="MySQL" scenario-types="db_tbl_sql_federation">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
+    <test-case sql="SELECT ATAN2(1.0), ATAN2(1), ATAN2('1'), ATAN2(1.0, 2.0), ATAN2(1, 2.0), ATAN2(-2, 2)" db-types="MySQL" scenario-types="db_tbl_sql_federation">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
+    <test-case sql="SELECT ATAN(res1.order_id), ATAN(res1.order_id, res2.item_id), ATAN2(res1.order_id), ATAN2(res1.order_id, res2.item_id)
+                    FROM (SELECT order_id FROM t_order limit 10) res1
+                    INNER JOIN (SELECT item_id, order_id FROM t_order_item limit 10) res2 ON res1.order_id = res2.order_id" db-types="MySQL" scenario-types="db_tbl_sql_federation">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
 </integration-test-cases>


### PR DESCRIPTION
Ref #31912.

Changes proposed in this pull request:
  - Improve atan and anan2 sql function for mysql

<img width="851" alt="2024-06-29 23 20 22" src="https://github.com/apache/shardingsphere/assets/106047330/4ba2a037-a730-4404-8f39-ad74ff2f0e69">


mysql is compatible with calls to different numbers of parameters

<img width="703" alt="截屏2024-06-30 00 04 22" src="https://github.com/apache/shardingsphere/assets/106047330/110aac1e-71b6-4027-a43c-3255f24a5f27">


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
