### PR TITLE
Move the teardown code for the DML E2E test to the finally block.

### DIFF
--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/DDLE2EIT.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/DDLE2EIT.java
@@ -83,8 +83,9 @@ class DDLE2EIT implements E2EEnvironmentAware {
                 executeUpdateForPreparedStatement(context, connection);
             }
             assertTableMetaData(testParam, context);
+        } finally {
+            tearDown(context);
         }
-        tearDown(context);
     }
     
     private void executeUpdateForStatement(final E2ETestContext context, final Connection connection) throws SQLException {
@@ -118,8 +119,9 @@ class DDLE2EIT implements E2EEnvironmentAware {
                 executeForPreparedStatement(context, connection);
             }
             assertTableMetaData(testParam, context);
+        } finally {
+            tearDown(context);
         }
-        tearDown(context);
     }
     
     private void executeForStatement(final E2ETestContext context, final Connection connection) throws SQLException {

--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/RALE2EIT.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/RALE2EIT.java
@@ -70,8 +70,11 @@ class RALE2EIT implements E2EEnvironmentAware {
         }
         E2ETestContext context = new E2ETestContext(testParam);
         init(context);
-        assertExecute(context);
-        tearDown(context);
+        try {
+            assertExecute(context);
+        } finally {
+            tearDown(context);
+        }
     }
     
     private void assertExecute(final E2ETestContext context) throws SQLException {

--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/RDLE2EIT.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/RDLE2EIT.java
@@ -70,8 +70,11 @@ class RDLE2EIT implements E2EEnvironmentAware {
         }
         E2ETestContext context = new E2ETestContext(testParam);
         init(context);
-        assertExecute(testParam, context);
-        tearDown(context);
+        try {
+            assertExecute(testParam, context);
+        } finally {
+            tearDown(context);
+        }
     }
     
     private void assertExecute(final AssertionTestParameter testParam, final E2ETestContext context) throws SQLException {

--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/dml/BatchDMLE2EIT.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/dml/BatchDMLE2EIT.java
@@ -49,12 +49,15 @@ class BatchDMLE2EIT extends BaseDMLE2EIT {
             return;
         }
         init(testParam);
-        int[] actualUpdateCounts;
-        try (Connection connection = getEnvironmentEngine().getTargetDataSource().getConnection()) {
-            actualUpdateCounts = executeBatchForPreparedStatement(testParam, connection);
+        try {
+            int[] actualUpdateCounts;
+            try (Connection connection = getEnvironmentEngine().getTargetDataSource().getConnection()) {
+                actualUpdateCounts = executeBatchForPreparedStatement(testParam, connection);
+            }
+            assertDataSet(actualUpdateCounts, testParam);
+        } finally {
+            tearDown(testParam);
         }
-        assertDataSet(actualUpdateCounts, testParam);
-        tearDown(testParam);
     }
     
     void init(final CaseTestParameter testParam) throws SQLException, IOException, JAXBException {
@@ -112,8 +115,9 @@ class BatchDMLE2EIT extends BaseDMLE2EIT {
             }
             preparedStatement.clearBatch();
             assertThat(preparedStatement.executeBatch().length, is(0));
+        } finally {
+            tearDown(testParam);
         }
-        tearDown(testParam);
     }
     
     private static boolean isEnabled() {

--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/dml/GeneralDMLE2EIT.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/engine/type/dml/GeneralDMLE2EIT.java
@@ -51,14 +51,17 @@ class GeneralDMLE2EIT extends BaseDMLE2EIT {
         }
         E2ETestContext context = new E2ETestContext(testParam);
         init(testParam);
-        int actualUpdateCount;
-        try (Connection connection = getEnvironmentEngine().getTargetDataSource().getConnection()) {
-            actualUpdateCount = SQLExecuteType.LITERAL == context.getSqlExecuteType()
-                    ? executeUpdateForStatement(context, connection)
-                    : executeUpdateForPreparedStatement(context, connection);
+        try {
+            int actualUpdateCount;
+            try (Connection connection = getEnvironmentEngine().getTargetDataSource().getConnection()) {
+                actualUpdateCount = SQLExecuteType.LITERAL == context.getSqlExecuteType()
+                        ? executeUpdateForStatement(context, connection)
+                        : executeUpdateForPreparedStatement(context, connection);
+            }
+            assertDataSet(context, actualUpdateCount, testParam);
+        } finally {
+            tearDown(context);
         }
-        assertDataSet(context, actualUpdateCount, testParam);
-        tearDown(context);
     }
     
     void init(final AssertionTestParameter testParam) throws SQLException, IOException, JAXBException {
@@ -96,14 +99,17 @@ class GeneralDMLE2EIT extends BaseDMLE2EIT {
         }
         E2ETestContext context = new E2ETestContext(testParam);
         init(testParam);
-        int actualUpdateCount;
-        try (Connection connection = getEnvironmentEngine().getTargetDataSource().getConnection()) {
-            actualUpdateCount = SQLExecuteType.LITERAL == context.getSqlExecuteType()
-                    ? executeForStatement(context, connection)
-                    : executeForPreparedStatement(context, connection);
+        try {
+            int actualUpdateCount;
+            try (Connection connection = getEnvironmentEngine().getTargetDataSource().getConnection()) {
+                actualUpdateCount = SQLExecuteType.LITERAL == context.getSqlExecuteType()
+                        ? executeForStatement(context, connection)
+                        : executeForPreparedStatement(context, connection);
+            }
+            assertDataSet(context, actualUpdateCount, testParam);
+        } finally {
+            tearDown(context);
         }
-        assertDataSet(context, actualUpdateCount, testParam);
-        tearDown(context);
     }
     
     private int executeForStatement(final E2ETestContext context, final Connection connection) throws SQLException {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
