### PR TITLE
Fix sql federation unknown type exception caused by calcite wrong result type with bigint

### DIFF
--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/SQLFederationResultSetMetaData.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/SQLFederationResultSetMetaData.java
@@ -17,9 +17,11 @@
 
 package org.apache.shardingsphere.sqlfederation.resultset;
 
+import org.apache.calcite.avatica.SqlType;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeFactoryImpl.JavaType;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -29,6 +31,7 @@ import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatem
 import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.sqlfederation.resultset.converter.SQLFederationColumnTypeConverter;
 
+import java.math.BigInteger;
 import java.sql.ResultSetMetaData;
 import java.util.List;
 import java.util.Map;
@@ -148,7 +151,12 @@ public final class SQLFederationResultSetMetaData extends WrapperAdapter impleme
     
     @Override
     public int getColumnType(final int column) {
-        int jdbcType = resultColumnType.getFieldList().get(column - 1).getType().getSqlTypeName().getJdbcOrdinal();
+        RelDataType relDataType = resultColumnType.getFieldList().get(column - 1).getType();
+        // TODO remove this logic when calcite supports BigInteger type
+        if (relDataType instanceof JavaType && BigInteger.class.isAssignableFrom(((JavaType) relDataType).getJavaClass())) {
+            return SqlType.BIGINT.id;
+        }
+        int jdbcType = relDataType.getSqlTypeName().getJdbcOrdinal();
         return columnTypeConverter.convertColumnType(jdbcType);
     }
     

--- a/kernel/sql-federation/executor/src/main/java/org/apache/shardingsphere/sqlfederation/executor/utils/EnumeratorUtils.java
+++ b/kernel/sql-federation/executor/src/main/java/org/apache/shardingsphere/sqlfederation/executor/utils/EnumeratorUtils.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sqlfederation.executor.utils;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.exception.kernel.data.UnsupportedDataTypeConversionException;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.driver.jdbc.type.util.ResultSetUtils;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.sqlfederation.optimizer.metadata.util.SQLFederationDataTypeUtils;
@@ -80,7 +81,7 @@ public final class EnumeratorUtils {
     private static Object convertValue(final Object[] rows, final Map<Integer, Class<?>> columnTypes, final int index) {
         try {
             return ResultSetUtils.convertValue(rows[index], columnTypes.get(index));
-        } catch (final SQLFeatureNotSupportedException ex) {
+        } catch (final SQLFeatureNotSupportedException | UnsupportedDataTypeConversionException ex) {
             return rows[index];
         }
     }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix sql federation unknown type exception caused by calcite wrong result type with bigint

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
