### PR TITLE
assertUpdate Test error due to environment dependency of newLine character in class QualifiedDataSourceStatePersistServiceTest

### DIFF
--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/persist/service/QualifiedDataSourceStatePersistServiceTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/persist/service/QualifiedDataSourceStatePersistServiceTest.java
@@ -59,6 +59,6 @@ class QualifiedDataSourceStatePersistServiceTest {
     @Test
     void assertUpdate() {
         qualifiedDataSourceStatePersistService.update("foo_db", "foo_group", "foo_ds", DataSourceState.ENABLED);
-        verify(repository).persist("/nodes/qualified_data_sources/foo_db.foo_group.foo_ds", "state: ENABLED\n");
+        verify(repository).persist("/nodes/qualified_data_sources/foo_db.foo_group.foo_ds", "state: ENABLED"+System.lineSeparator());
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/persist/service/QualifiedDataSourceStatePersistServiceTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/persist/service/QualifiedDataSourceStatePersistServiceTest.java
@@ -59,6 +59,6 @@ class QualifiedDataSourceStatePersistServiceTest {
     @Test
     void assertUpdate() {
         qualifiedDataSourceStatePersistService.update("foo_db", "foo_group", "foo_ds", DataSourceState.ENABLED);
-        verify(repository).persist("/nodes/qualified_data_sources/foo_db.foo_group.foo_ds", "state: ENABLED"+System.lineSeparator());
+        verify(repository).persist("/nodes/qualified_data_sources/foo_db.foo_group.foo_ds", "state: ENABLED" + System.lineSeparator());
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -
Replaced the newLine character \n with System.lineSeparator() as \n was giving test failure in different environment.
\n was giving the error as "" Argument(s) are different! ""
Used environment independent new Line Character System.ineSepaartor() which solves this issue.
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
