### PR TITLE
Replaces with `com.tisonkun.os:os-detector-maven-plugin` to support building with Maven `4.0.0-beta-4`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <!-- 3rd party library plugin versions -->
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
-        <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
+        <os-detector-maven-plugin.version>0.3.1</os-detector-maven-plugin.version>
         <native-maven-plugin.version>0.10.2</native-maven-plugin.version>
         
         <!-- Compile plugin versions -->
@@ -871,9 +871,9 @@
         
         <extensions>
             <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
+                <groupId>com.tisonkun.os</groupId>
+                <artifactId>os-detector-maven-plugin</artifactId>
+                <version>${os-detector-maven-plugin.version}</version>
             </extension>
         </extensions>
     </build>


### PR DESCRIPTION
Fixes #32568.

Changes proposed in this pull request:
  - Replaces with `com.tisonkun.os:os-detector-maven-plugin` to support building with Maven `4.0.0-beta-4`. According to the investigation extension of https://github.com/apache/opendal/discussions/5133 , https://github.com/trustin/os-maven-plugin has actually stopped maintenance and has never supported Maven 4.0.0-beta-4. See https://github.com/trustin/os-maven-plugin/pull/74 .
  - We now have https://github.com/tisonkun/os-detector to replace `kr.motd.maven:os-maven-plugin`. This clears the way for future OpenDAL integration ( https://github.com/apache/shardingsphere/issues/32872#issuecomment-2359957360 ). See https://github.com/tisonkun/os-detector/pull/9 and https://github.com/tisonkun/os-detector/pull/8 .
  - For ShardingSphere, only the `org.apache.shardingsphere:shardingsphere-data-pipeline-cdc` module needs to use `com.tisonkun.os:os-detector-maven-plugin`.
  - Since Maven 4.0.0-beta-3 began to require JDK17 runtime, there is no way to simply test ShardingSphere, which still uses JDK8 in CI. ShardingSphere has never required contributors to use Maven Toolchains to configure multiple JDKs locally, although ShardingSphere's documentation has required the use of `SDKMAN!` for testing in many places. We cannot expect the concept of builder POM and consumer POM to be introduced quickly right away. Also see https://github.com/linghengqian/hive-server2-jdbc-driver/commit/b04c33570aa4233b984f525a3d9d2b26c5df30af and https://github.com/linghengqian/hive-server2-jdbc-driver/commit/00de0c5c388c6a36487b28f9ab7b3f32131fbd92 .
  - But starting from this PR, nothing can affect building ShardingSphere with GraalVM CE For JDK 22.0.2 and Maven 4.0.0-beta-4. For example,
```bash
sdk install java 22.0.2-graalce
sdk install maven 4.0.0-beta-4
git clone git@github.com:apache/shardingsphere.git
cd ./shardingsphere/
sdk use java 22.0.2-graalce
sdk use maven 4.0.0-beta-4
mvn clean install -Prelease -T1C -DskipTests -Djacoco.skip=true -Dcheckstyle.skip=true -Drat.skip=true -Dmaven.javadoc.skip=true
```
- Enjoy it,
```bash
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:47 min (Wall Clock)
[INFO] Finished at: 2024-09-24T20:59:40+08:00
[INFO] ------------------------------------------------------------------------
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
