### PR TITLE
Use hintValueContext to replace extract sql hint from sql statement for solving shadow sql hint bug

### DIFF
--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/algorithm/shadow/hint/SQLHintShadowAlgorithm.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/algorithm/shadow/hint/SQLHintShadowAlgorithm.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.shadow.algorithm.shadow.hint;
 
-import org.apache.shardingsphere.infra.hint.SQLHintUtils;
 import org.apache.shardingsphere.shadow.spi.ShadowOperationType;
 import org.apache.shardingsphere.shadow.spi.hint.HintShadowAlgorithm;
 import org.apache.shardingsphere.shadow.spi.hint.PreciseHintShadowValue;
@@ -27,12 +26,12 @@ import java.util.Collection;
 /**
  * SQL hint shadow algorithm.
  */
-public final class SQLHintShadowAlgorithm implements HintShadowAlgorithm<String> {
+public final class SQLHintShadowAlgorithm implements HintShadowAlgorithm<Boolean> {
     
     @Override
-    public boolean isShadow(final Collection<String> shadowTableNames, final PreciseHintShadowValue<String> noteShadowValue) {
-        if (ShadowOperationType.HINT_MATCH == noteShadowValue.getShadowOperationType() || shadowTableNames.contains(noteShadowValue.getLogicTableName())) {
-            return SQLHintUtils.extractHint(noteShadowValue.getValue()).isShadow();
+    public boolean isShadow(final Collection<String> shadowTableNames, final PreciseHintShadowValue<Boolean> hintShadowValue) {
+        if (ShadowOperationType.HINT_MATCH == hintShadowValue.getShadowOperationType() || shadowTableNames.contains(hintShadowValue.getLogicTableName())) {
+            return hintShadowValue.getValue();
         }
         return false;
     }

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/condition/ShadowDetermineCondition.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/condition/ShadowDetermineCondition.java
@@ -20,9 +20,6 @@ package org.apache.shardingsphere.shadow.condition;
 import lombok.Getter;
 import org.apache.shardingsphere.shadow.spi.ShadowOperationType;
 
-import java.util.Collection;
-import java.util.LinkedList;
-
 /**
  * Shadow determine condition.
  */
@@ -35,22 +32,9 @@ public final class ShadowDetermineCondition {
     
     private ShadowColumnCondition shadowColumnCondition;
     
-    private final Collection<String> sqlComments = new LinkedList<>();
-    
     public ShadowDetermineCondition(final String tableName, final ShadowOperationType shadowOperationType) {
         this.tableName = tableName;
         this.shadowOperationType = shadowOperationType;
-    }
-    
-    /**
-     * Initialize SQL comments.
-     *
-     * @param sqlComments SQL comments
-     * @return shadow determine condition
-     */
-    public ShadowDetermineCondition initSQLComments(final Collection<String> sqlComments) {
-        this.sqlComments.addAll(sqlComments);
-        return this;
     }
     
     /**

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/ShadowRouteEngineFactory.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/ShadowRouteEngineFactory.java
@@ -19,11 +19,11 @@ package org.apache.shardingsphere.shadow.route.engine;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.infra.session.query.QueryContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.DeleteStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.UpdateStatementContext;
+import org.apache.shardingsphere.infra.session.query.QueryContext;
 import org.apache.shardingsphere.shadow.route.engine.dml.ShadowDeleteStatementRoutingEngine;
 import org.apache.shardingsphere.shadow.route.engine.dml.ShadowInsertStatementRoutingEngine;
 import org.apache.shardingsphere.shadow.route.engine.dml.ShadowSelectStatementRoutingEngine;
@@ -65,22 +65,22 @@ public final class ShadowRouteEngineFactory {
     }
     
     private static ShadowRouteEngine createShadowNonMDLStatementRoutingEngine(final QueryContext queryContext) {
-        return new ShadowNonDMLStatementRoutingEngine(queryContext.getSqlStatementContext());
+        return new ShadowNonDMLStatementRoutingEngine(queryContext.getHintValueContext());
     }
     
     private static ShadowRouteEngine createShadowSelectStatementRoutingEngine(final QueryContext queryContext) {
-        return new ShadowSelectStatementRoutingEngine((SelectStatementContext) queryContext.getSqlStatementContext(), queryContext.getParameters());
+        return new ShadowSelectStatementRoutingEngine((SelectStatementContext) queryContext.getSqlStatementContext(), queryContext.getParameters(), queryContext.getHintValueContext());
     }
     
     private static ShadowRouteEngine createShadowUpdateStatementRoutingEngine(final QueryContext queryContext) {
-        return new ShadowUpdateStatementRoutingEngine((UpdateStatementContext) queryContext.getSqlStatementContext(), queryContext.getParameters());
+        return new ShadowUpdateStatementRoutingEngine((UpdateStatementContext) queryContext.getSqlStatementContext(), queryContext.getParameters(), queryContext.getHintValueContext());
     }
     
     private static ShadowRouteEngine createShadowDeleteStatementRoutingEngine(final QueryContext queryContext) {
-        return new ShadowDeleteStatementRoutingEngine((DeleteStatementContext) queryContext.getSqlStatementContext(), queryContext.getParameters());
+        return new ShadowDeleteStatementRoutingEngine((DeleteStatementContext) queryContext.getSqlStatementContext(), queryContext.getParameters(), queryContext.getHintValueContext());
     }
     
     private static ShadowRouteEngine createShadowInsertStatementRoutingEngine(final QueryContext queryContext) {
-        return new ShadowInsertStatementRoutingEngine((InsertStatementContext) queryContext.getSqlStatementContext());
+        return new ShadowInsertStatementRoutingEngine((InsertStatementContext) queryContext.getSqlStatementContext(), queryContext.getHintValueContext());
     }
 }

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/determiner/HintShadowAlgorithmDeterminer.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/determiner/HintShadowAlgorithmDeterminer.java
@@ -19,14 +19,11 @@ package org.apache.shardingsphere.shadow.route.engine.determiner;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.shadow.condition.ShadowDetermineCondition;
+import org.apache.shardingsphere.shadow.rule.ShadowRule;
 import org.apache.shardingsphere.shadow.spi.ShadowOperationType;
 import org.apache.shardingsphere.shadow.spi.hint.HintShadowAlgorithm;
 import org.apache.shardingsphere.shadow.spi.hint.PreciseHintShadowValue;
-import org.apache.shardingsphere.shadow.condition.ShadowDetermineCondition;
-import org.apache.shardingsphere.shadow.rule.ShadowRule;
-
-import java.util.Collection;
-import java.util.stream.Collectors;
 
 /**
  * Hint shadow algorithm determiner.
@@ -40,22 +37,17 @@ public final class HintShadowAlgorithmDeterminer {
      * @param shadowAlgorithm hint shadow algorithm
      * @param shadowCondition shadow determine condition
      * @param shadowRule shadow rule
+     * @param useShadow use shadow or not
      * @return is shadow or not
      */
-    public static boolean isShadow(final HintShadowAlgorithm<Comparable<?>> shadowAlgorithm, final ShadowDetermineCondition shadowCondition, final ShadowRule shadowRule) {
-        Collection<PreciseHintShadowValue<Comparable<?>>> noteShadowValues = createNoteShadowValues(shadowCondition);
-        for (PreciseHintShadowValue<Comparable<?>> each : noteShadowValues) {
-            if (shadowAlgorithm.isShadow(shadowRule.getAllShadowTableNames(), each)) {
-                return true;
-            }
-        }
-        return false;
+    public static boolean isShadow(final HintShadowAlgorithm<Comparable<?>> shadowAlgorithm, final ShadowDetermineCondition shadowCondition, final ShadowRule shadowRule, final boolean useShadow) {
+        PreciseHintShadowValue<Comparable<?>> shadowValue = createNoteShadowValues(shadowCondition, useShadow);
+        return shadowAlgorithm.isShadow(shadowRule.getAllShadowTableNames(), shadowValue);
     }
     
-    private static Collection<PreciseHintShadowValue<Comparable<?>>> createNoteShadowValues(final ShadowDetermineCondition shadowDetermineCondition) {
+    private static PreciseHintShadowValue<Comparable<?>> createNoteShadowValues(final ShadowDetermineCondition shadowDetermineCondition, final boolean useShadow) {
         ShadowOperationType shadowOperationType = shadowDetermineCondition.getShadowOperationType();
         String tableName = shadowDetermineCondition.getTableName();
-        return shadowDetermineCondition.getSqlComments().stream()
-                .<PreciseHintShadowValue<Comparable<?>>>map(each -> new PreciseHintShadowValue<>(tableName, shadowOperationType, each)).collect(Collectors.toList());
+        return new PreciseHintShadowValue<>(tableName, shadowOperationType, useShadow);
     }
 }

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/dml/ShadowDeleteStatementRoutingEngine.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/dml/ShadowDeleteStatementRoutingEngine.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.shadow.route.engine.dml;
 
 import org.apache.shardingsphere.infra.binder.context.statement.dml.DeleteStatementContext;
+import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.shadow.spi.ShadowOperationType;
 import org.apache.shardingsphere.shadow.condition.ShadowColumnCondition;
 import org.apache.shardingsphere.shadow.route.engine.util.ShadowExtractor;
@@ -39,8 +40,8 @@ public final class ShadowDeleteStatementRoutingEngine extends AbstractShadowDMLS
     
     private final List<Object> parameters;
     
-    public ShadowDeleteStatementRoutingEngine(final DeleteStatementContext sqlStatementContext, final List<Object> parameters) {
-        super(sqlStatementContext, ShadowOperationType.DELETE);
+    public ShadowDeleteStatementRoutingEngine(final DeleteStatementContext sqlStatementContext, final List<Object> parameters, final HintValueContext hintValueContext) {
+        super(sqlStatementContext, hintValueContext, ShadowOperationType.DELETE);
         this.sqlStatementContext = sqlStatementContext;
         this.parameters = parameters;
     }

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/dml/ShadowInsertStatementRoutingEngine.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/dml/ShadowInsertStatementRoutingEngine.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.shadow.route.engine.dml;
 import org.apache.shardingsphere.infra.binder.context.segment.insert.values.InsertValueContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;
 import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
+import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.shadow.spi.ShadowOperationType;
 import org.apache.shardingsphere.shadow.condition.ShadowColumnCondition;
 import org.apache.shardingsphere.shadow.exception.syntax.UnsupportedShadowInsertValueException;
@@ -35,8 +36,8 @@ public final class ShadowInsertStatementRoutingEngine extends AbstractShadowDMLS
     
     private final InsertStatementContext sqlStatementContext;
     
-    public ShadowInsertStatementRoutingEngine(final InsertStatementContext sqlStatementContext) {
-        super(sqlStatementContext, ShadowOperationType.INSERT);
+    public ShadowInsertStatementRoutingEngine(final InsertStatementContext sqlStatementContext, final HintValueContext hintValueContext) {
+        super(sqlStatementContext, hintValueContext, ShadowOperationType.INSERT);
         this.sqlStatementContext = sqlStatementContext;
     }
     

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/dml/ShadowSelectStatementRoutingEngine.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/dml/ShadowSelectStatementRoutingEngine.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.shadow.route.engine.dml;
 
 import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;
+import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.shadow.spi.ShadowOperationType;
 import org.apache.shardingsphere.shadow.condition.ShadowColumnCondition;
 import org.apache.shardingsphere.shadow.route.engine.util.ShadowExtractor;
@@ -43,8 +44,8 @@ public final class ShadowSelectStatementRoutingEngine extends AbstractShadowDMLS
     
     private final List<Object> parameters;
     
-    public ShadowSelectStatementRoutingEngine(final SelectStatementContext sqlStatementContext, final List<Object> parameters) {
-        super(sqlStatementContext, ShadowOperationType.SELECT);
+    public ShadowSelectStatementRoutingEngine(final SelectStatementContext sqlStatementContext, final List<Object> parameters, final HintValueContext hintValueContext) {
+        super(sqlStatementContext, hintValueContext, ShadowOperationType.SELECT);
         this.sqlStatementContext = sqlStatementContext;
         this.parameters = parameters;
     }

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/dml/ShadowUpdateStatementRoutingEngine.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/dml/ShadowUpdateStatementRoutingEngine.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.shadow.route.engine.dml;
 
 import org.apache.shardingsphere.infra.binder.context.statement.dml.UpdateStatementContext;
+import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.shadow.spi.ShadowOperationType;
 import org.apache.shardingsphere.shadow.condition.ShadowColumnCondition;
 import org.apache.shardingsphere.shadow.route.engine.util.ShadowExtractor;
@@ -41,8 +42,8 @@ public final class ShadowUpdateStatementRoutingEngine extends AbstractShadowDMLS
     
     private final List<Object> parameters;
     
-    public ShadowUpdateStatementRoutingEngine(final UpdateStatementContext sqlStatementContext, final List<Object> parameters) {
-        super(sqlStatementContext, ShadowOperationType.UPDATE);
+    public ShadowUpdateStatementRoutingEngine(final UpdateStatementContext sqlStatementContext, final List<Object> parameters, final HintValueContext hintValueContext) {
+        super(sqlStatementContext, hintValueContext, ShadowOperationType.UPDATE);
         this.sqlStatementContext = sqlStatementContext;
         this.parameters = parameters;
     }

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/algorithm/shadow/hint/SQLHintShadowAlgorithmTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/algorithm/shadow/hint/SQLHintShadowAlgorithmTest.java
@@ -18,9 +18,9 @@
 package org.apache.shardingsphere.shadow.algorithm.shadow.hint;
 
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.shadow.spi.ShadowAlgorithm;
 import org.apache.shardingsphere.shadow.spi.ShadowOperationType;
 import org.apache.shardingsphere.shadow.spi.hint.PreciseHintShadowValue;
-import org.apache.shardingsphere.shadow.spi.ShadowAlgorithm;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,18 +41,7 @@ class SQLHintShadowAlgorithmTest {
     
     @Test
     void assertIsShadow() {
-        assertFalse(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), new PreciseHintShadowValue<>("t_auto", ShadowOperationType.INSERT, "/*shadow:true*/")));
-        assertFalse(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), createNoteShadowValue("/**/")));
-        assertFalse(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), createNoteShadowValue("/*")));
-        assertFalse(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), createNoteShadowValue("aaa  = bbb")));
-        assertFalse(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), createNoteShadowValue(" SHARDINGSPHERE_HINT: SHADOW=true */")));
-        assertFalse(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), createNoteShadowValue(" SHARDINGSPHERE_HINT: SHADOW=true ")));
-        assertFalse(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), createNoteShadowValue(" SHARDINGSPHERE_HINT: SHADOW=true, aaa=bbb ")));
-        assertFalse(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), createNoteShadowValue("/* SHARDINGSPHERE_HINT: SHADOW = true ")));
-        assertTrue(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), createNoteShadowValue("/* SHARDINGSPHERE_HINT: SHADOW=true */")));
-    }
-    
-    private PreciseHintShadowValue<String> createNoteShadowValue(final String sqlNote) {
-        return new PreciseHintShadowValue<>("t_user", ShadowOperationType.HINT_MATCH, sqlNote);
+        assertFalse(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), new PreciseHintShadowValue<>("t_auto", ShadowOperationType.INSERT, true)));
+        assertTrue(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), new PreciseHintShadowValue<>("t_user", ShadowOperationType.HINT_MATCH, false)));
     }
 }

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/algorithm/shadow/hint/SQLHintShadowAlgorithmTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/algorithm/shadow/hint/SQLHintShadowAlgorithmTest.java
@@ -42,6 +42,6 @@ class SQLHintShadowAlgorithmTest {
     @Test
     void assertIsShadow() {
         assertFalse(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), new PreciseHintShadowValue<>("t_auto", ShadowOperationType.INSERT, true)));
