### PR TITLE
ConditionValueInOperatorGenerator not excluding the case of not in. (#32076)

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueInOperatorGenerator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueInOperatorGenerator.java
@@ -41,6 +41,9 @@ public final class ConditionValueInOperatorGenerator implements ConditionValueGe
     @Override
     public Optional<ShardingConditionValue> generate(final InExpression predicate, final Column column, final List<Object> params, final TimestampServiceRule timestampServiceRule) {
         List<Comparable<?>> shardingConditionValues = new LinkedList<>();
+        if (predicate.isNot()) {
+            return Optional.empty();
+        }
         Collection<ExpressionSegment> expressionSegments = predicate.getExpressionList();
         List<Integer> parameterMarkerIndexes = new ArrayList<>(expressionSegments.size());
         for (ExpressionSegment each : expressionSegments) {

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueInOperatorGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/impl/ConditionValueInOperatorGeneratorTest.java
@@ -117,4 +117,14 @@ class ConditionValueInOperatorGeneratorTest {
         Optional<ShardingConditionValue> actual = generator.generate(predicate, column, new LinkedList<>(), timestampServiceRule);
         assertFalse(actual.isPresent());
     }
+    
+    @Test
+    void assertNotInExpression() {
+        ColumnSegment left = new ColumnSegment(0, 0, new IdentifierValue("id"));
+        ListExpression right = new ListExpression(0, 0);
+        right.getItems().add(new ParameterMarkerExpressionSegment(0, 0, 0));
+        InExpression inExpression = new InExpression(0, 0, left, right, true);
+        Optional<ShardingConditionValue> shardingConditionValue = generator.generate(inExpression, column, Collections.singletonList(1), timestampServiceRule);
+        assertFalse(shardingConditionValue.isPresent());
+    }
 }


### PR DESCRIPTION
Fixes #32076.

Changes proposed in this pull request:
  - excluding the case of `not in` in ConditionValueInOperatorGenerator 

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
