### PR TITLE
Add database environment checker for MySQL

### DIFF
--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/checker/DialectDatabaseEnvironmentChecker.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/checker/DialectDatabaseEnvironmentChecker.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.core.checker;
+
+import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPI;
+import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
+
+import javax.sql.DataSource;
+
+/**
+ * Dialect database environment checker.
+ */
+@SingletonSPI
+public interface DialectDatabaseEnvironmentChecker extends DatabaseTypedSPI {
+    
+    /**
+     * Check user privileges.
+     *
+     * @param dataSource data source to be checked
+     * @param privilegeCheckType privilege check type
+     */
+    void checkPrivilege(DataSource dataSource, PrivilegeCheckType privilegeCheckType);
+    
+    /**
+     * Check variables.
+     *
+     * @param dataSource data source to be checked
+     */
+    void checkVariable(DataSource dataSource);
+}

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/checker/PrivilegeCheckType.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/checker/PrivilegeCheckType.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.core.checker;
+
+/**
+ * Privilege check type.
+ */
+public enum PrivilegeCheckType {
+    
+    PIPELINE, SELECT, XA
+}

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/exception/CheckDatabaseEnvironmentFailedException.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/exception/CheckDatabaseEnvironmentFailedException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.core.exception;
+
+import org.apache.shardingsphere.infra.exception.core.external.sql.sqlstate.XOpenSQLState;
+import org.apache.shardingsphere.infra.exception.core.external.sql.type.kernel.category.MetaDataSQLException;
+
+import java.sql.SQLException;
+
+/**
+ * Check database environment failed exception.
+ */
+public final class CheckDatabaseEnvironmentFailedException extends MetaDataSQLException {
+    
+    private static final long serialVersionUID = 3913140870320566898L;
+    
+    public CheckDatabaseEnvironmentFailedException(final SQLException cause) {
+        super(XOpenSQLState.CONNECTION_EXCEPTION, 6, "Check database environment failed.", cause);
+    }
+}

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/exception/MissingRequiredPrivilegeException.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/exception/MissingRequiredPrivilegeException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.core.exception;
+
+import org.apache.shardingsphere.infra.exception.core.external.sql.sqlstate.XOpenSQLState;
+import org.apache.shardingsphere.infra.exception.core.external.sql.type.kernel.category.MetaDataSQLException;
+
+import java.util.Collection;
+
+/**
+ * Missing required privilege exception.
+ */
+public final class MissingRequiredPrivilegeException extends MetaDataSQLException {
+    
+    private static final long serialVersionUID = 3755362278200749857L;
+    
+    public MissingRequiredPrivilegeException(final Collection<String> privileges) {
+        super(XOpenSQLState.PRIVILEGE_NOT_GRANTED, 5, "Missing required privilege(s) `%s`.", privileges);
+    }
+}

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/exception/UnexpectedVariableValueException.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/exception/UnexpectedVariableValueException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.core.exception;
+
+import org.apache.shardingsphere.infra.exception.core.external.sql.sqlstate.XOpenSQLState;
+import org.apache.shardingsphere.infra.exception.core.external.sql.type.kernel.category.MetaDataSQLException;
+
+/**
+ * Unexpected variable value exception.
+ */
+public final class UnexpectedVariableValueException extends MetaDataSQLException {
+    
+    private static final long serialVersionUID = -8481467708967951766L;
+    
+    public UnexpectedVariableValueException(final String variableName, final String expectedValue, final String actualValue) {
+        super(XOpenSQLState.GENERAL_ERROR, 7, "Unexpected variable value of '%s', required '%s', now is '%s'.", variableName, expectedValue, actualValue);
+    }
+}

