### PR TITLE
Bump `opentelemetry-bom` to 1.41.0

### DIFF
--- a/agent/plugins/tracing/type/opentelemetry/pom.xml
+++ b/agent/plugins/tracing/type/opentelemetry/pom.xml
@@ -69,16 +69,6 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-jaeger</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-zipkin</artifactId>
             <exclusions>
                 <exclusion>
@@ -94,6 +84,11 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>${opentelemetry-semconv.version}</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,8 @@
         
         <prometheus-simpleclient.version>0.11.0</prometheus-simpleclient.version>
         <prometheus-jmx.version>0.16.1</prometheus-jmx.version>
-        <opentelemetry.version>1.31.0</opentelemetry.version>
+        <opentelemetry.version>1.41.0</opentelemetry.version>
+        <opentelemetry-semconv.version>1.27.0-alpha</opentelemetry-semconv.version>
         <kotlin-stdlib.version>1.9.10</kotlin-stdlib.version>
         
         <junit.version>5.10.3</junit.version>


### PR DESCRIPTION
Fixes #32786.

Changes proposed in this pull request:
  - Bump `opentelemetry-bom` to 1.41.0.
  - Introducing `opentelemetry-semconv`. See https://opentelemetry.io/docs/languages/java/exporters/#otlp-dependencies .
  - Apparently, https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-exporter-jaeger is no longer updated. Because according to https://opentelemetry.io/docs/languages/java/exporters/#jaeger we don't need something like that.
> [Jaeger](https://www.jaegertracing.io/) natively supports OTLP to receive trace data.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
