### PR TITLE
Publish the Source JAR to the local Maven repository when building locally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -833,6 +833,9 @@
         </pluginManagement>
         
         <plugins>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
             <!-- Release plugins -->
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
For #32765 .

Changes proposed in this pull request:
  - Publish the Source JAR to the local Maven repository when building locally.
  - This is mainly for debugging convenience for contributors. When executing a command like `./mvnw clean install -Prelease -T1C -DskipTests`, `shardingsphere-jdbc-5.5.1-SNAPSHOT-sources.jar` will be generated, which helps to trace the stack in IntelliJ IDEA. This helps with the debugging experience.
  - Obviously, gitea and gitlab in the figure are the metadata of the mirror source, not from shardingsphere.
  - ![image](https://github.com/user-attachments/assets/f61fc39c-31df-4bd7-aa3f-502af981e94c)


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
