### PR TITLE
Optimize the timezone support of PostgreSQLDateValueParser.

### DIFF
--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/text/impl/PostgreSQLDateValueParserTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/text/impl/PostgreSQLDateValueParserTest.java
@@ -19,9 +19,9 @@ package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.ex
 
 import org.junit.jupiter.api.Test;
 
+import java.sql.Date;
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.Date;
+import java.time.ZoneOffset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -30,6 +30,9 @@ class PostgreSQLDateValueParserTest {
     
     @Test
     void assertParse() {
-        assertThat(new PostgreSQLDateValueParser().parse("2020-01-01"), is(Date.from(LocalDate.of(2020, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant())));
+        assertThat(new PostgreSQLDateValueParser().parse("2020-01-01"), is(Date.valueOf(LocalDate.of(2020, 1, 1))));
+        assertThat(new PostgreSQLDateValueParser().parse("2020-01-01 +08"), is(Date.valueOf(LocalDate.of(2020, 1, 1).atStartOfDay(ZoneOffset.of("+8")).toLocalDate())));
+        assertThat(new PostgreSQLDateValueParser().parse("2020-01-01 +08:00"), is(Date.valueOf(LocalDate.of(2020, 1, 1).atStartOfDay(ZoneOffset.of("+8")).toLocalDate())));
+        assertThat(new PostgreSQLDateValueParser().parse("2020-01-01 +08:00:00"), is(Date.valueOf(LocalDate.of(2020, 1, 1).atStartOfDay(ZoneOffset.of("+8")).toLocalDate())));
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
