### PR TITLE
Improve the parsing of methods in MySQL #31565

### DIFF
--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -171,6 +171,22 @@
             </expression-projection>
         </projections>
     </select>
+    <select sql-case-id="select_substr">
+        <projections start-index="7" stop-index="32">
+            <expression-projection text="SUBSTR('foobarbar' from 4)" start-index="7" stop-index="32">
+                <expr>
+                    <function function-name="SUBSTR" start-index="7" stop-index="32" text="SUBSTR('foobarbar' from 4)" >
+                        <parameter>
+                            <literal-expression value="foobarbar" start-index="14" stop-index="24" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="4" start-index="31" stop-index="31" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
     <select sql-case-id="select_extract">
         <projections start-index="7" stop-index="37">
             <expression-projection text="EXTRACT(YEAR FROM '2019-07-02')" start-index="7" stop-index="37">
@@ -2488,6 +2504,141 @@
                         <parameter>
                             <literal-expression value="{}" start-index="34" stop-index="37" />
                         </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_std">
+        <projections start-index="7" stop-index="12">
+            <expression-projection start-index="7" stop-index="12" text="STD(1)">
+                <expr>
+                    <function function-name="STD" text="STD(1)" start-index="7" stop-index="12">
+                        <parameter>
+                            <literal-expression value="1" start-index="11" stop-index="11" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_stddev">
+        <projections start-index="7" stop-index="15">
+            <expression-projection start-index="7" stop-index="15" text="STDDEV(1)">
+                <expr>
+                    <function function-name="STDDEV" text="STDDEV(1)" start-index="7" stop-index="15">
+                        <parameter>
+                            <literal-expression value="1" start-index="14" stop-index="14" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_stddev_pop">
+        <projections start-index="7" stop-index="19">
+            <expression-projection start-index="7" stop-index="19" text="STDDEV_POP(1)">
+                <expr>
+                    <function function-name="STDDEV_POP" text="STDDEV_POP(1)" start-index="7" stop-index="19">
+                        <parameter>
+                            <literal-expression value="1" start-index="18" stop-index="18" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_stddev_samp">
+        <projections start-index="7" stop-index="20">
+            <expression-projection start-index="7" stop-index="20" text="STDDEV_SAMP(1)">
+                <expr>
+                    <function function-name="STDDEV_SAMP" text="STDDEV_SAMP(1)" start-index="7" stop-index="20">
+                        <parameter>
+                            <literal-expression value="1" start-index="19" stop-index="19" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_str_to_date">
+        <projections start-index="7" stop-index="41">
+            <expression-projection start-index="7" stop-index="41" text="STR_TO_DATE('01,5,2013','%d,%m,%Y')">
+                <expr>
+                    <function function-name="STR_TO_DATE" text="STR_TO_DATE('01,5,2013','%d,%m,%Y')" start-index="7" stop-index="41">
+                        <parameter>
+                            <literal-expression value="01,5,2013" start-index="19" stop-index="29" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="%d,%m,%Y" start-index="31" stop-index="40" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_strcmp">
+        <projections start-index="7" stop-index="29">
+            <expression-projection start-index="7" stop-index="29" text="STRCMP('text', 'text2')">
+                <expr>
+                    <function function-name="STRCMP" text="STRCMP('text', 'text2')" start-index="7" stop-index="29">
+                        <parameter>
+                            <literal-expression value="text" start-index="14" stop-index="19" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="text2" start-index="22" stop-index="28" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_subdate">
+        <projections start-index="7" stop-index="40">
+            <expression-projection start-index="7" stop-index="40" text="SUBDATE('2008-01-02 12:00:00', 31)">
+                <expr>
+                    <function function-name="SUBDATE" text="SUBDATE('2008-01-02 12:00:00', 31)" start-index="7" stop-index="40">
+                        <parameter>
+                            <literal-expression value="2008-01-02 12:00:00" start-index="15" stop-index="35" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="31" start-index="38" stop-index="39" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_subtime">
+        <projections start-index="7" stop-index="60">
+            <expression-projection start-index="7" stop-index="60" text="SUBTIME('2007-12-31 23:59:59.999999','1 1:1:1.000002')">
+                <expr>
+                    <function function-name="SUBTIME" text="SUBTIME('2007-12-31 23:59:59.999999','1 1:1:1.000002')" start-index="7" stop-index="60">
+                        <parameter>
+                            <literal-expression value="2007-12-31 23:59:59.999999" start-index="15" stop-index="42" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="1 1:1:1.000002" start-index="44" stop-index="59" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_sysdate">
+        <projections start-index="7" stop-index="15">
+            <expression-projection start-index="7" stop-index="15" text="SYSDATE()">
+                <expr>
+                    <function function-name="SYSDATE" text="SYSDATE()" start-index="7" stop-index="15">
                     </function>
                 </expr>
             </expression-projection>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
@@ -25,6 +25,7 @@
     <sql-case id="select_convert_function" value="SELECT CONVERT('2020-10-01', DATE)" db-types="MySQL" />
     <sql-case id="select_position" value="SELECT POSITION('bar' IN 'foobarbar')" db-types="MySQL" />
     <sql-case id="select_substring" value="SELECT SUBSTRING('foobarbar' from 4)" db-types="MySQL" />
+    <sql-case id="select_substr" value="SELECT SUBSTR('foobarbar' from 4)" db-types="MySQL" />
     <sql-case id="select_extract" value="SELECT EXTRACT(YEAR FROM '2019-07-02')" db-types="MySQL" />
     <sql-case id="select_extract_from_column" value="SELECT EXTRACT(YEAR FROM o.creation_date) FROM t_order o" db-types="MySQL,Presto" />
     <sql-case id="select_char" value="SELECT CHAR(77,121,83,81,'76')" db-types="MySQL" />
@@ -145,5 +146,14 @@
     <sql-case id="select_json_parse" value="SELECT JSON_PARSE('{&quot;k1&quot;:&quot;v31&quot;,&quot;k2&quot;:300}')" db-types="Doris" />
     <sql-case id="select_json_parse_error_to_null" value="SELECT JSON_PARSE('invalid json')" db-types="Doris" />
     <sql-case id="select_json_parse_error_to_value" value="SELECT JSON_PARSE('invalid json', '{}')" db-types="Doris" />
+    <sql-case id="select_std" value="SELECT STD(1)" db-types="MySQL" />
+    <sql-case id="select_stddev" value="SELECT STDDEV(1)" db-types="MySQL" />
+    <sql-case id="select_stddev_pop" value="SELECT STDDEV_POP(1)" db-types="MySQL" />
+    <sql-case id="select_stddev_samp" value="SELECT STDDEV_SAMP(1)" db-types="MySQL" />
+    <sql-case id="select_str_to_date" value="SELECT STR_TO_DATE('01,5,2013','%d,%m,%Y')" db-types="MySQL" />
+    <sql-case id="select_strcmp" value="SELECT STRCMP('text', 'text2')" db-types="MySQL" />
+    <sql-case id="select_subdate" value="SELECT SUBDATE('2008-01-02 12:00:00', 31)" db-types="MySQL" />
+    <sql-case id="select_subtime" value="SELECT SUBTIME('2007-12-31 23:59:59.999999','1 1:1:1.000002')" db-types="MySQL" />
+    <sql-case id="select_sysdate" value="SELECT SYSDATE()" db-types="MySQL" />
 
 </sql-cases>


### PR DESCRIPTION
Fixes #31565.

Changes proposed in this pull request:
  Improve the parsing of methods in MySQL

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
