### PR TITLE
Supports building ShardingSphere Agent's Docker Image locally

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -159,7 +159,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push Docker Image
         run: |
-          ./mvnw -am -pl distribution/agent -Prelease,docker.buildx.push -B -T1C -DskipTests -Dproxy.image.repository=${{ env.AGENT }} -Dproxy.image.tag=${{ github.sha }} clean package
+          ./mvnw -am -pl distribution/agent -Prelease,docker.buildx.push -B -T1C -DskipTests -Dagent.image.repository=${{ env.AGENT }} -Dagent.image.tag=${{ github.sha }} clean package
   build-cache:
     if: ${{ needs.global-environment.outputs.GLOBAL_IS_NIGHTLY_JOB_EXECUTABLE == 'true' }}
     name: Build Project

--- a/distribution/agent/pom.xml
+++ b/distribution/agent/pom.xml
@@ -101,11 +101,44 @@
             </build>
         </profile>
         <profile>
+            <id>docker</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>build</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <executable>docker</executable>
+                                    <arguments>
+                                        <argument>build</argument>
+                                        <argument>--build-arg</argument>
+                                        <argument>APP_NAME=apache-shardingsphere-${project.version}-shardingsphere-agent-bin</argument>
+                                        <argument>.</argument>
+                                        <argument>-t</argument>
+                                        <argument>apache/shardingsphere-agent:${project.version}</argument>
+                                        <argument>-t</argument>
+                                        <argument>apache/shardingsphere-agent:latest</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>docker.buildx.push</id>
             <properties>
-                <proxy.image.platform>linux/amd64,linux/arm64</proxy.image.platform>
-                <proxy.image.repository>apache/shardingsphere-agent</proxy.image.repository>
-                <proxy.image.tag>${project.version}</proxy.image.tag>
+                <agent.image.repository>apache/shardingsphere-agent</agent.image.repository>
+                <agent.image.tag>${project.version}</agent.image.tag>
             </properties>
             <build>
                 <plugins>
@@ -125,13 +158,12 @@
                                     <arguments>
                                         <argument>buildx</argument>
                                         <argument>create</argument>
-                                        <argument>--use</argument>
                                         <argument>--driver</argument>
                                         <argument>docker-container</argument>
                                         <argument>--name</argument>
                                         <argument>shardingsphere-builder</argument>
                                         <argument>--platform</argument>
-                                        <argument>${proxy.image.platform}</argument>
+                                        <argument>linux/amd64,linux/arm64</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -146,17 +178,18 @@
                                     <arguments>
                                         <argument>buildx</argument>
                                         <argument>build</argument>
-                                        <argument>--pull</argument>
                                         <argument>--push</argument>
+                                        <argument>--builder</argument>
+                                        <argument>shardingsphere-builder</argument>
                                         <argument>--platform</argument>
-                                        <argument>${proxy.image.platform}</argument>
+                                        <argument>linux/amd64,linux/arm64</argument>
                                         <argument>--build-arg</argument>
                                         <argument>APP_NAME=apache-shardingsphere-${project.version}-shardingsphere-agent-bin</argument>
                                         <argument>.</argument>
                                         <argument>-t</argument>
-                                        <argument>${proxy.image.repository}:${proxy.image.tag}</argument>
+                                        <argument>${agent.image.repository}:${agent.image.tag}</argument>
                                         <argument>-t</argument>
-                                        <argument>${proxy.image.repository}:latest</argument>
+                                        <argument>${agent.image.repository}:latest</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.en.md
@@ -112,27 +112,54 @@ java -javaagent:/agent/shardingsphere-agent-${latest.release.version}.jar -jar t
 + 3 Access to started service
 + 4 Check whether the corresponding plug-in is effective
 
-### Nightly Builds
+### Docker
 
-A nightly built Docker Image of ShardingSphere Agent exists at https://github.com/orgs/apache/packages?repo_name=shardingsphere .
+#### Local Build
 
-You can use ShardingSphere Agent in this Docker Image for a JAR like `example.jar` by using a `Dockerfile` like the following.
+ShardingSphere Agent has a `Dockerfile` available for easy distribution. You can execute the following command to build a Docker Image,
 
