### PR TITLE
Refactor `DefaultLoggingRuleConfigurationBuilder` to reduce usage of `logback-classic`

### DIFF
--- a/kernel/logging/core/pom.xml
+++ b/kernel/logging/core/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/kernel/logging/core/src/main/java/org/apache/shardingsphere/logging/rule/builder/DefaultLoggingRuleConfigurationBuilder.java
+++ b/kernel/logging/core/src/main/java/org/apache/shardingsphere/logging/rule/builder/DefaultLoggingRuleConfigurationBuilder.java
@@ -17,24 +17,24 @@
 
 package org.apache.shardingsphere.logging.rule.builder;
 
-import org.slf4j.Logger;
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.PatternLayout;
-import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.OutputStreamAppender;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import ch.qos.logback.core.pattern.PatternLayoutBase;
 import org.apache.shardingsphere.infra.rule.builder.global.DefaultGlobalRuleConfigurationBuilder;
 import org.apache.shardingsphere.logging.config.LoggingRuleConfiguration;
 import org.apache.shardingsphere.logging.constant.LoggingOrder;
 import org.apache.shardingsphere.logging.logger.ShardingSphereAppender;
 import org.apache.shardingsphere.logging.logger.ShardingSphereLogger;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.Objects;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -46,8 +46,12 @@ public final class DefaultLoggingRuleConfigurationBuilder implements DefaultGlob
     
     @Override
     public LoggingRuleConfiguration build() {
-        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-        return new LoggingRuleConfiguration(getDefaultLoggers(loggerContext), getDefaultAppenders(loggerContext));
+        ILoggerFactory iLoggerFactory = LoggerFactory.getILoggerFactory();
+        if ("ch.qos.logback.classic.LoggerContext".equals(iLoggerFactory.getClass().getName())) {
+            LoggerContext loggerContext = (LoggerContext) iLoggerFactory;
+            return new LoggingRuleConfiguration(getDefaultLoggers(loggerContext), getDefaultAppenders(loggerContext));
+        }
+        return new LoggingRuleConfiguration(Collections.emptyList(), Collections.emptySet());
     }
     
     private Collection<ShardingSphereLogger> getDefaultLoggers(final LoggerContext loggerContext) {
@@ -59,9 +63,8 @@ public final class DefaultLoggingRuleConfigurationBuilder implements DefaultGlob
     
     private Collection<ShardingSphereAppender> getDefaultAppenders(final LoggerContext loggerContext) {
         return loggerContext.getLoggerList().stream().filter(each -> null != each.getLevel()).filter(each -> !Logger.ROOT_LOGGER_NAME.equalsIgnoreCase(each.getName())).map(each -> {
-            Iterator<Appender<ILoggingEvent>> appenderIterator = each.iteratorForAppenders();
-            if (appenderIterator.hasNext()) {
-                Appender<ILoggingEvent> appender = appenderIterator.next();
+            if (each.iteratorForAppenders().hasNext()) {
+                Appender<?> appender = each.iteratorForAppenders().next();
                 ShardingSphereAppender shardingSphereAppender = new ShardingSphereAppender(appender.getName(), appender.getClass().getName(), getAppenderPattern(appender));
                 getFileOutput(appender, shardingSphereAppender);
                 return shardingSphereAppender;
@@ -70,19 +73,19 @@ public final class DefaultLoggingRuleConfigurationBuilder implements DefaultGlob
         }).filter(Objects::nonNull).collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(ShardingSphereAppender::getAppenderName))));
     }
     
-    private String getAppenderPattern(final Appender<ILoggingEvent> appender) {
+    private String getAppenderPattern(final Appender<?> appender) {
         if (appender instanceof OutputStreamAppender) {
-            OutputStreamAppender<ILoggingEvent> consoleAppender = (OutputStreamAppender<ILoggingEvent>) appender;
-            LayoutWrappingEncoder<ILoggingEvent> encoder = (LayoutWrappingEncoder<ILoggingEvent>) consoleAppender.getEncoder();
-            PatternLayout layout = (PatternLayout) encoder.getLayout();
+            OutputStreamAppender<?> consoleAppender = (OutputStreamAppender<?>) appender;
+            LayoutWrappingEncoder<?> encoder = (LayoutWrappingEncoder<?>) consoleAppender.getEncoder();
+            PatternLayoutBase<?> layout = (PatternLayoutBase<?>) encoder.getLayout();
             return layout.getPattern();
         }
         return "";
     }
     
-    private void getFileOutput(final Appender<ILoggingEvent> appender, final ShardingSphereAppender shardingSphereAppender) {
+    private void getFileOutput(final Appender<?> appender, final ShardingSphereAppender shardingSphereAppender) {
         if (appender instanceof FileAppender) {
-            shardingSphereAppender.setFile(((FileAppender<ILoggingEvent>) appender).getFile());
+            shardingSphereAppender.setFile(((FileAppender<?>) appender).getFile());
         }
     }
     

--- a/pom.xml
+++ b/pom.xml
@@ -990,6 +990,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.cedarsoftware</groupId>


### PR DESCRIPTION
Fixes #32377.

Changes proposed in this pull request:
  - Refactor `DefaultLoggingRuleConfigurationBuilder` to reduce usage of `logback-classic`. Apparently the adapter for `org.slf4j.impl.StaticLoggerBinder` is not in `logback-core`. It looks like there is no other way. Keep logback-classic in the classpath of shardingsphere jdbc.

```shell
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/linghengqian/.m2/repository/org/apache/logging/log4j/log4j-slf4j-impl/2.18.0/log4j-slf4j-impl-2.18.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/linghengqian/.m2/repository/org/slf4j/slf4j-log4j12/1.7.25/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/linghengqian/.m2/repository/ch/qos/logback/logback-classic/1.2.13/logback-classic-1.2.13.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
