### PR TITLE
Refactor : remove the dependency-check-maven since there is no uploaded nvd key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,6 @@
         <maven-jxr-plugin.version>3.3.0</maven-jxr-plugin.version>
         <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
         <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
-        <dependency-check-maven.version>10.0.3</dependency-check-maven.version>
     </properties>
     
     <dependencyManagement>
@@ -1192,11 +1191,6 @@
                         <aggregate>true</aggregate>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <groupId>org.owasp</groupId>
-                    <artifactId>dependency-check-maven</artifactId>
-                    <version>${dependency-check-maven.version}</version>
-                </plugin>
             </plugins>
         </pluginManagement>
         
@@ -1296,10 +1290,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>taglist-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
Changes proposed in this pull request:
  -  remove the dependency-check-maven since there is no uploaded nvd key

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
