### PR TITLE
Support primary key columns ordering for standard pipeline table metadata loader

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtils.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtils.java
@@ -30,6 +30,7 @@ import java.math.RoundingMode;
 import java.sql.Array;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -148,6 +149,33 @@ public final class DataConsistencyCheckUtils {
             }
         }
         return 0 == decimalOne.compareTo(decimalTwo);
+    }
+    
+    /**
+     * Compare lists.
+     *
+     * @param thisList this list
+     * @param thatList that list
+     * @return true if lists equals, otherwise false
+     */
+    public static boolean compareLists(final @Nullable Collection<?> thisList, final @Nullable Collection<?> thatList) {
+        if (null == thisList && null == thatList) {
+            return true;
+        }
+        if (null == thisList || null == thatList) {
+            return false;
+        }
+        if (thisList.size() != thatList.size()) {
+            return false;
+        }
+        Iterator<?> thisIterator = thisList.iterator();
+        Iterator<?> thatIterator = thatList.iterator();
+        while (thisIterator.hasNext() && thatIterator.hasNext()) {
+            if (!Objects.deepEquals(thisIterator.next(), thatIterator.next())) {
+                return false;
+            }
+        }
+        return true;
     }
     
     /**

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/model/PipelineIndexMetaData.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/model/PipelineIndexMetaData.java
@@ -35,4 +35,6 @@ public final class PipelineIndexMetaData {
     private final CaseInsensitiveIdentifier name;
     
     private final List<PipelineColumnMetaData> columns;
+    
+    private final boolean primaryKey;
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/model/PipelineTableMetaData.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/model/PipelineTableMetaData.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -62,8 +63,10 @@ public final class PipelineTableMetaData {
         List<PipelineColumnMetaData> columnMetaDataList = new ArrayList<>(columnMetaDataMap.values());
         Collections.sort(columnMetaDataList);
         columnNames = Collections.unmodifiableList(columnMetaDataList.stream().map(PipelineColumnMetaData::getName).collect(Collectors.toList()));
-        primaryKeyColumns = Collections.unmodifiableList(columnMetaDataList.stream().filter(PipelineColumnMetaData::isPrimaryKey)
-                .map(PipelineColumnMetaData::getName).collect(Collectors.toList()));
+        Optional<PipelineIndexMetaData> primaryKeyMetaData = uniqueIndexes.stream().filter(PipelineIndexMetaData::isPrimaryKey).findFirst();
+        primaryKeyColumns = primaryKeyMetaData.map(each -> each.getColumns().stream().map(PipelineColumnMetaData::getName).collect(Collectors.toList()))
+                .orElseGet(() -> Collections.unmodifiableList(columnMetaDataList.stream().filter(PipelineColumnMetaData::isPrimaryKey)
+                        .map(PipelineColumnMetaData::getName).collect(Collectors.toList())));
         this.uniqueIndexes = Collections.unmodifiableCollection(uniqueIndexes);
     }
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineStringUtils.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineStringUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * Pipeline string utils.
+ */
+@NoArgsConstructor(access = AccessLevel.NONE)
+public final class PipelineStringUtils {
+    
+    /**
+     * Equals ignore case.
+     *
+     * @param one one
+     * @param another another
+     * @return is equals ignore case
+     */
+    public static boolean equalsIgnoreCase(final Collection<String> one, final Collection<String> another) {
+        if (null == one && null == another) {
+            return true;
+        }
+        if (null == one || null == another) {
+            return false;
+        }
+        if (one.size() != another.size()) {
+            return false;
+        }
+        Iterator<String> oneIterator = one.iterator();
+        Iterator<String> anotherIterator = another.iterator();
+        while (oneIterator.hasNext() && anotherIterator.hasNext()) {
+            if (!oneIterator.next().equalsIgnoreCase(anotherIterator.next())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineStringUtilsTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineStringUtilsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PipelineStringUtilsTest {
+    
+    @Test
+    void assertEqualsIgnoreCase() {
+        assertTrue(PipelineStringUtils.equalsIgnoreCase(null, null));
+        assertFalse(PipelineStringUtils.equalsIgnoreCase(null, Collections.emptyList()));
+        assertFalse(PipelineStringUtils.equalsIgnoreCase(Collections.emptyList(), null));
+        assertFalse(PipelineStringUtils.equalsIgnoreCase(Collections.singletonList("test"), Collections.emptyList()));
+        assertFalse(PipelineStringUtils.equalsIgnoreCase(Collections.emptyList(), Collections.singletonList("test")));
+        assertTrue(PipelineStringUtils.equalsIgnoreCase(Collections.singletonList("test"), Collections.singletonList("test")));
+        assertTrue(PipelineStringUtils.equalsIgnoreCase(Collections.singletonList("TEST"), Collections.singletonList("test")));
+        assertTrue(PipelineStringUtils.equalsIgnoreCase(Collections.singletonList("test"), Collections.singletonList("TEST")));
+    }
+}


### PR DESCRIPTION

Changes proposed in this pull request:
  - Support primary key columns ordering for standard pipeline table metadata loader

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