--- a/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/checker/MySQLDatabaseEnvironmentChecker.java
+++ b/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/checker/MySQLDatabaseEnvironmentChecker.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.mysql.checker;
+
+import org.apache.shardingsphere.infra.database.core.checker.DialectDatabaseEnvironmentChecker;
+import org.apache.shardingsphere.infra.database.core.checker.PrivilegeCheckType;
+import org.apache.shardingsphere.infra.database.core.exception.CheckDatabaseEnvironmentFailedException;
+import org.apache.shardingsphere.infra.database.core.exception.MissingRequiredPrivilegeException;
+import org.apache.shardingsphere.infra.database.core.exception.UnexpectedVariableValueException;
+import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+/**
+ * Database environment checker for MySQL.
+ */
+public final class MySQLDatabaseEnvironmentChecker implements DialectDatabaseEnvironmentChecker {
+    
+    private static final String SHOW_GRANTS_SQL = "SHOW GRANTS";
+    
+    private static final int MYSQL_MAJOR_VERSION_8 = 8;
+    
+    // BINLOG MONITOR is a synonym for REPLICATION CLIENT for MariaDB
+    private static final String[][] PIPELINE_REQUIRED_PRIVILEGES =
+            {{"ALL PRIVILEGES", "ON *.*"}, {"REPLICATION SLAVE", "REPLICATION CLIENT", "ON *.*"}, {"REPLICATION SLAVE", "BINLOG MONITOR", "ON *.*"}};
+    
+    private static final String[][] XA_REQUIRED_PRIVILEGES = {{"ALL PRIVILEGES", "ON *.*"}, {"XA_RECOVER_ADMIN", "ON *.*"}};
+    
+    private static final Map<PrivilegeCheckType, String[][]> REQUIRED_PRIVILEGES = new HashMap<>(2, 1F);
+    
+    private static final Map<PrivilegeCheckType, Collection<String>> REQUIRED_PRIVILEGES_FOR_MESSAGE = new HashMap<>(2, 1F);
+    
+    private static final Map<String, String> REQUIRED_VARIABLES = new HashMap<>(3, 1F);
+    
+    private static final String SHOW_VARIABLES_SQL;
+    
+    static {
+        REQUIRED_PRIVILEGES.put(PrivilegeCheckType.PIPELINE, PIPELINE_REQUIRED_PRIVILEGES);
+        REQUIRED_PRIVILEGES_FOR_MESSAGE.put(PrivilegeCheckType.PIPELINE, Arrays.asList("REPLICATION SLAVE", "REPLICATION CLIENT"));
+        REQUIRED_PRIVILEGES.put(PrivilegeCheckType.XA, XA_REQUIRED_PRIVILEGES);
+        REQUIRED_PRIVILEGES_FOR_MESSAGE.put(PrivilegeCheckType.XA, Collections.singleton("XA_RECOVER_ADMIN"));
+        REQUIRED_VARIABLES.put("LOG_BIN", "ON");
+        REQUIRED_VARIABLES.put("BINLOG_FORMAT", "ROW");
+        // It does not exist in all versions of MySQL
+        REQUIRED_VARIABLES.put("BINLOG_ROW_IMAGE", "FULL");
+        SHOW_VARIABLES_SQL = String.format("SHOW VARIABLES WHERE Variable_name IN (%s)", REQUIRED_VARIABLES.keySet().stream().map(each -> "?").collect(Collectors.joining(",")));
+    }
+    
+    @Override
+    public void checkPrivilege(final DataSource dataSource, final PrivilegeCheckType privilegeCheckType) {
+        try (Connection connection = dataSource.getConnection()) {
+            if (PrivilegeCheckType.XA == privilegeCheckType && MYSQL_MAJOR_VERSION_8 != connection.getMetaData().getDatabaseMajorVersion()) {
+                return;
+            }
+            checkPrivilege(connection, privilegeCheckType);
+        } catch (final SQLException ex) {
+            throw new CheckDatabaseEnvironmentFailedException(ex);
+        }
+    }
+    
+    private void checkPrivilege(final Connection connection, final PrivilegeCheckType privilegeCheckType) {
+        try (
+                PreparedStatement preparedStatement = connection.prepareStatement(SHOW_GRANTS_SQL);
+                ResultSet resultSet = preparedStatement.executeQuery()) {
+            while (resultSet.next()) {
+                String privilege = resultSet.getString(1).toUpperCase();
+                if (matchPrivileges(privilege, REQUIRED_PRIVILEGES.get(privilegeCheckType))) {
+                    return;
+                }
+            }
+        } catch (final SQLException ex) {
+            throw new CheckDatabaseEnvironmentFailedException(ex);
+        }
+        throw new MissingRequiredPrivilegeException(REQUIRED_PRIVILEGES_FOR_MESSAGE.get(privilegeCheckType));
+    }
+    
+    private boolean matchPrivileges(final String privilege, final String[][] requiredPrivileges) {
+        return Arrays.stream(requiredPrivileges).anyMatch(each -> Arrays.stream(each).allMatch(privilege::contains));
+    }
+    
+    @Override
+    public void checkVariable(final DataSource dataSource) {
+        try (
+                Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(SHOW_VARIABLES_SQL)) {
+            int parameterIndex = 1;
+            for (Entry<String, String> entry : REQUIRED_VARIABLES.entrySet()) {
+                preparedStatement.setString(parameterIndex++, entry.getKey());
+            }
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                while (resultSet.next()) {
+                    String variableName = resultSet.getString(1).toUpperCase();
+                    String expectedValue = REQUIRED_VARIABLES.get(variableName);
+                    String actualValue = resultSet.getString(2);
+                    ShardingSpherePreconditions.checkState(expectedValue.equalsIgnoreCase(actualValue),
+                            () -> new UnexpectedVariableValueException(variableName, expectedValue, actualValue));
+                }
+            }
+        } catch (final SQLException ex) {
+            throw new CheckDatabaseEnvironmentFailedException(ex);
+        }
+    }
+    
+    @Override
+    public String getDatabaseType() {
+        return "MySQL";
+    }
+}

