### PR TITLE
Fix incorrect results for querying information_schema.SCHEMATA

### DIFF
--- a/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/information/SelectInformationSchemataExecutor.java
+++ b/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/information/SelectInformationSchemataExecutor.java
@@ -114,7 +114,8 @@ public final class SelectInformationSchemataExecutor extends DefaultDatabaseMeta
     private Map<String, String> getTheDefaultRowData() {
         Collection<ProjectionSegment> projections = sqlStatement.getProjections().getProjections();
         if (projections.stream().anyMatch(ShorthandProjectionSegment.class::isInstance)) {
-            return Stream.of(CATALOG_NAME, SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME, SQL_PATH, DEFAULT_ENCRYPTION).collect(Collectors.toMap(each -> each, each -> "", (oldValue, currentValue) -> oldValue, LinkedHashMap::new));
+            return Stream.of(CATALOG_NAME, SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME, SQL_PATH, DEFAULT_ENCRYPTION)
+                    .collect(Collectors.toMap(each -> each, each -> "", (oldValue, currentValue) -> oldValue, LinkedHashMap::new));
         }
         return getDefaultRowsFromProjections(projections);
     }

--- a/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/information/SelectInformationSchemataExecutor.java
+++ b/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/information/SelectInformationSchemataExecutor.java
@@ -105,20 +105,35 @@ public final class SelectInformationSchemataExecutor extends DefaultDatabaseMeta
         Map<String, String> defaultRowData = getTheDefaultRowData();
         SCHEMA_WITHOUT_DATA_SOURCE.forEach(each -> {
             Map<String, Object> row = new LinkedHashMap<>(defaultRowData);
-            row.replace(SCHEMA_NAME, each);
+            row.replace(schemaNameAlias, each);
             getRows().add(row);
         });
         SCHEMA_WITHOUT_DATA_SOURCE.clear();
     }
     
     private Map<String, String> getTheDefaultRowData() {
-        Map<String, String> result;
         Collection<ProjectionSegment> projections = sqlStatement.getProjections().getProjections();
         if (projections.stream().anyMatch(ShorthandProjectionSegment.class::isInstance)) {
-            result = Stream.of(CATALOG_NAME, SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME, SQL_PATH, DEFAULT_ENCRYPTION).collect(Collectors.toMap(each -> each, each -> ""));
-        } else {
-            result = projections.stream().map(each -> ((ColumnProjectionSegment) each).getColumn().getIdentifier())
-                    .map(each -> each.getValue().toUpperCase()).collect(Collectors.toMap(each -> each, each -> ""));
+            return Stream.of(CATALOG_NAME, SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME, SQL_PATH, DEFAULT_ENCRYPTION).collect(Collectors.toMap(each -> each, each -> "", (oldValue, currentValue) -> oldValue, LinkedHashMap::new));
+        }
+        return getDefaultRowsFromProjections(projections);
+    }
+    
+    private Map<String, String> getDefaultRowsFromProjections(final Collection<ProjectionSegment> projections) {
+        Map<String, String> result = new LinkedHashMap<>(projections.size(), 1F);
+        for (ProjectionSegment each : projections) {
+            if (!each.getClass().isAssignableFrom(ColumnProjectionSegment.class)) {
+                continue;
+            }
+            if (((ColumnProjectionSegment) each).getAlias().isPresent()) {
+                String alias = ((ColumnProjectionSegment) each).getAlias().get().getValue();
+                if (((ColumnProjectionSegment) each).getColumn().getIdentifier().getValue().equalsIgnoreCase(SCHEMA_NAME)) {
+                    schemaNameAlias = alias;
+                }
+                result.put(alias, "");
+                continue;
+            }
+            result.put(((ColumnProjectionSegment) each).getColumn().getIdentifier().getValue().toUpperCase(), "");
         }
         return result;
     }


### PR DESCRIPTION
Fixes #32510.

- fix column mapping error when `select *`
- fix incorrect label when using alias query

### Before
![image](https://github.com/user-attachments/assets/ff6543f9-32bc-4750-9771-fc5d4461259e)


### After
<img width="969" alt="image" src="https://github.com/user-attachments/assets/d02ecccd-4cbb-4c7b-9901-72b38c7d3a75">
