### PR TITLE
Improve the parsing of methods in MySQL

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -927,7 +927,7 @@ simpleExpr
     | EXISTS? subquery
     | LBE_ identifier expr RBE_
     | identifier (JSON_SEPARATOR | JSON_UNQUOTED_SEPARATOR) string_
-    | path (RETURNING dataType)? onEmptyError? 
+    | path (RETURNING dataType)? onEmpty? onError?
     | matchExpression
     | caseExpression
     | intervalExpression
@@ -937,8 +937,12 @@ path
     : string_
     ;
 
-onEmptyError
-    : (NULL | ERROR | DEFAULT literals) ON (EMPTY | ERROR)
+onEmpty
+    : (NULL | ERROR | DEFAULT literals) ON EMPTY
+    ;
+
+onError
+    : (NULL | ERROR | DEFAULT literals) ON ERROR
     ;
     
 columnRef
@@ -977,9 +981,17 @@ jsonTableColumns
 
 jsonTableColumn
     : name FOR ORDINALITY
-    | name dataType PATH path (NULL | DEFAULT string_ | ERROR) ON (EMPTY | ERROR)
+    | name dataType PATH path jsonTableColumnOnEmpty? jsonTableColumnOnError?
     | name dataType EXISTS PATH string_ path
     | NESTED PATH? path COLUMNS
+    ;
+
+jsonTableColumnOnEmpty
+    : (NULL | DEFAULT string_ | ERROR) ON EMPTY
+    ;
+
+jsonTableColumnOnError
+    : (NULL | DEFAULT string_ | ERROR) ON ERROR
     ;
 
 jsonFunctionName
@@ -997,7 +1009,7 @@ aggregationFunctionName
 distinct
     : DISTINCT
     ;
-    
+
 overClause
     : OVER (windowSpecification | identifier)
     ;
@@ -1062,7 +1074,7 @@ windowFunction
     | funcName = (FIRST_VALUE | LAST_VALUE) LP_ expr RP_ nullTreatment? windowingClause
     | funcName = NTH_VALUE LP_ expr COMMA_ simpleExpr RP_ (FROM (FIRST | LAST))? nullTreatment? windowingClause
     ;
-    
+
 windowingClause
     : OVER (windowName=identifier | windowSpecification)
     ;

--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -3223,4 +3223,307 @@
             </expression-projection>
         </projections>
     </select>
