### PR TITLE
Fixes the incorrect description of hint algorithm in Sharding and Readwrite Splitting features in the doc

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/sharding/hint.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/sharding/hint.cn.md
@@ -23,6 +23,11 @@ Hint 的主要使用场景：
 ### 规则配置
 
 Hint 分片算法需要用户实现 `org.apache.shardingsphere.sharding.api.sharding.hint.HintShardingAlgorithm` 接口。
+`org.apache.shardingsphere.sharding.api.sharding.hint.HintShardingAlgorithm` 存在两个内置实现为，
+
+- `org.apache.shardingsphere.sharding.algorithm.sharding.hint.HintInlineShardingAlgorithm`
+- `org.apache.shardingsphere.sharding.algorithm.sharding.classbased.ClassBasedShardingAlgorithm`
+
 Apache ShardingSphere 在进行路由时，将会从 HintManager 中获取分片值进行路由操作。
 
 参考配置如下：
@@ -35,10 +40,22 @@ rules:
       actualDataNodes: demo_ds_${0..1}.t_order_${0..1}
       databaseStrategy:
         hint:
-          algorithmClassName: xxx.xxx.xxx.HintXXXAlgorithm
+          shardingColumn: order_id
+          shardingAlgorithmName: hint_class_based
       tableStrategy:
         hint:
-          algorithmClassName: xxx.xxx.xxx.HintXXXAlgorithm
+          shardingColumn: order_id
+          shardingAlgorithmName: hint_inline
+  shardingAlgorithms:
+    hint_class_based:
+      type: CLASS_BASED
+      props:
+        strategy: STANDARD
+        algorithmClassName: xxx.xxx.xxx.HintXXXAlgorithm
+    hint_inline:
+      type: HINT_INLINE
+      props:
+        algorithm-expression: t_order_$->{value % 4}
   defaultTableStrategy:
     none:
   defaultKeyGenerateStrategy:

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/sharding/hint.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/sharding/hint.en.md
@@ -22,31 +22,48 @@ Main application scenarios for Hint:
 
 ### Hint Configuration
 
-Hint algorithms require users to implement the interface of `org.apache.shardingsphere.api.sharding.hint.HintShardingAlgorithm`. 
+Hint algorithms require users to implement the interface of `org.apache.shardingsphere.api.sharding.hint.HintShardingAlgorithm`.
+`org.apache.shardingsphere.sharding.api.sharding.hint.HintShardingAlgorithm` has two built-in implementations,
+
+- `org.apache.shardingsphere.sharding.algorithm.sharding.hint.HintInlineShardingAlgorithm`
+- `org.apache.shardingsphere.sharding.algorithm.sharding.classbased.ClassBasedShardingAlgorithm`
+
 Apache ShardingSphere will acquire sharding values from HintManager to route.
 
 Take the following configurations for reference:
 
 ```yaml
 rules:
-- !SHARDING
-  tables:
-    t_order:
-      actualDataNodes: demo_ds_${0..1}.t_order_${0..1}
-      databaseStrategy:
-        hint:
+  - !SHARDING
+    tables:
+      t_order:
+        actualDataNodes: demo_ds_${0..1}.t_order_${0..1}
+        databaseStrategy:
+          hint:
+            shardingColumn: order_id
+            shardingAlgorithmName: hint_class_based
+        tableStrategy:
+          hint:
+            shardingColumn: order_id
+            shardingAlgorithmName: hint_inline
+    shardingAlgorithms:
+      hint_class_based:
+        type: CLASS_BASED
+        props:
+          strategy: STANDARD
           algorithmClassName: xxx.xxx.xxx.HintXXXAlgorithm
-      tableStrategy:
-        hint:
-          algorithmClassName: xxx.xxx.xxx.HintXXXAlgorithm
-  defaultTableStrategy:
-    none:
-  defaultKeyGenerateStrategy:
-    type: SNOWFLAKE
-    column: order_id
+      hint_inline:
+        type: HINT_INLINE
+        props:
+          algorithm-expression: t_order_$->{value % 4}
+    defaultTableStrategy:
+      none:
+    defaultKeyGenerateStrategy:
+      type: SNOWFLAKE
+      column: order_id
 
 props:
-    sql-show: true
+  sql-show: true
 ```
 
 ### Get HintManager


### PR DESCRIPTION
Fixes #25985.

Changes proposed in this pull request:
  - Fixes the incorrect description of hint algorithm in Sharding and Readwrite Splitting features in the doc.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
