### PR TITLE
Removes the incorrectly placed Junit4 class in nativeTest under GraalVM Native Image

### DIFF
--- a/test/native/pom.xml
+++ b/test/native/pom.xml
@@ -165,6 +165,11 @@ using Seata Client under GraalVM Native Image requires using the version release
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/MySQLTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/MySQLTest.java
@@ -22,12 +22,13 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.shardingsphere.test.natived.jdbc.commons.TestShardingService;
 import org.awaitility.Awaitility;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledInNativeImage;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import javax.sql.DataSource;
@@ -47,6 +48,7 @@ import static org.hamcrest.Matchers.nullValue;
  * Background comes from <a href="https://github.com/testcontainers/testcontainers-java/issues/7954">testcontainers/testcontainers-java#7954</a>.
  */
 @EnabledInNativeImage
+@Testcontainers
 class MySQLTest {
     
     private static final String SYSTEM_PROP_KEY_PREFIX = "fixture.test-native.yaml.database.mysql.";
@@ -58,8 +60,8 @@ class MySQLTest {
     private static final String DATABASE = "test";
     
     @SuppressWarnings("resource")
-    @ClassRule
-    public static GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("mysql:8.4.0-oracle"))
+    @Container
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(DockerImageName.parse("mysql:8.4.0-oracle"))
             .withEnv("MYSQL_DATABASE", DATABASE)
             .withEnv("MYSQL_ROOT_PASSWORD", PASSWORD)
             .withExposedPorts(3306);
@@ -84,8 +86,7 @@ class MySQLTest {
     
     @Test
     void assertShardingInLocalTransactions() throws SQLException {
-        container.start();
-        jdbcUrlPrefix = "jdbc:mysql://localhost:" + container.getMappedPort(3306) + "/";
+        jdbcUrlPrefix = "jdbc:mysql://localhost:" + CONTAINER.getMappedPort(3306) + "/";
         DataSource dataSource = createDataSource();
         testShardingService = new TestShardingService(dataSource);
         initEnvironment();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/OpenGaussTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/OpenGaussTest.java
@@ -21,12 +21,13 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.shardingsphere.test.natived.jdbc.commons.TestShardingService;
 import org.awaitility.Awaitility;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledInNativeImage;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import javax.sql.DataSource;
@@ -41,6 +42,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+@Testcontainers
 @EnabledInNativeImage
 class OpenGaussTest {
     
@@ -53,8 +55,8 @@ class OpenGaussTest {
     private static final String DATABASE = "postgres";
     
     @SuppressWarnings("resource")
-    @ClassRule
-    public static GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("opengauss/opengauss:5.0.0"))
+    @Container
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(DockerImageName.parse("opengauss/opengauss:5.0.0"))
             .withEnv("GS_PASSWORD", PASSWORD)
             .withExposedPorts(5432);
     
@@ -78,8 +80,7 @@ class OpenGaussTest {
     
     @Test
     void assertShardingInLocalTransactions() throws SQLException {
-        container.start();
-        jdbcUrlPrefix = "jdbc:opengauss://localhost:" + container.getMappedPort(5432) + "/";
+        jdbcUrlPrefix = "jdbc:opengauss://localhost:" + CONTAINER.getMappedPort(5432) + "/";
         DataSource dataSource = createDataSource();
         testShardingService = new TestShardingService(dataSource);
         initEnvironment();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/transactions/base/SeataTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/transactions/base/SeataTest.java
@@ -21,13 +21,14 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.shardingsphere.test.natived.jdbc.commons.TestShardingService;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledInNativeImage;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -37,14 +38,15 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 @EnabledInNativeImage
+@Testcontainers
 class SeataTest {
     
     /**
      * TODO Further processing of `/health` awaits <a href="https://github.com/apache/incubator-seata/pull/6356">apache/incubator-seata#6356</a>.
      */
-    @ClassRule
     @SuppressWarnings("resource")
-    public static GenericContainer<?> container = new GenericContainer<>("seataio/seata-server:1.8.0")
+    @Container
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("seataio/seata-server:1.8.0")
             .withExposedPorts(7091, 8091)
             .waitingFor(Wait.forHttp("/health").forPort(7091).forStatusCode(HttpStatus.SC_UNAUTHORIZED));
     
@@ -64,8 +66,7 @@ class SeataTest {
     
     @Test
     void assertShardingInSeataTransactions() throws SQLException {
-        container.start();
-        DataSource dataSource = createDataSource(container.getMappedPort(8091));
+        DataSource dataSource = createDataSource(CONTAINER.getMappedPort(8091));
         testShardingService = new TestShardingService(dataSource);
         initEnvironment();
         testShardingService.processSuccess();


### PR DESCRIPTION
For #31982.

Changes proposed in this pull request:
  - Removes the incorrectly placed Junit4 class in nativeTest under GraalVM Native Image.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
