### PR TITLE
Fixes the incorrect description of Seata TCC Mode in the doc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <netty.version>4.1.106.Final</netty.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
         
-        <curator.version>5.6.0</curator.version>
+        <curator.version>5.7.0</curator.version>
         <zookeeper.version>3.9.2</zookeeper.version>
         <audience-annotations.version>0.12.0</audience-annotations.version>
         <jetcd.version>0.7.7</jetcd.version>


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/discussions/32023 .

Changes proposed in this pull request:
  - Fixes the incorrect description of Seata TCC Mode in the doc.
  - Updates Curator to 5.7.0 to prevent unstable CI failures. See https://issues.apache.org/jira/browse/CURATOR-688 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
