### PR TITLE
Provides Standalone Mode implementations of hsqldb and apache/derby

### DIFF
--- a/docs/document/content/user-manual/common-config/builtin-algorithm/metadata-repository.cn.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/metadata-repository.cn.md
@@ -11,19 +11,58 @@ Apache ShardingSphere 为不同的运行模式提供了不同的元数据持久�
 
 ### 数据库持久化
 
+`provider` 的可选值为 H2，MySQL，EmbeddedDerby，DerbyNetworkServer，HSQLDB。
+由于第三方的 Vulnerability Report 时常误报 H2 Database，避免在 ShardingSphere Standalone Mode 使用 H2 Database 可能是一种选择。
+讨论 `provider` 不为默认值 `H2` 的情况。
+
+1. 若 `provider` 设置为 `MySQL`，则要求存在已就绪的 MySQL Server。classpath 应包含 `com.mysql:mysql-connector-j:9.0.0` 的 Maven 依赖。
+2. 若 `provider` 设置为 `EmbeddedDerby`，则 Derby 数据库引擎将在与应用程序相同的 JVM 内运行。
+classpath 应包含 `org.apache.derby:derby:10.17.1.0` 和 `org.apache.derby:derbytools:10.17.1.0` 的 Maven 依赖，
+且要求编译或运行下游项目的 JDK 版本大于或等于 JDK19。可能的配置如下。
+
+```yaml
+mode:
+  type: Standalone
+  repository:
+    type: JDBC
+    props:
+      provider: EmbeddedDerby
+      jdbc_url: jdbc:derby:memory:config;create=true
+      username:
+```
+
+3. 若 `provider` 设置为 `DerbyNetworkServer`，则要求存在已就绪的 Derby Network Server。
+Derby Network Server 不存在可用的 Docker Image，用户可能需要手动启动 Derby Network Server。
+classpath 应包含 `org.apache.derby:derbyclient:10.17.1.0` 和 `org.apache.derby:derbytools:10.17.1.0` 的 Maven 依赖，
+且要求编译或运行下游项目的 JDK 版本大于或等于 JDK19。
+4. 若 `provider` 设置为 `HSQLDB`，则要求存在已就绪的采用 Server Modes 的 HyperSQL，或以 in-process database 的方式创建数据库。
+classpath 应包含 `classifier` 为 `jdk8` 的 `org.hsqldb:hsqldb:2.7.3` 的 Maven 依赖。
+采用 Server Modes 的 HyperSQL 不存在可用的 Docker Image，用户可能需要手动启动 Server Modes 的 HyperSQL。
+若使用 mem: protocol 的 HyperSQL，则可能的配置如下，
+
+```yaml
+mode:
+  type: Standalone
+  repository:
+    type: JDBC
+    props:
+      provider: HSQLDB
+      jdbc_url: jdbc:hsqldb:mem:config
+      username: SA
+```
+
 类型：JDBC
 
 适用模式：Standalone
 
 可配置属性：
 
-| *名称*     | *数据类型* | *说明*                  | *默认值*                                                                   |
-|----------|--------|-----------------------|-------------------------------------------------------------------------|
-| provider | String | 元数据存储类型，可选值为 H2，MySQL | H2                                                                      |
-| jdbc_url | String | JDBC URL              | jdbc:h2:mem:config;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL |
-| username | String | 账号                    | sa                                                                      |
-| password | String | 密码                    |                                                                         |
-
+| *名称*     | *数据类型* | *说明*     | *默认值*                                                                   |
+|----------|--------|----------|-------------------------------------------------------------------------|
+| provider | String | 元数据存储类型  | H2                                                                      |
+| jdbc_url | String | JDBC URL | jdbc:h2:mem:config;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL |
+| username | String | 账号       | sa                                                                      |
+| password | String | 密码       |                                                                         |
 
 ### ZooKeeper 持久化
 

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/metadata-repository.en.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/metadata-repository.en.md
@@ -11,19 +11,58 @@ Apache ShardingSphere provides different metadata persistence methods for differ
 
 ### Database Repository
 