-        assertTrue(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), new PreciseHintShadowValue<>("t_user", ShadowOperationType.HINT_MATCH, false)));
+        assertTrue(shadowAlgorithm.isShadow(Arrays.asList("t_user", "t_order"), new PreciseHintShadowValue<>("t_user", ShadowOperationType.HINT_MATCH, true)));
     }
 }

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/engine/determiner/HintShadowAlgorithmDeterminerTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/engine/determiner/HintShadowAlgorithmDeterminerTest.java
@@ -18,15 +18,16 @@
 package org.apache.shardingsphere.shadow.route.engine.determiner;
 
 import org.apache.shardingsphere.infra.algorithm.core.config.AlgorithmConfiguration;
+import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.shadow.condition.ShadowDetermineCondition;
 import org.apache.shardingsphere.shadow.config.ShadowRuleConfiguration;
 import org.apache.shardingsphere.shadow.config.datasource.ShadowDataSourceConfiguration;
 import org.apache.shardingsphere.shadow.config.table.ShadowTableConfiguration;
-import org.apache.shardingsphere.shadow.spi.ShadowOperationType;
-import org.apache.shardingsphere.shadow.spi.hint.HintShadowAlgorithm;
-import org.apache.shardingsphere.shadow.condition.ShadowDetermineCondition;
 import org.apache.shardingsphere.shadow.rule.ShadowRule;
 import org.apache.shardingsphere.shadow.spi.ShadowAlgorithm;
