### PR TITLE
Bump the Presto JDBC Driver version used in the unit test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <clickhouse-jdbc.version>0.6.3</clickhouse-jdbc.version>
         <hive.version>4.0.0</hive.version>
         <hive-server2-jdbc-driver-thin.version>1.2.0</hive-server2-jdbc-driver-thin.version>
-        <presto.version>0.282</presto.version>
+        <presto.version>0.288.1</presto.version>
         
         <hikari-cp.version>4.0.3</hikari-cp.version>
         


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/security/dependabot/80 .

Changes proposed in this pull request:
  - Bump the Presto JDBC Driver version used in the unit test. Warnings like https://github.com/apache/shardingsphere/security/dependabot/80 were plaguing committer mailbox, and the dependency in question was only used to execute unit tests. These are GHSA-86q5-qcjc-7pv4 and GHSA-xm7x-f3w2-4hjm respectively.
  - Before the release of Presto 0.289, we were unable to add shardingsphere's Presto integration to nativeTest under GraalVM Native Image because it was blocked by https://github.com/prestodb/presto/issues/15916 and https://github.com/prestodb/presto/issues/23226.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
