### PR TITLE
Remove useless null judge in SQLHintUtils#containsSQLHint method

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/hint/SQLHintUtils.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/hint/SQLHintUtils.java
@@ -99,7 +99,7 @@ public final class SQLHintUtils {
     }
     
     private static boolean containsSQLHint(final String sql) {
-        return null != sql && (sql.contains(SQLHintTokenType.SQL_START_HINT_TOKEN.getKey())
+        return (sql.contains(SQLHintTokenType.SQL_START_HINT_TOKEN.getKey())
                 || sql.contains(SQLHintTokenType.SQL_START_HINT_TOKEN.getAlias())) && sql.contains(SQL_COMMENT_PREFIX) && sql.contains(SQL_COMMENT_SUFFIX);
     }
     


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove useless null judge in SQLHintUtils#containsSQLHint method

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
