### PR TITLE
Improve ShardingSphereSQLException error message formatting

### DIFF
--- a/infra/exception/core/src/main/java/org/apache/shardingsphere/infra/exception/core/external/sql/ShardingSphereSQLException.java
+++ b/infra/exception/core/src/main/java/org/apache/shardingsphere/infra/exception/core/external/sql/ShardingSphereSQLException.java
@@ -43,11 +43,11 @@ public abstract class ShardingSphereSQLException extends ShardingSphereExternalE
     private final Exception cause;
     
     protected ShardingSphereSQLException(final SQLState sqlState, final int typeOffset, final int errorCode, final String reason, final Object... messageArgs) {
-        this(sqlState.getValue(), typeOffset, errorCode, null == reason ? null : String.format(reason, formatMessageArguments(messageArgs)), null);
+        this(sqlState.getValue(), typeOffset, errorCode, formatMessage(reason, messageArgs), null);
     }
     
     protected ShardingSphereSQLException(final SQLState sqlState, final int typeOffset, final int errorCode, final Exception cause, final String reason, final Object... messageArgs) {
-        this(sqlState.getValue(), typeOffset, errorCode, null == reason ? null : String.format(reason, formatMessageArguments(messageArgs)), cause);
+        this(sqlState.getValue(), typeOffset, errorCode, formatMessage(reason, messageArgs), cause);
     }
     
     protected ShardingSphereSQLException(final String sqlState, final int typeOffset, final int errorCode, final String reason, final Exception cause) {
@@ -58,6 +58,16 @@ public abstract class ShardingSphereSQLException extends ShardingSphereExternalE
         vendorCode = typeOffset * 10000 + errorCode;
         this.reason = null == cause || Strings.isNullOrEmpty(cause.getMessage()) ? reason : String.format("%s%sMore details: %s", reason, System.lineSeparator(), cause.getMessage());
         this.cause = cause;
+    }
+    
+    private static String formatMessage(final String reason, final Object[] messageArgs) {
+        if (null == reason) {
+            return null;
+        }
+        if (0 == messageArgs.length) {
+            return reason;
+        }
+        return String.format(reason, formatMessageArguments(messageArgs));
     }
     
     private static Object[] formatMessageArguments(final Object... messageArgs) {

--- a/infra/exception/core/src/main/java/org/apache/shardingsphere/infra/exception/core/internal/ShardingSphereInternalException.java
+++ b/infra/exception/core/src/main/java/org/apache/shardingsphere/infra/exception/core/internal/ShardingSphereInternalException.java
@@ -29,7 +29,7 @@ public abstract class ShardingSphereInternalException extends Exception {
     private static final long serialVersionUID = -8238061892944243621L;
     
     protected ShardingSphereInternalException(final String errorMessage, final Object... args) {
-        super(String.format(errorMessage, args));
+        super(formatMessage(errorMessage, args));
     }
     
     protected ShardingSphereInternalException(final Exception cause) {
@@ -38,5 +38,15 @@ public abstract class ShardingSphereInternalException extends Exception {
     
     protected ShardingSphereInternalException(final String message, final Exception cause) {
         super(message, cause);
+    }
+    
+    private static String formatMessage(final String reason, final Object[] messageArgs) {
+        if (null == reason) {
+            return null;
+        }
+        if (0 == messageArgs.length) {
+            return reason;
+        }
+        return String.format(reason, messageArgs);
     }
 }

--- a/infra/exception/core/src/test/java/org/apache/shardingsphere/infra/exception/core/sql/ShardingSphereSQLExceptionTest.java
+++ b/infra/exception/core/src/test/java/org/apache/shardingsphere/infra/exception/core/sql/ShardingSphereSQLExceptionTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.exception.core.sql;
+
+import org.apache.shardingsphere.infra.exception.core.external.sql.ShardingSphereSQLException;
+import org.apache.shardingsphere.infra.exception.core.external.sql.sqlstate.XOpenSQLState;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ShardingSphereSQLExceptionTest {
+    
+    @Test
+    void assertNoStringFormatErrorWhenNoArgs() {
+        assertNotNull(new MalformedFormatMessageSQLException().getMessage());
+    }
+    
+    private static class MalformedFormatMessageSQLException extends ShardingSphereSQLException {
+        
+        private static final long serialVersionUID = 139616805450096292L;
+        
+        MalformedFormatMessageSQLException() {
+            super(XOpenSQLState.GENERAL_ERROR, 0, 1, "Fixture %2");
+        }
+    }
+}


### PR DESCRIPTION

Changes proposed in this pull request:
  - No String.format when varargs is empty to avoid possible formatting error

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
