### PR TITLE
Remove varargs in pipeline exception constructor to avoid transfer cause to varargs

### DIFF
--- a/infra/exception/core/src/main/java/org/apache/shardingsphere/infra/exception/core/external/sql/type/kernel/category/PipelineSQLException.java
+++ b/infra/exception/core/src/main/java/org/apache/shardingsphere/infra/exception/core/external/sql/type/kernel/category/PipelineSQLException.java
@@ -29,7 +29,11 @@ public abstract class PipelineSQLException extends KernelSQLException {
     
     private static final int KERNEL_CODE = 8;
     
-    protected PipelineSQLException(final SQLState sqlState, final int errorCode, final String reason, final Object... messageArgs) {
-        super(sqlState, KERNEL_CODE, errorCode, reason, messageArgs);
+    protected PipelineSQLException(final SQLState sqlState, final int errorCode, final String reason) {
+        super(sqlState, KERNEL_CODE, errorCode, reason);
+    }
+    
+    protected PipelineSQLException(final SQLState sqlState, final int errorCode, final String reason, final Exception cause) {
+        super(sqlState, KERNEL_CODE, errorCode, cause, reason);
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/data/PipelineDataException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/data/PipelineDataException.java
@@ -30,8 +30,8 @@ public abstract class PipelineDataException extends PipelineSQLException {
     
     private static final int JOB_CODE = 2;
     
-    protected PipelineDataException(final SQLState sqlState, final int errorCode, final String reason, final Object... messageArgs) {
-        super(sqlState, getErrorCode(errorCode), reason, messageArgs);
+    protected PipelineDataException(final SQLState sqlState, final int errorCode, final String reason) {
+        super(sqlState, getErrorCode(errorCode), reason);
     }
     
     protected PipelineDataException(final SQLState sqlState, final int errorCode, final String reason, final Exception cause) {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/data/PipelineUnexpectedDataRecordOrderException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/data/PipelineUnexpectedDataRecordOrderException.java
@@ -28,6 +28,6 @@ public final class PipelineUnexpectedDataRecordOrderException extends PipelineDa
     private static final long serialVersionUID = 6023695604738387750L;
     
     public PipelineUnexpectedDataRecordOrderException(final DataRecord beforeDataRecord, final DataRecord afterDataRecord) {
-        super(XOpenSQLState.GENERAL_ERROR, 0, "Before data record is '%s', after data record is '%s'.", beforeDataRecord, afterDataRecord);
+        super(XOpenSQLState.GENERAL_ERROR, 0, String.format("Before data record is '%s', after data record is '%s'.", beforeDataRecord, afterDataRecord));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/data/UnsupportedPipelineDatabaseTypeException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/data/UnsupportedPipelineDatabaseTypeException.java
@@ -28,6 +28,6 @@ public final class UnsupportedPipelineDatabaseTypeException extends PipelineData
     private static final long serialVersionUID = -4100671584682823997L;
     
     public UnsupportedPipelineDatabaseTypeException(final DatabaseType databaseType) {
-        super(XOpenSQLState.FEATURE_NOT_SUPPORTED, 2, "Unsupported pipeline database type '%s'.", databaseType.getType());
+        super(XOpenSQLState.FEATURE_NOT_SUPPORTED, 2, String.format("Unsupported pipeline database type '%s'.", databaseType.getType()));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/ConsistencyCheckJobNotFoundException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/ConsistencyCheckJobNotFoundException.java
@@ -27,6 +27,6 @@ public final class ConsistencyCheckJobNotFoundException extends PipelineJobExcep
     private static final long serialVersionUID = 6881217592831423520L;
     
     public ConsistencyCheckJobNotFoundException(final String jobId) {
-        super(XOpenSQLState.GENERAL_ERROR, 12, "Can not find consistency check job of '%s'.", jobId);
+        super(XOpenSQLState.GENERAL_ERROR, 12, String.format("Can not find consistency check job of '%s'.", jobId));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/CreateTableSQLGenerateException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/CreateTableSQLGenerateException.java
@@ -27,6 +27,6 @@ public final class CreateTableSQLGenerateException extends PipelineJobException 
     private static final long serialVersionUID = -219467568498936298L;
     
     public CreateTableSQLGenerateException(final String tableName) {
-        super(XOpenSQLState.GENERAL_ERROR, 14, "Failed to get DDL for table '%s'.", tableName);
+        super(XOpenSQLState.GENERAL_ERROR, 14, String.format("Failed to get DDL for table '%s'.", tableName));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/MissingRequiredTargetDatabaseException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/MissingRequiredTargetDatabaseException.java
@@ -27,6 +27,6 @@ public final class MissingRequiredTargetDatabaseException extends PipelineJobExc
     private static final long serialVersionUID = -1557471818392592482L;
     
     public MissingRequiredTargetDatabaseException(final String databaseName) {
-        super(XOpenSQLState.NOT_FOUND, 0, "Target database '%s' does not exist.", databaseName);
+        super(XOpenSQLState.NOT_FOUND, 0, String.format("Target database '%s' does not exist.", databaseName));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PipelineJobCreationWithInvalidShardingCountException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PipelineJobCreationWithInvalidShardingCountException.java
@@ -27,6 +27,6 @@ public final class PipelineJobCreationWithInvalidShardingCountException extends 
     private static final long serialVersionUID = 5829502315976905271L;
     
     public PipelineJobCreationWithInvalidShardingCountException(final String jobId) {
-        super(XOpenSQLState.CHECK_OPTION_VIOLATION, 2, "Sharding count of job '%s' is 0.", jobId);
+        super(XOpenSQLState.CHECK_OPTION_VIOLATION, 2, String.format("Sharding count of job '%s' is 0.", jobId));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PipelineJobException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PipelineJobException.java
@@ -30,8 +30,8 @@ public abstract class PipelineJobException extends PipelineSQLException {
     
     private static final int JOB_CODE = 1;
     
-    protected PipelineJobException(final SQLState sqlState, final int errorCode, final String reason, final Object... messageArgs) {
-        super(sqlState, getErrorCode(errorCode), reason, messageArgs);
+    protected PipelineJobException(final SQLState sqlState, final int errorCode, final String reason) {
+        super(sqlState, getErrorCode(errorCode), reason);
     }
     
     protected PipelineJobException(final SQLState sqlState, final int errorCode, final String reason, final Exception cause) {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PipelineJobNotFoundException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PipelineJobNotFoundException.java
@@ -27,6 +27,6 @@ public final class PipelineJobNotFoundException extends PipelineJobException {
     private static final long serialVersionUID = -903289953649758722L;
     
     public PipelineJobNotFoundException(final String jobId) {
-        super(XOpenSQLState.NOT_FOUND, 1, "Can not find pipeline job '%s'.", jobId);
+        super(XOpenSQLState.NOT_FOUND, 1, String.format("Can not find pipeline job '%s'.", jobId));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PrepareJobWithInvalidSourceDataSourceException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PrepareJobWithInvalidSourceDataSourceException.java
@@ -27,6 +27,6 @@ public final class PrepareJobWithInvalidSourceDataSourceException extends Pipeli
     private static final long serialVersionUID = -7710035889344958565L;
     
     public PrepareJobWithInvalidSourceDataSourceException(final String dataSourceKey, final String toBeCheckedValue, final String actualValue) {
-        super(XOpenSQLState.GENERAL_ERROR, 7, "Source data source required '%s = %s', now is '%s'.", dataSourceKey, toBeCheckedValue, actualValue);
+        super(XOpenSQLState.GENERAL_ERROR, 7, String.format("Source data source required '%s = %s', now is '%s'.", dataSourceKey, toBeCheckedValue, actualValue));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PrepareJobWithTargetTableNotEmptyException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PrepareJobWithTargetTableNotEmptyException.java
@@ -27,6 +27,6 @@ public final class PrepareJobWithTargetTableNotEmptyException extends PipelineJo
     private static final long serialVersionUID = -8462039913248251254L;
     
     public PrepareJobWithTargetTableNotEmptyException(final String tableName) {
-        super(XOpenSQLState.GENERAL_ERROR, 5, "Target table '%s' is not empty.", tableName);
+        super(XOpenSQLState.GENERAL_ERROR, 5, String.format("Target table '%s' is not empty.", tableName));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PrepareJobWithoutEnoughPrivilegeException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PrepareJobWithoutEnoughPrivilegeException.java
@@ -29,6 +29,6 @@ public final class PrepareJobWithoutEnoughPrivilegeException extends PipelineJob
     private static final long serialVersionUID = -8462039913248251254L;
     
     public PrepareJobWithoutEnoughPrivilegeException(final Collection<String> privileges) {
-        super(XOpenSQLState.PRIVILEGE_NOT_GRANTED, 6, "Source data source lacks '%s' privilege(s).", privileges);
+        super(XOpenSQLState.PRIVILEGE_NOT_GRANTED, 6, String.format("Source data source lacks '%s' privilege(s).", privileges));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PrepareJobWithoutUserException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PrepareJobWithoutUserException.java
@@ -27,6 +27,6 @@ public final class PrepareJobWithoutUserException extends PipelineJobException {
     private static final long serialVersionUID = 7250019436391155770L;
     
     public PrepareJobWithoutUserException(final String username) {
-        super(XOpenSQLState.NOT_FOUND, 8, "User '%s' does exist.", username);
+        super(XOpenSQLState.NOT_FOUND, 8, String.format("User '%s' does exist.", username));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/TableNotFoundWhenSplitPipelineJobByRangeException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/TableNotFoundWhenSplitPipelineJobByRangeException.java
@@ -27,6 +27,6 @@ public final class TableNotFoundWhenSplitPipelineJobByRangeException extends Pip
     private static final long serialVersionUID = -8509592086832334026L;
     
     public TableNotFoundWhenSplitPipelineJobByRangeException(final String tableName) {
-        super(XOpenSQLState.NOT_FOUND, 3, "Can not get meta data for table '%s' when split by range.", tableName);
+        super(XOpenSQLState.NOT_FOUND, 3, String.format("Can not get meta data for table '%s' when split by range.", tableName));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/UncompletedConsistencyCheckJobExistsException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/UncompletedConsistencyCheckJobExistsException.java
@@ -28,6 +28,6 @@ public final class UncompletedConsistencyCheckJobExistsException extends Pipelin
     private static final long serialVersionUID = 2854259384634892428L;
     
     public UncompletedConsistencyCheckJobExistsException(final String jobId, final ConsistencyCheckJobItemProgress progress) {
-        super(XOpenSQLState.GENERAL_ERROR, 13, "Uncompleted consistency check job '%s' exists, progress '%s'.", jobId, progress);
+        super(XOpenSQLState.GENERAL_ERROR, 13, String.format("Uncompleted consistency check job '%s' exists, progress '%s'.", jobId, progress));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/param/PipelineInvalidParameterException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/param/PipelineInvalidParameterException.java
@@ -28,6 +28,6 @@ public final class PipelineInvalidParameterException extends PipelineSQLExceptio
     private static final long serialVersionUID = -2162309404414015630L;
     
     public PipelineInvalidParameterException(final String message) {
-        super(XOpenSQLState.INVALID_PARAMETER_VALUE, 0, "There is invalid parameter value '%s'.", message);
+        super(XOpenSQLState.INVALID_PARAMETER_VALUE, 0, String.format("There is invalid parameter value '%s'.", message));
     }
 }

--- a/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/exception/PipelineCDCException.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/exception/PipelineCDCException.java
@@ -30,8 +30,8 @@ public abstract class PipelineCDCException extends PipelineSQLException {
     
     private static final int CDC_CODE = 4;
     
-    protected PipelineCDCException(final SQLState sqlState, final int errorCode, final String reason, final Object... messageArgs) {
-        super(sqlState, getErrorCode(errorCode), reason, messageArgs);
+    protected PipelineCDCException(final SQLState sqlState, final int errorCode, final String reason) {
+        super(sqlState, getErrorCode(errorCode), reason);
     }
     
     private static int getErrorCode(final int errorCode) {

--- a/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/exception/StreamDatabaseNotFoundException.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/exception/StreamDatabaseNotFoundException.java
@@ -27,6 +27,6 @@ public final class StreamDatabaseNotFoundException extends PipelineCDCException 
     private static final long serialVersionUID = -1064162731346147038L;
     
     public StreamDatabaseNotFoundException(final String database) {
-        super(XOpenSQLState.NOT_FOUND, 1, "Database '%s' does not exist.", database);
+        super(XOpenSQLState.NOT_FOUND, 1, String.format("Database '%s' does not exist.", database));
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Remove varargs in pipeline exception constructor to avoid transfer cause to varargs

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
