### PR TITLE
Add NullsOrderType.LOW and NullsOrderType.HIGH to handle NULL order by in sharding feature

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/ShardingProjectionsTokenGenerator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/ShardingProjectionsTokenGenerator.java
@@ -25,7 +25,6 @@ import org.apache.shardingsphere.infra.binder.context.segment.select.projection.
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.DerivedProjection;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;
-import org.apache.shardingsphere.infra.database.core.metadata.database.DialectDatabaseMetaData;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
@@ -37,10 +36,10 @@ import org.apache.shardingsphere.infra.route.context.RouteUnit;
 import org.apache.shardingsphere.sharding.rewrite.token.generator.IgnoreForSingleRoute;
 import org.apache.shardingsphere.sharding.rewrite.token.pojo.ProjectionsToken;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.OrderDirection;
-import org.apache.shardingsphere.sql.parser.statement.core.util.TableExtractor;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.item.ColumnOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.OwnerSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.util.TableExtractor;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
 import java.util.Collection;
@@ -140,7 +139,6 @@ public final class ShardingProjectionsTokenGenerator implements OptionalSQLToken
     }
     
     private NullsOrderType generateNewNullsOrderType(final OrderDirection orderDirection, final DatabaseType databaseType) {
-        DialectDatabaseMetaData dialectDatabaseMetaData = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData();
-        return OrderDirection.ASC == orderDirection ? dialectDatabaseMetaData.getDefaultNullsOrderType() : dialectDatabaseMetaData.getDefaultNullsOrderType().getReversedOrderType();
+        return new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getDefaultNullsOrderType().getResolvedOrderType(orderDirection.name());
     }
 }

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/enums/NullsOrderType.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/enums/NullsOrderType.java
@@ -23,6 +23,16 @@ package org.apache.shardingsphere.infra.database.core.metadata.database.enums;
 public enum NullsOrderType {
     
     /**
+     * Nulls first for DESC, nulls last for ASC.
+     */
+    HIGH,
+    
+    /**
+     * Nulls last for DESC, nulls first for ASC.
+     */
+    LOW,
+    
+    /**
      * Nulls first.
      */
     FIRST,
@@ -33,11 +43,18 @@ public enum NullsOrderType {
     LAST;
     
     /**
-     * Get reversed order type.
+     * Get resolved order type.
      *
-     * @return reversed order type
+     * @param orderDirection order direction
+     * @return resolved order type
      */
-    public NullsOrderType getReversedOrderType() {
-        return this == FIRST ? LAST : FIRST;
+    public NullsOrderType getResolvedOrderType(final String orderDirection) {
+        if (HIGH == this) {
+            return "DESC".equalsIgnoreCase(orderDirection) ? FIRST : LAST;
+        }
+        if (LOW == this) {
+            return "DESC".equalsIgnoreCase(orderDirection) ? LAST : FIRST;
+        }
+        return this;
     }
 }

--- a/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/metadata/database/fixture/BranchDialectDatabaseMetaData.java
+++ b/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/metadata/database/fixture/BranchDialectDatabaseMetaData.java
@@ -30,7 +30,7 @@ public final class BranchDialectDatabaseMetaData implements DialectDatabaseMetaD
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.FIRST;
+        return NullsOrderType.LOW;
     }
     
     @Override

--- a/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/metadata/database/fixture/TrunkDialectDatabaseMetaData.java
+++ b/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/metadata/database/fixture/TrunkDialectDatabaseMetaData.java
@@ -32,7 +32,7 @@ public final class TrunkDialectDatabaseMetaData implements DialectDatabaseMetaDa
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.FIRST;
+        return NullsOrderType.LOW;
     }
     
     @Override

--- a/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/type/enums/NullsOrderTypeTest.java
+++ b/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/type/enums/NullsOrderTypeTest.java
@@ -26,8 +26,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class NullsOrderTypeTest {
     
     @Test
-    void assertGetReversedOrderType() {
-        assertThat(NullsOrderType.FIRST.getReversedOrderType(), CoreMatchers.is(NullsOrderType.LAST));
-        assertThat(NullsOrderType.LAST.getReversedOrderType(), CoreMatchers.is(NullsOrderType.FIRST));
+    void assertGetResolvedOrderType() {
+        assertThat(NullsOrderType.HIGH.getResolvedOrderType("DESC"), CoreMatchers.is(NullsOrderType.FIRST));
+        assertThat(NullsOrderType.HIGH.getResolvedOrderType("ASC"), CoreMatchers.is(NullsOrderType.LAST));
+        assertThat(NullsOrderType.LOW.getResolvedOrderType("DESC"), CoreMatchers.is(NullsOrderType.LAST));
+        assertThat(NullsOrderType.LOW.getResolvedOrderType("ASC"), CoreMatchers.is(NullsOrderType.FIRST));
     }
 }

--- a/infra/database/type/clickhouse/src/main/java/org/apache/shardingsphere/infra/database/clickhouse/metadata/database/ClickHouseDatabaseMetaData.java
+++ b/infra/database/type/clickhouse/src/main/java/org/apache/shardingsphere/infra/database/clickhouse/metadata/database/ClickHouseDatabaseMetaData.java
@@ -33,7 +33,7 @@ public final class ClickHouseDatabaseMetaData implements DialectDatabaseMetaData
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.FIRST;
+        return NullsOrderType.LOW;
     }
     
     @Override