+
+    <select sql-case-id="select_json_objectagg">
+        <projections start-index="7" stop-index="38">
+            <expression-projection start-index="7" stop-index="38" text="JSON_OBJECTAGG(attribute, value)">
+                <expr>
+                    <function function-name="JSON_OBJECTAGG" text="JSON_OBJECTAGG(attribute, value)" start-index="7" stop-index="38">
+                        <parameter>
+                            <column name="attribute" start-index="22" stop-index="30" />
+                        </parameter>
+                        <parameter>
+                            <column name="value" start-index="33" stop-index="37" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table name="t" start-index="45" stop-index="45" />
+        </from>
+        <group-by>
+            <column-item name="id" start-index="56" stop-index="57" />
+        </group-by>
+    </select>
+
+    <select sql-case-id="select_json_overlaps">
+        <projections start-index="7" stop-index="43">
+            <expression-projection start-index="7" stop-index="43" text="JSON_OVERLAPS(&quot;[1,3,5,7]&quot;, &quot;[2,5,7]&quot;)">
+                <expr>
+                    <function function-name="JSON_OVERLAPS" text="JSON_OVERLAPS(&quot;[1,3,5,7]&quot;, &quot;[2,5,7]&quot;)" start-index="7" stop-index="43">
+                        <parameter>
+                            <literal-expression value="[1,3,5,7]" start-index="21" stop-index="31"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="[2,5,7]" start-index="34" stop-index="42"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_pretty">
+        <projections start-index="7" stop-index="24">
+            <expression-projection start-index="7" stop-index="24" text="JSON_PRETTY('123')">
+                <expr>
+                    <function function-name="JSON_PRETTY" text="JSON_PRETTY('123')" start-index="7" stop-index="24">
+                        <parameter>
+                            <literal-expression value="123" start-index="19" stop-index="23"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_quote">
+        <projections start-index="7" stop-index="21">
+            <expression-projection start-index="7" stop-index="21" text="JSON_QUOTE('a')">
+                <expr>
+                    <function function-name="JSON_QUOTE" text="JSON_QUOTE('a')" start-index="7" stop-index="21">
+                        <parameter>
+                            <literal-expression value="a" start-index="18" stop-index="20"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_remove">
+        <projections start-index="7" stop-index="44">
+            <expression-projection start-index="7" stop-index="44" text="JSON_REMOVE('[&quot;a&quot;, &quot;b&quot;, &quot;d&quot;]', '$[0]')">
+                <expr>
+                    <function function-name="JSON_REMOVE" text="JSON_REMOVE('[&quot;a&quot;, &quot;b&quot;, &quot;d&quot;]', '$[0]')" start-index="7" stop-index="44">
+                        <parameter>
+                            <literal-expression value="[&quot;a&quot;, &quot;b&quot;, &quot;d&quot;]" start-index="19" stop-index="35"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="$[0]" start-index="38" stop-index="43"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_replace">
+        <projections start-index="7" stop-index="52">
+            <expression-projection start-index="7" stop-index="52" text="JSON_REPLACE('{ &quot;a&quot;: 1, &quot;b&quot;: &quot;2&quot;}', '$.a', 10)">
+                <expr>
+                    <function function-name="JSON_REPLACE" text="JSON_REPLACE('{ &quot;a&quot;: 1, &quot;b&quot;: &quot;2&quot;}', '$.a', 10)" start-index="7" stop-index="52">
+                        <parameter>
+                            <literal-expression value="{ &quot;a&quot;: 1, &quot;b&quot;: &quot;2&quot;}" start-index="20" stop-index="40"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="$.a" start-index="43" stop-index="47"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="10" start-index="50" stop-index="51"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_schema_valid">
+        <projections start-index="7" stop-index="98">
+            <expression-projection start-index="7" stop-index="98" text="JSON_SCHEMA_VALID('{&quot;type&quot;:&quot;object&quot;,&quot;required&quot;:[&quot;name&quot;,&quot;value&quot;]}','{&quot;name&quot;:&quot;a&quot;,&quot;value&quot;:10}')">
+                <expr>
+                    <function function-name="JSON_SCHEMA_VALID" text="JSON_SCHEMA_VALID('{&quot;type&quot;:&quot;object&quot;,&quot;required&quot;:[&quot;name&quot;,&quot;value&quot;]}','{&quot;name&quot;:&quot;a&quot;,&quot;value&quot;:10}')" start-index="7" stop-index="98">
+                        <parameter>
+                            <literal-expression value="{&quot;type&quot;:&quot;object&quot;,&quot;required&quot;:[&quot;name&quot;,&quot;value&quot;]}" start-index="25" stop-index="71"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="{&quot;name&quot;:&quot;a&quot;,&quot;value&quot;:10}" start-index="73" stop-index="97"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_schema_validation_report">
+        <projections start-index="7" stop-index="110">
+            <expression-projection start-index="7" stop-index="110" text="JSON_SCHEMA_VALIDATION_REPORT('{&quot;type&quot;:&quot;object&quot;,&quot;required&quot;:[&quot;name&quot;,&quot;value&quot;]}','{&quot;name&quot;:&quot;a&quot;,&quot;value&quot;:10}')">
+                <expr>
+                    <function function-name="JSON_SCHEMA_VALIDATION_REPORT" text="JSON_SCHEMA_VALIDATION_REPORT('{&quot;type&quot;:&quot;object&quot;,&quot;required&quot;:[&quot;name&quot;,&quot;value&quot;]}','{&quot;name&quot;:&quot;a&quot;,&quot;value&quot;:10}')" start-index="7" stop-index="110">
+                        <parameter>
+                            <literal-expression value="{&quot;type&quot;:&quot;object&quot;,&quot;required&quot;:[&quot;name&quot;,&quot;value&quot;]}" start-index="37" stop-index="83"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="{&quot;name&quot;:&quot;a&quot;,&quot;value&quot;:10}" start-index="85" stop-index="109"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_search">
+        <projections start-index="7" stop-index="54">
+            <expression-projection start-index="7" stop-index="54" text="JSON_SEARCH('[&quot;abc&quot;,{&quot;x&quot;:&quot;abc&quot;}]', 'one', 'abc')">
+                <expr>
+                    <function function-name="JSON_SEARCH" text="JSON_SEARCH('[&quot;abc&quot;,{&quot;x&quot;:&quot;abc&quot;}]', 'one', 'abc')" start-index="7" stop-index="54">
+                        <parameter>
+                            <literal-expression value="[&quot;abc&quot;,{&quot;x&quot;:&quot;abc&quot;}]" start-index="19" stop-index="39"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="one" start-index="42" stop-index="46"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="abc" start-index="49" stop-index="53"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_set">
+        <projections start-index="7" stop-index="44">
+            <expression-projection start-index="7" stop-index="44" text="JSON_SET('{&quot;a&quot;:1,&quot;b&quot;:[2,3]}','$.c',10)">
+                <expr>
+                    <function  start-index="7" stop-index="44" function-name="JSON_SET" text="JSON_SET('{&quot;a&quot;:1,&quot;b&quot;:[2,3]}','$.c',10)">
+                        <parameter>
+                            <literal-expression value="{&quot;a&quot;:1,&quot;b&quot;:[2,3]}" start-index="16" stop-index="34"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="$.c" start-index="36" stop-index="40"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="10" start-index="42" stop-index="43"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_storage_free">
+        <projections start-index="7" stop-index="33">
+            <expression-projection start-index="7" stop-index="33" text="JSON_STORAGE_FREE(json_col)">
+                <expr>
+                    <function  start-index="7" stop-index="33" function-name="JSON_STORAGE_FREE" text="JSON_STORAGE_FREE(json_col)">
+                        <parameter>
+                            <column name="json_col" start-index="25" stop-index="32"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table name="t" start-index="40" stop-index="40" />
+        </from>
+    </select>
+
+    <select sql-case-id="select_json_storage_size">
+        <projections start-index="7" stop-index="33">
+            <expression-projection start-index="7" stop-index="33" text="JSON_STORAGE_SIZE(json_col)">
+                <expr>
+                    <function  start-index="7" stop-index="33" function-name="JSON_STORAGE_SIZE" text="JSON_STORAGE_SIZE(json_col)">
+                        <parameter>
+                            <column name="json_col" start-index="25" stop-index="32"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table name="t" start-index="40" stop-index="40" />
+        </from>
+    </select>
+
+    <select sql-case-id="select_json_table">
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <from start-index="14" stop-index="100">
+            <function-table start-index="14" stop-index="100" table-alias="t">
+                <table-function function-name="JSON_TABLE" text="JSON_TABLE('[{&quot;name&quot;: 2}]','$[*]' COLUMNS( name INT PATH '$.name' error on empty))">
+                    <parameter>
+                        <literal-expression value="[{&quot;name&quot;: 2}]" start-index="25" stop-index="39" />
+                    </parameter>
+                    <parameter>
+                        <literal-expression value="$[*]" start-index="41" stop-index="46" />
+                    </parameter>
+                    <parameter>
+                        <literal-expression value="COLUMNS( name INT PATH '$.name' error on empty)" start-index="48" stop-index="94" />
+                    </parameter>
+                </table-function>
+            </function-table>
+        </from>
+    </select>
+
+    <select sql-case-id="select_json_type">
+        <projections start-index="7" stop-index="26">
+            <expression-projection start-index="7" stop-index="26" text="JSON_TYPE('[1,2,3]')">
+                <expr>
+                    <function  start-index="7" stop-index="26" function-name="JSON_TYPE" text="JSON_TYPE('[1,2,3]')">
+                        <parameter>
+                            <literal-expression value="[1,2,3]" start-index="17" stop-index="25"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_unquote">
+        <projections start-index="7" stop-index="27">
+            <expression-projection start-index="7" stop-index="27" text="JSON_UNQUOTE('&quot;abc&quot;')">
+                <expr>
+                    <function  start-index="7" stop-index="27" function-name="JSON_UNQUOTE" text="JSON_UNQUOTE('&quot;abc&quot;')">
+                        <parameter>
+                            <literal-expression value="&quot;abc&quot;" start-index="20" stop-index="26"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_valid">
+        <projections start-index="7" stop-index="28">
+            <expression-projection start-index="7" stop-index="28" text="JSON_VALID('{&quot;a&quot;: 1}')">
+                <expr>
+                    <function  start-index="7" stop-index="28" function-name="JSON_VALID" text="JSON_VALID('{&quot;a&quot;: 1}')">
+                        <parameter>
+                            <literal-expression value="{&quot;a&quot;: 1}" start-index="18" stop-index="27"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_value">
+        <projections start-index="7" stop-index="105">
+            <expression-projection start-index="7" stop-index="105" text="JSON_VALUE('{&quot;price&quot;: &quot;49.95&quot;}', '$.price' RETURNING DECIMAL(4,1) null on empty default 0 on error)">
+                <expr>
+                    <function  start-index="7" stop-index="105" function-name="JSON_VALUE" text="JSON_VALUE('{&quot;price&quot;: &quot;49.95&quot;}', '$.price' RETURNING DECIMAL(4,1) null on empty default 0 on error)">
+                        <parameter>
+                            <literal-expression value="{&quot;price&quot;: &quot;49.95&quot;}" start-index="18" stop-index="37" />
+                        </parameter>
+                        <parameter>
+                            <list-expression start-index="40" stop-index="104" >
+                                <items>
+                                    <literal-expression value="'$.price'" start-index="40" stop-index="48" />
+                                </items>
+                                <items>
+                                    <literal-expression value="RETURNING" start-index="50" stop-index="58" />
+                                </items>
+                                <items>
+                                    <data-type value="DECIMAL" start-index="60" stop-index="71" />
+                                </items>
+                            </list-expression>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
@@ -191,4 +191,21 @@
     <sql-case id="select_multilinestring" value="SELECT MultiLineString(ST_GeomFromText('LineString(1 1, 2 2)'),ST_GeomFromText('LineString(1 1, 2 2)'))" db-types="MySQL" />
     <sql-case id="select_multipoint" value="SELECT MultiPoint(point(1,1),point(1,1))" db-types="MySQL" />
     <sql-case id="select_multipolygon" value="SELECT MultiPolygon(ST_GeomFromText('Polygon((0 0, 1 0, 1 1, 0 1, 0 0))'),ST_GeomFromText('Polygon((0 0, 1 0, 1 1, 0 1, 0 0))'))" db-types="MySQL" />
