### PR TITLE
Make jul-to-slf4j work in ShardingSphere-Proxy only

### DIFF
--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/eventbus/EventBusContext.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/eventbus/EventBusContext.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.infra.util.eventbus;
 
 import com.google.common.eventbus.EventBus;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 
 /**
  * Event bus context.
@@ -26,11 +25,6 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 public final class EventBusContext {
     
     private final EventBus eventBus = new EventBus();
-    
-    static {
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-        SLF4JBridgeHandler.install();
-    }
     
     /**
      * Register event subscriber.

--- a/pom.xml
+++ b/pom.xml
@@ -988,10 +988,6 @@
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>

--- a/proxy/bootstrap/pom.xml
+++ b/proxy/bootstrap/pom.xml
@@ -143,6 +143,10 @@
             <artifactId>logback-classic</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/Bootstrap.java
+++ b/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/Bootstrap.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.proxy.frontend.CDCServer;
 import org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy;
 import org.apache.shardingsphere.proxy.frontend.ssl.ProxySSLContext;
 import org.apache.shardingsphere.proxy.initializer.BootstrapInitializer;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -41,6 +42,11 @@ import java.util.Optional;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class Bootstrap {
+    
+    static {
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+    }
     
     /**
      * Main entrance.


### PR DESCRIPTION
ShardingSphere-JDBC is a SDK. When integrating ShardingSphere-JDBC into project which using JUL for logging, StackOverflowError would be occurred.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
