### PR TITLE
Fix null result in federated query for a single projected column

### DIFF
--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/SQLFederationResultSet.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/SQLFederationResultSet.java
@@ -105,7 +105,7 @@ public final class SQLFederationResultSet extends AbstractUnsupportedOperationSQ
         if (result && null != enumerator.current()) {
             currentRows = enumerator.current().getClass().isArray() && !(enumerator.current() instanceof byte[]) ? (Object[]) enumerator.current() : new Object[]{enumerator.current()};
         } else {
-            currentRows = new Object[]{};
+            currentRows = new Object[]{null};
         }
         return result;
     }

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/function/mysql/impl/MySQLBinFunction.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/function/mysql/impl/MySQLBinFunction.java
@@ -42,14 +42,14 @@ public final class MySQLBinFunction {
         if (value instanceof Number && !(value instanceof BigInteger)) {
             return Long.toBinaryString(((Number) value).longValue());
         }
+        if (value instanceof String && ((String) value).isEmpty()) {
+            return null;
+        }
         BigInteger bigIntegerValue = value instanceof BigInteger ? (BigInteger) value : new BigInteger(getFirstNumbers(String.valueOf(value)));
         return -1 == bigIntegerValue.signum() ? bigIntegerValue.add(BigInteger.ONE.shiftLeft(Long.SIZE).subtract(BigInteger.ONE)).add(BigInteger.ONE).toString(2) : bigIntegerValue.toString(2);
     }
     
     private static String getFirstNumbers(final String value) {
-        if (value.isEmpty()) {
-            return "0";
-        }
         boolean isNegative = '-' == value.charAt(0);
         StringBuilder result = new StringBuilder();
         if (isNegative) {

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/function/mysql/impl/MySQLBitCountFunction.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/function/mysql/impl/MySQLBitCountFunction.java
@@ -39,7 +39,7 @@ public final class MySQLBitCountFunction {
     @SuppressWarnings("unused")
     public static Object bitCount(final Object value) {
         if (null == value) {
-            return 0;
+            return null;
         }
         if (value instanceof byte[]) {
             return bitCount((byte[]) value);

--- a/test/e2e/sql/src/test/resources/cases/dql/e2e-dql-select.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/e2e-dql-select.xml
@@ -306,6 +306,10 @@
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
     
+    <test-case sql="SELECT BIT_COUNT(NULL)" db-types="MySQL" scenario-types="db_tbl_sql_federation">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
     <test-case sql="SELECT bit_count(123456), bit_count('123456'), bit_count('abcdefg'), BIT_COUNT('abcdef1234'), bit_count(''), bit_count(1 + 1)" db-types="MySQL" scenario-types="db_tbl_sql_federation">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
@@ -368,6 +372,18 @@
                                 bin(type_unsigned_double), bin(type_unsigned_decimal) FROM t_product_extend
                                ) t2 ON t1.product_id = t2.product_id
                     INNER JOIN t_order_item t3 ON t2.product_id = t3.product_id INNER JOIN t_order t4 ON t4.order_id = t3.order_id order by t1.product_id" db-types="MySQL" scenario-types="db_tbl_sql_federation">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
+    <test-case sql="SELECT BIN(NULL)" db-types="MySQL" scenario-types="db_tbl_sql_federation">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
+    <test-case sql="SELECT BIN('')" db-types="MySQL" scenario-types="db_tbl_sql_federation">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
+    <test-case sql="SELECT BIN(NULL), BIN(''), BIN(' ')" db-types="MySQL" scenario-types="db_tbl_sql_federation">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 </e2e-test-cases>


### PR DESCRIPTION
Fixes #32417.

Changes proposed in this pull request:
  - Fix null result in federated query for a single projected column
  - Adjusts the return value of the function for an invalid argument

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
