### PR TITLE
NPE occurs when execute show table status

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
@@ -88,7 +88,7 @@ public final class ShowTableStatusMergedResult extends MemoryMergedResult<Shardi
         return BigInteger.ZERO.equals(numberBigInteger) ? BigInteger.ZERO : getNonNullBigInteger(sum).divide(numberBigInteger);
     }
 
-    private static BigInteger getNonNullBigInteger(final Object value) {
+    private BigInteger getNonNullBigInteger(final Object value) {
         return Optional.ofNullable(value)
                 .filter(BigInteger.class::isInstance)
                 .map(BigInteger.class::cast)

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
@@ -87,7 +87,7 @@ public final class ShowTableStatusMergedResult extends MemoryMergedResult<Shardi
         BigInteger numberBigInteger = getNonNullBigInteger(number);
         return BigInteger.ZERO.equals(numberBigInteger) ? BigInteger.ZERO : getNonNullBigInteger(sum).divide(numberBigInteger);
     }
-
+    
     private BigInteger getNonNullBigInteger(final Object value) {
         return Optional.ofNullable(value)
                 .filter(BigInteger.class::isInstance)

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
@@ -74,10 +74,16 @@ public final class ShowTableStatusMergedResult extends MemoryMergedResult<Shardi
     }
     
     private BigInteger sum(final Object num1, final Object num2) {
+        if (num1 == null || num2 == null){
+            return BigInteger.ZERO;
+        }
         return ((BigInteger) num1).add((BigInteger) num2);
     }
     
     private BigInteger avg(final Object sum, final Object number) {
+        if (sum == null || number == null){
+            return BigInteger.ZERO;
+        }
         return BigInteger.ZERO.equals(number) ? BigInteger.ZERO : ((BigInteger) sum).divide((BigInteger) number);
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sharding.merge.dal.show;
 
+import com.google.common.base.MoreObjects;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResult;
 import org.apache.shardingsphere.infra.merge.result.impl.memory.MemoryMergedResult;
@@ -74,16 +75,24 @@ public final class ShowTableStatusMergedResult extends MemoryMergedResult<Shardi
     }
     
     private BigInteger sum(final Object num1, final Object num2) {
-        if (num1 == null || num2 == null) {
+        if (num1 == null && num2 == null) {
             return null;
         }
-        return ((BigInteger) num1).add((BigInteger) num2);
+        return getNonNullBigInteger(num1).add(getNonNullBigInteger(num2));
     }
     
     private BigInteger avg(final Object sum, final Object number) {
-        if (sum == null || number == null) {
+        if (sum == null && number == null) {
             return null;
         }
-        return BigInteger.ZERO.equals(number) ? BigInteger.ZERO : ((BigInteger) sum).divide((BigInteger) number);
+        BigInteger numberBigInteger = getNonNullBigInteger(number);
+        return BigInteger.ZERO.equals(numberBigInteger) ? BigInteger.ZERO : getNonNullBigInteger(sum).divide(numberBigInteger);
+    }
+
+    private static BigInteger getNonNullBigInteger(Object value) {
+        return Optional.ofNullable(value)
+                .filter(BigInteger.class::isInstance)
+                .map(BigInteger.class::cast)
+                .orElse(BigInteger.ZERO);
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
@@ -75,14 +75,14 @@ public final class ShowTableStatusMergedResult extends MemoryMergedResult<Shardi
     
     private BigInteger sum(final Object num1, final Object num2) {
         if (num1 == null || num2 == null){
-            return BigInteger.ZERO;
+            return null;
         }
         return ((BigInteger) num1).add((BigInteger) num2);
     }
     
     private BigInteger avg(final Object sum, final Object number) {
         if (sum == null || number == null){
-            return BigInteger.ZERO;
+            return null;
         }
         return BigInteger.ZERO.equals(number) ? BigInteger.ZERO : ((BigInteger) sum).divide((BigInteger) number);
     }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
@@ -74,14 +74,14 @@ public final class ShowTableStatusMergedResult extends MemoryMergedResult<Shardi
     }
     
     private BigInteger sum(final Object num1, final Object num2) {
-        if (num1 == null || num2 == null){
+        if (num1 == null || num2 == null) {
             return null;
         }
         return ((BigInteger) num1).add((BigInteger) num2);
     }
     
     private BigInteger avg(final Object sum, final Object number) {
-        if (sum == null || number == null){
+        if (sum == null || number == null) {
             return null;
         }
         return BigInteger.ZERO.equals(number) ? BigInteger.ZERO : ((BigInteger) sum).divide((BigInteger) number);

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.sharding.merge.dal.show;
 
-import com.google.common.base.MoreObjects;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResult;
 import org.apache.shardingsphere.infra.merge.result.impl.memory.MemoryMergedResult;
@@ -89,7 +88,7 @@ public final class ShowTableStatusMergedResult extends MemoryMergedResult<Shardi
         return BigInteger.ZERO.equals(numberBigInteger) ? BigInteger.ZERO : getNonNullBigInteger(sum).divide(numberBigInteger);
     }
 
-    private static BigInteger getNonNullBigInteger(Object value) {
+    private static BigInteger getNonNullBigInteger(final Object value) {
         return Optional.ofNullable(value)
                 .filter(BigInteger.class::isInstance)
                 .map(BigInteger.class::cast)


### PR DESCRIPTION
Fixes #32680 .

Changes proposed in this pull request:

To safely handle cases where either object is null and avoid NPE during type conversion, you can add an early return check for null values and return 0 if either object is null. This approach ensures that your method won't attempt to perform operations on null objects, which would cause an NPE.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
