### PR TITLE
Fix Index0utOfBoundsException in GeneratedKeyContextEngine caused by wrong generated flag in metadata

### DIFF
--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/metadata/ShardingMetaDataReviseEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/metadata/ShardingMetaDataReviseEngineTest.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.infra.metadata.database.schema.reviser.MetaData
 import org.apache.shardingsphere.infra.rule.attribute.RuleAttributes;
 import org.apache.shardingsphere.infra.rule.attribute.datanode.DataNodeRuleAttribute;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
+import org.apache.shardingsphere.sharding.rule.ShardingTable;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Types;
@@ -51,15 +52,19 @@ class ShardingMetaDataReviseEngineTest {
         Map<String, SchemaMetaData> actual = new MetaDataReviseEngine(Collections.singleton(mockShardingRule())).revise(Collections.singletonMap("sharding_db",
                 new SchemaMetaData("sharding_db", Collections.singleton(createTableMetaData()))), material);
         Iterator<ColumnMetaData> columns = actual.get("sharding_db").getTables().iterator().next().getColumns().iterator();
+        assertFalse(columns.next().isGenerated());
+        assertFalse(columns.next().isGenerated());
         assertTrue(columns.next().isGenerated());
-        assertFalse(columns.next().isGenerated());
-        assertFalse(columns.next().isGenerated());
     }
     
     private ShardingRule mockShardingRule() {
         ShardingRule result = mock(ShardingRule.class);
         DataNodeRuleAttribute ruleAttribute = mock(DataNodeRuleAttribute.class);
         when(ruleAttribute.findLogicTableByActualTable("t_order")).thenReturn(Optional.of("t_order"));
+        ShardingTable shardingTable = mock(ShardingTable.class);
+        when(shardingTable.getGenerateKeyColumn()).thenReturn(Optional.of("product_id"));
+        when(result.getShardingTable("t_order")).thenReturn(shardingTable);
+        when(result.findShardingTableByActualTable("t_order")).thenReturn(Optional.of(shardingTable));
         when(result.getAttributes()).thenReturn(new RuleAttributes(ruleAttribute));
         return result;
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/column/ColumnReviseEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/column/ColumnReviseEngine.java
@@ -61,7 +61,7 @@ public final class ColumnReviseEngine<T extends ShardingSphereRule> {
                 continue;
             }
             String name = nameReviser.isPresent() ? nameReviser.get().revise(each.getName()) : each.getName();
-            boolean generated = generatedReviser.map(optional -> optional.revise(each)).orElseGet(each::isGenerated);
+            boolean generated = generatedReviser.map(optional -> optional.revise(each)).orElse(false);
             result.add(new ColumnMetaData(name, each.getDataType(), each.isPrimaryKey(), generated, each.isCaseSensitive(), each.isVisible(), each.isUnsigned(), each.isNullable()));
         }
         return result;

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/column/ColumnReviseEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/column/ColumnReviseEngine.java
@@ -55,7 +55,7 @@ public final class ColumnReviseEngine<T extends ShardingSphereRule> {
         Optional<? extends ColumnExistedReviser> existedReviser = reviseEntry.getColumnExistedReviser(rule, tableName);
         Optional<? extends ColumnNameReviser> nameReviser = reviseEntry.getColumnNameReviser(rule, tableName);
         Optional<? extends ColumnGeneratedReviser> generatedReviser = reviseEntry.getColumnGeneratedReviser(rule, tableName);
-        Collection<ColumnMetaData> result = new LinkedHashSet<>();
+        Collection<ColumnMetaData> result = new LinkedHashSet<>(originalMetaDataList.size(), 1F);
         for (ColumnMetaData each : originalMetaDataList) {
             if (existedReviser.isPresent() && !existedReviser.get().isExisted(each.getName())) {
                 continue;

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/schema/SchemaMetaDataReviseEngineTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/schema/SchemaMetaDataReviseEngineTest.java
@@ -32,6 +32,7 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Properties;
 
@@ -56,7 +57,19 @@ class SchemaMetaDataReviseEngineTest {
         SchemaMetaData actual = new SchemaMetaDataReviseEngine(
                 Collections.singleton(new FixtureGlobalRule()), new ConfigurationProperties(new Properties()), mock(DatabaseType.class), mock(DataSource.class)).revise(schemaMetaData);
         assertThat(actual.getName(), is(schemaMetaData.getName()));
-        assertThat(actual.getTables(), is(schemaMetaData.getTables()));
+        assertThat(actual.getTables().size(), is(schemaMetaData.getTables().size()));
+        TableMetaData actualTableMetaData = actual.getTables().iterator().next();
+        TableMetaData expectedTableMetaData = schemaMetaData.getTables().iterator().next();
+        assertThat(actualTableMetaData.getName(), is(expectedTableMetaData.getName()));
+        assertThat(actualTableMetaData.getType(), is(expectedTableMetaData.getType()));
+        assertThat(actualTableMetaData.getIndexes(), is(expectedTableMetaData.getIndexes()));
+        assertThat(actualTableMetaData.getConstraints(), is(expectedTableMetaData.getConstraints()));
+        assertThat(actualTableMetaData.getColumns().size(), is(expectedTableMetaData.getColumns().size()));
+        Iterator<ColumnMetaData> actualColumnIterator = actualTableMetaData.getColumns().iterator();
+        Iterator<ColumnMetaData> expectedColumnIterator = expectedTableMetaData.getColumns().iterator();
+        while (actualColumnIterator.hasNext() && expectedColumnIterator.hasNext()) {
+            assertColumnMetaData(actualColumnIterator.next(), expectedColumnIterator.next());
+        }
     }
     
     private TableMetaData createTableMetaData() {
@@ -68,4 +81,14 @@ class SchemaMetaDataReviseEngineTest {
         return new TableMetaData("table_name", columns, Collections.singletonList(indexMetaData), Collections.singleton(constraintMetaData));
     }
     
+    private void assertColumnMetaData(final ColumnMetaData actualColumnMetaData, final ColumnMetaData expectedColumnMetaData) {
+        assertThat(actualColumnMetaData.getName(), is(expectedColumnMetaData.getName()));
+        assertThat(actualColumnMetaData.getDataType(), is(expectedColumnMetaData.getDataType()));
+        assertThat(actualColumnMetaData.isPrimaryKey(), is(expectedColumnMetaData.isPrimaryKey()));
+        assertThat(actualColumnMetaData.isGenerated(), is(false));
+        assertThat(actualColumnMetaData.isCaseSensitive(), is(expectedColumnMetaData.isCaseSensitive()));
+        assertThat(actualColumnMetaData.isVisible(), is(expectedColumnMetaData.isVisible()));
+        assertThat(actualColumnMetaData.isUnsigned(), is(expectedColumnMetaData.isUnsigned()));
+        assertThat(actualColumnMetaData.isNullable(), is(expectedColumnMetaData.isNullable()));
+    }
 }


### PR DESCRIPTION
Fixes #32934.

Changes proposed in this pull request:
  - Fix Index0utOfBoundsException in GeneratedKeyContextEngine caused by wrong generated flag in metadata

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