-Assume `example.jar` is an Uber JAR of Spring Boot that will use ShardingSphere Agent,
-and `custom-agent.yaml` contains the configuration of ShardingSphere Agent.
-
-```dockerfile
-FROM ghcr.io/apache/shardingsphere-agent:latest
-COPY ./example.jar /example.jar
-COPY ./custom-agent.yaml /usr/agent/conf/agent.yaml
-ENTRYPOINT java \
-    -javaagent:/usr/agent/shardingsphere-agent-5.5.1-SNAPSHOT.jar
-    -jar \
-    /example.jar
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/agent -Prelease,docker -T1C -DskipTests clean package
 ```
 
-The content of `custom-agent.yaml` may be as follows,
-`http://localhost:4318` points to the locally deployed `otel/opentelemetry-collector-contrib:0.108.0` Docker Container.
+If you add the following statement in your custom `Dockerfile`, it will copy the ShardingSphere Agent directory to `/shardingsphere-agent/`.
+
+```dockerfile
+COPY --from=apache/shardingsphere-agent:latest /usr/agent/ /shardingsphere-agent/
+```
+
+#### Nightly Build
+
+ShardingSphere Agent has a nightly built Docker Image at https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-agent .
+
+If you add the following statement in your custom `Dockerfile`, it will copy the ShardingSphere Agent directory to `/shardingsphere-agent/`.
+
+```dockerfile
+COPY --from=ghcr.io/apache/shardingsphere-agent:latest /usr/agent/ /shardingsphere-agent/
+```
+
+#### Using Dockerfile
+
+Introduce a typical scenario,
+
+1. Assume that the Jaeger All in One Docker Container is deployed through the following Bash command,
+
+```shell
+docker network create example-net
+docker run --rm -d \
+  --name jaeger \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -p 9411:9411 \
+  --network example-net \
+  jaegertracing/all-in-one:1.60.0
+```
+
+2. Assume `./custom-agent.yaml` contains the configuration of ShardingSphere Agent, and the content may be as follows,
 
 ```yaml
 plugins:
@@ -140,13 +167,33 @@ plugins:
     OpenTelemetry:
       props:
         otel.service.name: "example"
-        otel.exporter.otlp.traces.endpoint: "http://localhost:4318"
+        otel.exporter.otlp.traces.endpoint: "http://jaeger:4318"
 ```
 
-Or add the following statement in `Dockerfile`, which will copy the Agent directory to `/shardingsphere-agent/`.
+3. Assuming `./target/example.jar` is an Uber JAR of Spring Boot that will use ShardingSphere Agent, 
+you can use the ShardingSphere Agent in the nightly built Docker Image for a JAR like `example.jar` through a `Dockerfile` like the following.
+
+```dockerfile 
+FROM ghcr.io/apache/shardingsphere-agent:latest 
+COPY ./target/example.jar /app.jar 
+COPY ./custom-agent.yaml /usr/agent/conf/agent.yaml 
+ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent-5.5.1-SNAPSHOT.jar","-jar","/app.jar "] 
+```
+
+If you build the Docker Image of `apache/shardingsphere-agent:latest` locally, the `Dockerfile` may be as follows,
 
 ```dockerfile
-COPY --from=ghcr.io/apache/shardingsphere-agent:latest /usr/agent/ /shardingsphere-agent/
+FROM apache/shardingsphere-agent:latest
+COPY ./target/example.jar /app.jar
+COPY ./custom-agent.yaml /usr/agent/conf/agent.yaml
+ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent-5.5.1-SNAPSHOT.jar","-jar","/app.jar"]
+```
+
+4. Enjoy it, 
+
+```shell 
+docker build -t example/gs-spring-boot-docker:latest . 
+docker run --network example-net example/gs-spring-boot-docker:latest 
 ```
 
 ## Metrics


### PR DESCRIPTION
Fixes #32777.

Changes proposed in this pull request:
  - Supports building ShardingSphere Agent's Docker Image locally

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
