### PR TITLE
Optimize MetaDataRefreshEngine, use storage unit database type when refresh metadata

### DIFF
--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/MetaDataRefreshEngine.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/MetaDataRefreshEngine.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
 import org.apache.shardingsphere.infra.route.context.RouteUnit;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mode.persist.service.MetaDataManagerPersistService;
@@ -45,6 +46,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.RenameT
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -98,13 +100,8 @@ public final class MetaDataRefreshEngine {
     }
     
     private Optional<DatabaseType> findStorageUnitDatabaseType(final Collection<RouteUnit> routeUnits) {
-        for (RouteUnit each : routeUnits) {
-            String storageUnitName = each.getDataSourceMapper().getActualName();
-            if (database.getResourceMetaData().getStorageUnits().containsKey(storageUnitName)) {
-                return Optional.of(database.getResourceMetaData().getStorageUnits().get(storageUnitName).getStorageType());
-            }
-        }
-        return Optional.empty();
+        return routeUnits.stream().map(each -> database.getResourceMetaData().getStorageUnits().get(each.getDataSourceMapper().getActualName()))
+                .filter(Objects::nonNull).findFirst().map(StorageUnit::getStorageType);
     }
     
     private String getSchemaName(final SQLStatementContext sqlStatementContext) {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Optimize MetaDataRefreshEngine, use storage unit database type when refresh metadata

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
