### PR TITLE
Improve the parsing of methods in MySQL,fix issue #31547

### DIFF
--- a/test/it/parser/src/main/resources/case/dml/select-aggregate.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-aggregate.xml
@@ -453,6 +453,34 @@
         </where>
     </select>
 
+    <select sql-case-id="select_bit_and">
+        <projections start-index="7" stop-index="16">
+            <expression-projection start-index="7" stop-index="16" text="BIT_AND(1)">
+                <expr>
+                    <function function-name="BIT_AND" text="BIT_AND(1)" start-index="7" stop-index="16">
+                        <parameter>
+                            <literal-expression value="1" start-index="15" stop-index="15" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_bit_or">
+        <projections start-index="7" stop-index="15">
+            <expression-projection start-index="7" stop-index="15" text="BIT_OR(1)">
+                <expr>
+                    <function function-name="BIT_OR" text="BIT_OR(1)" start-index="7" stop-index="15">
+                        <parameter>
+                            <literal-expression value="1" start-index="14" stop-index="14" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
     <select sql-case-id="select_bit_xor">
         <from>
             <simple-table name="t_order" start-index="29" stop-index="35" />

--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -1242,4 +1242,92 @@
             </expression-projection>
         </projections>
     </select>
+
+    <select sql-case-id="select_bin">
+        <projections start-index="7" stop-index="13">
+            <expression-projection start-index="7" stop-index="13" text="BIN(12)">
+                <expr>
+                    <function function-name="BIN" text="BIN(12)" start-index="7" stop-index="13">
+                        <parameter>
+                            <literal-expression value="12" start-index="11" stop-index="12" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_bin_uuid">
+        <projections start-index="7" stop-index="70">
+            <expression-projection start-index="7" stop-index="70" text="BIN_TO_UUID(UUID_TO_BIN('6ccd780c-baba-1026-9564-5b8c656024db'))">
+                <expr>
+                    <function function-name="BIN_TO_UUID" text="BIN_TO_UUID(UUID_TO_BIN('6ccd780c-baba-1026-9564-5b8c656024db'))" start-index="7" stop-index="70">
+                        <parameter>
+                            <function function-name="UUID_TO_BIN" text="UUID_TO_BIN('6ccd780c-baba-1026-9564-5b8c656024db')" start-index="19" stop-index="69">
+                                <parameter>
+                                    <literal-expression value="6ccd780c-baba-1026-9564-5b8c656024db" start-index="31" stop-index="68" />
+                                </parameter>
+                            </function>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_bit_length">
+        <projections start-index="7" stop-index="19">
+            <expression-projection start-index="7" stop-index="19" text="BIT_LENGTH(1)">
+                <expr>
+                    <function function-name="BIT_LENGTH" text="BIT_LENGTH(1)" start-index="7" stop-index="19">
+                        <parameter>
+                            <literal-expression value="1" start-index="18" stop-index="18" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_bit_count">
+        <projections start-index="7" stop-index="18">
+            <expression-projection start-index="7" stop-index="18" text="BIT_COUNT(1)">
+                <expr>
+                    <function function-name="BIT_COUNT" text="BIT_COUNT(1)" start-index="7" stop-index="18">
+                        <parameter>
+                            <literal-expression value="1" start-index="17" stop-index="17" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_ceil">
+        <projections start-index="7" stop-index="15">
+            <expression-projection start-index="7" stop-index="15" text="CEIL(1.1)">
+                <expr>
+                    <function function-name="CEIL" text="CEIL(1.1)" start-index="7" stop-index="15">
+                        <parameter>
+                            <literal-expression value="1.1" start-index="12" stop-index="14" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_ceiling">
+        <projections start-index="7" stop-index="18">
+            <expression-projection start-index="7" stop-index="18" text="CEILING(1.1)">
+                <expr>
+                    <function function-name="CEILING" text="CEILING(1.1)" start-index="7" stop-index="18">
+                        <parameter>
+                            <literal-expression value="1.1" start-index="15" stop-index="17" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-aggregate.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-aggregate.xml
@@ -32,6 +32,8 @@
     <sql-case id="select_count_with_sample_seed_clause" value="SELECT COUNT(*) * 10 FROM orders SAMPLE(10) SEED (1)" db-types="Oracle" />
     <sql-case id="select_count_with_in_clause" value="SELECT COUNT(*) FROM t_order WHERE last_value IN (?, ?)" db-types="MySQL" />
     <sql-case id="select_count_with_not_in_clause" value="SELECT COUNT(*) FROM t_order WHERE category IN (?, ?) AND last_value NOT IN (?, ?)" db-types="MySQL" />
+    <sql-case id="select_bit_and" value="SELECT BIT_AND(1)" db-types="MySQL" />
+    <sql-case id="select_bit_or" value="SELECT BIT_OR(1)" db-types="MySQL" />
     <sql-case id="select_bit_xor" value="SELECT BIT_XOR(user_id) FROM t_order" db-types="MySQL" />
     <sql-case id="select_approx_count"
               value="select owner, approx_count(*) , approx_rank(partition by owner order by approx_count(*) desc) from t group by owner having approx_rank(partition by owner order by approx_count(*) desc) &lt;= 1 order by 1"

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
@@ -63,4 +63,10 @@
     <sql-case id="select_aes_decrypt" value="SELECT AES_DECRYPT('encrypt_text','key_str')" db-types="MySQL" />
     <sql-case id="select_any_value" value="SELECT ANY_VALUE(age) FROM t" db-types="MySQL" />
     <sql-case id="select_ascii" value="SELECT ASCII('2')" db-types="MySQL" />
+    <sql-case id="select_bin" value="SELECT BIN(12)" db-types="MySQL" />
+    <sql-case id="select_bin_uuid" value="SELECT BIN_TO_UUID(UUID_TO_BIN('6ccd780c-baba-1026-9564-5b8c656024db'))" db-types="MySQL" />
+    <sql-case id="select_bit_length" value="SELECT BIT_LENGTH(1)" db-types="MySQL" />
+    <sql-case id="select_bit_count" value="SELECT BIT_COUNT(1)" db-types="MySQL" />
+    <sql-case id="select_ceil" value="SELECT CEIL(1.1)" db-types="MySQL" />
+    <sql-case id="select_ceiling" value="SELECT CEILING(1.1)" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
Fixes #31547.

Changes proposed in this pull request:
  Improve the parsing of methods in MySQL

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
