### PR TITLE
Refactor inventory dumper and data consistency streaming query to page query

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/result/RecordSingleTableInventoryCalculatedResult.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/result/RecordSingleTableInventoryCalculatedResult.java
@@ -67,8 +67,9 @@ public final class RecordSingleTableInventoryCalculatedResult implements SingleT
         final RecordSingleTableInventoryCalculatedResult that = (RecordSingleTableInventoryCalculatedResult) o;
         EqualsBuilder equalsBuilder = new EqualsBuilder();
         if (recordsCount != that.recordsCount || !DataConsistencyCheckUtils.isMatched(equalsBuilder, maxUniqueKeyValue, that.maxUniqueKeyValue)) {
-            log.warn("Record count or max unique key value not match, recordCount1={}, recordCount2={}, maxUniqueKeyValue1={}, maxUniqueKeyValue2={}.",
-                    recordsCount, that.recordsCount, maxUniqueKeyValue, that.maxUniqueKeyValue);
+            log.warn("Record count or max unique key value not match, recordCount1={}, recordCount2={}, maxUniqueKeyValue1={}, maxUniqueKeyValue2={}, value1.class={}, value2.class={}.",
+                    recordsCount, that.recordsCount, maxUniqueKeyValue, that.maxUniqueKeyValue,
+                    null == maxUniqueKeyValue ? "" : maxUniqueKeyValue.getClass().getName(), null == that.maxUniqueKeyValue ? "" : that.maxUniqueKeyValue.getClass().getName());
             return false;
         }
         Iterator<Map<String, Object>> thisRecordsIterator = records.iterator();

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/TableInventoryCheckParameter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/TableInventoryCheckParameter.java
@@ -19,11 +19,11 @@ package org.apache.shardingsphere.data.pipeline.core.consistencycheck.table;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.infra.metadata.caseinsensitive.CaseInsensitiveQualifiedTable;
-import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineColumnMetaData;
-import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSourceWrapper;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.ConsistencyCheckJobItemProgressContext;
+import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSourceWrapper;
+import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineColumnMetaData;
 import org.apache.shardingsphere.data.pipeline.core.ratelimit.JobRateLimitAlgorithm;
