### PR TITLE
Add nativeTest under GraalVM Native Image for all E2E related unit tests

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -55,5 +55,34 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
           native-image-job-reports: 'true'
+      - name: Run test with GraalVM Tracing Agent
+        run: |
+          ./mvnw -B clean install -am -pl test/e2e/operation/transaction -Pit.env.docker -DskipTests
+          ./mvnw -PgenerateMetadata -DskipNativeTests -e clean test native:metadata-copy -Dtransaction.it.env.type=docker -Dtransaction.it.docker.mysql.version=mysql:5.7
       - name: Run nativeTest with GraalVM CE for ${{ matrix.java-version }}
-        run: ./mvnw -PnativeTestInShardingSphere -e clean test
+        run: |
+          ./mvnw -PnativeTestInShardingSphere -e clean test
+      - name: Run transaction on mysql:5.7
+        run: |
+          ./mvnw -B clean install -am -pl test/e2e/operation/transaction -Pit.env.docker -DskipTests
+          ./mvnw -PnativeTestInShardingSphere -e clean test -Dtransaction.it.env.type=docker -Dtransaction.it.docker.mysql.version=mysql:5.7
+      - name: Run transaction on postgres:12-alpine
+        run: |
+          ./mvnw -B clean install -am -pl test/e2e/operation/transaction -Pit.env.docker -DskipTests
+          ./mvnw -PnativeTestInShardingSphere -e clean test -Dtransaction.it.env.type=docker -Dtransaction.it.docker.postgresql.version=postgres:12-alpine
+      - name: Run pipeline on mysql:5.7
+        run: |
+          ./mvnw -B clean install -am -pl test/e2e/operation/pipeline -Pit.env.docker -DskipTests
+          ./mvnw -PnativeTestInShardingSphere -e clean test -Dpipeline.it.env.type=docker -Dpipeline.it.docker.mysql.version=mysql:5.7
+      - name: Run pipeline on postgres:12-alpine
+        run: |
+          ./mvnw -B clean install -am -pl test/e2e/operation/pipeline -Pit.env.docker -DskipTests
+          ./mvnw -PnativeTestInShardingSphere -e clean test -Dpipeline.it.env.type=docker -Dpipeline.it.docker.postgresql.version=postgres:12-alpine
+      - name: Run pipeline on mariadb:11
+        run: |
+          ./mvnw -B clean install -am -pl test/e2e/operation/pipeline -Pit.env.docker -DskipTests
+          ./mvnw -PnativeTestInShardingSphere -e clean test -Dpipeline.it.env.type=docker -Dpipeline.it.docker.mariadb.version=mariadb:5.7
+      - name: Run showprocesslist on mysql:5.7
+        run: |
+          ./mvnw -B clean install -am -pl test/e2e/operation/showprocesslist -Pit.env.docker -DskipTests
+          ./mvnw -PnativeTestInShardingSphere -e clean test -Dshowprocesslist.it.env.type=docker -Dshowprocesslist.it.docker.mysql.version=mysql:5.7

--- a/pom.xml
+++ b/pom.xml
@@ -1023,6 +1023,7 @@
                             <configuration>
                                 <includes>
                                     <include>org.apache.shardingsphere.test.natived.**</include>
+                                    <include>org.apache.shardingsphere.test.e2e.**</include>
                                 </includes>
                             </configuration>
                         </plugin>
@@ -1082,6 +1083,7 @@
                             <configuration>
                                 <includes>
                                     <include>org.apache.shardingsphere.test.natived.**</include>
+                                    <include>org.apache.shardingsphere.test.e2e.**</include>
                                 </includes>
                             </configuration>
                         </plugin>

--- a/test/e2e/operation/pipeline/pom.xml
+++ b/test/e2e/operation/pipeline/pom.xml
@@ -115,6 +115,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.graalvm.buildtools</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <version>${native-maven-plugin.version}</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/natived/SimpleTest.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/natived/SimpleTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.data.pipeline.natived;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledInNativeImage;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@EnabledInNativeImage
+public class SimpleTest {
+    
+    @Test
+    void testSimple() {
+        assertThat(1 + 2, is(3));
+    }
+}

--- a/test/e2e/operation/showprocesslist/pom.xml
+++ b/test/e2e/operation/showprocesslist/pom.xml
@@ -55,4 +55,14 @@
             <artifactId>awaitility</artifactId>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.graalvm.buildtools</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <version>${native-maven-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/test/e2e/operation/showprocesslist/src/test/java/org/apache/shardingsphere/test/e2e/showprocesslist/natived/SimpleTest.java
+++ b/test/e2e/operation/showprocesslist/src/test/java/org/apache/shardingsphere/test/e2e/showprocesslist/natived/SimpleTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.showprocesslist.natived;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledInNativeImage;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@EnabledInNativeImage
+public class SimpleTest {
+    
+    @Test
+    void testSimple() {
+        assertThat(1 + 2, is(3));
+    }
+}

--- a/test/e2e/operation/transaction/pom.xml
+++ b/test/e2e/operation/transaction/pom.xml
@@ -122,4 +122,14 @@
             <artifactId>awaitility</artifactId>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.graalvm.buildtools</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <version>${native-maven-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/natived/SimpleTest.java
+++ b/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/natived/SimpleTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.transaction.natived;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledInNativeImage;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@EnabledInNativeImage
+public class SimpleTest {
+    
+    @Test
+    void testSimple() {
+        assertThat(1 + 2, is(3));
+    }
+}


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Add nativeTest under GraalVM Native Image for all E2E related unit tests.
  - It looks like the E2E Docker Image should not need to be rebuilt.
  - Is there no easy way to aggregate the execution of unit tests?
  - Commands like `./mvnw -PgenerateMetadata -DskipNativeTests -e clean test native:metadata-copy -Dtransaction.it.env.type=docker -Dtransaction.it.docker.mysql.version=mysql:5.7` are too verbose.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
