### PR TITLE
Refactor : upgrade the jdk to 21 in workflow

### DIFF
--- a/.github/workflows/e2e-agent.yml
+++ b/.github/workflows/e2e-agent.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 21
       - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
@@ -109,6 +109,7 @@ jobs:
       max-parallel: 20
       fail-fast: false
       matrix:
+        java-version: [ 11, 21 ]
         include:
           - adapter: proxy
             feature: tracing
@@ -139,7 +140,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: ${{ matrix.java-version }}
       - uses: actions/cache@v4
         with:
           path: ~/.m2/repository

--- a/.github/workflows/e2e-agent.yml
+++ b/.github/workflows/e2e-agent.yml
@@ -101,7 +101,7 @@ jobs:
           
   agent-mysql:
     if: ${{ needs.global-environment.outputs.GLOBAL_JOB_ENABLED == 'true' }}
-    name: E2E - Agent with MySQL
+    name: E2E - Agent with MySQL(JDK ${{ matrix.java-version }})
     needs: [ global-environment, build-e2e-image ]
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/nightly-e2e-operation.yml
+++ b/.github/workflows/nightly-e2e-operation.yml
@@ -42,6 +42,7 @@ jobs:
     strategy:
       max-parallel: 20
       fail-fast: false
+      jdk: [ 11, 21 ]
       matrix:
         operation: [ transaction, pipeline, showprocesslist ]
         image: [ { type: "it.docker.mysql.version", version: "mysql:5.7,mysql:8.0" }, { type: "it.docker.postgresql.version", version: "postgres:10-alpine,postgres:11-alpine,postgres:12-alpine,postgres:13-alpine,postgres:14-alpine" }, { type: "it.docker.opengauss.version", version: "enmotech/opengauss:2.1.0,enmotech/opengauss:3.0.0" }, { type: "it.docker.mariadb.version", version: "mariadb:11" } ]
@@ -66,11 +67,11 @@ jobs:
           restore-keys: |
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-e2e-cache-
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-
-      - name: Setup JDK 11
+      - name: Setup JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: ${{ matrix.jdk }}
       - name: Build ${{ matrix.operation }} E2E Image
         run: ./mvnw -B clean install -am -pl test/e2e/operation/${{ matrix.operation }} -Pit.env.docker -DskipTests
       - name: Run ${{ matrix.operation }} on ${{ matrix.image.version }}

--- a/.github/workflows/nightly-e2e-operation.yml
+++ b/.github/workflows/nightly-e2e-operation.yml
@@ -42,8 +42,8 @@ jobs:
     strategy:
       max-parallel: 20
       fail-fast: false
-      jdk: [ 11, 21 ]
       matrix:
+        java-version: [ 11, 21 ]
         operation: [ transaction, pipeline, showprocesslist ]
         image: [ { type: "it.docker.mysql.version", version: "mysql:5.7,mysql:8.0" }, { type: "it.docker.postgresql.version", version: "postgres:10-alpine,postgres:11-alpine,postgres:12-alpine,postgres:13-alpine,postgres:14-alpine" }, { type: "it.docker.opengauss.version", version: "enmotech/opengauss:2.1.0,enmotech/opengauss:3.0.0" }, { type: "it.docker.mariadb.version", version: "mariadb:11" } ]
         exclude:
@@ -67,11 +67,11 @@ jobs:
           restore-keys: |
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-e2e-cache-
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-
-      - name: Setup JDK ${{ matrix.jdk }}
+      - name: Setup JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: ${{ matrix.jdk }}
+          java-version: ${{ matrix.java-version }}
       - name: Build ${{ matrix.operation }} E2E Image
         run: ./mvnw -B clean install -am -pl test/e2e/operation/${{ matrix.operation }} -Pit.env.docker -DskipTests
       - name: Run ${{ matrix.operation }} on ${{ matrix.image.version }}

--- a/.github/workflows/nightly-e2e-sql.yml
+++ b/.github/workflows/nightly-e2e-sql.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 21
       - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
@@ -73,6 +73,7 @@ jobs:
       max-parallel: 20
       fail-fast: false
       matrix:
+        java-version: [ 11, 21 ]
         adapter: [ proxy, jdbc ]
         mode: [ Standalone, Cluster ]
         database: [ MySQL, PostgreSQL, openGauss ]
@@ -110,7 +111,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: ${{ matrix.java-version }}
       - name: Download E2E Image
         if: matrix.adapter == 'proxy'
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Changes proposed in this pull request:
  - upgrade the jdk to 21 in operation workflow
  - upgrade the jdk to 21 in sql e2e workflow
  - upgrade the jdk to 21 in agent workflow

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
