### PR TITLE
Add instructions for Apache Seata 2.1.0-RC4 to Seata AT integration documentation

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.cn.md
@@ -49,14 +49,20 @@ Apache ShardingSphere 提供 BASE 事务，集成了 Seata 的实现。本文所
 
 ### 启动 Seata Server
 
-按照 [seata-fescar-workshop](https://github.com/seata/fescar-workshop) 或 https://hub.docker.com/r/seataio/seata-server 中的步骤，
-下载并启动 Seata 服务器。
+按照如下任一链接的步骤，下载并启动 Seata 服务器。
+合理的启动方式应通过 Docker Hub 中的 `seataio/seata-server` 的 Docker Image 来实例化 Seata 服务器。
+对于 `apache/incubator-seata:v2.0.0` 及更早的 Seata 版本，应使用 Docker Hub 中的 `seataio/seata-server`。
+否则应使用 Docker Hub 中的 `apache/seata-server`。
+
+- [seata-fescar-workshop](https://github.com/seata/fescar-workshop)
+- https://hub.docker.com/r/seataio/seata-server
+- https://hub.docker.com/r/apache/seata-server
 
 ### 创建 undo_log 表
 
-在每一个分片数据库实例中执创建 `undo_log` 表（以 MySQL 为例）。
+在每一个 ShardingSphere 涉及的真实数据库实例中创建 `undo_log` 表。
 SQL 的内容以 https://github.com/apache/incubator-seata/tree/v2.0.0/script/client/at/db 内对应的数据库为准。
-
+以下内容以 MySQL 为例。
 ```sql
 CREATE TABLE IF NOT EXISTS `undo_log`
 (
@@ -95,6 +101,16 @@ client {
     application.id = example
     transaction.service.group = default_tx_group
 }
+```
+
+一个最小配置的 `seata.conf` 如下。
+请注意，由 ShardingSphere 管理的 `seata.conf` 中， `client.transaction.service.group` 的默认值设置为 `default` 是出于历史原因。
+假设用户使用的 Seata Server 和 Seata Client 的 `registry.conf` 中，`registry.type` 和 `config.type` 均为 `file`，
+则对于 `registry.conf` 的 `config.file.name` 配置的 `.conf` 文件中，事务分组名在 `apache/incubator-seata:v1.5.1` 之后默认值为 `default_tx_group`，
+反之则为 `my_test_tx_group`。
+
+```conf
+client.application.id = example
 ```
 
 根据实际场景修改 Seata 的 `registry.conf` 文件。

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.en.md
@@ -50,14 +50,21 @@ Introduce Maven dependencies and exclude the outdated Maven dependencies of `org
 
 ### Start Seata Server
 
-Follow the steps in [seata-fescar-workshop](https://github.com/seata/fescar-workshop) or https://hub.docker.com/r/seataio/seata-server ,
-download and start the Seata server.
+Follow the steps in one of the links below to download and start Seata Server.
+
+The proper way to start Seata Server is to instantiate it through the Docker Image of `seataio/seata-server` in Docker Hub.
+For `apache/incubator-seata:v2.0.0` and earlier Seata versions, `seataio/seata-server` from Docker Hub should be used.
+Otherwise, `apache/seata-server` from Docker Hub should be used.
+
+- [seata-fescar-workshop](https://github.com/seata/fescar-workshop)
+- https://hub.docker.com/r/seataio/seata-server
+- https://hub.docker.com/r/apache/seata-server
 
 ### Create undo_log table
 
-Create the `undo_log` table in each shard database instance (take MySQL as an example).
-The content of SQL is subject to the corresponding database in https://github.com/apache/incubator-seata/tree/v2.0.0/script/client/at/db .
-
+Create the `undo_log` table in each real database instance involved in ShardingSphere.
+The SQL content is based on the corresponding database in https://github.com/apache/incubator-seata/tree/v2.0.0/script/client/at/db .
+The following content takes MySQL as an example.
 ```sql
 CREATE TABLE IF NOT EXISTS `undo_log`
 (
@@ -96,6 +103,16 @@ client {
     application.id = example
     transaction.service.group = default_tx_group
 }
+```
+
+A minimally configured `seata.conf` is as follows.
+Please note that in `seata.conf` managed by ShardingSphere, the default value of `client.transaction.service.group` is set to `default` for historical reasons.
+Assuming that in the `registry.conf` of Seata Server and Seata Client used by the user, `registry.type` and `config.type` are both `file`,
+then for the `.conf` file configured by `config.file.name` of `registry.conf`, 
+the default value of the transaction group name is `default_tx_group` after `apache/incubator-seata:v1.5.1`, otherwise it is `my_test_tx_group`.
+
+```conf
+client.application.id = example
 ```
 
 Modify the `registry.conf` file of Seata as required.


### PR DESCRIPTION
For #31715.

Changes proposed in this pull request:
  - Add instructions for Apache Seata 2.1.0-RC4 to Seata AT integration documentation. Refer to https://lists.apache.org/thread/s0gxv49802kk8y3dnxr8ytxy6ghkkjr6 .
  - Updates to the Docker Image are available at https://github.com/apache/incubator-seata/pull/6349 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
