### PR TITLE
Use CaseInsensitiveMap to replace toLowerCase method in ShardingSphereStatistics, ShardingSphereDatabaseData, ShardingSphereSchemaData

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/statistics/ShardingSphereDatabaseData.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/statistics/ShardingSphereDatabaseData.java
@@ -17,9 +17,9 @@
 
 package org.apache.shardingsphere.infra.metadata.statistics;
 
+import com.cedarsoftware.util.CaseInsensitiveMap;
 import lombok.Getter;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -28,7 +28,7 @@ import java.util.Map;
 @Getter
 public final class ShardingSphereDatabaseData {
     
-    private final Map<String, ShardingSphereSchemaData> schemaData = new LinkedHashMap<>();
+    private final Map<String, ShardingSphereSchemaData> schemaData = new CaseInsensitiveMap<>();
     
     /**
      * Get ShardingSphere schema data.
@@ -37,7 +37,7 @@ public final class ShardingSphereDatabaseData {
      * @return ShardingSphere schema data
      */
     public ShardingSphereSchemaData getSchema(final String schemaName) {
-        return schemaData.get(schemaName.toLowerCase());
+        return schemaData.get(schemaName);
     }
     
     /**
@@ -47,7 +47,7 @@ public final class ShardingSphereDatabaseData {
      * @param schema ShardingSphere schema data
      */
     public void putSchema(final String schemaName, final ShardingSphereSchemaData schema) {
-        schemaData.put(schemaName.toLowerCase(), schema);
+        schemaData.put(schemaName, schema);
     }
     
     /**
@@ -56,7 +56,7 @@ public final class ShardingSphereDatabaseData {
      * @param schemaName schema name
      */
     public void removeSchema(final String schemaName) {
-        schemaData.remove(schemaName.toLowerCase());
+        schemaData.remove(schemaName);
     }
     
     /**
@@ -66,6 +66,6 @@ public final class ShardingSphereDatabaseData {
      * @return Contains schema from database or not
      */
     public boolean containsSchema(final String schemaName) {
-        return schemaData.containsKey(schemaName.toLowerCase());
+        return schemaData.containsKey(schemaName);
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/statistics/ShardingSphereSchemaData.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/statistics/ShardingSphereSchemaData.java
@@ -17,9 +17,9 @@
 
 package org.apache.shardingsphere.infra.metadata.statistics;
 
+import com.cedarsoftware.util.CaseInsensitiveMap;
 import lombok.Getter;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -28,7 +28,7 @@ import java.util.Map;
 @Getter
 public final class ShardingSphereSchemaData {
     
-    private final Map<String, ShardingSphereTableData> tableData = new LinkedHashMap<>();
+    private final Map<String, ShardingSphereTableData> tableData = new CaseInsensitiveMap<>();
     
     /**
      * Get ShardingSphere table meta data via table name.
@@ -37,7 +37,7 @@ public final class ShardingSphereSchemaData {
      * @return ShardingSphere table data
      */
     public ShardingSphereTableData getTable(final String tableName) {
-        return tableData.get(tableName.toLowerCase());
+        return tableData.get(tableName);
     }
     
     /**
@@ -47,7 +47,7 @@ public final class ShardingSphereSchemaData {
      * @param table ShardingSphere table data
      */
     public void putTable(final String tableName, final ShardingSphereTableData table) {
-        tableData.put(tableName.toLowerCase(), table);
+        tableData.put(tableName, table);
     }
     
     /**
@@ -56,7 +56,7 @@ public final class ShardingSphereSchemaData {
      * @param tableName table name
      */
     public void removeTable(final String tableName) {
-        tableData.remove(tableName.toLowerCase());
+        tableData.remove(tableName);
     }
     
     /**
@@ -66,6 +66,6 @@ public final class ShardingSphereSchemaData {
      * @return contains ShardingSphere table from table metadata or not
      */
     public boolean containsTable(final String tableName) {
-        return tableData.containsKey(tableName.toLowerCase());
+        return tableData.containsKey(tableName);
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/statistics/ShardingSphereStatistics.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/statistics/ShardingSphereStatistics.java
@@ -17,9 +17,9 @@
 
 package org.apache.shardingsphere.infra.metadata.statistics;
 
+import com.cedarsoftware.util.CaseInsensitiveMap;
 import lombok.Getter;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -28,7 +28,7 @@ import java.util.Map;
 @Getter
 public final class ShardingSphereStatistics {
     
-    private final Map<String, ShardingSphereDatabaseData> databaseData = new LinkedHashMap<>();
+    private final Map<String, ShardingSphereDatabaseData> databaseData = new CaseInsensitiveMap<>();
     
     /**
      * Get ShardingSphere database.
@@ -37,7 +37,7 @@ public final class ShardingSphereStatistics {
      * @return ShardingSphere database data
      */
     public ShardingSphereDatabaseData getDatabase(final String databaseName) {
-        return databaseData.get(databaseName.toLowerCase());
+        return databaseData.get(databaseName);
     }
     
     /**
@@ -47,7 +47,7 @@ public final class ShardingSphereStatistics {
      * @param database ShardingSphere database
      */
     public void putDatabase(final String databaseName, final ShardingSphereDatabaseData database) {
-        databaseData.put(databaseName.toLowerCase(), database);
+        databaseData.put(databaseName, database);
     }
     
     /**
@@ -56,7 +56,7 @@ public final class ShardingSphereStatistics {
      * @param databaseName database name
      */
     public void dropDatabase(final String databaseName) {
-        databaseData.remove(databaseName.toLowerCase());
+        databaseData.remove(databaseName);
     }
     
     /**
@@ -66,6 +66,6 @@ public final class ShardingSphereStatistics {
      * @return contains ShardingSphere database from meta data or not
      */
     public boolean containsDatabase(final String databaseName) {
-        return databaseData.containsKey(databaseName.toLowerCase());
+        return databaseData.containsKey(databaseName);
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Use CaseInsensitiveMap to replace toLowerCase method in ShardingSphereStatistics, ShardingSphereDatabaseData, ShardingSphereSchemaData

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