+    <sql-case id="select_json_objectagg" value="SELECT JSON_OBJECTAGG(attribute, value) FROM t GROUP BY id" db-types="MySQL" />
+    <sql-case id="select_json_overlaps" value="SELECT JSON_OVERLAPS(&quot;[1,3,5,7]&quot;, &quot;[2,5,7]&quot;)" db-types="MySQL" />
+    <sql-case id="select_json_pretty" value="SELECT JSON_PRETTY('123')" db-types="MySQL" />
+    <sql-case id="select_json_quote" value="SELECT JSON_QUOTE('a')" db-types="MySQL" />
+    <sql-case id="select_json_remove" value="SELECT JSON_REMOVE('[&quot;a&quot;, &quot;b&quot;, &quot;d&quot;]', '$[0]')" db-types="MySQL" />
+    <sql-case id="select_json_replace" value="SELECT JSON_REPLACE('{ &quot;a&quot;: 1, &quot;b&quot;: &quot;2&quot;}', '$.a', 10)" db-types="MySQL" />
+    <sql-case id="select_json_schema_valid" value="SELECT JSON_SCHEMA_VALID('{&quot;type&quot;:&quot;object&quot;,&quot;required&quot;:[&quot;name&quot;,&quot;value&quot;]}','{&quot;name&quot;:&quot;a&quot;,&quot;value&quot;:10}')" db-types="MySQL" />
+    <sql-case id="select_json_schema_validation_report" value="SELECT JSON_SCHEMA_VALIDATION_REPORT('{&quot;type&quot;:&quot;object&quot;,&quot;required&quot;:[&quot;name&quot;,&quot;value&quot;]}','{&quot;name&quot;:&quot;a&quot;,&quot;value&quot;:10}')" db-types="MySQL" />
+    <sql-case id="select_json_search" value="SELECT JSON_SEARCH('[&quot;abc&quot;,{&quot;x&quot;:&quot;abc&quot;}]', 'one', 'abc')" db-types="MySQL" />
+    <sql-case id="select_json_set" value="SELECT JSON_SET('{&quot;a&quot;:1,&quot;b&quot;:[2,3]}','$.c',10)" db-types="MySQL" />
+    <sql-case id="select_json_storage_free" value="SELECT JSON_STORAGE_FREE(json_col) FROM t" db-types="MySQL" />
+    <sql-case id="select_json_storage_size" value="SELECT JSON_STORAGE_SIZE(json_col) FROM t" db-types="MySQL" />
+    <sql-case id="select_json_table" value="SELECT * FROM JSON_TABLE('[{&quot;name&quot;: 2}]','$[*]' COLUMNS( name INT PATH '$.name' error on empty)) as t" db-types="MySQL" />
+    <sql-case id="select_json_type" value="SELECT JSON_TYPE('[1,2,3]')" db-types="MySQL" />
+    <sql-case id="select_json_unquote" value="SELECT JSON_UNQUOTE('&quot;abc&quot;')" db-types="MySQL" />
+    <sql-case id="select_json_valid" value="SELECT JSON_VALID('{&quot;a&quot;: 1}')" db-types="MySQL" />
+    <sql-case id="select_json_value" value="SELECT JSON_VALUE('{&quot;price&quot;: &quot;49.95&quot;}', '$.price' RETURNING DECIMAL(4,1) null on empty default 0 on error)" db-types="MySQL" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
@@ -180,21 +180,21 @@
     <sql-case id="select_roles_graphml" value="SELECT ROLES_GRAPHML()" db-types="MySQL" />
     <sql-case id="select_round" value="SELECT ROUND(1.58)" db-types="MySQL" />
     <sql-case id="select_row_count" value="SELECT ROW_COUNT()" db-types="MySQL" />
