### PR TITLE
Fixes HotSpot JDK 22 CI failure due to GR-54293

### DIFF
--- a/docs/document/content/user-manual/common-config/builtin-algorithm/expr.cn.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/expr.cn.md
@@ -76,7 +76,7 @@ weight = 10
 此为可选实现，你需要在自有项目的 `pom.xml` 主动声明如下依赖。并且请确保自有项目通过 OpenJDK 21+ 或其下游发行版编译。
 
 由于 https://www.graalvm.org/jdk21/reference-manual/java-on-truffle/faq/#does-java-running-on-truffle-run-on-hotspot-too 的限制，
-当此模块在非 GraalVM Native Image 的环境中被使用时，仅在 Linux 上就绪。
+当此模块在非 GraalVM Native Image 的环境中被使用时，仅在 System Property `os.arch` 为 `amd64` 的 Linux 上就绪。
 
 Truffle 与 JDK 的向后兼容性矩阵位于 https://medium.com/graalvm/40027a59c401 。
 
@@ -90,13 +90,18 @@ Truffle 与 JDK 的向后兼容性矩阵位于 https://medium.com/graalvm/40027a
     <dependency>
         <groupId>org.graalvm.polyglot</groupId>
         <artifactId>polyglot</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.2</version>
     </dependency>
     <dependency>
         <groupId>org.graalvm.polyglot</groupId>
         <artifactId>java-community</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.2</version>
         <type>pom</type>
+    </dependency>
+    <dependency>
+        <groupId>org.graalvm.espresso</groupId>
+        <artifactId>espresso-runtime-resources-linux-amd64</artifactId>
+        <version>24.0.2</version>
     </dependency>
 </dependencies>
 ```

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/expr.en.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/expr.en.md
@@ -85,8 +85,8 @@ Example:
 This is an optional implementation. You need to actively declare the following dependencies in the `pom.xml` of your own project. 
 And please make sure your own projects are compiled with OpenJDK 21+ or its downstream distribution.
 
-Due to the limitations of https://www.graalvm.org/jdk21/reference-manual/java-on-truffle/faq/#does-java-running-on-truffle-run-on-hotspot-too , 
-this module is only ready on Linux when used in environments other than GraalVM Native Image.
+Due to the limitation of https://www.graalvm.org/jdk21/reference-manual/java-on-truffle/faq/#does-java-running-on-truffle-run-on-hotspot-too,
+when this module is used in a non-GraalVM Native Image environment, it is only ready on Linux with System Property `os.arch` set to `amd64`.
 
 Truffle's backward compatibility matrix with the JDK is located at https://medium.com/graalvm/40027a59c401 .
 
@@ -100,13 +100,18 @@ Truffle's backward compatibility matrix with the JDK is located at https://mediu
     <dependency>
         <groupId>org.graalvm.polyglot</groupId>
         <artifactId>polyglot</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.2</version>
     </dependency>
     <dependency>
         <groupId>org.graalvm.polyglot</groupId>
         <artifactId>java-community</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.2</version>
         <type>pom</type>
+    </dependency>
+    <dependency>
+        <groupId>org.graalvm.espresso</groupId>
+        <artifactId>espresso-runtime-resources-linux-amd64</artifactId>
+        <version>24.0.2</version>
     </dependency>
 </dependencies>
 ```

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.cn.md
@@ -355,8 +355,8 @@ ShardingSphere 定义了 `nativeTestInShardingSphere` 的 Maven Profile 用于�
 sudo apt install unzip zip curl sed -y
 curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"
-sdk install java 22.0.1-graalce
-sdk use java 22.0.1-graalce
+sdk install java 22.0.2-graalce
+sdk use java 22.0.2-graalce
 sudo apt-get install build-essential zlib1g-dev -y
 
 git clone git@github.com:apache/shardingsphere.git

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.en.md
@@ -371,8 +371,8 @@ You must install Docker Engine to execute `testcontainers-java` related unit tes
 sudo apt install unzip zip curl sed -y
 curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"
-sdk install java 21.0.2-graalce
-sdk use java 21.0.2-graalce
+sdk install java 22.0.2-graalce
+sdk use java 22.0.2-graalce
 sudo apt-get install build-essential zlib1g-dev -y
 
 git clone git@github.com:apache/shardingsphere.git

--- a/infra/expr/type/espresso/pom.xml
+++ b/infra/expr/type/espresso/pom.xml
@@ -56,6 +56,12 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.espresso</groupId>
+            <artifactId>espresso-runtime-resources-linux-amd64</artifactId>
+            <version>${graal-sdk.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/infra/expr/type/espresso/src/test/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParserTest.java
+++ b/infra/expr/type/espresso/src/test/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParserTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @EnabledForJreRange(min = JRE.JAVA_22)
-@EnabledOnOs(value = OS.LINUX, disabledReason = "Refer to https://www.graalvm.org/jdk21/reference-manual/java-on-truffle/faq/#does-java-running-on-truffle-run-on-hotspot-too .")
+@EnabledOnOs(value = OS.LINUX, architectures = "amd64", disabledReason = "See https://www.graalvm.org/jdk21/reference-manual/java-on-truffle/faq/#does-java-running-on-truffle-run-on-hotspot-too")
 class EspressoInlineExpressionParserTest {
     
     @Test


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/actions/runs/10081728571/job/27887106603 .

Changes proposed in this pull request:
  - Fixes HotSpot JDK 22 CI failure due to GR-54293. Refer to https://github.com/oracle/graal/pull/9020 . This is the change introduced by https://github.com/apache/shardingsphere/pull/32246 .
  - Starting from GraalVM CE For JDK 22.0.2, using Truffle's Espresso implementation in OpenJDK requires including the `RuntimeResourceId` related Maven dependencies in the classpath, because Espresso's `RuntimeResourceId` is allowed to have multiple configurations. Currently, there is only one known implementation of RuntimeResourceId, which is `org.graalvm.espresso:espresso-runtime-resources-linux-amd64:24.0.2`. But I still think this is not reasonable, after all, I also need this Maven dependency on GraalVM CE For JDK 22.0.2.
  - The following figure uses SDKMAN! related `sdk use java 21.0.2-open` to verify that the execution of unit tests under HotSpot JDK has returned to normal.
  - ![image](https://github.com/user-attachments/assets/86848694-93e8-4b3c-8c7d-e9afc808d371)



---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