+The optional values of `provider` are H2, MySQL, EmbeddedDerby, DerbyNetworkServer and HSQLDB.
+Since third-party Vulnerability Reports often misreport H2 Database, avoiding the use of H2 Database in ShardingSphere Standalone Mode may be an option.
+Discuss the case where `provider` is not the default value `H2`.
+
+1. If `provider` is set to `MySQL`, a ready MySQL Server is required. The classpath should contain the Maven dependency of `com.mysql:mysql-connector-j:9.0.0`.
+2. If `provider` is set to `EmbeddedDerby`, the Derby database engine will run in the same JVM as the application.
+   The classpath should contain Maven dependencies of `org.apache.derby:derby:10.17.1.0` and `org.apache.derby:derbytools:10.17.1.0`, 
+   and the JDK version required to compile or run the downstream project is greater than or equal to JDK19. Possible configurations are as follows.
+
+```yaml
+mode:
+  type: Standalone
+  repository:
+    type: JDBC
+    props:
+      provider: EmbeddedDerby
+      jdbc_url: jdbc:derby:memory:config;create=true
+      username:
+```
+
+3. If `provider` is set to `DerbyNetworkServer`, a ready Derby Network Server is required.
+   There is no available Docker Image for Derby Network Server, and users may need to start Derby Network Server manually.
+   The classpath should contain Maven dependencies of `org.apache.derby:derbyclient:10.17.1.0` and `org.apache.derby:derbytools:10.17.1.0`, 
+   and the JDK version required to compile or run the downstream project is greater than or equal to JDK19.
+4. If `provider` is set to `HSQLDB`, a ready HyperSQL using Server Modes is required, or a database is created as an in-process database.
+   The classpath should contain the Maven dependency of `org.hsqldb:hsqldb:2.7.3` with `classifier` as `jdk8`.
+   There is no available Docker Image for HyperSQL using Server Modes, and users may need to manually start HyperSQL using Server Modes.
+   If HyperSQL using mem: protocol is used, the possible configuration is as follows,
+
+```yaml
+mode:
+   type: Standalone
+   repository:
+      type: JDBC
+      props:
+         provider: HSQLDB
+         jdbc_url: jdbc:hsqldb:mem:config
+         username: SA
+```
+
 Type: JDBC
 
 Mode: Standalone
 
 Attributes:
 
-| *Name*   | *Type* | *Description*                                              | *Default Value*                                                         |
-|----------|--------|------------------------------------------------------------|-------------------------------------------------------------------------|
-| provider | String | Type for metadata persist, the optional value is H2, MySQL | H2                                                                      |
-| jdbc_url | String | JDBC URL                                                   | jdbc:h2:mem:config;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL |
-| username | String | username                                                   | sa                                                                      |
-| password | String | password                                                   |                                                                         |
-
+| *Name*   | *Type* | *Description*             | *Default Value*                                                         |
+|----------|--------|---------------------------|-------------------------------------------------------------------------|
+| provider | String | Type for metadata persist | H2                                                                      |
+| jdbc_url | String | JDBC URL                  | jdbc:h2:mem:config;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL |
+| username | String | username                  | sa                                                                      |
+| password | String | password                  |                                                                         |
 
 ### ZooKeeper Repository
 

--- a/mode/type/standalone/repository/provider/jdbc/src/main/resources/sql/DerbyNetworkServer.xml
+++ b/mode/type/standalone/repository/provider/jdbc/src/main/resources/sql/DerbyNetworkServer.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql type="DerbyNetworkServer" driver-class-name="org.apache.derby.jdbc.ClientDriver">
+    <create-table>CREATE TABLE repository(id varchar(36) PRIMARY KEY, "key" varchar(32672), value varchar(32672), parent varchar(32672))</create-table>
+    <select-by-key>SELECT value FROM repository WHERE "key" = ?</select-by-key>
+    <select-by-parent>SELECT DISTINCT("key") FROM repository WHERE parent = ?</select-by-parent>
+    <insert>INSERT INTO repository VALUES(?, ?, ?, ?)</insert>
+    <update>UPDATE repository SET value = ? WHERE "key" = ?</update>
+    <delete>DELETE FROM repository WHERE "key" LIKE ?</delete>
+</sql>