+import org.apache.shardingsphere.infra.metadata.caseinsensitive.CaseInsensitiveQualifiedTable;
 
 import java.util.List;
 

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/CalculationContext.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/CalculationContext.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.infra.util.close.QuietlyCloser;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -34,6 +35,8 @@ public final class CalculationContext implements AutoCloseable {
     private final AtomicReference<PreparedStatement> preparedStatement = new AtomicReference<>();
     
     private final AtomicReference<ResultSet> resultSet = new AtomicReference<>();
+    
+    private final AtomicBoolean closed = new AtomicBoolean(false);
     
     /**
      * Get connection.
@@ -80,10 +83,23 @@ public final class CalculationContext implements AutoCloseable {
         this.resultSet.set(resultSet);
     }
     
+    /**
+     * Is closed.
+     *
+     * @return closed or not
+     */
+    public boolean isClosed() {
+        return closed.get();
+    }
+    
     @Override
     public void close() {
+        closed.set(true);
         QuietlyCloser.close(resultSet.get());
         QuietlyCloser.close(preparedStatement.get());
         QuietlyCloser.close(connection.get());
+        resultSet.set(null);
+        preparedStatement.set(null);
+        connection.set(null);
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/SingleTableInventoryCalculateParameter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/SingleTableInventoryCalculateParameter.java
@@ -19,13 +19,18 @@ package org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calc
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.infra.metadata.caseinsensitive.CaseInsensitiveQualifiedTable;
-import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineColumnMetaData;
 import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSourceWrapper;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.QueryRange;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.QueryType;
+import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineColumnMetaData;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.metadata.caseinsensitive.CaseInsensitiveQualifiedTable;
 
+import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * Single table inventory calculate parameter.
@@ -50,9 +55,27 @@ public final class SingleTableInventoryCalculateParameter {
      */
     private final List<PipelineColumnMetaData> uniqueKeys;
     
-    private final Object tableCheckPosition;
-    
     private final AtomicReference<AutoCloseable> calculationContext = new AtomicReference<>();
+    
+    private final AtomicReference<Collection<Object>> uniqueKeysValues = new AtomicReference<>();
+    
+    private final AtomicReference<QueryRange> uniqueKeysValuesRange = new AtomicReference<>();
+    
+    private final AtomicReference<List<String>> shardingColumnsNames = new AtomicReference<>();
+    
+    private final AtomicReference<List<Object>> shardingColumnsValues = new AtomicReference<>();
+    
+    private final QueryType queryType;
+    
+    public SingleTableInventoryCalculateParameter(final PipelineDataSourceWrapper dataSource, final CaseInsensitiveQualifiedTable table, final List<String> columnNames,
+                                                  final List<PipelineColumnMetaData> uniqueKeys, final Object tableCheckPosition) {
+        this.dataSource = dataSource;
+        this.table = table;
+        this.columnNames = columnNames;
+        this.uniqueKeys = uniqueKeys;
+        queryType = QueryType.RANGE_QUERY;
+        setQueryRange(new QueryRange(tableCheckPosition, false, null));
+    }
     
     /**
      * Get database type.
@@ -106,5 +129,86 @@ public final class SingleTableInventoryCalculateParameter {
      */
     public void setCalculationContext(final AutoCloseable calculationContext) {
         this.calculationContext.set(calculationContext);
+    }
+    
+    /**
+     * Get unique keys names.
+     *
+     * @return unique keys names
+     */
+    public List<String> getUniqueKeysNames() {
+        return uniqueKeys.stream().map(PipelineColumnMetaData::getName).collect(Collectors.toList());
+    }
+    
+    /**
+     * Get unique keys values.
+     *
+     * @return unique keys values
+     */
+    public Collection<Object> getUniqueKeysValues() {
+        return uniqueKeysValues.get();
+    }
+    
+    /**
+     * Set unique keys values.
+     *
+     * @param uniqueKeysValues unique keys values
+     */
+    public void setUniqueKeysValues(final Collection<Object> uniqueKeysValues) {
+        this.uniqueKeysValues.set(uniqueKeysValues);
+    }
+    
+    /**
+     * Get query range.
+     *
+     * @return query range
+     */
+    public QueryRange getQueryRange() {
+        return uniqueKeysValuesRange.get();
+    }
+    
+    /**
+     * Set query range.
+     *
+     * @param queryRange query range
+     */
+    public void setQueryRange(final QueryRange queryRange) {
+        this.uniqueKeysValuesRange.set(queryRange);
+    }
+    
+    /**
+     * Get sharding columns names.
+     *
+     * @return sharding columns names
+     */
+    public @Nullable List<String> getShardingColumnsNames() {
+        return shardingColumnsNames.get();
+    }
+    
+    /**
+     * Set sharding columns names.
+     *
+     * @param shardingColumnsNames sharding columns names
+     */
+    public void setShardingColumnsNames(final List<String> shardingColumnsNames) {
+        this.shardingColumnsNames.set(shardingColumnsNames);
+    }
+    
+    /**
+     * Get sharding columns values.
+     *
+     * @return sharding columns values
+     */
+    public @Nullable List<Object> getShardingColumnsValues() {
+        return shardingColumnsValues.get();
+    }
+    
+    /**
+     * Set sharding columns values.
+     *
+     * @param shardingColumnsValues sharding columns values
+     */
+    public void setShardingColumnsValues(final List<Object> shardingColumnsValues) {
+        this.shardingColumnsValues.set(shardingColumnsValues);
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumper.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumper.java
@@ -115,7 +115,7 @@ public class InventoryDumper extends AbstractPipelineLifecycleRunnable implement
         try (Connection connection = dataSource.getConnection()) {
             if (!Strings.isNullOrEmpty(dumperContext.getQuerySQL()) || !dumperContext.hasUniqueKey()
                     || position instanceof PrimaryKeyIngestPosition && null == ((PrimaryKeyIngestPosition<?>) position).getBeginValue()
-                    && null == ((PrimaryKeyIngestPosition<?>) position).getEndValue()) {
+                            && null == ((PrimaryKeyIngestPosition<?>) position).getEndValue()) {
                 dumpWithStreamingQuery(connection);
             } else {
                 dumpPageByPage(connection);
@@ -347,7 +347,7 @@ public class InventoryDumper extends AbstractPipelineLifecycleRunnable implement
     protected IngestPosition newDataRecordPosition(final ResultSet resultSet) throws SQLException {
         return dumperContext.hasUniqueKey()
                 ? PrimaryKeyIngestPositionFactory.newInstance(
-                resultSet.getObject(dumperContext.getUniqueKeyColumns().get(0).getName()), ((PrimaryKeyIngestPosition<?>) dumperContext.getCommonContext().getPosition()).getEndValue())
+                        resultSet.getObject(dumperContext.getUniqueKeyColumns().get(0).getName()), ((PrimaryKeyIngestPosition<?>) dumperContext.getCommonContext().getPosition()).getEndValue())
                 : new IngestPlaceholderPosition();
     }
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumper.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumper.java
@@ -21,11 +21,12 @@ import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.data.pipeline.core.channel.PipelineChannel;
 import org.apache.shardingsphere.data.pipeline.core.constant.PipelineSQLOperationType;
 import org.apache.shardingsphere.data.pipeline.core.exception.IngestException;
+import org.apache.shardingsphere.data.pipeline.core.exception.PipelineInternalException;
 import org.apache.shardingsphere.data.pipeline.core.exception.param.PipelineInvalidParameterException;
 import org.apache.shardingsphere.data.pipeline.core.execute.AbstractPipelineLifecycleRunnable;
-import org.apache.shardingsphere.data.pipeline.core.channel.PipelineChannel;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.Dumper;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.column.InventoryColumnValueReaderEngine;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.IngestPosition;
@@ -43,11 +44,12 @@ import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineTable
 import org.apache.shardingsphere.data.pipeline.core.query.JDBCStreamQueryBuilder;
 import org.apache.shardingsphere.data.pipeline.core.ratelimit.JobRateLimitAlgorithm;
 import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql.PipelineInventoryDumpSQLBuilder;
+import org.apache.shardingsphere.data.pipeline.core.util.DatabaseTypeUtils;
 import org.apache.shardingsphere.data.pipeline.core.util.PipelineJdbcUtils;
 import org.apache.shardingsphere.infra.annotation.HighFrequencyInvocation;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.database.mysql.type.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
+import org.apache.shardingsphere.infra.metadata.caseinsensitive.CaseInsensitiveIdentifier;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -56,19 +58,21 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * Inventory dumper.
  */
 @HighFrequencyInvocation
 @Slf4j
-public final class InventoryDumper extends AbstractPipelineLifecycleRunnable implements Dumper {
+public class InventoryDumper extends AbstractPipelineLifecycleRunnable implements Dumper {
     
     @Getter(AccessLevel.PROTECTED)
     private final InventoryDumperContext dumperContext;
@@ -84,6 +88,11 @@ public final class InventoryDumper extends AbstractPipelineLifecycleRunnable imp
     private final InventoryColumnValueReaderEngine columnValueReaderEngine;
     
     private final AtomicReference<Statement> runningStatement = new AtomicReference<>();
+    
+    private PipelineTableMetaData tableMetaData;
+    
+    // TODO now Remove
+    private List<CaseInsensitiveIdentifier> uniqueKeysNames = Collections.emptyList();
     
     public InventoryDumper(final InventoryDumperContext dumperContext, final PipelineChannel channel, final DataSource dataSource, final PipelineTableMetaDataLoader metaDataLoader) {
         this.dumperContext = dumperContext;
@@ -102,29 +111,58 @@ public final class InventoryDumper extends AbstractPipelineLifecycleRunnable imp
             log.info("Ignored because of already finished.");
             return;
         }
-        PipelineTableMetaData tableMetaData = metaDataLoader.getTableMetaData(
-                dumperContext.getCommonContext().getTableAndSchemaNameMapper().getSchemaName(dumperContext.getLogicTableName()), dumperContext.getActualTableName());
+        init();
         try (Connection connection = dataSource.getConnection()) {
-            dump(tableMetaData, connection);
-        } catch (final SQLException ex) {
-            log.error("Inventory dump, ex caught, msg={}.", ex.getMessage());
+            if (!Strings.isNullOrEmpty(dumperContext.getQuerySQL()) || !dumperContext.hasUniqueKey()
+                    || position instanceof PrimaryKeyIngestPosition && null == ((PrimaryKeyIngestPosition<?>) position).getBeginValue()
+                    && null == ((PrimaryKeyIngestPosition<?>) position).getEndValue()) {
+                dumpWithStreamingQuery(connection);
+            } else {
+                dumpPageByPage(connection);
+            }
+            // CHECKSTYLE:OFF
+        } catch (final SQLException | RuntimeException ex) {
+            // CHECKSTYLE:ON
+            log.error("Inventory dump failed on {}", dumperContext.getActualTableName(), ex);
             throw new IngestException("Inventory dump failed on " + dumperContext.getActualTableName(), ex);
         }
     }
     
+    /**
+     * Initialize.
+     */
+    public void init() {
+        if (null == uniqueKeysNames) {
+            uniqueKeysNames = getUniqueKeysNames();
+        }
+        if (null == tableMetaData) {
+            tableMetaData = metaDataLoader.getTableMetaData(
+                    dumperContext.getCommonContext().getTableAndSchemaNameMapper().getSchemaName(dumperContext.getLogicTableName()), dumperContext.getActualTableName());
+        }
+    }
+    
+    private List<CaseInsensitiveIdentifier> getUniqueKeysNames() {
+        if (dumperContext.hasUniqueKey()) {
+            return dumperContext.getUniqueKeyColumns().stream().map(each -> new CaseInsensitiveIdentifier(each.getName())).collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+    
     @SuppressWarnings("MagicConstant")
-    private void dump(final PipelineTableMetaData tableMetaData, final Connection connection) throws SQLException {
+    private void dumpWithStreamingQuery(final Connection connection) throws SQLException {
         int batchSize = dumperContext.getBatchSize();
         DatabaseType databaseType = dumperContext.getCommonContext().getDataSourceConfig().getDatabaseType();
         if (null != dumperContext.getTransactionIsolation()) {
             connection.setTransactionIsolation(dumperContext.getTransactionIsolation());
         }
-        try (PreparedStatement preparedStatement = JDBCStreamQueryBuilder.build(databaseType, connection, buildInventoryDumpSQL())) {
+        try (PreparedStatement preparedStatement = JDBCStreamQueryBuilder.build(databaseType, connection, buildInventoryDumpSQLWithStreamingQuery())) {
             runningStatement.set(preparedStatement);
-            if (!(databaseType instanceof MySQLDatabaseType)) {
+            if (!DatabaseTypeUtils.isMySQL(databaseType)) {
                 preparedStatement.setFetchSize(batchSize);
             }
-            setParameters(preparedStatement);
+            PrimaryKeyIngestPosition<?> primaryPosition = (PrimaryKeyIngestPosition<?>) dumperContext.getCommonContext().getPosition();
+            InventoryQueryParameter queryParam = InventoryQueryParameter.buildForRangeQuery(new QueryRange(primaryPosition.getBeginValue(), true, primaryPosition.getEndValue()));
+            setParameters(preparedStatement, queryParam, true);
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
                 int rowCount = 0;
                 JobRateLimitAlgorithm rateLimitAlgorithm = dumperContext.getRateLimitAlgorithm();
@@ -135,7 +173,7 @@ public final class InventoryDumper extends AbstractPipelineLifecycleRunnable imp
                         channel.push(dataRecords);
                         dataRecords = new LinkedList<>();
                     }
-                    dataRecords.add(loadDataRecord(resultSet, resultSetMetaData, tableMetaData));
+                    dataRecords.add(loadDataRecord(resultSet, resultSetMetaData));
                     ++rowCount;
                     if (!isRunning()) {
                         log.info("Broke because of inventory dump is not running.");
@@ -147,75 +185,169 @@ public final class InventoryDumper extends AbstractPipelineLifecycleRunnable imp
                 }
                 dataRecords.add(new FinishedRecord(new IngestFinishedPosition()));
                 channel.push(dataRecords);
-                log.info("Inventory dump done, rowCount={}, dataSource={}, actualTable={}", rowCount, dumperContext.getCommonContext().getDataSourceName(), dumperContext.getActualTableName());
+                log.info("Inventory dump with streaming query done, rowCount={}, dataSource={}, actualTable={}",
+                        rowCount, dumperContext.getCommonContext().getDataSourceName(), dumperContext.getActualTableName());
             } finally {
                 runningStatement.set(null);
             }
         }
     }
     
-    private String buildInventoryDumpSQL() {
+    private String buildInventoryDumpSQLWithStreamingQuery() {
         if (!Strings.isNullOrEmpty(dumperContext.getQuerySQL())) {
             return dumperContext.getQuerySQL();
         }
         String schemaName = dumperContext.getCommonContext().getTableAndSchemaNameMapper().getSchemaName(dumperContext.getLogicTableName());
-        if (!dumperContext.hasUniqueKey()) {
-            return inventoryDumpSQLBuilder.buildFetchAllSQL(schemaName, dumperContext.getActualTableName());
-        }
-        PrimaryKeyIngestPosition<?> primaryKeyPosition = (PrimaryKeyIngestPosition<?>) dumperContext.getCommonContext().getPosition();
-        PipelineColumnMetaData firstColumn = dumperContext.getUniqueKeyColumns().get(0);
-        Collection<String> columnNames = Collections.singleton("*");
-        if (PipelineJdbcUtils.isIntegerColumn(firstColumn.getDataType()) || PipelineJdbcUtils.isStringColumn(firstColumn.getDataType())) {
-            if (null != primaryKeyPosition.getBeginValue() && null != primaryKeyPosition.getEndValue()) {
-                return inventoryDumpSQLBuilder.buildDivisibleSQL(schemaName, dumperContext.getActualTableName(), columnNames, firstColumn.getName());
-            }
-            if (null != primaryKeyPosition.getBeginValue() && null == primaryKeyPosition.getEndValue()) {
-                return inventoryDumpSQLBuilder.buildUnlimitedDivisibleSQL(schemaName, dumperContext.getActualTableName(), columnNames, firstColumn.getName());
-            }
-        }
-        return inventoryDumpSQLBuilder.buildIndivisibleSQL(schemaName, dumperContext.getActualTableName(), columnNames, firstColumn.getName());
+        List<String> columnNames = getQueryColumnNames();
+        return inventoryDumpSQLBuilder.buildFetchAllSQL(schemaName, dumperContext.getActualTableName(), columnNames);
     }
     
-    private void setParameters(final PreparedStatement preparedStatement) throws SQLException {
+    @SuppressWarnings("MagicConstant")
+    private void dumpPageByPage(final Connection connection) throws SQLException {
+        if (null != dumperContext.getTransactionIsolation()) {
+            connection.setTransactionIsolation(dumperContext.getTransactionIsolation());
+        }
+        boolean firstQuery = true;
+        AtomicLong rowCount = new AtomicLong();
+        IngestPosition position = dumperContext.getCommonContext().getPosition();
+        while (true) {
+            PrimaryKeyIngestPosition<?> primaryPosition = (PrimaryKeyIngestPosition<?>) position;
+            InventoryQueryParameter queryParam = InventoryQueryParameter.buildForRangeQuery(new QueryRange(primaryPosition.getBeginValue(), firstQuery, primaryPosition.getEndValue()));
+            List<Record> dataRecords = dumpPageByPage0(connection, queryParam, rowCount);
+            if (dataRecords.size() > 1 && Objects.deepEquals(getFirstUniqueKeyValue(dataRecords, 0), getFirstUniqueKeyValue(dataRecords, dataRecords.size() - 1))) {
+                queryParam = InventoryQueryParameter.buildForPointQuery(getFirstUniqueKeyValue(dataRecords, 0));
+                dataRecords = dumpPageByPage0(connection, queryParam, rowCount);
+            }
+            firstQuery = false;
+            if (dataRecords.isEmpty()) {
+                position = new IngestFinishedPosition();
+                dataRecords.add(new FinishedRecord(position));
+                log.info("Inventory dump done, rowCount={}, dataSource={}, actualTable={}", rowCount, dumperContext.getCommonContext().getDataSourceName(), dumperContext.getActualTableName());
+            } else {
+                position = PrimaryKeyIngestPositionFactory.newInstance(getFirstUniqueKeyValue(dataRecords, dataRecords.size() - 1), primaryPosition.getEndValue());
+            }
+            channel.push(dataRecords);
+            dumperContext.getCommonContext().setPosition(position);
+            if (position instanceof IngestFinishedPosition) {
+                break;
+            }
+        }
+    }
+    
+    private Object getFirstUniqueKeyValue(final List<Record> dataRecords, final int index) {
+        return ((DataRecord) dataRecords.get(index)).getUniqueKeyValue().iterator().next();
+    }
+    
+    private List<Record> dumpPageByPage0(final Connection connection, final InventoryQueryParameter queryParam,
+                                         final AtomicLong rowCount) throws SQLException {
+        DatabaseType databaseType = dumperContext.getCommonContext().getDataSourceConfig().getDatabaseType();
+        int batchSize = dumperContext.getBatchSize();
+        try (PreparedStatement preparedStatement = JDBCStreamQueryBuilder.build(databaseType, connection, buildInventoryDumpPageByPageSQL(queryParam))) {
+            runningStatement.set(preparedStatement);
+            if (!DatabaseTypeUtils.isMySQL(databaseType)) {
+                preparedStatement.setFetchSize(batchSize);
+            }
+            setParameters(preparedStatement, queryParam, false);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                JobRateLimitAlgorithm rateLimitAlgorithm = dumperContext.getRateLimitAlgorithm();
+                ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+                List<Record> result = new LinkedList<>();
+                while (resultSet.next()) {
+                    if (result.size() >= batchSize) {
+                        if (!dumperContext.hasUniqueKey()) {
+                            channel.push(result);
+                        }
+                        result = new LinkedList<>();
+                    }
+                    result.add(loadDataRecord(resultSet, resultSetMetaData));
+                    rowCount.incrementAndGet();
+                    if (!isRunning()) {
+                        log.info("Broke because of inventory dump is not running.");
+                        break;
+                    }
+                    if (null != rateLimitAlgorithm && 0 == rowCount.get() % batchSize) {
+                        rateLimitAlgorithm.intercept(PipelineSQLOperationType.SELECT, 1);
+                    }
+                }
+                return result;
+            } finally {
+                runningStatement.set(null);
+            }
+        }
+    }
+    
+    private String buildInventoryDumpPageByPageSQL(final InventoryQueryParameter queryParam) {
+        String schemaName = dumperContext.getCommonContext().getTableAndSchemaNameMapper().getSchemaName(dumperContext.getLogicTableName());
+        PipelineColumnMetaData firstColumn = dumperContext.getUniqueKeyColumns().get(0);
+        List<String> columnNames = getQueryColumnNames();
+        if (QueryType.POINT_QUERY == queryParam.getQueryType()) {
+            return inventoryDumpSQLBuilder.buildPointQuerySQL(schemaName, dumperContext.getActualTableName(), columnNames, firstColumn.getName());
+        }
+        QueryRange queryRange = queryParam.getUniqueKeyValueRange();
+        boolean lowerInclusive = queryRange.isLowerInclusive();
+        if (null != queryRange.getLower() && null != queryRange.getUpper()) {
+            return inventoryDumpSQLBuilder.buildDivisibleSQL(schemaName, dumperContext.getActualTableName(), columnNames, firstColumn.getName(), lowerInclusive);
+        }
+        if (null != queryRange.getLower()) {
+            return inventoryDumpSQLBuilder.buildUnlimitedDivisibleSQL(schemaName, dumperContext.getActualTableName(), columnNames, firstColumn.getName(), lowerInclusive);
+        }
+        throw new PipelineInternalException("Primary key position is invalid.");
+    }
+    
+    private List<String> getQueryColumnNames() {
+        return Optional.ofNullable(dumperContext.getInsertColumnNames()).orElse(Collections.singletonList("*"));
+    }
+    
+    private void setParameters(final PreparedStatement preparedStatement, final InventoryQueryParameter queryParam, final boolean streamingQuery) throws SQLException {
+        if (!Strings.isNullOrEmpty(dumperContext.getQuerySQL())) {
+            for (int i = 0; i < dumperContext.getQueryParams().size(); i++) {
+                preparedStatement.setObject(i + 1, dumperContext.getQueryParams().get(i));
+            }
+            return;
+        }
         if (!dumperContext.hasUniqueKey()) {
             return;
         }
-        PipelineColumnMetaData firstColumn = dumperContext.getUniqueKeyColumns().get(0);
-        PrimaryKeyIngestPosition<?> position = (PrimaryKeyIngestPosition<?>) dumperContext.getCommonContext().getPosition();
-        if (PipelineJdbcUtils.isIntegerColumn(firstColumn.getDataType()) && null != position.getBeginValue() && null != position.getEndValue()) {
-            preparedStatement.setObject(1, position.getBeginValue());
-            preparedStatement.setObject(2, position.getEndValue());
-            return;
-        }
-        if (PipelineJdbcUtils.isStringColumn(firstColumn.getDataType())) {
-            if (null != position.getBeginValue()) {
-                preparedStatement.setObject(1, position.getBeginValue());
+        int parameterIndex = 1;
+        if (QueryType.RANGE_QUERY == queryParam.getQueryType()) {
+            Object lower = queryParam.getUniqueKeyValueRange().getLower();
+            if (null != lower) {
+                preparedStatement.setObject(parameterIndex++, lower);
             }
-            if (null != position.getEndValue()) {
-                preparedStatement.setObject(2, position.getEndValue());
+            Object upper = queryParam.getUniqueKeyValueRange().getUpper();
+            if (null != upper) {
+                preparedStatement.setObject(parameterIndex++, upper);
             }
+            if (!streamingQuery) {
+                preparedStatement.setInt(parameterIndex, dumperContext.getBatchSize());
+            }
+        } else if (QueryType.POINT_QUERY == queryParam.getQueryType()) {
+            preparedStatement.setObject(parameterIndex, queryParam.getUniqueKeyValue());
+        } else {
+            throw new UnsupportedOperationException("Query type: " + queryParam.getQueryType());
         }
     }
     
-    private DataRecord loadDataRecord(final ResultSet resultSet, final ResultSetMetaData resultSetMetaData, final PipelineTableMetaData tableMetaData) throws SQLException {
+    private DataRecord loadDataRecord(final ResultSet resultSet, final ResultSetMetaData resultSetMetaData) throws SQLException {
         int columnCount = resultSetMetaData.getColumnCount();
-        DataRecord result = new DataRecord(PipelineSQLOperationType.INSERT, dumperContext.getLogicTableName(), newPosition(resultSet), columnCount);
+        DataRecord result = new DataRecord(PipelineSQLOperationType.INSERT, dumperContext.getLogicTableName(), newDataRecordPosition(resultSet), columnCount);
         List<String> insertColumnNames = Optional.ofNullable(dumperContext.getInsertColumnNames()).orElse(Collections.emptyList());
         ShardingSpherePreconditions.checkState(insertColumnNames.isEmpty() || insertColumnNames.size() == resultSetMetaData.getColumnCount(),
-                () -> new PipelineInvalidParameterException("Insert colum names count not equals ResultSet column count"));
+                () -> new PipelineInvalidParameterException("Insert column names count not equals ResultSet column count"));
         for (int i = 1; i <= columnCount; i++) {
             String columnName = insertColumnNames.isEmpty() ? resultSetMetaData.getColumnName(i) : insertColumnNames.get(i - 1);
             ShardingSpherePreconditions.checkNotNull(tableMetaData.getColumnMetaData(columnName), () -> new PipelineInvalidParameterException(String.format("Column name is %s", columnName)));
             boolean isUniqueKey = tableMetaData.getColumnMetaData(columnName).isUniqueKey();
             result.addColumn(new Column(columnName, columnValueReaderEngine.read(resultSet, resultSetMetaData, i), true, isUniqueKey));
         }
+        result.setActualTableName(dumperContext.getActualTableName());
         return result;
     }
     
-    private IngestPosition newPosition(final ResultSet resultSet) throws SQLException {
+    protected IngestPosition newDataRecordPosition(final ResultSet resultSet) throws SQLException {
         return dumperContext.hasUniqueKey()
                 ? PrimaryKeyIngestPositionFactory.newInstance(
-                        resultSet.getObject(dumperContext.getUniqueKeyColumns().get(0).getName()), ((PrimaryKeyIngestPosition<?>) dumperContext.getCommonContext().getPosition()).getEndValue())
+                resultSet.getObject(dumperContext.getUniqueKeyColumns().get(0).getName()), ((PrimaryKeyIngestPosition<?>) dumperContext.getCommonContext().getPosition()).getEndValue())
                 : new IngestPlaceholderPosition();
     }
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumperContext.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumperContext.java
@@ -46,6 +46,8 @@ public final class InventoryDumperContext {
     
     private String querySQL;
     
+    private List<Object> queryParams;
+    
     private Integer transactionIsolation;
     
     private int shardingItem;

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryQueryParameter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryQueryParameter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Inventory query parameter.
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public final class InventoryQueryParameter {
+    
+    private final QueryType queryType;
+    
+    private final Object uniqueKeyValue;
+    
+    private final QueryRange uniqueKeyValueRange;
+    
+    /**
+     * Build for point query.
+     *
+     * @param uniqueKeyValue unique key value
+     * @return inventory query parameter
+     */
+    public static InventoryQueryParameter buildForPointQuery(final Object uniqueKeyValue) {
+        return new InventoryQueryParameter(QueryType.POINT_QUERY, uniqueKeyValue, null);
+    }
+    
+    /**
+     * Build for range query.
+     *
+     * @param uniqueKeyValueRange unique key value range
+     * @return inventory query parameter
+     */
+    public static InventoryQueryParameter buildForRangeQuery(final QueryRange uniqueKeyValueRange) {
+        return new InventoryQueryParameter(QueryType.RANGE_QUERY, null, uniqueKeyValueRange);
+    }
+}

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/QueryRange.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/QueryRange.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Query range.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class QueryRange {
+    
+    private final Object lower;
+    
+    private final boolean lowerInclusive;
+    
+    private final Object upper;
+}

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/QueryType.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/QueryType.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory;
+
+/**
+ * Query type.
+ */
+public enum QueryType {
+    
+    RANGE_QUERY, POINT_QUERY
+}

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/dialect/DialectPipelineSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/dialect/DialectPipelineSQLBuilder.java
@@ -100,4 +100,14 @@ public interface DialectPipelineSQLBuilder extends DatabaseTypedSPI {
     default Optional<String> buildQueryCurrentPositionSQL() {
         return Optional.empty();
     }
+    
+    /**
+     * Wrap with page query.
+     *
+     * @param sql SQL
+     * @return wrapped SQL
+     */
+    default String wrapWithPageQuery(String sql) {
+        return sql + " LIMIT ?";
+    }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineImportSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineImportSQLBuilder.java
@@ -23,8 +23,8 @@ import org.apache.shardingsphere.data.pipeline.core.ingest.record.Column;
 import org.apache.shardingsphere.data.pipeline.core.ingest.record.DataRecord;
 import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.dialect.DialectPipelineSQLBuilder;
 import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.segment.PipelineSQLSegmentBuilder;
-import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 
 import java.util.Collection;
 import java.util.Objects;

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelinePrepareSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelinePrepareSQLBuilder.java
@@ -19,8 +19,8 @@ package org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql;
 
 import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.dialect.DialectPipelineSQLBuilder;
 import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.segment.PipelineSQLSegmentBuilder;
-import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 
 import java.util.Optional;
 

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/util/DatabaseTypeUtils.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/util/DatabaseTypeUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.database.mysql.type.MySQLDatabaseType;
+
+/**
+ * Database type utility class.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DatabaseTypeUtils {
+    
+    /**
+     * Check whether database type is MySQL, include trunk database type.
+     *
+     * @param databaseType database type
+     * @return is MySQL or not
+     */
+    public static boolean isMySQL(final DatabaseType databaseType) {
+        return getTrunkDatabaseType(databaseType) instanceof MySQLDatabaseType;
+    }
+    
+    /**
+     * Get trunk database type.
+     *
+     * @param databaseType database type
+     * @return trunk database type
+     */
+    public static DatabaseType getTrunkDatabaseType(final DatabaseType databaseType) {
+        return databaseType.getTrunkDatabaseType().orElse(databaseType);
+    }
+}

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/PipelineInventoryDumpSQLBuilderTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/PipelineInventoryDumpSQLBuilderTest.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,14 +34,18 @@ class PipelineInventoryDumpSQLBuilderTest {
     
     @Test
     void assertBuildDivisibleSQL() {
-        String actual = inventoryDumpSQLBuilder.buildDivisibleSQL(null, "t_order", Arrays.asList("order_id", "user_id", "status"), "order_id");
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? AND order_id<=? ORDER BY order_id ASC"));
+        String actual = inventoryDumpSQLBuilder.buildDivisibleSQL(null, "t_order", Arrays.asList("order_id", "user_id", "status"), "order_id", true);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? AND order_id<=? ORDER BY order_id ASC LIMIT ?"));
+        actual = inventoryDumpSQLBuilder.buildDivisibleSQL(null, "t_order", Arrays.asList("order_id", "user_id", "status"), "order_id", false);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? AND order_id<=? ORDER BY order_id ASC LIMIT ?"));
     }
     
     @Test
     void assertBuildUnlimitedDivisibleSQL() {
-        String actual = inventoryDumpSQLBuilder.buildUnlimitedDivisibleSQL(null, "t_order", Arrays.asList("order_id", "user_id", "status"), "order_id");
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? ORDER BY order_id ASC"));
+        String actual = inventoryDumpSQLBuilder.buildUnlimitedDivisibleSQL(null, "t_order", Arrays.asList("order_id", "user_id", "status"), "order_id", true);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? ORDER BY order_id ASC LIMIT ?"));
+        actual = inventoryDumpSQLBuilder.buildUnlimitedDivisibleSQL(null, "t_order", Arrays.asList("order_id", "user_id", "status"), "order_id", false);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? ORDER BY order_id ASC LIMIT ?"));
     }
     
     @Test
@@ -50,8 +55,16 @@ class PipelineInventoryDumpSQLBuilderTest {
     }
     
     @Test
+    void assertBuildPointQuerySQL() {
+        String actual = inventoryDumpSQLBuilder.buildPointQuerySQL(null, "t_order", Arrays.asList("order_id", "user_id", "status"), "order_id");
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id=?"));
+    }
+    
+    @Test
     void assertBuildFetchAllSQL() {
-        String actual = inventoryDumpSQLBuilder.buildFetchAllSQL(null, "t_order");
+        String actual = inventoryDumpSQLBuilder.buildFetchAllSQL(null, "t_order", Arrays.asList("order_id", "user_id", "status"));
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order"));
+        actual = inventoryDumpSQLBuilder.buildFetchAllSQL(null, "t_order", Collections.singletonList("*"));
         assertThat(actual, is("SELECT * FROM t_order"));
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Refactor inventory dumper and data consistency streaming query to page query. Support: 1) Duplicated PK values, 2) Multiple columns PK

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
