### PR TITLE
Set DatabaseMetaData.getIndexInfo approximate param from false to true

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/loader/StandardPipelineTableMetaDataLoader.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/loader/StandardPipelineTableMetaDataLoader.java
@@ -120,7 +120,7 @@ public final class StandardPipelineTableMetaDataLoader implements PipelineTableM
     private Map<CaseInsensitiveIdentifier, Collection<CaseInsensitiveIdentifier>> loadUniqueIndexesOfTable(final Connection connection,
                                                                                                            final String schemaName, final String tableName) throws SQLException {
         Map<String, SortedMap<Short, CaseInsensitiveIdentifier>> orderedColumnsOfIndexes = new LinkedHashMap<>();
-        try (ResultSet resultSet = connection.getMetaData().getIndexInfo(connection.getCatalog(), schemaName, tableName, true, false)) {
+        try (ResultSet resultSet = connection.getMetaData().getIndexInfo(connection.getCatalog(), schemaName, tableName, true, true)) {
             while (resultSet.next()) {
                 String indexName = resultSet.getString("INDEX_NAME");
                 if (null == indexName) {


### PR DESCRIPTION

Changes proposed in this pull request:
  - Set DatabaseMetaData.getIndexInfo approximate param from false to true. To improve performance in some databases

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