+import org.apache.shardingsphere.shadow.spi.ShadowOperationType;
+import org.apache.shardingsphere.shadow.spi.hint.HintShadowAlgorithm;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
@@ -42,7 +43,14 @@ class HintShadowAlgorithmDeterminerTest {
     @Test
     void assertIsShadow() {
         HintShadowAlgorithm hintShadowAlgorithm = (HintShadowAlgorithm) TypedSPILoader.getService(ShadowAlgorithm.class, "SQL_HINT", new Properties());
-        assertTrue(HintShadowAlgorithmDeterminer.isShadow(hintShadowAlgorithm, createShadowDetermineCondition(), new ShadowRule(createShadowRuleConfiguration())));
+        HintValueContext hintValueContext = createHintValueContext();
+        assertTrue(HintShadowAlgorithmDeterminer.isShadow(hintShadowAlgorithm, createShadowDetermineCondition(), new ShadowRule(createShadowRuleConfiguration()), hintValueContext.isShadow()));
+    }
+    
+    private HintValueContext createHintValueContext() {
+        HintValueContext result = new HintValueContext();
+        result.setShadow(true);
+        return result;
     }
     
     private ShadowRuleConfiguration createShadowRuleConfiguration() {
@@ -61,6 +69,6 @@ class HintShadowAlgorithmDeterminerTest {
     }
     
     private ShadowDetermineCondition createShadowDetermineCondition() {
-        return new ShadowDetermineCondition("t_order", ShadowOperationType.INSERT).initSQLComments(Collections.singleton("/* SHARDINGSPHERE_HINT: SHADOW=true */"));
+        return new ShadowDetermineCondition("t_order", ShadowOperationType.INSERT);
     }
 }

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/engine/impl/ShadowNonDMLStatementRoutingEngineTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/route/engine/impl/ShadowNonDMLStatementRoutingEngineTest.java
@@ -17,9 +17,8 @@
 
 package org.apache.shardingsphere.shadow.route.engine.impl;
 
-import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
-import org.apache.shardingsphere.infra.binder.context.statement.ddl.CreateTableStatementContext;
 import org.apache.shardingsphere.infra.algorithm.core.config.AlgorithmConfiguration;
+import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.route.context.RouteMapper;
 import org.apache.shardingsphere.infra.route.context.RouteUnit;
@@ -27,8 +26,6 @@ import org.apache.shardingsphere.shadow.config.ShadowRuleConfiguration;
 import org.apache.shardingsphere.shadow.config.datasource.ShadowDataSourceConfiguration;
 import org.apache.shardingsphere.shadow.config.table.ShadowTableConfiguration;
 import org.apache.shardingsphere.shadow.rule.ShadowRule;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.CommentSegment;
-import org.apache.shardingsphere.sql.parser.statement.mysql.ddl.MySQLCreateTableStatement;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.apache.shardingsphere.test.util.PropertiesBuilder.Property;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,8 +37,6 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class ShadowNonDMLStatementRoutingEngineTest {
     
@@ -49,14 +44,12 @@ class ShadowNonDMLStatementRoutingEngineTest {
     
     @BeforeEach
     void init() {
-        shadowRouteEngine = new ShadowNonDMLStatementRoutingEngine(createSQLStatementContext());
+        shadowRouteEngine = new ShadowNonDMLStatementRoutingEngine(createHintValueContext());
     }
     
-    private SQLStatementContext createSQLStatementContext() {
-        CreateTableStatementContext result = mock(CreateTableStatementContext.class);
-        MySQLCreateTableStatement sqlStatement = new MySQLCreateTableStatement(false);
-        sqlStatement.getCommentSegments().add(new CommentSegment("/* SHARDINGSPHERE_HINT: SHADOW=true */", 0, 20));
-        when(result.getSqlStatement()).thenReturn(sqlStatement);
+    private HintValueContext createHintValueContext() {
+        HintValueContext result = new HintValueContext();
+        result.setShadow(true);
         return result;
     }
     

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/features/ShadowTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/features/ShadowTest.java
@@ -25,7 +25,6 @@ import org.apache.shardingsphere.test.natived.jdbc.commons.entity.OrderItem;
 import org.apache.shardingsphere.test.natived.jdbc.commons.repository.AddressRepository;
 import org.apache.shardingsphere.test.natived.jdbc.commons.repository.OrderItemRepository;
 import org.apache.shardingsphere.test.natived.jdbc.commons.repository.OrderRepository;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
@@ -48,7 +47,6 @@ class ShadowTest {
     
     private AddressRepository addressRepository;
     
-    @Disabled("Fix this unit test when shadow comment get value from hint value context")
     @Test
     void assertShadowInLocalTransactions() throws SQLException {
         HikariConfig config = new HikariConfig();


### PR DESCRIPTION
Fixes #33045.

Changes proposed in this pull request:
  - Use hintValueContext to replace extract sql hint from sql statement for solving shadow sql hint bug
  - modify unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