--- a/mode/type/standalone/repository/provider/jdbc/src/main/resources/sql/EmbeddedDerby.xml
+++ b/mode/type/standalone/repository/provider/jdbc/src/main/resources/sql/EmbeddedDerby.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql type="EmbeddedDerby" driver-class-name="org.apache.derby.jdbc.EmbeddedDriver">
+    <create-table>CREATE TABLE repository(id varchar(36) PRIMARY KEY, "key" varchar(32672), value varchar(32672), parent varchar(32672))</create-table>
+    <select-by-key>SELECT value FROM repository WHERE "key" = ?</select-by-key>
+    <select-by-parent>SELECT DISTINCT("key") FROM repository WHERE parent = ?</select-by-parent>
+    <insert>INSERT INTO repository VALUES(?, ?, ?, ?)</insert>
+    <update>UPDATE repository SET value = ? WHERE "key" = ?</update>
+    <delete>DELETE FROM repository WHERE "key" LIKE ?</delete>
+</sql>

--- a/mode/type/standalone/repository/provider/jdbc/src/main/resources/sql/HSQLDB.xml
+++ b/mode/type/standalone/repository/provider/jdbc/src/main/resources/sql/HSQLDB.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql type="HSQLDB" driver-class-name="org.hsqldb.jdbc.JDBCDriver">
+    <create-table>CREATE TABLE IF NOT EXISTS repository(id varchar(36) PRIMARY KEY, key varchar(32672), value varchar(32672), parent varchar(32672))</create-table>
+    <select-by-key>SELECT value FROM repository WHERE key = ?</select-by-key>
+    <select-by-parent>SELECT DISTINCT(key) FROM repository WHERE parent = ?</select-by-parent>
+    <insert>INSERT INTO repository VALUES(?, ?, ?, ?)</insert>
+    <update>UPDATE repository SET value = ? WHERE key = ?</update>
+    <delete>DELETE FROM repository WHERE key LIKE ?</delete>
+</sql>

--- a/mode/type/standalone/repository/provider/jdbc/src/test/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQLLoaderTest.java
+++ b/mode/type/standalone/repository/provider/jdbc/src/test/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/sql/JDBCRepositorySQLLoaderTest.java
@@ -27,6 +27,9 @@ class JDBCRepositorySQLLoaderTest {
     @Test
     void assertLoad() {
         assertThat(JDBCRepositorySQLLoader.load("MySQL").getType(), is("MySQL"));
+        assertThat(JDBCRepositorySQLLoader.load("EmbeddedDerby").getType(), is("EmbeddedDerby"));
+        assertThat(JDBCRepositorySQLLoader.load("DerbyNetworkServer").getType(), is("DerbyNetworkServer"));
+        assertThat(JDBCRepositorySQLLoader.load("HSQLDB").getType(), is("HSQLDB"));
     }
     
     @Test


### PR DESCRIPTION
Fixes #30926.

Changes proposed in this pull request:
  - Provides Standalone Mode implementations of Embedded Derby, Derby Network Server, HyperSQL HSQL Server, HyperSQL HTTP Server, HyperSQL HTTP Servlet and (Embedded) HyperSQL .
  - For a potential Docker image for HyperSQL HSQL Server, I opened https://sourceforge.net/p/hsqldb/feature-requests/371/ .
  - apache/derby uses svn ( https://svn.apache.org/repos/asf/db/derby/code/trunk/ ) instead of git for collaboration. As a result, the content of https://github.com/apache/derby is actually out of date. But Derby Network Server is indeed encouraged to use JAR to start, and there is no Docker Image available. Refer to https://issues.apache.org/jira/browse/DERBY-7165 and https://issues.apache.org/jira/browse/DERBY-7166 .
  - `org.apache.derby:derby:10.17.1.0` has restricted itself to be available only on JDK19+. Refer to https://db.apache.org/derby/derby_downloads.html .
```bash
java.lang.UnsupportedClassVersionError: org/apache/derby/jdbc/EmbeddedDriver has been compiled by a more recent version of the Java Runtime (class file version 63.0), this version of the Java Runtime only recognizes class file versions up to 61.0

	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	at com.zaxxer.hikari.HikariConfig.attemptFromContextLoader(HikariConfig.java:973)
	at com.zaxxer.hikari.HikariConfig.setDriverClassName(HikariConfig.java:483)
	at com.lingh.DatabaseTest.test(DatabaseTest.java:16)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