--- a/infra/database/type/mysql/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.database.core.checker.DialectDatabaseEnvironmentChecker
+++ b/infra/database/type/mysql/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.database.core.checker.DialectDatabaseEnvironmentChecker
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.infra.database.mysql.checker.MySQLDatabaseEnvironmentChecker

--- a/infra/database/type/mysql/src/test/java/org/apache/shardingsphere/infra/database/mysql/checker/MySQLDatabaseEnvironmentCheckerTest.java
+++ b/infra/database/type/mysql/src/test/java/org/apache/shardingsphere/infra/database/mysql/checker/MySQLDatabaseEnvironmentCheckerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.mysql.checker;
+
+import org.apache.shardingsphere.infra.database.core.checker.PrivilegeCheckType;
+import org.apache.shardingsphere.infra.database.core.exception.CheckDatabaseEnvironmentFailedException;
+import org.apache.shardingsphere.infra.database.core.exception.MissingRequiredPrivilegeException;
+import org.apache.shardingsphere.infra.database.core.exception.UnexpectedVariableValueException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MySQLDatabaseEnvironmentCheckerTest {
+    
+    @Mock
+    private PreparedStatement preparedStatement;
+    
+    @Mock
+    private ResultSet resultSet;
+    
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private DataSource dataSource;
+    
+    @BeforeEach
+    void setUp() throws SQLException {
+        when(dataSource.getConnection().prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+    }
+    
+    @Test
+    void assertCheckPrivilegeWithParticularSuccess() throws SQLException {
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(1)).thenReturn("GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO '%'@'%'");
+        new MySQLDatabaseEnvironmentChecker().checkPrivilege(dataSource, PrivilegeCheckType.PIPELINE);
+        verify(preparedStatement).executeQuery();
+    }
+    
+    @Test
+    void assertCheckPrivilegeWithAllSuccess() throws SQLException {
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(1)).thenReturn("GRANT ALL PRIVILEGES CLIENT ON *.* TO '%'@'%'");
+        new MySQLDatabaseEnvironmentChecker().checkPrivilege(dataSource, PrivilegeCheckType.PIPELINE);
+        verify(preparedStatement).executeQuery();
+    }
+    
+    @Test
+    void assertCheckPrivilegeLackPrivileges() {
+        assertThrows(MissingRequiredPrivilegeException.class, () -> new MySQLDatabaseEnvironmentChecker().checkPrivilege(dataSource, PrivilegeCheckType.PIPELINE));
+    }
+    
+    @Test
+    void assertCheckPrivilegeFailure() throws SQLException {
+        when(resultSet.next()).thenThrow(new SQLException(""));
+        assertThrows(CheckDatabaseEnvironmentFailedException.class, () -> new MySQLDatabaseEnvironmentChecker().checkPrivilege(dataSource, PrivilegeCheckType.PIPELINE));
+    }
+    
+    @Test
+    void assertCheckVariableSuccess() throws SQLException {
+        when(resultSet.next()).thenReturn(true, true, true, false);
+        when(resultSet.getString(1)).thenReturn("LOG_BIN", "BINLOG_FORMAT", "BINLOG_ROW_IMAGE");
+        when(resultSet.getString(2)).thenReturn("ON", "ROW", "FULL");
+        assertDoesNotThrow(() -> new MySQLDatabaseEnvironmentChecker().checkVariable(dataSource));
+        verify(preparedStatement, times(1)).executeQuery();
+    }
+    
+    @Test
+    void assertCheckVariableWithWrongVariable() throws SQLException {
+        when(resultSet.next()).thenReturn(true, true, false);
+        when(resultSet.getString(1)).thenReturn("BINLOG_FORMAT", "LOG_BIN");
+        when(resultSet.getString(2)).thenReturn("ROW", "OFF");
+        assertThrows(UnexpectedVariableValueException.class, () -> new MySQLDatabaseEnvironmentChecker().checkVariable(dataSource));
+    }
+    
+    @Test
+    void assertCheckVariableFailure() throws SQLException {
+        when(resultSet.next()).thenThrow(new SQLException(""));
+        assertThrows(CheckDatabaseEnvironmentFailedException.class, () -> new MySQLDatabaseEnvironmentChecker().checkVariable(dataSource));
+    }
+}


### PR DESCRIPTION
For #32044

Changes proposed in this pull request:
  - Add database environment checker for MySQL

TODO
 - Merge XATransactionPrivilegeChecker & DialectDataSourceChecker to DialectDatabaseEnvironmentChecker
 - Add SELECT privilege check when register storage unit
 - Update docs for error code