-    <sql-case id="select_md5" value="SELECT MD5('testing')" db-types="MySQL" />
+    <sql-case id="select_md5" value="SELECT MD5('testing')" db-types="MySQL,Doris" />
     <sql-case id="select_member_of" value="SELECT 'ab' MEMBER OF('[23, &quot;abc&quot;, 17, &quot;ab&quot;, 10]')" db-types="MySQL" />
     <sql-case id="select_microsecond" value="SELECT MICROSECOND('12:00:00.123456')" db-types="MySQL" />
     <sql-case id="select_mid" value="SELECT MID('foobarbar' from 4)" db-types="MySQL" />
-    <sql-case id="select_minute" value="SELECT MINUTE('2008-02-03 10:05:03')" db-types="MySQL" />
-    <sql-case id="select_mod" value="SELECT MOD(234, 10)" db-types="MySQL" />
-    <sql-case id="select_month" value="SELECT MONTH('2008-02-03')" db-types="MySQL" />
-    <sql-case id="select_monthname" value="SELECT MONTHNAME('2008-02-03')" db-types="MySQL" />
+    <sql-case id="select_minute" value="SELECT MINUTE('2008-02-03 10:05:03')" db-types="MySQL,Doris" />
+    <sql-case id="select_mod" value="SELECT MOD(234, 10)" db-types="MySQL,Doris" />
+    <sql-case id="select_month" value="SELECT MONTH('2008-02-03')" db-types="MySQL,Doris" />
+    <sql-case id="select_monthname" value="SELECT MONTHNAME('2008-02-03')" db-types="MySQL,Doris" />
     <sql-case id="select_multilinestring" value="SELECT MultiLineString(ST_GeomFromText('LineString(1 1, 2 2)'),ST_GeomFromText('LineString(1 1, 2 2)'))" db-types="MySQL" />
     <sql-case id="select_multipoint" value="SELECT MultiPoint(point(1,1),point(1,1))" db-types="MySQL" />
     <sql-case id="select_multipolygon" value="SELECT MultiPolygon(ST_GeomFromText('Polygon((0 0, 1 0, 1 1, 0 1, 0 0))'),ST_GeomFromText('Polygon((0 0, 1 0, 1 1, 0 1, 0 0))'))" db-types="MySQL" />
     <sql-case id="select_json_objectagg" value="SELECT JSON_OBJECTAGG(attribute, value) FROM t GROUP BY id" db-types="MySQL" />
     <sql-case id="select_json_overlaps" value="SELECT JSON_OVERLAPS(&quot;[1,3,5,7]&quot;, &quot;[2,5,7]&quot;)" db-types="MySQL" />
     <sql-case id="select_json_pretty" value="SELECT JSON_PRETTY('123')" db-types="MySQL" />
-    <sql-case id="select_json_quote" value="SELECT JSON_QUOTE('a')" db-types="MySQL" />
+    <sql-case id="select_json_quote" value="SELECT JSON_QUOTE('a')" db-types="MySQL,Doris" />
     <sql-case id="select_json_remove" value="SELECT JSON_REMOVE('[&quot;a&quot;, &quot;b&quot;, &quot;d&quot;]', '$[0]')" db-types="MySQL" />
     <sql-case id="select_json_replace" value="SELECT JSON_REPLACE('{ &quot;a&quot;: 1, &quot;b&quot;: &quot;2&quot;}', '$.a', 10)" db-types="MySQL" />
     <sql-case id="select_json_schema_valid" value="SELECT JSON_SCHEMA_VALID('{&quot;type&quot;:&quot;object&quot;,&quot;required&quot;:[&quot;name&quot;,&quot;value&quot;]}','{&quot;name&quot;:&quot;a&quot;,&quot;value&quot;:10}')" db-types="MySQL" />


### PR DESCRIPTION
Fixes #31555.

Changes proposed in this pull request:
  - Improve the parsing of methods in MySQL

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
