### PR TITLE
Fixes the problem that the Seata integration module cannot correctly determine the status of distributed transactions in multi-microservice scenarios

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.en.md
@@ -7,6 +7,7 @@ weight = 7
 
 Apache ShardingSphere provides BASE transactions that integrate the Seata implementation.
 All references to Seata integration in this article refer to Seata AT mode.
+Integration of Seata TCC mode is blocked by https://github.com/apache/shardingsphere/discussions/32023 .
 
 ## Prerequisites
 
@@ -83,15 +84,28 @@ ALTER TABLE `undo_log` ADD INDEX `ix_log_created` (`log_created`);
 
 ### Modify configuration
 
+Write the following content in the YAML configuration file of ShardingSphere of your own project, 
+refer to [Distributed Transaction](/en/user-manual/shardingsphere-jdbc/yaml-config/rules/transaction).
+
+If Java API is used when initializing ShardingSphere JDBC DataSource, 
+refer to [Distributed Transaction](/en/user-manual/shardingsphere-jdbc/java-api/rules/transaction).
+
+```yaml
+transaction:
+  defaultType: BASE
+  providerType: Seata
+```
+
 Add the `seata.conf` file to the root directory of the classpath.
 The configuration file format refers to the [JavaDoc](https://github.com/apache/incubator-seata/blob/v2.0.0/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java) of `io.seata.config.FileConfiguration`.
 
 There are four properties in `seata.conf`,
 
-1. `shardingsphere.transaction.seata.at.enable`, when this value is `true`, ShardingSphere's Seata AT integration is enabled, there is a default value of `true`
-2. `shardingsphere.transaction.seata.tx.timeout`, global transaction timeout in SECONDS, there is a default value of `60`
-3. `client.application.id`, apply the only primary key
-4. `client.transaction.service.group`, the transaction group it belongs to, there is a default value of `default`
+1. `shardingsphere.transaction.seata.at.enable`, when this value is `true`, enable ShardingSphere's Seata AT integration. The default value is `true`
+2. `shardingsphere.transaction.seata.tx.timeout`, global transaction timeout (seconds). The default value is `60`
+3. `client.application.id`, application unique primary key, used to set `applicationId` of Seata Transaction Manager Client and Seata Resource Manager Client
+4. `client.transaction.service.group`, transaction group, used to set `transactionServiceGroup` of Seata Transaction Manager Client and Seata Resource Manager Client.
+The default value is `default`
 
 A fully configured `seata.conf` is as follows,
 
@@ -129,7 +143,7 @@ That is, when using ShardingSphere's Seata integration, users should avoid using
 For ShardingSphere data source, discuss 6 situations,
 
 1. Manually obtain the `java.sql.Connection` instance created from the ShardingSphere data source,
-   and manually calling the `setAutoCommit()`, `commit()` and `rollback()` methods is allowed.
+and manually calling the `setAutoCommit()`, `commit()` and `rollback()` methods is allowed.
 
 2. Using the Jakarta EE 8 `javax.transaction.Transactional` annotation on the function is allowed.
 
@@ -142,25 +156,10 @@ For ShardingSphere data source, discuss 6 situations,
 6. Manually create `io.seata.tm.api.GlobalTransaction` instance from `io.seata.tm.api.GlobalTransactionContext`,
 calling the `begin()`, `commit()` and `rollback()` methods of an `io.seata.tm.api.GlobalTransaction` instance is **not allowed**.
 
-For Seata Server 2.0.0,
-Seata Server does not pass the return value of `io.seata.core.context.RootContext.getXID()` to all connected Seata Client instances of the same **transaction group**,
-Reference https://seata.apache.org/docs/user/api/ .
-This requires discussing two situations,
-
-1. In the scenario of using ShardingSphere JDBC,
-   transaction scenarios across multiple microservices need to consider using `io.seata.core.context.RootContext.getXID()` in the context of the starting microservice to obtain the Seata XID and then pass it to the ending microservice through RPC,
-   and call `io.seata.core.context.RootContext.bind(rpcXid)` in the business function of the endpoint microservice.
-
-2. In the scenario of using ShardingSphere Proxy,
-   Multiple microservices operate local transactions against the logical dataSource of ShardingSphere Proxy,
-   this will be converted into distributed transaction operations on the server side of ShardingSphere Proxy,
-   there are no additional Seata XIDs to consider.
-
-In the actual scenario of using Spring Boot OSS,
-`com.alibaba.cloud:spring-cloud-starter-alibaba-seata` and `io.seata:seata-spring-boot-starter` are often introduced transitively by other Maven dependencies.
-In order to avoid transaction conflicts, users need to manually turn off Seata's auto-config class.
-And set the `seata.enable-auto-data-source-proxy` property to `false` in the Spring Boot OSS configuration file. 
-A possible dependency is as follows.
+In actual scenarios where Spring Boot is used, 
+`com.alibaba.cloud:spring-cloud-starter-alibaba-seata` and `io.seata:seata-spring-boot-starter` are often transitively imported by other Maven dependencies.
+To avoid transaction conflicts, users need to set the property `seata.enable-auto-data-source-proxy` to `false` in the Spring Boot configuration file. 
+A possible dependency relationship is as follows.
 
 ```xml
 <project>
@@ -190,30 +189,257 @@ A possible dependency is as follows.
 </project>
 ```
 
-The corresponding Spring Boot OSS bootstrap class may be as follows.
-
-```java
-import io.seata.spring.boot.autoconfigure.SeataAutoConfiguration;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-@SpringBootApplication(exclude = SeataAutoConfiguration.class)
-public class ExampleApplication {
-
-     public static void main(String[] args) {
-         SpringApplication.run(ExampleApplication.class, args);
-     }
-
-}
-```
-
-The corresponding `application.yml` under the classpath needs to contain the following configuration.
-In this case, the equivalent configuration of Seata's `registry.conf` defined in `application.yaml` of Spring Boot OSS may not be valid.
-This depends on the Seata Client.
-When a downstream project uses the Maven module `org.apache.shardingsphere:shardingsphere-transaction-base-seata-at`,
-users are always encouraged to configure Seata Client using `registry.conf`.
+The corresponding `application.yml` under classpath needs to contain the following configuration.
+In this case, the equivalent configuration of Seata's `registry.conf` defined in Spring Boot's `application.yaml` is still valid.
+When downstream projects use the Maven module of `org.apache.shardingsphere:shardingsphere-transaction-base-seata-at`, 
+it is always encouraged to use `registry.conf` to configure Seata Client.
 
 ```yaml
 seata:
    enable-auto-data-source-proxy: false
 ```
+
+### Transactional propagation across service calls
+
+Transactional propagationn in cross-service call scenarios is not as out-of-the-box as transaction operations within a single microservice.
+For Seata Server, transactional propagation in cross-service call scenarios requires passing XID to the service provider through service calls and binding it to `io.seata.core.context.RootContext`.
+Refer to https://seata.apache.org/docs/user/api/ . This requires discussing two situations,
+
+1. In the scenario of using ShardingSphere JDBC, 
+transaction scenarios across multiple microservices need to consider using `io.seata.core.context.RootContext.getXID()` to obtain Seata XID in the context of the starting microservice,
+and passing it to the end microservice through HTTP or RPC, and processing it in the Filter or Spring WebMVC HandlerInterceptor of the end microservice.
+Spring WebMVC HandlerInterceptor is only applicable to Spring Boot microservices and is invalid for Quarkus, Micronaut Framework and Helidon.
+
+2. In the scenario of using ShardingSphere Proxy, multiple microservices operate local transactions against the logical data source of ShardingSphere Proxy.
+This will be converted into distributed transaction operations on the server side of ShardingSphere Proxy, without considering additional Seata XID.
+
+Introduce a simple scenario to continue discussing the transactional propagation across service calls in the scenario of using ShardingSphere JDBC.
+
+1. MySQL database instance `a-mysql`, all databases have created `UNDO_LOG` table and business table.
+2. MySQL database instance `b-mysql`, all databases have created `UNDO_LOG` table and business table.
+3. Seata Server instance `a-seata-server` using `file` as configuration center and registration center.
+4. Microservice instance `a-service`. This microservice creates a ShardingSphere JDBC DataSource that only configures the database instance `a-mysql`.
+This ShardingSphere JDBC DataSource configuration uses the Seata AT integration connected to the Seata Server instance `a-seata-server`, 
+whose Seata Application Id is `service-a`, whose Seata transaction group is `default_tx_group`, 
+and the Seata Transaction Coordinator cluster group pointed to by its `Virtual Group Mapping` is `default`.
+This microservice instance `a-service` exposes a single Restful API GET endpoint as `/hello`,
+and the business function `aMethod` of this Restful API endpoint uses a common local transaction annotation.
+If this microservice is based on Spring Boot,
+
+```java
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DemoController {
+   @Transactional
+   @GetMapping("/hello")
+   public String aMethod() {
+      // ... Perform an UPDATE operation on the database instance `a-mysql`
+      return "Hello World!";
+   }
+}
+```
+
+5. Microservice instance `b-service`. This microservice creates a ShardingSphere JDBC DataSource that only configures the database instance `b-mysql`.
+This ShardingSphere JDBC DataSource configuration uses the Seata AT integration connected to the Seata Server instance `a-seata-server`, 
+whose Seata Application Id is `service-b`, whose Seata transaction group is `default_tx_group`, 
+and whose `Virtual Group Mapping` points to the Seata Transaction Coordinator cluster group as `default`.
+The business function `bMethod` of this microservice instance `b-service` uses a normal local transaction annotation, 
+and calls the `/hello` Restful API endpoint of the microservice instance `a-service` through the HTTP Client in `bMethod`.
+If this microservice is based on Spring Boot,
+
+```java
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class DemoService {
+   @Transactional
+   public void bMethod() {
+      RestTemplate restTemplate = new RestTemplateBuilder().build();
+      restTemplate.getForEntity("http://a-service/hello", String.class);
+      // ... Perform an UPDATE operation on the database instance `b-mysql`
+   }
+}
+```
+
+For this simple scenario, there is a single Seata Server Cluster, which contains a single `Virtual Group` as `default`. 
+This `Virtual Group` contains a single Seata Server instance as `a-seata-server`.
+
+Discuss transaction propagation for single service calls. When the business function `aMethod` of the microservice instance `a-service` throws an exception, 
+the changes to the MySQL database instance `a-mysql` in the business function will be rolled back normally.
+
+Discuss transaction propagation for cross-service calls. When the business function `bMethod` of the microservice instance `b-service` throws an exception, 
+the changes to the MySQL database instance `b-mysql` in the business function will be rolled back normally,
+and the `io.seata.core.context.RootContext` of the microservice instance `a-service` is not bound to the Seata XID of the business function `bMethod` of the microservice instance `b-service`,
+so the changes to the MySQL database instance `a-mysql` in the business function will not be rolled back.
+
+In order to achieve that when the business function `bMethod` of the microservice instance `b-service` throws an exception, 
+the changes to the MySQL database instances `a-mysql` and `b-mysql` in the business function are rolled back normally,
+discuss the common processing solutions in different scenarios.
+
+1. The microservice instances `a-service` and `b-service` are both Spring Boot 2 microservices based on Jakarta EE 8.
+Users can use `org.springframework.web.client.RestTemplate` in the business function `bMethod` of the microservice instance `b-service` to pass the XID to the microservice instance `a-service` through the service call.
+The possible transformation logic is as follows.
+
+```java
+import io.seata.core.context.RootContext;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class DemoService {
+    @Transactional
+    public void bMethod() {
+        RestTemplate restTemplate = new RestTemplateBuilder().additionalInterceptors((request, body, execution) -> {
+                    String xid = RootContext.getXID();
+                    if (null != xid) {
+                        request.getHeaders().add(RootContext.KEY_XID, xid);
+                    }
+                    return execution.execute(request, body);
+                })
+                .build();
+        restTemplate.getForEntity("http://a-service/hello", String.class);
+        // ... Perform an UPDATE operation on the database instance `b-mysql`
+    }
+}
+```
+
+At this time, custom `org.springframework.web.servlet.config.annotation.WebMvcConfigurer` implementations need to be added to the microservice instances `a-service` and `b-service`.
+
+```java
+import io.seata.integration.http.TransactionPropagationInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CustomWebMvcConfigurer implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new TransactionPropagationInterceptor());
+    }
+}
+```
+
+At this time, when the business function `bMethod` of the microservice instance `b-service` throws an exception, 
+the changes to the MySQL database instances `a-mysql` and `b-mysql` in the business function are rolled back normally.
+
+2. The microservice instances `a-service` and `b-service` are both Spring Boot 3 microservices based on Jakarta EE 9/10.
+Users can use `org.springframework.web.client.RestClient` in the business function `bMethod` of the microservice instance `b-service` to pass the XID to the microservice instance `a-service` through a service call.
+The possible transformation logic is as follows.
+
+```java
+import io.seata.core.context.RootContext;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class DemoService {
+    @Transactional
+    public void bMethod() {
+        RestClient restClient = RestClient.builder().requestInterceptor((request, body, execution) -> {
+                    String xid = RootContext.getXID();
+                    if (null != xid) {
+                        request.getHeaders().add(RootContext.KEY_XID, xid);
+                    }
+                    return execution.execute(request, body);
+                })
+                .build();
+        restClient.get().uri("http://a-service/hello").retrieve().body(String.class);
+        // ... Perform an UPDATE operation on the database instance `b-mysql`
+    }
+}
+```
+
+At this time, custom `org.springframework.web.servlet.config.annotation.WebMvcConfigurer` implementations need to be added to the microservice instances `a-service` and `b-service`.
+
+```java
+import io.seata.integration.http.JakartaTransactionPropagationInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CustomWebMvcConfigurer implements WebMvcConfigurer {
+
+   @Override
+   public void addInterceptors(InterceptorRegistry registry) {
+      registry.addInterceptor(new JakartaTransactionPropagationInterceptor());
+   }
+}
+```
+
+At this time, when the business function `bMethod` of the microservice instance `b-service` throws an exception, 
+the changes to the MySQL database instances `a-mysql` and `b-mysql` in the business function are rolled back normally.
+
+3. The microservice instances `a-service` and `b-service` are both Spring Boot microservices, 
+but the API gateway middleware used blocks all HTTP requests containing the HTTP Header of `TX_XID`.
+The user needs to consider changing the HTTP Header used to pass XID to the microservice instance `a-service` through service calls, 
+or use the RPC framework to pass XID to the microservice instance `a-service` through service calls.
+Refer to https://github.com/apache/incubator-seata/tree/v2.0.0/integration .
+
+4. The microservice instances `a-service` and `b-service` are both microservices such as Quarkus, Micronaut Framework and Helidon. 
+In this case, Spring WebMVC HandlerInterceptor cannot be used.
+You can refer to the following Spring Boot 3 custom WebMvcConfigurer implementation to implement Filter.
+
+```java
+import io.seata.common.util.StringUtils;
+import io.seata.core.context.RootContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CustomWebMvcConfigurer implements WebMvcConfigurer {
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new HandlerInterceptor() {
+            @Override
+            public boolean preHandle(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) {
+                String rpcXid = request.getHeader(RootContext.KEY_XID);
+                String xid = RootContext.getXID();
+                if (StringUtils.isBlank(xid) && StringUtils.isNotBlank(rpcXid)) {
+                    RootContext.bind(rpcXid);
+                }
+                return true;
+            }
+
+            @Override
+            public void afterCompletion(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler, Exception ex) {
+                if (RootContext.inGlobalTransaction()) {
+                    String rpcXid = request.getHeader(RootContext.KEY_XID);
+                    String xid = RootContext.getXID();
+                    if (StringUtils.isNotBlank(xid)) {
+                        String unbindXid = RootContext.unbind();
+                        if (!StringUtils.equalsIgnoreCase(rpcXid, unbindXid)) {
+                            if (StringUtils.isNotBlank(unbindXid)) {
+                                RootContext.bind(unbindXid);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+```
+
+5. Both microservice instances `a-service` and `b-service` are Spring Boot microservices, but the components used are Spring WebFlux instead of Spring WebMVC.
+ShardingSphere JDBC cannot handle R2DBC DataSource under the reactive programming API, only JDBC DataSource.
+Avoid creating ShardingSphere JDBC DataSource in Spring Boot microservices using WebFlux components.
+
+6. The Seata Client used by the microservice instances `a-service` and `b-service` is `org.apache.seata:seata-all`, not `io.seata:seata-all`.
+Change all calls to the `io.seata` package to the `org.apache.seata` package.

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -121,7 +121,7 @@ services:
 ## 可观察性
 
 针对 GraalVM Native Image 形态的 ShardingSphere Proxy，其提供的可观察性的能力与
-https://shardingsphere.apache.org/document/current/cn/user-manual/shardingsphere-proxy/observability/ 并不一致。
+[可观察性](/cn/user-manual/shardingsphere-proxy/observability) 并不一致。
 
 你可以使用 https://www.graalvm.org/jdk22/tools/ 提供的一系列命令行工具或可视化工具观察 GraalVM Native Image 的内部行为，
 并根据其要求使用 VSCode 完成调试工作。如果你正在使用 IntelliJ IDEA 并且希望调试生成的 GraalVM Native Image，你可以关注

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -129,8 +129,7 @@ services:
 ## Observability
 
 ShardingSphere for GraalVM Native Image form Proxy, which provides observability capabilities
-with https://shardingsphere.apache.org/document/current/cn/user-manual/shardingsphere-proxy/observability/
-not consistent.
+with [Observability](/en/user-manual/shardingsphere-proxy/observability) not consistent.
 
 You can observe GraalVM Native Image using a series of command line tools or visualization tools available
 at https://www.graalvm.org/jdk22/tools/, and use VSCode to debug it according to its requirements.

--- a/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingSphereTransactionManager.java
+++ b/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingSphereTransactionManager.java
@@ -87,7 +87,7 @@ public final class SeataATShardingSphereTransactionManager implements ShardingSp
     @Override
     public boolean isInTransaction() {
         checkSeataATEnabled();
-        return null != RootContext.getXID();
+        return null != SeataTransactionHolder.get();
     }
     
     @Override


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/discussions/32012 .

Changes proposed in this pull request:
  - Fixes the problem that the Seata integration module cannot correctly determine the status of distributed transactions in multi-microservice scenarios . Refer to https://github.com/apache/shardingsphere/discussions/32012#discussioncomment-10031799 .
> `@Famezyy`: I think the root reason is that in `SeataATShardingSphereTransactionManager:isInTransaction` it's just checking `null != RootContext.getXID()`, if it is true then the `ShardingSphereConnection:beginDistributedTransaction` will not be triggered when executing `ShardingSphereConnection:processDistributedTransaction`, and `TransactionConnectionContext:beginTransaction` is not called, so that the `transactionConnectionContext.inTransaction` is not set to true. this cause the `proxyConnection` not been used as when getting the connection it is checking if `transactionConnectionContext.inTransaction == true`. 
coming back to our microservice case, we have to pass and set the XID into `RootContext` across microservices ( basically we no need to set the XID ourself, the `JakartaTransactionPropagationInterceptor` which is one component provided by seata-all will handle it), in this case XID is there in `RootContext` so `SeataATShardingSphereTransactionManager:isInTransaction` will return true, and it will not call `ShardingSphereConnection:beginDistributedTransaction`.
So instead of checking `null != RootContext.getXID()`, we can check `null != SeataTransactionHolder.get()`, because for BASE transaction, only after the `ShardingSphereConnection:beginDistributedTransaction` run, the shardingsphere transaction starts, and it will set the `globalTransaction` into `SeataTransactionHolder`.
  - Also fixes https://github.com/apache/shardingsphere/discussions/32006 .
  - Also fixes #30721 .
  - Also fixes #30525 .
  - Also fixes #22995 .
  - Also fixes https://github.com/apache/incubator-seata/issues/6657 .
  - Also fixes https://github.com/apache/incubator-seata/issues/3103 .
  - Add the documentation for using ShardingSphere's Seata integration between multiple microservices in 6 scenarios.
  - Fixes an incorrect URL reference in the documentation.
  - Integration tests prove that excluding `io.seata.spring.boot.autoconfigure.SeataAutoConfiguration` is meaningless. Remove related documents.
  - Since the Seata Client instance is globally unique in a single project, I personally think it is not reasonable to add 2 independent modules for Seata's integration testing in the master branch of sharingsphere. Once https://github.com/apache/incubator-seata/issues/6614 is completed, I can try to add relevant integration tests. I have provided an integration test for the current PR at https://github.com/linghengqian/code-repo/tree/re-test . You can view the results by executing the following command on `Ubuntu 22.04.4` with `SDKMAN!` and `Docker Engine` installed, please ensure that ports `3306`, `3307`, `8081` and `18091` on the host device are free for use by `testcontainers-java`.
```bash
sdk install java 17.0.11-ms
sdk use java 17.0.11-ms

git clone git@github.com:linghengqian/shardingsphere.git -b seata-fix
cd ./shardingsphere/
./mvnw clean install -Prelease -T1C -DskipTests -Djacoco.skip=true -Dcheckstyle.skip=true -Drat.skip=true -Dmaven.javadoc.skip=true
cd ../

git clone git@github.com:linghengqian/code-repo.git -b re-test
cd ./code-repo/
cd ./springboot-example/seata-provider/
./gradlew clean bootJar -x test

cd ../seata-consumer/
./gradlew clean test
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
