### PR TITLE
For #32857, support binary type bool value for PostgreSQL

### DIFF
--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBinaryProtocolValueFactory.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBinaryProtocolValueFactory.java
@@ -54,6 +54,7 @@ public final class PostgreSQLBinaryProtocolValueFactory {
         setStringArrayBinaryProtocolValue();
         setByteaBinaryProtocolValue();
         setUUIDBinaryProtocolValue();
+        setBoolBinaryProtocolValue();
     }
     
     private static void setUnspecifiedBinaryProtocolValue() {
@@ -143,6 +144,10 @@ public final class PostgreSQLBinaryProtocolValueFactory {
     
     private static void setUUIDBinaryProtocolValue() {
         BINARY_PROTOCOL_VALUES.put(PostgreSQLColumnType.UUID, new PostgreSQLUUIDBinaryProtocolValue());
+    }
+    
+    private static void setBoolBinaryProtocolValue() {
+        BINARY_PROTOCOL_VALUES.put(PostgreSQLColumnType.BOOL, new PostgreSQLBoolBinaryProtocolValue());
     }
     
     /**

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolBinaryProtocolValue.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.bind.protocol;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
+import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
+
+/**
+ * Binary protocol value for bool for PostgreSQL.
+ */
+@Slf4j
+public final class PostgreSQLBoolBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
+    
+    @Override
+    public int getColumnLength(final Object value) {
+        return 1;
+    }
+    
+    @Override
+    public Object read(final PostgreSQLPacketPayload payload, final int parameterValueLength) {
+        return payload.getByteBuf().readBoolean();
+    }
+    
+    @Override
+    public void write(final PostgreSQLPacketPayload payload, final Object value) {
+        throw new UnsupportedSQLOperationException("PostgreSQLBoolBinaryProtocolValue.write()");
+    }
+}

--- a/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/data/loader/PostgreSQLMetaDataLoader.java
+++ b/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/data/loader/PostgreSQLMetaDataLoader.java
@@ -36,6 +36,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -219,7 +220,11 @@ public final class PostgreSQLMetaDataLoader implements DialectMetaDataLoader {
         // TODO user defined collation which deterministic is false
         boolean caseSensitive = true;
         boolean isNullable = "YES".equals(resultSet.getString("is_nullable"));
-        return new ColumnMetaData(columnName, dataTypeMap.get(dataType), isPrimaryKey, generated, caseSensitive, true, false, isNullable);
+        return new ColumnMetaData(columnName, getDataType(dataTypeMap, dataType), isPrimaryKey, generated, caseSensitive, true, false, isNullable);
+    }
+    
+    private Integer getDataType(final Map<String, Integer> dataTypeMap, final String dataTypeName) {
+        return "bool".equals(dataTypeName) ? Types.BOOLEAN : dataTypeMap.get(dataTypeName);
     }
     
     private Map<String, Multimap<String, ConstraintMetaData>> loadConstraintMetaDataMap(final Connection connection, final Collection<String> schemaNames) throws SQLException {


### PR DESCRIPTION
Fixes #32857.

Changes proposed in this pull request:
- When loading column metadata, distinguish between bit and bool
- Add binary protocol value for bool
