### PR TITLE
Mock get/set networkTimeout of `java.sql.Connection` in JDBC Driver to prevent HikariCP's Warning

### DIFF
--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnection.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnection.java
@@ -42,6 +42,7 @@ import java.sql.Savepoint;
 import java.sql.Statement;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
 
 /**
  * ShardingSphere connection.
@@ -262,6 +263,30 @@ public final class ShardingSphereConnection extends AbstractConnectionAdapter {
     public void setReadOnly(final boolean readOnly) throws SQLException {
         this.readOnly = readOnly;
         databaseConnectionManager.setReadOnly(readOnly);
+    }
+    
+    /**
+     * This is just to avoid the Warning in <a href="https://github.com/brettwooldridge/HikariCP/issues/2196">brettwooldridge/HikariCP#2196</a>.
+     * ShardingSphere does not propagate this property to the real JDBC Driver.
+     * `0` is actually the default value of {@link java.net.Socket#getSoTimeout()}.
+     */
+    @Override
+    public int getNetworkTimeout() {
+        return 0;
+    }
+    
+    /**
+     * This is just to avoid the Warning in <a href="https://github.com/brettwooldridge/HikariCP/issues/2196">brettwooldridge/HikariCP#2196</a>.
+     * ShardingSphere does not propagate this property to the real JDBC Driver.
+     *
+     * @param executor     Not used.
+     * @param milliseconds The time in milliseconds to wait for the database operation to complete.
+     */
+    @Override
+    public void setNetworkTimeout(final Executor executor, final int milliseconds) throws SQLException {
+        if (0 > milliseconds) {
+            throw new SQLException("Network timeout must be a value greater than or equal to 0.");
+        }
     }
     
     @Override

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationConnection.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationConnection.java
@@ -75,12 +75,12 @@ public abstract class AbstractUnsupportedOperationConnection extends WrapperAdap
     }
     
     @Override
-    public final int getNetworkTimeout() throws SQLException {
+    public int getNetworkTimeout() throws SQLException {
         throw new SQLFeatureNotSupportedException("getNetworkTimeout");
     }
     
     @Override
-    public final void setNetworkTimeout(final Executor executor, final int milliseconds) throws SQLException {
+    public void setNetworkTimeout(final Executor executor, final int milliseconds) throws SQLException {
         throw new SQLFeatureNotSupportedException("setNetworkTimeout");
     }
     

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationConnectionTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationConnectionTest.java
@@ -31,6 +31,7 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.util.Collections;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -78,12 +79,12 @@ class UnsupportedOperationConnectionTest {
     
     @Test
     void assertGetNetworkTimeout() {
-        assertThrows(SQLFeatureNotSupportedException.class, shardingSphereConnection::getNetworkTimeout);
+        assertDoesNotThrow(shardingSphereConnection::getNetworkTimeout);
     }
     
     @Test
     void assertSetNetworkTimeout() {
-        assertThrows(SQLFeatureNotSupportedException.class, () -> shardingSphereConnection.setNetworkTimeout(null, 0));
+        assertDoesNotThrow(() -> shardingSphereConnection.setNetworkTimeout(null, 0));
     }
     
     @Test


### PR DESCRIPTION
For https://github.com/apache/shardingsphere/issues/32765#issuecomment-2374469288 .

Changes proposed in this pull request:
  - Mock get/set networkTimeout of `java.sql.Connection` in JDBC Driver to prevent HikariCP's Warning. See https://github.com/pgjdbc/pgjdbc/pull/849 .
  - The default value of `java.net.Socket#getSoTimeout()` is normally `0`. A quick test using `org.apache.httpcomponents:httpclient:4.5.14`,
```java
    @Test
    public void test() throws SocketException {
        int soTimeout = org.apache.http.conn.scheme.PlainSocketFactory.getSocketFactory().createSocket().getSoTimeout();
        System.out.println(soTimeout);
    }
```
  - Also fixes https://github.com/brettwooldridge/HikariCP/issues/2196 .
```shell
13:01:12.583 [main] INFO com.zaxxer.hikari.pool.PoolBase - HikariPool-1 - Driver does not support get/set network timeout for connections. (getNetworkTimeout)
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
