### PR TITLE
Add more unit tests for ExpressionSegmentBinder(#28538)

### DIFF
--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/expression/impl/BinaryOperationExpressionBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/expression/impl/BinaryOperationExpressionBinderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.segment.expression.impl;
+
+import org.apache.shardingsphere.infra.binder.segment.SegmentType;
+import org.apache.shardingsphere.infra.binder.statement.SQLStatementBinderContext;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+class BinaryOperationExpressionBinderTest {
+    
+    @Test
+    void assertBinaryOperationExpression() {
+        BinaryOperationExpression binaryOperationExpression = new BinaryOperationExpression(0, 0,
+                new LiteralExpressionSegment(0, 0, "test"),
+                new LiteralExpressionSegment(0, 0, "test"), "=", "test");
+        SQLStatementBinderContext statementBinderContext = mock(SQLStatementBinderContext.class);
+        BinaryOperationExpression actual = BinaryOperationExpressionBinder.bind(binaryOperationExpression, SegmentType.PROJECTION,
+                statementBinderContext, Collections.emptyMap(), Collections.emptyMap());
+        assertThat(actual.getLeft().getText(), is("test"));
+        assertThat(actual.getRight().getText(), is("test"));
+        assertThat(actual.getOperator(), is("="));
+        assertThat(actual.getText(), is("test"));
+    }
+}

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/expression/impl/ExistsSubqueryExpressionBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/expression/impl/ExistsSubqueryExpressionBinderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.segment.expression.impl;
+
+import org.apache.shardingsphere.infra.binder.statement.SQLStatementBinderContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExistsSubqueryExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubquerySegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionsSegment;
+import org.apache.shardingsphere.sql.parser.statement.mysql.dml.MySQLSelectStatement;
+import org.apache.shardingsphere.test.fixture.database.MockedDatabaseType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ExistsSubqueryExpressionBinderTest {
+    
+    @Test
+    void assertBindExistsSubqueryExpression() {
+        MySQLSelectStatement selectStatement = new MySQLSelectStatement();
+        selectStatement.setProjections(new ProjectionsSegment(0, 0));
+        ExistsSubqueryExpression existsSubqueryExpression = new ExistsSubqueryExpression(0, 0,
+                new SubquerySegment(0, 0, selectStatement, "t_test"));
+        SQLStatementBinderContext statementBinderContext = new SQLStatementBinderContext(mock(ShardingSphereMetaData.class),
+                DefaultDatabase.LOGIC_NAME, new MockedDatabaseType(), Collections.emptyList());
+        ExistsSubqueryExpression actual = ExistsSubqueryExpressionBinder.bind(existsSubqueryExpression, statementBinderContext, Collections.emptyMap());
+        assertThat(actual.getStartIndex(), is(existsSubqueryExpression.getStartIndex()));
+        assertThat(actual.getStopIndex(), is(existsSubqueryExpression.getStopIndex()));
+        assertThat(actual.getText(), is("t_test"));
+        assertThat(actual.getSubquery().getStartIndex(), is(existsSubqueryExpression.getSubquery().getStartIndex()));
+        assertThat(actual.getSubquery().getStopIndex(), is(existsSubqueryExpression.getSubquery().getStopIndex()));
+        assertThat(actual.getSubquery().getSubqueryType(), is(existsSubqueryExpression.getSubquery().getSubqueryType()));
+        assertThat(actual.getSubquery().getText(), is("t_test"));
+        assertThat(actual.getSubquery().getSelect().getDatabaseType(), is(existsSubqueryExpression.getSubquery().getSelect().getDatabaseType()));
+    }
+}

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/expression/impl/FunctionExpressionSegmentBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/expression/impl/FunctionExpressionSegmentBinderTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.segment.expression.impl;
+
+import org.apache.shardingsphere.infra.binder.segment.SegmentType;
+import org.apache.shardingsphere.infra.binder.statement.SQLStatementBinderContext;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.FunctionSegment;
+import org.apache.shardingsphere.test.fixture.database.MockedDatabaseType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class FunctionExpressionSegmentBinderTest {
+    
+    @Test
+    void assertBindFunctionExpressionSegment() {
+        FunctionSegment functionSegment = new FunctionSegment(0, 0, "CONCAT", "('%','abc','%')");
+        SQLStatementBinderContext statementBinderContext = new SQLStatementBinderContext(new ShardingSphereMetaData(), DefaultDatabase.LOGIC_NAME, new MockedDatabaseType(), Collections.emptyList());
+        FunctionSegment actual = FunctionExpressionSegmentBinder.bind(functionSegment, SegmentType.PROJECTION, statementBinderContext, Collections.emptyMap(), Collections.emptyMap());
+        assertThat(actual.getStartIndex(), is(functionSegment.getStartIndex()));
+        assertThat(actual.getStopIndex(), is(functionSegment.getStopIndex()));
+        assertThat(actual.getFunctionName(), is("CONCAT"));
+        assertThat(actual.getText(), is("('%','abc','%')"));
+    }
+}

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/expression/impl/InExpressionBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/expression/impl/InExpressionBinderTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.segment.expression.impl;
+
+import org.apache.shardingsphere.infra.binder.segment.SegmentType;
+import org.apache.shardingsphere.infra.binder.statement.SQLStatementBinderContext;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.InExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class InExpressionBinderTest {
+    
+    @Test
+    void assertInExpressionBinder() {
+        InExpression inExpression = new InExpression(0, 10,
+                new LiteralExpressionSegment(0, 0, "left"),
+                new LiteralExpressionSegment(0, 0, "right"), true);
+        SQLStatementBinderContext statementBinderContext = mock(SQLStatementBinderContext.class);
+        InExpression actual = InExpressionBinder.bind(inExpression, SegmentType.PROJECTION,
+                statementBinderContext, Collections.emptyMap(), Collections.emptyMap());
+        assertThat(actual.getText(), is("leftright"));
+        assertTrue(actual.isNot());
+    }
+}


### PR DESCRIPTION
Fixes #28538.

Changes proposed in this pull request:
  Add more unit tests for ExpressionSegmentBinder

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
