### PR TITLE
Remove useless lastColumn in SubstitutableColumnNameToken

### DIFF
--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/SubstitutableColumnNameToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/SubstitutableColumnNameToken.java
@@ -34,7 +34,6 @@ import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.Iden
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -50,33 +49,26 @@ public final class SubstitutableColumnNameToken extends SQLToken implements Subs
     
     private final Collection<Projection> projections;
     
-    private final boolean lastColumn;
-    
     private final QuoteCharacter quoteCharacter;
     
     public SubstitutableColumnNameToken(final int startIndex, final int stopIndex, final Collection<Projection> projections, final DatabaseType databaseType) {
         super(startIndex);
         this.stopIndex = stopIndex;
-        lastColumn = false;
         quoteCharacter = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getQuoteCharacter();
         this.projections = projections;
     }
     
     @Override
     public String toString(final RouteUnit routeUnit) {
-        Map<String, String> logicAndActualTables = new HashMap<>();
-        if (null != routeUnit) {
-            logicAndActualTables.putAll(getLogicAndActualTables(routeUnit));
-        }
+        Map<String, String> logicAndActualTables = getLogicAndActualTables(routeUnit);
         StringBuilder result = new StringBuilder();
-        int count = 0;
+        int index = 0;
         for (Projection each : projections) {
-            if (0 == count && !lastColumn) {
-                result.append(getColumnExpression(each, logicAndActualTables));
-            } else {
-                result.append(COLUMN_NAME_SPLITTER).append(getColumnExpression(each, logicAndActualTables));
+            if (index > 0) {
+                result.append(COLUMN_NAME_SPLITTER);
             }
-            count++;
+            result.append(getColumnExpression(each, logicAndActualTables));
+            index++;
         }
         return result.toString();
     }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove useless lastColumn in SubstitutableColumnNameToken

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