--- a/infra/database/type/h2/src/main/java/org/apache/shardingsphere/infra/database/h2/metadata/database/H2DatabaseMetaData.java
+++ b/infra/database/type/h2/src/main/java/org/apache/shardingsphere/infra/database/h2/metadata/database/H2DatabaseMetaData.java
@@ -33,7 +33,7 @@ public final class H2DatabaseMetaData implements DialectDatabaseMetaData {
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.FIRST;
+        return NullsOrderType.LOW;
     }
     
     @Override

--- a/infra/database/type/hive/src/main/java/org/apache/shardingsphere/infra/database/hive/metadata/database/HiveDatabaseMetaData.java
+++ b/infra/database/type/hive/src/main/java/org/apache/shardingsphere/infra/database/hive/metadata/database/HiveDatabaseMetaData.java
@@ -35,7 +35,7 @@ public final class HiveDatabaseMetaData implements DialectDatabaseMetaData {
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.FIRST;
+        return NullsOrderType.LOW;
     }
     
     @Override

--- a/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/MySQLDatabaseMetaData.java
+++ b/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/MySQLDatabaseMetaData.java
@@ -75,7 +75,7 @@ public final class MySQLDatabaseMetaData implements DialectDatabaseMetaData {
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.FIRST;
+        return NullsOrderType.LOW;
     }
     
     @Override

--- a/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
+++ b/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
@@ -52,7 +52,7 @@ public final class OpenGaussDatabaseMetaData implements DialectDatabaseMetaData 
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.LAST;
+        return NullsOrderType.HIGH;
     }
     
     @Override

--- a/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/OracleDatabaseMetaData.java
+++ b/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/OracleDatabaseMetaData.java
@@ -51,7 +51,7 @@ public final class OracleDatabaseMetaData implements DialectDatabaseMetaData {
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.LAST;
+        return NullsOrderType.HIGH;
     }
     
     @Override

--- a/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/PostgreSQLDatabaseMetaData.java
+++ b/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/PostgreSQLDatabaseMetaData.java
@@ -49,7 +49,7 @@ public final class PostgreSQLDatabaseMetaData implements DialectDatabaseMetaData
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.LAST;
+        return NullsOrderType.HIGH;
     }
     
     @Override

--- a/infra/database/type/presto/src/main/java/org/apache/shardingsphere/infra/database/presto/metadata/database/PrestoDatabaseMetaData.java
+++ b/infra/database/type/presto/src/main/java/org/apache/shardingsphere/infra/database/presto/metadata/database/PrestoDatabaseMetaData.java
@@ -35,7 +35,7 @@ public final class PrestoDatabaseMetaData implements DialectDatabaseMetaData {
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.FIRST;
+        return NullsOrderType.LOW;
     }
     
     @Override

--- a/infra/database/type/sql92/src/main/java/org/apache/shardingsphere/infra/database/sql92/metadata/database/SQL92DatabaseMetaData.java
+++ b/infra/database/type/sql92/src/main/java/org/apache/shardingsphere/infra/database/sql92/metadata/database/SQL92DatabaseMetaData.java
@@ -33,7 +33,7 @@ public final class SQL92DatabaseMetaData implements DialectDatabaseMetaData {
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.FIRST;
+        return NullsOrderType.LOW;
     }
     
     @Override

--- a/infra/database/type/sqlserver/src/main/java/org/apache/shardingsphere/infra/database/sqlserver/metadata/database/SQLServerDatabaseMetaData.java
+++ b/infra/database/type/sqlserver/src/main/java/org/apache/shardingsphere/infra/database/sqlserver/metadata/database/SQLServerDatabaseMetaData.java
@@ -35,7 +35,7 @@ public final class SQLServerDatabaseMetaData implements DialectDatabaseMetaData 
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.FIRST;
+        return NullsOrderType.LOW;
     }
     
     @Override

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dml/order/item/OrderByItemSegment.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dml/order/item/OrderByItemSegment.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.it
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.infra.database.core.metadata.database.DialectDatabaseMetaData;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
@@ -62,7 +61,6 @@ public abstract class OrderByItemSegment implements SQLSegment {
         if (null != nullsOrderType) {
             return nullsOrderType;
         }
-        DialectDatabaseMetaData dialectDatabaseMetaData = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData();
-        return OrderDirection.ASC == orderDirection ? dialectDatabaseMetaData.getDefaultNullsOrderType() : dialectDatabaseMetaData.getDefaultNullsOrderType().getReversedOrderType();
+        return new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getDefaultNullsOrderType().getResolvedOrderType(orderDirection.name());
     }
 }

--- a/test/fixture/database/src/main/java/org/apache/shardingsphere/test/fixture/database/DialectDatabaseMetaDataFixture.java
+++ b/test/fixture/database/src/main/java/org/apache/shardingsphere/test/fixture/database/DialectDatabaseMetaDataFixture.java
@@ -30,7 +30,7 @@ public final class DialectDatabaseMetaDataFixture implements DialectDatabaseMeta
     
     @Override
     public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.FIRST;
+        return NullsOrderType.LOW;
     }
     
     @Override


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Add NullsOrderType.LOW and NullsOrderType.HIGH to handle NULL order by in sharding feature

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
