### PR TITLE
Support running DistSQL under Proxy Native in the form of GraalVM Native Image

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -133,7 +133,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push Docker Image
         run: |
-          ./mvnw -am -pl distribution/proxy-native -Prelease.native,docker.buildx.push.native -B -T1C -DskipTests -Dproxy.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.image.tag=${{ github.sha }} clean package
+          ./mvnw -am -pl distribution/proxy-native -Prelease.native,docker.buildx.push.native -B -T1C -DskipTests -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }} clean package
   build-agent-image:
     if: github.repository == 'apache/shardingsphere'
     name: Build Agent Image

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,7 @@
 ### Enhancement
 
 1. SQL Parser: Support PostgreSQL, openGauss function table and update from segment parse - [#32994](https://github.com/apache/shardingsphere/pull/32994)
+2. DistSQL: Support running DistSQL under Proxy Native in the form of GraalVM Native Image - [#33095](https://github.com/apache/shardingsphere/pull/33095)
 
 ### Bug Fix
 

--- a/distribution/proxy-native/pom.xml
+++ b/distribution/proxy-native/pom.xml
@@ -24,11 +24,14 @@
         <version>5.5.1-SNAPSHOT</version>
     </parent>
     <artifactId>shardingsphere-proxy-native-distribution</artifactId>
+    <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     
     <properties>
-        <imageName>apache-shardingsphere-proxy-native</imageName>
-        <native.image.repository>apache/shardingsphere-proxy-native</native.image.repository>
+        <proxy.native.image.name>proxy-native</proxy.native.image.name>
+        <proxy.native.image.platform>linux/amd64,linux/arm64</proxy.native.image.platform>
+        <proxy.native.image.repository>apache/shardingsphere-proxy-native</proxy.native.image.repository>
+        <proxy.native.image.tag>${project.version}</proxy.native.image.tag>
     </properties>
     
     <dependencies>
@@ -86,6 +89,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <mainClass>org.apache.shardingsphere.proxy.Bootstrap</mainClass>
+                            <imageName>${proxy.native.image.name}</imageName>
                             <buildArgs>
                                 <buildArg>-H:+AddAllCharsets</buildArg>
                             </buildArgs>
@@ -116,7 +120,7 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>shardingsphere-proxy-native-bin</id>
+                                <id>build and package</id>
                                 <goals>
                                     <goal>single</goal>
                                 </goals>
@@ -133,10 +137,6 @@
         </profile>
         <profile>
             <id>docker.native</id>
-            <properties>
-                <proxy.image.repository>${native.image.repository}</proxy.image.repository>
-                <proxy.image.tag>${project.version}</proxy.image.tag>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -145,7 +145,7 @@
                         <version>${exec-maven-plugin.version}</version>
                         <executions>
                             <execution>
-                                <id>build</id>
+                                <id>build docker image</id>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
@@ -154,16 +154,13 @@
                                     <executable>docker</executable>
                                     <arguments>
                                         <argument>build</argument>
-                                        <argument>--pull</argument>
                                         <argument>--build-arg</argument>
-                                        <argument>APP_NAME=${project.build.finalName}-shardingsphere-proxy-native-bin</argument>
-                                        <argument>--build-arg</argument>
-                                        <argument>NATIVE_IMAGE_NAME=${imageName}</argument>
+                                        <argument>OUTPUT_DIRECTORY_NAME=${project.build.finalName}-shardingsphere-proxy-native-bin</argument>
                                         <argument>.</argument>
                                         <argument>-t</argument>
-                                        <argument>${proxy.image.repository}:${proxy.image.tag}</argument>
+                                        <argument>${proxy.native.image.repository}:${proxy.native.image.tag}</argument>
                                         <argument>-t</argument>
-                                        <argument>${proxy.image.repository}:latest</argument>
+                                        <argument>${proxy.native.image.repository}:latest</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -174,11 +171,6 @@
         </profile>
         <profile>
             <id>docker.buildx.push.native</id>
-            <properties>
-                <proxy.image.platform>linux/amd64,linux/arm64</proxy.image.platform>
-                <proxy.image.repository>${native.image.repository}</proxy.image.repository>
-                <proxy.image.tag>${project.version}</proxy.image.tag>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -197,40 +189,17 @@
                                     <arguments>
                                         <argument>buildx</argument>
                                         <argument>create</argument>
-                                        <argument>--use</argument>
                                         <argument>--driver</argument>
                                         <argument>docker-container</argument>
                                         <argument>--name</argument>
                                         <argument>shardingsphere-builder</argument>
                                         <argument>--platform</argument>
-                                        <argument>${proxy.image.platform}</argument>
+                                        <argument>${proxy.native.image.platform}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>build</id>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <phase>package</phase>
-                                <configuration>
-                                    <executable>docker</executable>
-                                    <arguments>
-                                        <argument>buildx</argument>
-                                        <argument>build</argument>
-                                        <argument>--pull</argument>
-                                        <argument>--platform</argument>
-                                        <argument>${proxy.image.platform}</argument>
-                                        <argument>--build-arg</argument>
-                                        <argument>APP_NAME=${project.build.finalName}-shardingsphere-proxy-native-bin</argument>
-                                        <argument>--build-arg</argument>
-                                        <argument>NATIVE_IMAGE_NAME=${imageName}</argument>
-                                        <argument>.</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>push</id>
+                                <id>build and push docker image</id>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
@@ -241,17 +210,17 @@
                                         <argument>buildx</argument>
                                         <argument>build</argument>
                                         <argument>--push</argument>
+                                        <argument>--builder</argument>
+                                        <argument>shardingsphere-builder</argument>
                                         <argument>--platform</argument>
-                                        <argument>${proxy.image.platform}</argument>
+                                        <argument>${proxy.native.image.platform}</argument>
                                         <argument>--build-arg</argument>
-                                        <argument>APP_NAME=${project.build.finalName}-shardingsphere-proxy-native-bin</argument>
-                                        <argument>--build-arg</argument>
-                                        <argument>NATIVE_IMAGE_NAME=${imageName}</argument>
+                                        <argument>OUTPUT_DIRECTORY_NAME=${project.build.finalName}-shardingsphere-proxy-native-bin</argument>
                                         <argument>.</argument>
                                         <argument>-t</argument>
-                                        <argument>${proxy.image.repository}:${proxy.image.tag}</argument>
+                                        <argument>${proxy.native.image.repository}:${proxy.native.image.tag}</argument>
                                         <argument>-t</argument>
-                                        <argument>${proxy.image.repository}:latest</argument>
+                                        <argument>${proxy.native.image.repository}:latest</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/distribution/proxy-native/src/main/assembly/shardingsphere-proxy-native-binary-distribution.xml
+++ b/distribution/proxy-native/src/main/assembly/shardingsphere-proxy-native-binary-distribution.xml
@@ -19,16 +19,17 @@
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
     <id>shardingsphere-proxy-native-bin</id>
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
-    <includeBaseDirectory>true</includeBaseDirectory>
-    <baseDirectory>${project.build.finalName}-shardingsphere-proxy-native-bin</baseDirectory>
+    <includeBaseDirectory>false</includeBaseDirectory>
     
     <fileSets>
         <fileSet>
             <directory>${project.build.directory}</directory>
             <includes>
-                <include>${imageName}</include>
+                <include>${proxy.native.image.name}</include>
+                <include>*.so</include>
             </includes>
             <outputDirectory>/</outputDirectory>
             <fileMode>0755</fileMode>
@@ -41,7 +42,9 @@
         <fileSet>
             <directory>../../distribution/proxy/src/main/release-docs</directory>
             <includes>
-                <include>**/*</include>
+                <include>licenses/*</include>
+                <include>LICENSE</include>
+                <include>NOTICE</include>
             </includes>
             <outputDirectory>/</outputDirectory>
         </fileSet>

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -5,17 +5,22 @@ weight = 2
 
 ## 背景信息
 
-本节主要介绍如何通过 `GraalVM` 的 `native-image` 组件构建 ShardingSphere-Proxy 的 `Native Image` 和对应的 `Docker Image`。
+本节主要介绍如何通过 `GraalVM` 的 `native-image` 命令行工具构建 ShardingSphere Proxy 的 `GraalVM Native Image`，
+以及包含此 `GraalVM Native Image` 的 `Docker Image`。
+
+ShardingSphere Proxy 的 `GraalVM Native Image` 在本文即指代 ShardingSphere Proxy Native。
+
+GraalVM Native Image 的背景信息可参考 https://www.graalvm.org 。
 
 ## 注意事项
 
-- ShardingSphere Proxy 尚未准备好与 GraalVM Native Image 集成。 Proxy 的 Native Image 产物在
-  https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-proxy-native 存在每夜构建。假设存在包
-  含`global.yaml` 的 `conf` 文件夹为 `./custom/conf`，你可通过如下的 `docker-compose.yml` 文件进行测试。
+本节涉及的所有 Docker Image 均不通过 https://downloads.apache.org ，https://repository.apache.org/ 等 ASF 官方渠道进行分发。
+Docker Image 仅在 `ghcr.io` 等下游渠道提供以方便使用。
+
+Proxy 的 Native Image 产物在 https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-proxy-native 存在每夜构建。
+假设存在包含 `global.yaml` 的 `conf` 文件夹为 `./custom/conf`，你可通过如下的 `docker-compose.yml` 文件进行测试。
 
 ```yaml
-version: "3.8"
-
 services:
   apache-shardingsphere-proxy-native:
     image: ghcr.io/apache/shardingsphere-proxy-native:latest
@@ -25,83 +30,107 @@ services:
       - "3307:3307"
 ```
 
-- 本节假定处于 Linux（amd64，aarch64），MacOS（amd64，aarch64/M1）或 Windows（amd64）环境。
+ShardingSphere Proxy Native 可执行 DistSQL，这意味着实际上不需要任何定义逻辑数据库的 YAML 文件。
 
-- 本节依然受到 ShardingSphere JDBC 一侧的 [GraalVM Native Image](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image) 的已记录内容的限制。
+默认情况下，ShardingSphere Proxy Native 的 GraalVM Native Image 中仅包含，
+
+1. ShardingSphere 维护的自有及部分第三方依赖的 GraalVM Reachability Metadata
+2. H2database, OpenGauss 和 PostgreSQL 的 JDBC Driver
+3. HikariCP 的数据库连接池
+4. Logback 的日志框架
+
+如果用户需要在 ShardingSphere Proxy Native 中使用第三方 JAR，则需要修改 `distribution/proxy-native/pom.xml` 的内容，以构建以下的任意输出，
+
+1. 自定义的 GraalVM Native Image
+2. 包含自定义的 GraalVM Native Image 的自定义 Docker Image
+
+本节假定处于以下的系统环境之一，
+
+1. Linux（amd64，aarch64）
+2. MacOS（amd64，aarch64/M1）
+3. Windows（amd64）
+
+若处于 Linux（riscv64）等 Graal compiler 不支持的系统环境，
+请根据 https://medium.com/graalvm/graalvm-native-image-meets-risc-v-899be38eddd9 的内容启用 LLVM backend 来使用 LLVM compiler。
+
+本节依然受到 ShardingSphere JDBC 一侧的 [GraalVM Native Image](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image) 的已记录内容的限制。
 
 ## 前提条件
 
-1. 根据 https://www.graalvm.org/downloads/ 要求安装和配置 JDK 23 对应的 `GraalVM Community Edition`
-   或 `GraalVM Community Edition` 的下游发行版。若使用 `SDKMAN!`，
+1. 根据 https://www.graalvm.org/downloads/ 要求安装和配置 JDK 22 对应的 `GraalVM Community Edition` 或 `GraalVM Community Edition` 的下游发行版。
+若使用 `SDKMAN!`，
 
 ```shell
-sdk install java 23-graalce
+sdk install java 22.0.2-graalce
+sdk use java 22.0.2-graalce
 ```
 
 2. 根据 https://www.graalvm.org/jdk23/reference-manual/native-image/#prerequisites 的要求安装本地工具链。
 
-3. 如果需要构建 Docker Image， 确保 `docker-ce` 已安装。
+3. 如果需要构建 Docker Image， 确保 `Docker Engine` 已安装。
 
 ## 操作步骤
 
 1. 获取 Apache ShardingSphere Git Source
 
-- 在[下载页面](https://shardingsphere.apache.org/document/current/en/downloads/)
-  或 https://github.com/apache/shardingsphere/tree/master 获取。
+在[下载页面](https://shardingsphere.apache.org/document/current/en/downloads/)或 https://github.com/apache/shardingsphere/tree/master 获取。
 
 2. 在命令行构建产物, 分两种情形。
 
-- 情形一：不需要使用存在 SPI 实现的 JAR 或第三方依赖的 JAR
-
-- 在 Git Source 同级目录下执行如下命令, 直接完成 Native Image 的构建。
+情形一：不需要使用存在自定义 SPI 实现的 JAR 或第三方依赖的 JAR 。在 Git Source 同级目录下执行如下命令, 直接完成 Native Image 的构建。
 
 ```bash
+cd ./shardingsphere/
 ./mvnw -am -pl distribution/proxy-native -T1C -Prelease.native -DskipTests clean package
 ```
 
-- 情形二：需要使用存在 SPI 实现的 JAR 或 GPL V2 等 LICENSE 的第三方依赖的 JAR。
+情形二：需要使用存在自定义 SPI 实现的 JAR 或第三方依赖的 JAR。在 `distribution/proxy-native/pom.xml` 的 `dependencies` 加入如下选项之一，
 
-- 在 `distribution/proxy-native/pom.xml` 的 `dependencies` 加入存在 SPI 实现的 JAR
-  或第三方依赖的 JAR。示例如下
+(1) 存在 SPI 实现的 JAR
+(2) 第三方依赖的 JAR
+
+示例如下，这些 JAR 应预先置入本地 Maven 仓库或 Maven Central 等远程 Maven 仓库。
 
 ```xml
-
 <dependencies>
-  <dependency>
-    <groupId>com.mysql</groupId>
-    <artifactId>mysql-connector-j</artifactId>
-    <version>8.1.0</version>
-  </dependency>
+    <dependency>
+        <groupId>com.mysql</groupId>
+        <artifactId>mysql-connector-j</artifactId>
+        <version>9.0.0</version>
+    </dependency>
 </dependencies>
 ```
 
-- 通过命令行构建 GraalVM Native Image。
+随后通过命令行构建 GraalVM Native Image。
 
 ```bash
+cd ./shardingsphere/
 ./mvnw -am -pl distribution/proxy-native -T1C -Prelease.native -DskipTests clean package
 ```
 
-3. 通过命令行启动 Native Image, 需要带上 4 个参数。
-   第一个参数为 ShardingSphere Proxy 使用的端口，第二个参数为你编写的包含 `global.yaml` 的 `/conf` 文件夹，
-   第三个参数为绑定端口的 Address，第四个参数为 Force Start，如果为 true 则保证 ShardingSphere Proxy Native 无论能否连接都能正常启动。
-   假设已存在文件夹`./custom/conf`，示例为
+3. 通过命令行启动 Native Image, 需要带上 4 个参数，
+   第 1 个参数为 ShardingSphere Proxy Native 使用的端口，
+   第 2 个参数为用户编写的包含 `global.yaml` 配置文件的文件夹，
+   第 3 个参数为要侦听的主机，如果为 `0.0.0.0` 则允许任意数据库客户端均可访问 ShardingSphere Proxy Native
+   第 4 个参数为 Force Start，如果为 `true` 则保证 ShardingSphere Proxy Native 无论能否连接都能正常启动。
+
+假设已存在文件夹`./custom/conf`，示例为，
 
 ```bash
-./apache-shardingsphere-proxy-native 3307 ./custom/conf "0.0.0.0" false
+cd ./shardingsphere/
+cd ./distribution/proxy-native/target/apache-shardingsphere-5.5.1-SNAPSHOT-shardingsphere-proxy-native-bin/
+./proxy-native "3307" "./custom/conf" "0.0.0.0" "false"
 ```
 
-4. 如果需要构建 Docker Image, 在添加存在 SPI 实现的依赖或第三方依赖后, 在命令行执行如下命令。
+4. 如果需要构建 Docker Image, 在添加存在 SPI 实现的依赖或第三方依赖后, 在命令行执行如下命令，
 
 ```shell
 ./mvnw -am -pl distribution/proxy-native -T1C -Prelease.native,docker.native -DskipTests clean package
 ```
 
-- 假设存在包含`global.yaml` 的 `conf` 文件夹为 `./custom/conf`，可通过如下的 `docker-compose.yml` 文件启动 GraalVM Native
-  Image 对应的 Docker Image。
+假设存在包含 `global.yaml` 的 `conf` 文件夹为 `./custom/conf`，可通过如下的 `docker-compose.yml` 文件启动包含 GraalVM Native Image 的 Docker Image。
 
 ```yaml
-version: "3.8"
-
 services:
   apache-shardingsphere-proxy-native:
     image: apache/shardingsphere-proxy-native:latest
@@ -111,25 +140,23 @@ services:
       - "3307:3307"
 ```
 
-- 如果你不对 Git Source 做任何更改， 上文提及的命令将使用 `oraclelinux:9-slim` 作为 Base Docker Image。
-  但如果你希望使用 `busybox:glic`，`gcr.io/distroless/base` 或 `scratch` 等更小体积的 Docker Image 作为 Base Docker
-  Image，你需要根据 https://www.graalvm.org/jdk23/reference-manual/native-image/guides/build-static-executables/ 的要求，
-  做为 `pom.xml`的 `native profile` 添加 `-H:+StaticExecutableWithDynamicLibC` 的 `jvmArgs` 等操作。
-  另请注意，某些第三方依赖将需要在 `Dockerfile` 安装更多系统库，例如 `libdl`。
-  因此请确保根据你的使用情况调整 `distribution/proxy-native` 下的 `pom.xml` 和 `Dockerfile` 的内容。
+如果你不对 Git Source 做任何更改， 上文提及的命令将使用 `oraclelinux:9-slim` 作为 Base Docker Image。
+但如果你希望使用 `busybox:glic`，`gcr.io/distroless/base` 或 `scratch` 等更小体积的 Docker Image 作为 Base Docker
+Image，你需要根据 https://www.graalvm.org/jdk23/reference-manual/native-image/guides/build-static-executables/ 的要求，
+做为 `pom.xml`的 `native profile` 添加 `-H:+StaticExecutableWithDynamicLibC` 的 `jvmArgs` 等操作。
+另请注意，某些第三方依赖将需要在 `Dockerfile` 安装更多系统库，例如 `libdl`。
+因此请确保根据你的使用情况调整 `distribution/proxy-native` 下的 `pom.xml` 和 `Dockerfile` 的内容。
 
 ## 可观察性
 
-针对 GraalVM Native Image 形态的 ShardingSphere Proxy，其提供的可观察性的能力与
-[可观察性](/cn/user-manual/shardingsphere-proxy/observability) 并不一致。
+针对 GraalVM Native Image 形态的 ShardingSphere Proxy，其提供的可观察性的能力与[可观察性](/cn/user-manual/shardingsphere-proxy/observability)并不一致。
 
-你可以使用 https://www.graalvm.org/jdk23/tools/ 提供的一系列命令行工具或可视化工具观察 GraalVM Native Image 的内部行为，
-并根据其要求使用 VSCode 完成调试工作。如果你正在使用 IntelliJ IDEA 并且希望调试生成的 GraalVM Native Image，你可以关注
-https://blog.jetbrains.com/idea/2022/06/intellij-idea-2022-2-eap-5/#Experimental_GraalVM_Native_Debugger_for_Java
-及其后继。如果你使用的不是 Linux，则无法对 GraalVM Native Image 进行 Debug，请关注尚未关闭的
-https://github.com/oracle/graal/issues/5648 。
+用户可以使用 https://www.graalvm.org/jdk23/tools/ 提供的一系列命令行工具或可视化工具观察 GraalVM Native Image 的内部行为，
+并根据其要求使用 VSCode 完成调试工作。如果用户正在使用 IntelliJ IDEA 并且希望调试生成的 GraalVM Native Image，
+用户可以关注 https://blog.jetbrains.com/idea/2022/06/intellij-idea-2022-2-eap-5/#Experimental_GraalVM_Native_Debugger_for_Java 及其后继。
+如果用户使用的不是 Linux，则无法对 GraalVM Native Image 进行 Debug，请关注尚未关闭的 https://github.com/oracle/graal/issues/5648 。
 
-对于使用 `ShardingSphere Agent` 等 Java Agent 的情形， GraalVM 的 `native-image` 组件尚未完全支持在构建 Native
-Image 时使用 javaagent，你需要关注尚未关闭的 https://github.com/oracle/graal/issues/1065 。
+对于使用 `ShardingSphere Agent` 等 Java Agent 的情形， GraalVM 的 `native-image` 组件尚未完全支持在构建 Native Image 时使用 javaagent，
+用户需要关注尚未关闭的 https://github.com/oracle/graal/issues/1065 。
 
 若用户期望在 ShardingSphere Proxy Native 下使用这类 Java Agent，则需要关注 https://github.com/oracle/graal/pull/8077 涉及的变动。

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -5,19 +5,22 @@ weight = 2
 
 ## Background
 
-This section mainly introduces how to build the `Native Image` of ShardingSphere-Proxy and the
-corresponding `Docker Image` through the `native-image` component of `GraalVM`.
+This section mainly introduces it how to build the `GraalVM Native Image` of ShardingSphere Proxy through the `native-image` command line tool of `GraalVM`,
+and the `Docker Image` containing this `GraalVM Native Image`.
+
+The `GraalVM Native Image` of ShardingSphere Proxy refers to ShardingSphere Proxy Native in this article.
+
+For background information about GraalVM Native Image, please refer to https://www.graalvm.org .
 
 ## Notice
 
-- ShardingSphere Proxy is not yet ready to integrate with GraalVM Native Image. Proxy's Native Image artifacts are
-  built nightly at https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-proxy-native .
-  Assuming there is a `conf` folder containing `global.yaml` as `./custom/conf`, you can test it with the
-  following `docker-compose.yml` file.
+All Docker Images mentioned in this section are not distributed through ASF official channels such as https://downloads.apache.org and https://repository.apache.org/ .
+Docker Images are only provided on downstream channels such as `ghcr.io` for convenience.
 
-````yaml
-version: "3.8"
+Native Image products of Proxy exist in nightly builds at https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-proxy-native .
+Assuming that there is a `conf` folder containing `global.yaml` as `./custom/conf`, you can test it with the following `docker-compose.yml` file.
 
+```yaml
 services:
   apache-shardingsphere-proxy-native:
     image: ghcr.io/apache/shardingsphere-proxy-native:latest
@@ -25,89 +28,113 @@ services:
       - ./custom/conf:/opt/shardingsphere-proxy-native/conf
     ports:
       - "3307:3307"
-````
+```
 
-- This section assumes a Linux (amd64, aarch64), MacOS (amd64, aarch64/M1) or Windows (amd64) environment.
+ShardingSphere Proxy Native can execute DistSQL, which means that no YAML file that defines the logical database is actually required.
 
-- This section is still subject to the documented content of [GraalVM Native Image](/en/user-manual/shardingsphere-jdbc/graalvm-native-image) on the ShardingSphere JDBC side.
+By default, the GraalVM Native Image of ShardingSphere Proxy Native only contains,
+
+1. GraalVM Reachability Metadata maintained by ShardingSphere and some third-party dependencies
+2. JDBC Driver for H2database, OpenGauss and PostgreSQL
+3. HikariCP database connection pool
+4. Logback logging framework
+
+If the user needs to use third-party JAR in ShardingSphere Proxy Native, 
+the content of `distribution/proxy-native/pom.xml` needs to be modified to build any of the following outputs,
+
+1. Customized GraalVM Native Image
+2. Customized Docker Image containing customized GraalVM Native Image
+
+This section assumes that you are in one of the following system environments:
+
+1. Linux (amd64, aarch64)
+2. MacOS (amd64, aarch64/M1)
+3. Windows (amd64)
+
+If you are in a system environment that Graal compiler does not support, such as Linux (riscv64),
+please enable LLVM backend according to the content of https://medium.com/graalvm/graalvm-native-image-meets-risc-v-899be38eddd9 to use the LLVM compiler.
+
+This section is still limited by the documented content of the [GraalVM Native Image](/us/user-manual/shardingsphere-jdbc/graalvm-native-image) on the ShardingSphere JDBC side.
 
 ## Premise
 
-1. Install and configure `GraalVM Community Edition` or a downstream distribution of `GraalVM Community Edition` for
-JDK 23 according to https://www.graalvm.org/downloads/. If `SDKMAN!` is used,
+1. Install and configure `GraalVM Community Edition` or a downstream distribution of `GraalVM Community Edition` for JDK 22 according to https://www.graalvm.org/downloads/ .
+   If using `SDKMAN!`,
 
 ```shell
-sdk install java 23-graalce
+sdk install java 22.0.2-graalce
+sdk use java 22.0.2-graalce
 ```
 
-2. Install the local toolchain as required by https://www.graalvm.org/jdk23/reference-manual/native-image/#prerequisites.
+2. Install the native toolchain according to https://www.graalvm.org/jdk23/reference-manual/native-image/#prerequisites .
 
-3. If you need to build a Docker Image, make sure `docker-ce` is installed.
+3. If you need to build a Docker Image, make sure `Docker Engine` is installed.
 
 ## Steps
 
 1. Get Apache ShardingSphere Git Source
 
-- Get it at the [download page](https://shardingsphere.apache.org/document/current/en/downloads/)
-  or https://github.com/apache/shardingsphere/tree/master.
+Get it from [Download page](https://shardingsphere.apache.org/document/current/en/downloads/) or https://github.com/apache/shardingsphere/tree/master .
 
-2. Build the product on the command line, in two cases.
+2. Build the product in the command line, divided into two cases.
 
-- Scenario 1: No need to use JARs with SPI implementations or 3rd party dependencies
-
-- Execute the following command in the same directory of Git Source to directly complete the construction of Native
-  Image.
+Case 1: No need to use JAR with custom SPI implementation or third-party dependent JAR. Execute the following command in the same directory as Git Source to directly complete the construction of Native Image.
 
 ```bash
+cd ./shardingsphere/
 ./mvnw -am -pl distribution/proxy-native -T1C -Prelease.native -DskipTests clean package
 ```
 
-- Scenario 2: It is necessary to use a JAR that has an SPI implementation or a third-party dependent JAR of a LICENSE
-  such as GPL V2.
+Case 2: Need to use JAR with custom SPI implementation or third-party dependent JAR. Add one of the following options to the `dependencies` of `distribution/proxy-native/pom.xml`:
 
-- Add SPI implementation JARs or third-party dependent JARs to `dependencies`
-  in `distribution/proxy-native/pom.xml`. Examples are as follows
+(1) JARs with SPI implementations
+(2) JARs with third-party dependencies
+
+The examples are as follows. 
+These JARs should be pre-placed in the local Maven repository or a remote Maven repository such as Maven Central.
 
 ```xml
-
 <dependencies>
     <dependency>
         <groupId>com.mysql</groupId>
         <artifactId>mysql-connector-j</artifactId>
-        <version>8.1.0</version>
+        <version>9.0.0</version>
     </dependency>
 </dependencies>
 ```
 
-- Build GraalVM Native Image via command line.
+Then build the GraalVM Native Image through the command line.
 
 ```bash
+cd ./shardingsphere/
 ./mvnw -am -pl distribution/proxy-native -T1C -Prelease.native -DskipTests clean package
 ```
 
-3. To start Native Image through the command line, you need to bring 4 parameters. The first parameter is the `Port`
-   used by ShardingSphere Proxy, the second parameter is the `/conf` folder containing `global.yaml` written by you, the
-   third parameter is the `Address` of the bound port, and the fourth parameter is `Force Start`, if it is true, it will
-   ensure that ShardingSphere Proxy Native can start normally no matter whether it is connected or not. Assuming the
-   folder `./custom/conf` already exists, the example is
+3. To start Native Image through the command line, you need to bring 4 parameters.
+   The first parameter is the port used by ShardingSphere Proxy Native.
+   The second parameter is the folder containing the `global.yaml` configuration file written by the user.
+   The third parameter is the host to listen to. If it is `0.0.0.0`, any database client is allowed to access ShardingSphere Proxy Native.
+   The fourth parameter is Force Start. If it is `true`, it ensures that ShardingSphere Proxy Native can start normally regardless of whether it can be connected.
+
+Assuming the folder `./custom/conf` already exists, the example is.
 
 ```bash
-./apache-shardingsphere-proxy-native 3307 ./custom/conf "0.0.0.0" false
-````
+cd ./shardingsphere/
+cd ./distribution/proxy-native/target/apache-shardingsphere-5.5.1-SNAPSHOT-shardingsphere-proxy-native-bin/
+./proxy-native "3307" "./custom/conf" "0.0.0.0" "false"
+```
 
-4. If you need to build a Docker Image, execute the following command on the command line after adding dependencies that
-   exist for SPI implementation or third-party dependencies.
+4. If you need to build a Docker Image, after adding the dependencies that have SPI implementation or third-party dependencies, 
+   execute the following command in the command line:
 
 ```shell
 ./mvnw -am -pl distribution/proxy-native -T1C -Prelease.native,docker.native -DskipTests clean package
 ```
 
-- Assuming that there is a `conf` folder containing `global.yaml` as `./custom/conf`, you can start the Docker Image
-  corresponding to GraalVM Native Image through the following `docker-compose.yml` file.
+Assuming that there is a conf folder called `./custom/conf` containing `global.yaml`, 
+you can start the Docker Image containing the GraalVM Native Image using the following `docker-compose.yml` file,
 
 ```yaml
-version: "3.8"
-
 services:
   apache-shardingsphere-proxy-native:
     image: apache/shardingsphere-proxy-native:latest
@@ -117,28 +144,25 @@ services:
       - "3307:3307"
 ```
 
-- If you don't make any changes to the Git Source, the commands mentioned above will use `oraclelinux:9-slim` as the
-  Base Docker Image. But if you want to use a smaller Docker Image like `busybox:glic`, `gcr.io/distroless/base` or
-  `scratch` as the Base Docker Image, you need according
-  to https://www.graalvm.org/jdk23/reference-manual/native-image/guides/build-static-executables/,
-  add operations such as `-H:+StaticExecutableWithDynamicLibC` to `jvmArgs` as the `native profile` of `pom.xml`.
-  Also note that some 3rd-party dependencies will require more system libraries such as `libdl` to be installed in
-  the `Dockerfile`. So make sure to tune `distribution/proxy-native` according to your usage `pom.xml` and `Dockerfile`
-  below.
+If you do not make any changes to the Git Source, 
+the commands mentioned above will use `oraclelinux:9-slim` as the Base Docker Image.
+But if you want to use a smaller Docker Image such as `busybox:glic`, 
+`gcr.io/distroless/base` or `scratch` as the Base Docker Image, 
+you need to follow the requirements of https://www.graalvm.org/jdk23/reference-manual/native-image/guides/build-static-executables/ and add `-H:+StaticExecutableWithDynamicLibC` to the `jvmArgs` of the `native profile` in `pom.xml`.
+Also note that some third-party dependencies will require more system libraries to be installed in the `Dockerfile`, such as `libdl`.
+So make sure to adjust the contents of `pom.xml` and `Dockerfile` under `distribution/proxy-native` according to your usage.
 
 ## Observability
 
-ShardingSphere for GraalVM Native Image form Proxy, which provides observability capabilities
-with [Observability](/en/user-manual/shardingsphere-proxy/observability) not consistent.
+The observability provided by ShardingSphere Proxy in the form of GraalVM Native Image is not consistent with [observability](/cn/user-manual/shardingsphere-proxy/observability).
 
-You can observe GraalVM Native Image using a series of command line tools or visualization tools available
-at https://www.graalvm.org/jdk23/tools/, and use VSCode to debug it according to its requirements.
-If you are using IntelliJ IDEA and want to debug the generated GraalVM Native Image, You can follow
-https://blog.jetbrains.com/idea/2022/06/intellij-idea-2022-2-eap-5/#Experimental_GraalVM_Native_Debugger_for_Java
-and its successors. If you are not using Linux, you cannot debug GraalVM Native Image, please pay attention
-to https://github.com/oracle/graal/issues/5648 which has not been closed yet.
+Users can use a series of command-line tools or visualization tools provided by https://www.graalvm.org/jdk23/tools/ to observe the internal behavior of GraalVM Native Image,
+and use VSCode to complete debugging work according to their requirements. 
+If users are using IntelliJ IDEA and want to debug the generated GraalVM Native Image,
+users can follow https://blog.jetbrains.com/idea/2022/06/intellij-idea-2022-2-eap-5/#Experimental_GraalVM_Native_Debugger_for_Java and its successors.
+If users are not using Linux, they cannot debug GraalVM Native Image. Please follow https://github.com/oracle/graal/issues/5648 which has not been closed.
 
-For the use of Java Agents such as `ShardingSphere Agent`, GraalVM's `native-image` component does not yet fully support building Native
-when using javaagent with Image, you need to pay attention to https://github.com/oracle/graal/issues/1065 which has not yet been closed.
+For Java Agents such as `ShardingSphere Agent`, the `native-image` component of GraalVM does not fully support the use of javaagent when building Native Image.
+Users need to pay attention to https://github.com/oracle/graal/issues/1065 which has not been closed.
 
-If users expect to use this type of Java Agent under ShardingSphere Proxy Native, they need to pay attention to the changes involved in https://github.com/oracle/graal/pull/8077 .
+If users expect to use such Java Agents under ShardingSphere Proxy Native, they need to pay attention to the changes involved in https://github.com/oracle/graal/pull/8077 .

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/4.0.3/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/4.0.3/reflect-config.json
@@ -9,6 +9,11 @@
 {
   "condition":{"typeReachable":"com.zaxxer.hikari.HikariDataSource"},
   "name":"com.zaxxer.hikari.HikariDataSource",
-  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"isClosed","parameterTypes":[] }, {"name":"isRunning","parameterTypes":[] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"isClosed","parameterTypes":[] }, {"name":"isRunning","parameterTypes":[] }, {"name":"getHikariPoolMXBean","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.zaxxer.hikari.pool.HikariPool"},
+  "name":"com.zaxxer.hikari.pool.HikariPool",
+  "methods":[{"name":"getActiveConnections","parameterTypes":[] }]
 }
 ]

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.seata/seata-all/2.1.0/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.seata/seata-all/2.1.0/reflect-config.json
@@ -1,21 +1,5 @@
 [
 {
-  "condition":{"typeReachable":"org.apache.seata.rm.datasource.undo.parser.JacksonUndoLogParser"},
-  "name":"[Lcom.fasterxml.jackson.databind.deser.Deserializers;"
-},
-{
-  "condition":{"typeReachable":"org.apache.seata.rm.datasource.undo.parser.JacksonUndoLogParser"},
-  "name":"[Lcom.fasterxml.jackson.databind.ser.Serializers;"
-},
-{
-  "condition":{"typeReachable":"org.apache.seata.rm.datasource.DataSourceProxy"},
-  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
-},
-{
-  "condition":{"typeReachable":"org.apache.seata.rm.datasource.undo.AbstractUndoLogManager"},
-  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
-},
-{
   "condition":{"typeReachable":"org.apache.seata.config.ConfigurationFactory"},
   "name":"io.seata.config.ConfigurationProvider"
 },

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/proxy-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/proxy-config.json
@@ -1,10 +1,10 @@
 [
   {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
     "interfaces":["java.sql.Connection"]
   },
   {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "interfaces":["org.apache.hive.service.rpc.thrift.TCLIService$Iface"]
   },
   {

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
@@ -1,6 +1,6 @@
 [
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
   "name":"JdkLogger"
 },
 {
@@ -12,7 +12,7 @@
   "name":"[Lcom.fasterxml.jackson.databind.ser.BeanSerializerModifier;"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
   "name":"[Lcom.github.dockerjava.api.model.VolumesFrom;"
 },
 {
@@ -32,6 +32,10 @@
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.mysql.checker.MySQLDatabasePrivilegeChecker"},
+  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.opengauss.metadata.data.loader.OpenGaussMetaDataLoader"},
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
@@ -48,11 +52,27 @@
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.destroyer.DataSourcePoolDestroyer"},
+  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.SchemaMetaDataManager"},
+  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"},
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
   "name":"[Ljava.lang.String;"
 },
 {
@@ -60,13 +80,35 @@
   "name":"[Ljava.sql.Statement;"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.mysql.checker.MySQLDatabasePrivilegeChecker"},
+  "name":"[Ljava.sql.Statement;"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"},
   "name":"[Ljava.sql.Statement;"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.broadcast.rule.changed.BroadcastTableChangedProcessor"},
+  "name":"java.util.LinkedHashSet",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"java.util.Properties",
   "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.rule.changed.ShardingAlgorithmChangedProcessor"},
+  "name":"java.util.Properties",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"},
+  "name":"org.apache.shardingsphere.authority.checker.AuthoritySQLExecutionChecker"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.authority.distsql.parser.facade.AuthorityDistSQLParserFacade"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.authority.rule.AuthorityRule"},
@@ -77,12 +119,19 @@
   "name":"org.apache.shardingsphere.authority.provider.simple.AllPermittedPrivilegeProvider"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.authority.rule.builder.AuthorityRuleBuilder"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.authority.rule.builder.DefaultAuthorityRuleConfigurationBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+  "name":"org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration",
+  "allDeclaredFields":true,
+  "queryAllPublicMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setPrivilege","parameterTypes":["org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"] }, {"name":"setUsers","parameterTypes":["java.util.Collection"] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"},
@@ -95,25 +144,70 @@
   "methods":[{"name":"getAuthenticators","parameterTypes":[] }, {"name":"getDefaultAuthenticator","parameterTypes":[] }, {"name":"getPrivilege","parameterTypes":[] }, {"name":"getUsers","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration",
-  "queryAllPublicMethods":true
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfigurationBeanInfo"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfigurationCustomizer"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+  "name":"org.apache.shardingsphere.authority.yaml.config.YamlUserConfiguration",
+  "allDeclaredFields":true,
+  "queryAllPublicMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setPassword","parameterTypes":["java.lang.String"] }, {"name":"setUser","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+  "name":"org.apache.shardingsphere.authority.yaml.config.YamlUserConfigurationBeanInfo"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+  "name":"org.apache.shardingsphere.authority.yaml.config.YamlUserConfigurationCustomizer"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.broadcast.distsql.handler.update.CreateBroadcastTableRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.broadcast.distsql.handler.update.DropBroadcastTableRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLLexer",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.CharStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLParser",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.TokenStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLStatementVisitor",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.broadcast.distsql.parser.facade.BroadcastDistSQLParserFacade"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+  "name":"org.apache.shardingsphere.broadcast.metadata.nodepath.BroadcastRuleNodePathProvider"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.route.engine.impl.PartialSQLRouteExecutor"},
   "name":"org.apache.shardingsphere.broadcast.route.BroadcastSQLRouter"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.broadcast.rule.builder.BroadcastRuleBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.broadcast.rule.changed.BroadcastTableChangedProcessor"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -132,6 +226,11 @@
   "allDeclaredFields":true
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+  "name":"org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
+  "allDeclaredFields":true
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfigurationBeanInfo"
 },
@@ -140,7 +239,136 @@
   "name":"org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfigurationCustomizer"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.RegisterMigrationSourceStorageUnitExecutor"},
+  "name":"org.apache.shardingsphere.data.pipeline.cdc.api.CDCJobAPI"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.cdc.distsql.parser.facade.CDCDistSQLParserFacade"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.data.pipeline.core.listener.PipelineContextManagerLifecycleListener"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.cdc.update.DropStreamingExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.CheckMigrationJobExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.CommitMigrationExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.DropMigrationCheckExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.MigrateTableExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.RegisterMigrationSourceStorageUnitExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.RollbackMigrationExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.StartMigrationCheckExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.StartMigrationExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.StopMigrationCheckExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.StopMigrationExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.UnregisterMigrationSourceStorageUnitExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.distsql.handler.transmission.update.AlterTransmissionRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.data.pipeline.migration.distsql.parser.facade.MigrationDistSQLParserFacade"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.RegisterMigrationSourceStorageUnitExecutor"},
+  "name":"org.apache.shardingsphere.data.pipeline.scenario.migration.api.MigrationJobAPI"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.netty.ServerHandlerInitializer"},
+  "name":"org.apache.shardingsphere.db.protocol.codec.PacketCodec"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.db.protocol.constant.DatabaseProtocolServerInfo"},
+  "name":"org.apache.shardingsphere.db.protocol.mysql.constant.MySQLProtocolDefaultVersionProvider"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.mysql.MySQLFrontendEngine"},
+  "name":"org.apache.shardingsphere.db.protocol.mysql.netty.MySQLSequenceIdInboundHandler",
+  "methods":[{"name":"channelRead","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.netty.ServerHandlerInitializer"},
+  "name":"org.apache.shardingsphere.db.protocol.netty.ChannelAttrInitializer",
+  "methods":[{"name":"channelActive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.netty.ServerHandlerInitializer"},
+  "name":"org.apache.shardingsphere.db.protocol.netty.ProxyFlowControlHandler",
+  "methods":[{"name":"userEventTriggered","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.db.protocol.constant.DatabaseProtocolServerInfo"},
+  "name":"org.apache.shardingsphere.db.protocol.opengauss.constant.OpenGaussProtocolDefaultVersionProvider"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.db.protocol.constant.DatabaseProtocolServerInfo"},
+  "name":"org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLProtocolDefaultVersionProvider"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.distsql.handler.executor.rdl.resource.AlterStorageUnitExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.distsql.handler.executor.rdl.resource.UnregisterStorageUnitExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLStatementParserEngine"},
+  "name":"org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLLexer",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.CharStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLStatementParserEngine"},
+  "name":"org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLParser",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.TokenStream"] }]
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.DatabaseTypeEngine"},
+  "name":"org.apache.shardingsphere.driver.ShardingSphereDriver"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.mysql.checker.MySQLDatabasePrivilegeChecker"},
   "name":"org.apache.shardingsphere.driver.ShardingSphereDriver"
 },
 {
@@ -191,11 +419,36 @@
   "name":"org.apache.shardingsphere.encrypt.checker.config.EncryptRuleConfigurationChecker"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.encrypt.checker.sql.EncryptSupportedSQLCheckersBuilder",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.encrypt.distsql.handler.update.AlterEncryptRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.encrypt.distsql.handler.update.CreateEncryptRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.encrypt.distsql.handler.update.DropEncryptRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.encrypt.distsql.parser.facade.EncryptDistSQLParserFacade"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.merge.MergeEngine"},
   "name":"org.apache.shardingsphere.encrypt.merge.EncryptResultDecoratorEngine"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+  "name":"org.apache.shardingsphere.encrypt.metadata.nodepath.EncryptRuleNodePathProvider"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
   "name":"org.apache.shardingsphere.encrypt.metadata.reviser.EncryptMetaDataReviseEntry"
 },
 {
@@ -203,8 +456,21 @@
   "name":"org.apache.shardingsphere.encrypt.rewrite.context.EncryptSQLRewriteContextDecorator"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.encrypt.rule.builder.EncryptRuleBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.encrypt.rule.changed.EncryptTableChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.encrypt.rule.changed.EncryptorChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
+  "name":"org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration",
+  "allDeclaredFields":true
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -216,11 +482,6 @@
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"},
   "name":"org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration"
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration",
-  "allDeclaredFields":true
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -261,17 +522,17 @@
   "name":"org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnRuleConfigurationCustomizer"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
+  "name":"org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration",
+  "allDeclaredFields":true,
+  "methods":[{"name":"getColumns","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }]
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setColumns","parameterTypes":["java.util.Map"] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration",
-  "allDeclaredFields":true,
-  "methods":[{"name":"getColumns","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -282,11 +543,19 @@
   "name":"org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfigurationCustomizer"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.globalclock.distsql.parser.facade.GlobalClockDistSQLParserFacade"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager"},
+  "name":"org.apache.shardingsphere.globalclock.executor.GlobalClockTransactionHook"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.globalclock.rule.builder.DefaultGlobalClockRuleConfigurationBuilder"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.globalclock.rule.builder.GlobalClockRuleBuilder"
 },
 {
@@ -300,16 +569,16 @@
   "methods":[{"name":"getProps","parameterTypes":[] }, {"name":"getProvider","parameterTypes":[] }, {"name":"getType","parameterTypes":[] }, {"name":"isEnabled","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfiguration",
   "queryAllPublicMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationBeanInfo"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationCustomizer"
 },
 {
@@ -324,6 +593,24 @@
   "name":"org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
   "allDeclaredFields":true,
   "methods":[{"name":"getProps","parameterTypes":[] }, {"name":"getType","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+  "name":"org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
+  "allDeclaredFields":true,
+  "methods":[{"name":"getProps","parameterTypes":[] }, {"name":"getType","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.rule.changed.KeyGeneratorChangedProcessor"},
+  "name":"org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
+  "allDeclaredFields":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setType","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.rule.changed.ShardingAlgorithmChangedProcessor"},
+  "name":"org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
+  "allDeclaredFields":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setProps","parameterTypes":["java.util.Properties"] }, {"name":"setType","parameterTypes":["java.lang.String"] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -344,12 +631,22 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.distsql.handler.checker.ShardingTableRuleStatementChecker"},
+  "name":"org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.sharding.rule.ShardingRule"},
   "name":"org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sharding.checker.ShardingRuleConfigurationChecker"},
+  "name":"org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.distsql.handler.checker.ShardingTableRuleStatementChecker"},
   "name":"org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -389,12 +686,24 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.clickhouse.connector.ClickHouseConnectionPropertiesParser"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry"},
   "name":"org.apache.shardingsphere.infra.database.clickhouse.metadata.database.ClickHouseDatabaseMetaData"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.clickhouse.type.ClickHouseDatabaseType"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.h2.checker.H2DatabasePrivilegeChecker"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.h2.connector.H2ConnectionPropertiesParser"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.metadata.data.loader.MetaDataLoader"},
@@ -409,8 +718,12 @@
   "name":"org.apache.shardingsphere.infra.database.h2.metadata.database.system.H2SystemDatabase"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.h2.type.H2DatabaseType"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.hive.connector.HiveConnectionPropertiesParser"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.metadata.data.loader.MetaDataLoader"},
@@ -421,12 +734,20 @@
   "name":"org.apache.shardingsphere.infra.database.hive.metadata.database.HiveDatabaseMetaData"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.hive.type.HiveDatabaseType"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.mariadb.type.MariaDBDatabaseType"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.mysql.checker.MySQLDatabasePrivilegeChecker"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.mysql.connector.MySQLConnectionPropertiesParser"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"},
@@ -445,8 +766,16 @@
   "name":"org.apache.shardingsphere.infra.database.mysql.metadata.database.system.MySQLSystemDatabase"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.mysql.type.MySQLDatabaseType"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.opengauss.checker.OpenGaussDatabasePrivilegeChecker"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.opengauss.connector.OpenGaussConnectionPropertiesParser"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.metadata.data.loader.MetaDataLoader"},
@@ -461,8 +790,12 @@
   "name":"org.apache.shardingsphere.infra.database.opengauss.metadata.database.system.OpenGaussSystemDatabase"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.opengauss.type.OpenGaussDatabaseType"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.oracle.connector.OracleConnectionPropertiesParser"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.metadata.data.loader.MetaDataLoader"},
@@ -473,12 +806,20 @@
   "name":"org.apache.shardingsphere.infra.database.oracle.metadata.database.OracleDatabaseMetaData"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.oracle.type.OracleDatabaseType"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.p6spy.type.P6spyMySQLDatabaseType"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.postgresql.checker.PostgreSQLDatabasePrivilegeChecker"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.postgresql.connector.PostgreSQLConnectionPropertiesParser"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.metadata.data.loader.MetaDataLoader"},
@@ -493,16 +834,24 @@
   "name":"org.apache.shardingsphere.infra.database.postgresql.metadata.database.system.PostgreSQLSystemDatabase"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.postgresql.type.PostgreSQLDatabaseType"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.sql92.connector.SQL92ConnectionPropertiesParser"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry"},
   "name":"org.apache.shardingsphere.infra.database.sql92.metadata.database.SQL92DatabaseMetaData"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.sql92.type.SQL92DatabaseType"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.database.sqlserver.connector.SQLServerConnectionPropertiesParser"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.metadata.data.loader.MetaDataLoader"},
@@ -513,40 +862,48 @@
   "name":"org.apache.shardingsphere.infra.database.sqlserver.metadata.database.SQLServerDatabaseMetaData"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.sqlserver.type.SQLServerDatabaseType"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.testcontainers.type.TcClickHouseDatabaseType"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.testcontainers.type.TcMariaDBDatabaseType"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.testcontainers.type.TcMySQLDatabaseType"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.testcontainers.type.TcOracleDatabaseType"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.testcontainers.type.TcPostgreSQLDatabaseType"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.testcontainers.type.TcSQLServerDatabaseType"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
   "name":"org.apache.shardingsphere.infra.database.testcontainers.type.TcTiDBDatabaseType"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.destroyer.DataSourcePoolDestroyer"},
+  "name":"org.apache.shardingsphere.infra.datasource.pool.hikari.detector.HikariDataSourcePoolActiveDetector"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties"},
   "name":"org.apache.shardingsphere.infra.datasource.pool.hikari.metadata.HikariDataSourcePoolMetaData"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+  "name":"org.apache.shardingsphere.infra.datasource.pool.hikari.metadata.HikariDataSourcePoolPropertiesContentValidator"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.executor.sql.prepare.driver.DriverExecutionPrepareEngine"},
@@ -572,6 +929,14 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.infra.instance.metadata.jdbc.JDBCInstanceMetaDataBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.infra.instance.metadata.proxy.ProxyInstanceMetaDataBuilder"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.persist.service.ComputeNodePersistService"},
   "name":"org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeData",
   "allDeclaredFields":true,
@@ -585,6 +950,14 @@
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.persist.service.ComputeNodePersistService"},
   "name":"org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeDataCustomizer"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.infra.metadata.statistics.builder.dialect.MySQLShardingSphereStatisticsBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.infra.metadata.statistics.builder.dialect.PostgreSQLShardingSphereStatisticsBuilder"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheBuilder"},
@@ -609,17 +982,17 @@
   "queryAllPublicMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.metadata.persist.service.metadata.table.TableRowDataPersistService"},
-  "name":"org.apache.shardingsphere.infra.util.yaml.YamlConfiguration",
-  "queryAllPublicMethods":true
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.persist.ClusterMetaDataManagerPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.infra.util.yaml.YamlConfiguration",
   "queryAllPublicMethods":true
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.persist.service.ComputeNodePersistService"},
+  "name":"org.apache.shardingsphere.infra.util.yaml.YamlConfiguration",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.infra.util.yaml.YamlConfiguration",
   "queryAllPublicMethods":true
 },
@@ -654,7 +1027,12 @@
   "name":"org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlPersistRepositoryConfigurationCustomizer"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+  "name":"org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlGlobalRuleConfiguration",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlGlobalRuleConfiguration",
   "queryAllPublicMethods":true
 },
@@ -677,16 +1055,7 @@
   "condition":{"typeReachable":"org.apache.shardingsphere.metadata.persist.service.metadata.table.TableRowDataPersistService"},
   "name":"org.apache.shardingsphere.infra.yaml.data.pojo.YamlShardingSphereRowData",
   "allDeclaredFields":true,
-  "queryAllPublicMethods":true,
-  "methods":[{"name":"getRows","parameterTypes":[] }, {"name":"getUniqueKey","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.metadata.persist.service.metadata.table.TableRowDataPersistService"},
-  "name":"org.apache.shardingsphere.infra.yaml.data.pojo.YamlShardingSphereRowDataBeanInfo"
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.metadata.persist.service.metadata.table.TableRowDataPersistService"},
-  "name":"org.apache.shardingsphere.infra.yaml.data.pojo.YamlShardingSphereRowDataCustomizer"
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getRows","parameterTypes":[] }, {"name":"getUniqueKey","parameterTypes":[] }, {"name":"setRows","parameterTypes":["java.util.List"] }, {"name":"setUniqueKey","parameterTypes":["java.lang.String"] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase"},
@@ -706,6 +1075,19 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setCaseSensitive","parameterTypes":["boolean"] }, {"name":"setDataType","parameterTypes":["int"] }, {"name":"setGenerated","parameterTypes":["boolean"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setNullable","parameterTypes":["boolean"] }, {"name":"setPrimaryKey","parameterTypes":["boolean"] }, {"name":"setUnsigned","parameterTypes":["boolean"] }, {"name":"setVisible","parameterTypes":["boolean"] }]
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumnBeanInfo"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumnCustomizer"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
   "methods":[{"name":"setColumns","parameterTypes":["java.util.Collection"] }, {"name":"setUnique","parameterTypes":["boolean"] }]
@@ -721,6 +1103,19 @@
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
   "allDeclaredFields":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setUnique","parameterTypes":["boolean"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndexBeanInfo"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndexCustomizer"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase"},
@@ -740,25 +1135,29 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getColumns","parameterTypes":[] }, {"name":"getConstraints","parameterTypes":[] }, {"name":"getIndexes","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }, {"name":"getType","parameterTypes":[] }, {"name":"setColumns","parameterTypes":["java.util.Map"] }, {"name":"setIndexes","parameterTypes":["java.util.Map"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setType","parameterTypes":["org.apache.shardingsphere.infra.database.core.metadata.database.enums.TableType"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.persist.ClusterMetaDataManagerPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
   "queryAllPublicMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.persist.ClusterMetaDataManagerPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTableBeanInfo"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.persist.ClusterMetaDataManagerPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTableCustomizer"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.logging.rule.builder.DefaultLoggingRuleConfigurationBuilder"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.logging.rule.builder.LoggingRuleBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.logging.type.logback.ShardingSphereLogbackBuilder"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"},
@@ -771,16 +1170,16 @@
   "methods":[{"name":"getAppenders","parameterTypes":[] }, {"name":"getLoggers","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.logging.yaml.config.YamlLoggingRuleConfiguration",
   "queryAllPublicMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.logging.yaml.config.YamlLoggingRuleConfigurationBeanInfo"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.logging.yaml.config.YamlLoggingRuleConfigurationCustomizer"
 },
 {
@@ -868,12 +1267,45 @@
   "name":"org.apache.shardingsphere.mask.checker.MaskRuleConfigurationChecker"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.mask.distsql.handler.update.AlterMaskRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.mask.distsql.handler.update.CreateMaskRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.mask.distsql.handler.update.DropMaskRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.mask.distsql.parser.facade.MaskDistSQLParserFacade"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.merge.MergeEngine"},
   "name":"org.apache.shardingsphere.mask.merge.MaskResultDecoratorEngine"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+  "name":"org.apache.shardingsphere.mask.metadata.nodepath.MaskRuleNodePathProvider"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.mask.rule.builder.MaskRuleBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.mask.rule.changed.MaskAlgorithmChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.mask.rule.changed.MaskTableChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
+  "name":"org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfiguration",
+  "allDeclaredFields":true
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -885,11 +1317,6 @@
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"},
   "name":"org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfiguration"
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfiguration",
-  "allDeclaredFields":true
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -915,17 +1342,17 @@
   "name":"org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskColumnRuleConfigurationCustomizer"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
+  "name":"org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfiguration",
+  "allDeclaredFields":true,
+  "methods":[{"name":"getColumns","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }]
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfiguration",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setColumns","parameterTypes":["java.util.Map"] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfiguration",
-  "allDeclaredFields":true,
-  "methods":[{"name":"getColumns","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -934,6 +1361,10 @@
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfigurationCustomizer"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.eventbus.EventBusContext"},
@@ -972,7 +1403,7 @@
   "queryAllDeclaredMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.listener.DatabaseMetaDataChangedListener$$Lambda/0x00007fdb8b5dc4f0"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.listener.DatabaseMetaDataChangedListener$$Lambda/0x00007f535f9cb118"},
   "name":"org.apache.shardingsphere.mode.manager.cluster.event.subscriber.dispatch.MetaDataChangedSubscriber"
 },
 {
@@ -1015,6 +1446,10 @@
   "name":"org.apache.shardingsphere.mode.manager.cluster.yaml.ClusterYamlPersistRepositoryConfigurationSwapper"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.persist.PersistServiceFacade"},
   "name":"org.apache.shardingsphere.mode.manager.standalone.persist.StandalonePersistServiceBuilder",
   "methods":[{"name":"<init>","parameterTypes":[] }]
@@ -1022,6 +1457,58 @@
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.swapper.mode.YamlModeConfigurationSwapper"},
   "name":"org.apache.shardingsphere.mode.manager.standalone.yaml.StandaloneYamlPersistRepositoryConfigurationSwapper"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.index.AlterIndexStatementSchemaRefresher"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.index.CreateIndexStatementSchemaRefresher"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.index.DropIndexStatementSchemaRefresher"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.schema.AlterSchemaStatementSchemaRefresher"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.schema.CreateSchemaStatementSchemaRefresher"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.schema.DropSchemaStatementSchemaRefresher"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.table.AlterTableStatementSchemaRefresher"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.table.CreateTableStatementSchemaRefresher"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.table.DropTableStatementSchemaRefresher"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.table.RenameTableStatementSchemaRefresher"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.view.AlterViewStatementSchemaRefresher"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.view.CreateViewStatementSchemaRefresher"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+  "name":"org.apache.shardingsphere.mode.metadata.refresher.type.view.DropViewStatementSchemaRefresher"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
@@ -1053,17 +1540,25 @@
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.standalone.jdbc.sql.JDBCRepositorySQLLoader"},
   "name":"org.apache.shardingsphere.mode.repository.standalone.jdbc.sql.JDBCRepositorySQL",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true,
-  "queryAllDeclaredConstructors":true,
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.mode.repository.standalone.jdbc.sql.JDBCRepositorySQL",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.parser.distsql.parser.facade.SQLParserDistSQLParserFacade"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.parser.rule.builder.DefaultSQLParserRuleConfigurationBuilder"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.parser.rule.builder.SQLParserRuleBuilder"
 },
 {
@@ -1089,17 +1584,154 @@
   "methods":[{"name":"getParseTreeCache","parameterTypes":[] }, {"name":"getSqlStatementCache","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration",
   "queryAllPublicMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationBeanInfo"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationCustomizer"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfiguration",
+  "allDeclaredFields":true,
+  "queryAllPublicMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setAuthority","parameterTypes":["org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"] }, {"name":"setMode","parameterTypes":["org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfiguration"] }, {"name":"setProps","parameterTypes":["java.util.Properties"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfigurationBeanInfo"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfigurationCustomizer"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"},
+  "name":"org.apache.shardingsphere.proxy.backend.handler.checker.AuditSQLExecutionChecker"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.ImportDatabaseConfigurationExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.ImportMetaDataExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.LabelComputeNodeExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.LockClusterExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.RefreshDatabaseMetaDataExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.RefreshTableMetaDataExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.SetComputeNodeStateExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.SetDistVariableExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.UnlabelComputeNodeExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.UnlockClusterExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.jdbc.statement.JDBCBackendStatement"},
+  "name":"org.apache.shardingsphere.proxy.backend.mysql.connector.jdbc.statement.MySQLStatementMemoryStrictlyFetchSizeSetter"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.admin.DatabaseAdminBackendHandlerFactory"},
+  "name":"org.apache.shardingsphere.proxy.backend.mysql.handler.admin.MySQLAdminExecutorCreator"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetSetExecutor"},
+  "name":"org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.charset.MySQLSetCharsetExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.session.SessionVariableRecordExecutor"},
+  "name":"org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.session.MySQLReplayedSessionVariableProvider"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilderEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.mysql.response.header.query.MySQLQueryHeaderBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.jdbc.statement.JDBCBackendStatement"},
+  "name":"org.apache.shardingsphere.proxy.backend.opengauss.connector.jdbc.statement.OpenGaussStatementMemoryStrictlyFetchSizeSetter"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.admin.DatabaseAdminBackendHandlerFactory"},
+  "name":"org.apache.shardingsphere.proxy.backend.opengauss.handler.admin.OpenGaussAdminExecutorCreator"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilderEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.opengauss.response.header.query.OpenGaussQueryHeaderBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.jdbc.statement.JDBCBackendStatement"},
+  "name":"org.apache.shardingsphere.proxy.backend.postgresql.connector.jdbc.statement.PostgreSQLStatementMemoryStrictlyFetchSizeSetter"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.admin.DatabaseAdminBackendHandlerFactory"},
+  "name":"org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.PostgreSQLAdminExecutorCreator"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetSetExecutor"},
+  "name":"org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.executor.variable.charset.PostgreSQLSetCharsetExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilderEngine"},
+  "name":"org.apache.shardingsphere.proxy.backend.postgresql.response.header.query.PostgreSQLQueryHeaderBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.netty.ServerHandlerInitializer"},
+  "name":"org.apache.shardingsphere.proxy.frontend.mysql.MySQLFrontendEngine",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.authentication.AuthenticatorFactory"},
+  "name":"org.apache.shardingsphere.proxy.frontend.mysql.authentication.authenticator.impl.MySQLNativePasswordAuthenticator",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.netty.ServerHandlerInitializer"},
+  "name":"org.apache.shardingsphere.proxy.frontend.netty.FrontendChannelInboundHandler",
+  "methods":[{"name":"channelActive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] }, {"name":"channelInactive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] }, {"name":"channelRead","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object"] }, {"name":"channelWritabilityChanged","parameterTypes":["io.netty.channel.ChannelHandlerContext"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.netty.ServerHandlerInitializer"},
+  "name":"org.apache.shardingsphere.proxy.frontend.netty.FrontendChannelLimitationInboundHandler",
+  "methods":[{"name":"channelActive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] }, {"name":"channelInactive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.netty.ServerHandlerInitializer"},
+  "name":"org.apache.shardingsphere.proxy.frontend.opengauss.OpenGaussFrontendEngine",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.netty.ServerHandlerInitializer"},
+  "name":"org.apache.shardingsphere.proxy.frontend.postgresql.PostgreSQLFrontendEngine",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.spi.type.ordered.OrderedSPILoader"},
@@ -1110,6 +1742,30 @@
   "name":"org.apache.shardingsphere.readwritesplitting.datanode.ReadwriteSplittingDataNodeBuilder"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.readwritesplitting.distsql.handler.update.AlterReadwriteSplittingRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.readwritesplitting.distsql.handler.update.AlterReadwriteSplittingStorageUnitStatusExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.readwritesplitting.distsql.handler.update.CreateReadwriteSplittingRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.readwritesplitting.distsql.handler.update.DropReadwriteSplittingRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.readwritesplitting.distsql.parser.facade.ReadwriteSplittingDistSQLParserFacade"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+  "name":"org.apache.shardingsphere.readwritesplitting.metadata.nodepath.ReadwriteSplittingRuleNodePathProvider"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.route.engine.impl.PartialSQLRouteExecutor"},
   "name":"org.apache.shardingsphere.readwritesplitting.route.ReadwriteSplittingSQLRouter"
 },
@@ -1118,8 +1774,21 @@
   "name":"org.apache.shardingsphere.readwritesplitting.route.standard.filter.DisabledReadDataSourcesFilter"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.readwritesplitting.rule.builder.ReadwriteSplittingRuleBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.readwritesplitting.rule.changed.ReadwriteSplittingDataSourceChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.readwritesplitting.rule.changed.ReadwriteSplittingLoadBalancerChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
+  "name":"org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfiguration",
+  "allDeclaredFields":true
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -1133,17 +1802,18 @@
   "name":"org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfiguration"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfiguration",
-  "allDeclaredFields":true
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfigurationBeanInfo"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfigurationCustomizer"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
+  "name":"org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfiguration",
+  "allDeclaredFields":true,
+  "methods":[{"name":"getLoadBalancerName","parameterTypes":[] }, {"name":"getReadDataSourceNames","parameterTypes":[] }, {"name":"getTransactionalReadQueryStrategy","parameterTypes":[] }, {"name":"getWriteDataSourceName","parameterTypes":[] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -1153,18 +1823,16 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setReadDataSourceNames","parameterTypes":["java.util.List"] }, {"name":"setWriteDataSourceName","parameterTypes":["java.lang.String"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfiguration",
-  "allDeclaredFields":true,
-  "methods":[{"name":"getLoadBalancerName","parameterTypes":[] }, {"name":"getReadDataSourceNames","parameterTypes":[] }, {"name":"getTransactionalReadQueryStrategy","parameterTypes":[] }, {"name":"getWriteDataSourceName","parameterTypes":[] }]
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfigurationBeanInfo"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfigurationCustomizer"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+  "name":"org.apache.shardingsphere.schedule.core.job.statistics.collect.StatisticsCollectContextManagerLifecycleListener"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.shadow.checker.ShadowRuleConfigurationChecker"},
@@ -1205,12 +1873,69 @@
   "name":"org.apache.shardingsphere.shadow.datanode.ShadowDataNodeBuilder"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.shadow.distsql.handler.update.AlterDefaultShadowAlgorithmExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.shadow.distsql.handler.update.AlterShadowRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.shadow.distsql.handler.update.CreateDefaultShadowAlgorithmExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.shadow.distsql.handler.update.CreateShadowRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.shadow.distsql.handler.update.DropDefaultShadowAlgorithmExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.shadow.distsql.handler.update.DropShadowAlgorithmExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.shadow.distsql.handler.update.DropShadowRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.shadow.distsql.parser.facade.ShadowDistSQLParserFacade"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+  "name":"org.apache.shardingsphere.shadow.metadata.nodepath.ShadowRuleNodePathProvider"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.route.engine.impl.PartialSQLRouteExecutor"},
   "name":"org.apache.shardingsphere.shadow.route.ShadowSQLRouter"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.shadow.rule.builder.ShadowRuleBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.shadow.rule.changed.DefaultShadowAlgorithmNameChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.shadow.rule.changed.ShadowAlgorithmChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.shadow.rule.changed.ShadowDataSourceChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.shadow.rule.changed.ShadowTableChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
+  "name":"org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfiguration",
+  "allDeclaredFields":true
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -1224,11 +1949,6 @@
   "name":"org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfiguration"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfiguration",
-  "allDeclaredFields":true
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfigurationBeanInfo"
 },
@@ -1237,17 +1957,17 @@
   "name":"org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfigurationCustomizer"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
+  "name":"org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfiguration",
+  "allDeclaredFields":true,
+  "methods":[{"name":"getProductionDataSourceName","parameterTypes":[] }, {"name":"getShadowDataSourceName","parameterTypes":[] }]
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfiguration",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setProductionDataSourceName","parameterTypes":["java.lang.String"] }, {"name":"setShadowDataSourceName","parameterTypes":["java.lang.String"] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfiguration",
-  "allDeclaredFields":true,
-  "methods":[{"name":"getProductionDataSourceName","parameterTypes":[] }, {"name":"getShadowDataSourceName","parameterTypes":[] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -1258,17 +1978,17 @@
   "name":"org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfigurationCustomizer"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
+  "name":"org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfiguration",
+  "allDeclaredFields":true,
+  "methods":[{"name":"getDataSourceNames","parameterTypes":[] }, {"name":"getShadowAlgorithmNames","parameterTypes":[] }]
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfiguration",
   "allDeclaredFields":true,
   "queryAllPublicMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setDataSourceNames","parameterTypes":["java.util.Collection"] }, {"name":"setShadowAlgorithmNames","parameterTypes":["java.util.Collection"] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfiguration",
-  "allDeclaredFields":true,
-  "methods":[{"name":"getDataSourceNames","parameterTypes":[] }, {"name":"getShadowAlgorithmNames","parameterTypes":[] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -1396,11 +2116,82 @@
   "name":"org.apache.shardingsphere.sharding.decider.ShardingSQLFederationDecider"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.handler.update.AlterDefaultShardingStrategyExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.handler.update.AlterShardingTableReferenceRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.handler.update.AlterShardingTableRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.handler.update.CreateDefaultShardingStrategyExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.handler.update.CreateShardingTableReferenceRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.handler.update.CreateShardingTableRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.handler.update.DropDefaultShardingStrategyExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.handler.update.DropShardingAlgorithmExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.handler.update.DropShardingAuditorExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.handler.update.DropShardingKeyGeneratorExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.handler.update.DropShardingTableReferenceExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.handler.update.DropShardingTableRuleExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLLexer",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.CharStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLParser",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.TokenStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLStatementVisitor",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.sharding.distsql.parser.facade.ShardingDistSQLParserFacade"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.merge.MergeEngine"},
   "name":"org.apache.shardingsphere.sharding.merge.ShardingResultMergerEngine"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+  "name":"org.apache.shardingsphere.sharding.metadata.nodepath.ShardingRuleNodePathProvider"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
   "name":"org.apache.shardingsphere.sharding.metadata.reviser.ShardingMetaDataReviseEntry"
 },
 {
@@ -1412,8 +2203,56 @@
   "name":"org.apache.shardingsphere.sharding.route.engine.ShardingSQLRouter"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.sharding.rule.builder.ShardingRuleBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.sharding.rule.changed.DefaultDatabaseShardingStrategyChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.sharding.rule.changed.DefaultKeyGenerateStrategyChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.sharding.rule.changed.DefaultShardingAuditorStrategyChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.sharding.rule.changed.DefaultShardingColumnChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.sharding.rule.changed.DefaultTableShardingStrategyChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.sharding.rule.changed.KeyGeneratorChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.sharding.rule.changed.ShardingAlgorithmChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.sharding.rule.changed.ShardingAuditorChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.sharding.rule.changed.ShardingAutoTableChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.sharding.rule.changed.ShardingCacheChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.sharding.rule.changed.ShardingTableChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.sharding.rule.changed.ShardingTableReferenceChangedProcessor"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
@@ -1432,6 +2271,11 @@
   "allDeclaredFields":true
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+  "name":"org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
+  "allDeclaredFields":true
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfigurationBeanInfo"
 },
@@ -1443,7 +2287,6 @@
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
   "allDeclaredFields":true,
-  "queryAllPublicMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setActualDataNodes","parameterTypes":["java.lang.String"] }, {"name":"setKeyGenerateStrategy","parameterTypes":["org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"] }]
 },
 {
@@ -1453,38 +2296,42 @@
   "methods":[{"name":"getActualDataNodes","parameterTypes":[] }, {"name":"getAuditStrategy","parameterTypes":[] }, {"name":"getDatabaseStrategy","parameterTypes":[] }, {"name":"getKeyGenerateStrategy","parameterTypes":[] }, {"name":"getLogicTable","parameterTypes":[] }, {"name":"getTableStrategy","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+  "name":"org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
+  "allDeclaredFields":true,
+  "queryAllPublicMethods":true,
+  "methods":[{"name":"getActualDataNodes","parameterTypes":[] }, {"name":"getAuditStrategy","parameterTypes":[] }, {"name":"getDatabaseStrategy","parameterTypes":[] }, {"name":"getKeyGenerateStrategy","parameterTypes":[] }, {"name":"getLogicTable","parameterTypes":[] }, {"name":"getTableStrategy","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.rule.changed.ShardingTableChangedProcessor"},
+  "name":"org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
+  "allDeclaredFields":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setActualDataNodes","parameterTypes":["java.lang.String"] }, {"name":"setKeyGenerateStrategy","parameterTypes":["org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"] }, {"name":"setLogicTable","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigurationBeanInfo"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigurationCustomizer"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration",
   "allDeclaredFields":true,
-  "queryAllPublicMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setColumn","parameterTypes":["java.lang.String"] }, {"name":"setKeyGeneratorName","parameterTypes":["java.lang.String"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
-  "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfigurationBeanInfo"
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
-  "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfigurationCustomizer"
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
-  "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlBaseShardingStrategyConfiguration",
-  "queryAllPublicMethods":true
+  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.rule.changed.ShardingTableChangedProcessor"},
+  "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration",
+  "allDeclaredFields":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setColumn","parameterTypes":["java.lang.String"] }, {"name":"setKeyGeneratorName","parameterTypes":["java.lang.String"] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
   "allDeclaredFields":true,
-  "queryAllPublicMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setStandard","parameterTypes":["org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"] }]
 },
 {
@@ -1494,38 +2341,72 @@
   "methods":[{"name":"getComplex","parameterTypes":[] }, {"name":"getHint","parameterTypes":[] }, {"name":"getNone","parameterTypes":[] }, {"name":"getStandard","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+  "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
+  "allDeclaredFields":true,
+  "queryAllPublicMethods":true,
+  "methods":[{"name":"getComplex","parameterTypes":[] }, {"name":"getHint","parameterTypes":[] }, {"name":"getNone","parameterTypes":[] }, {"name":"getStandard","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.rule.changed.DefaultDatabaseShardingStrategyChangedProcessor"},
+  "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
+  "allDeclaredFields":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setStandard","parameterTypes":["org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfigurationBeanInfo"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfigurationCustomizer"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration",
   "allDeclaredFields":true,
-  "queryAllPublicMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setShardingAlgorithmName","parameterTypes":["java.lang.String"] }, {"name":"setShardingColumn","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.sharding.rule.changed.DefaultDatabaseShardingStrategyChangedProcessor"},
+  "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration",
+  "allDeclaredFields":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setShardingAlgorithmName","parameterTypes":["java.lang.String"] }, {"name":"setShardingColumn","parameterTypes":["java.lang.String"] }]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
-  "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfigurationBeanInfo"
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
-  "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfigurationCustomizer"
+  "name":"org.apache.shardingsphere.sharding.yaml.engine.construct.NoneShardingStrategyConfigurationYamlConstruct"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.engine.SQLFederationEngine"},
   "name":"org.apache.shardingsphere.single.decider.SingleSQLFederationDecider"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.metadata.persist.MetaDataPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"},
   "name":"org.apache.shardingsphere.single.decorator.SingleRuleConfigurationDecorator"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.single.distsql.handler.update.LoadSingleTableExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.single.distsql.handler.update.SetDefaultSingleTableStorageUnitExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+  "name":"org.apache.shardingsphere.single.distsql.handler.update.UnloadSingleTableExecutor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.single.distsql.parser.facade.SingleDistSQLParserFacade"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+  "name":"org.apache.shardingsphere.single.metadata.nodepath.SingleRuleNodePathProvider"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
   "name":"org.apache.shardingsphere.single.metadata.reviser.SingleMetaDataReviseEntry"
 },
 {
@@ -1537,15 +2418,28 @@
   "name":"org.apache.shardingsphere.single.rule.builder.DefaultSingleRuleConfigurationBuilder"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.single.rule.builder.SingleRuleBuilder"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.single.rule.changed.DefaultDataSourceChangedProcessor"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+  "name":"org.apache.shardingsphere.single.rule.changed.SingleTableChangedProcessor"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"},
   "name":"org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.tuple.RepositoryTupleSwapperEngine"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.metadata.persist.MetaDataPersistService"},
+  "name":"org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration",
+  "allDeclaredFields":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration",
   "allDeclaredFields":true
 },
@@ -1558,6 +2452,10 @@
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"},
   "name":"org.apache.shardingsphere.sql.parser.clickhouse.parser.ClickHouseParser",
   "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.TokenStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
+  "name":"org.apache.shardingsphere.sql.parser.clickhouse.parser.ClickHouseParserFacade"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
@@ -1574,19 +2472,27 @@
   "name":"org.apache.shardingsphere.sql.parser.core.database.cache.ParseTreeCacheLoader"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
+  "name":"org.apache.shardingsphere.sql.parser.hive.parser.HiveParserFacade"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
   "name":"org.apache.shardingsphere.sql.parser.hive.visitor.statement.HiveStatementVisitorFacade",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.SQLParserFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.parser.SQLParserExecutor"},
   "name":"org.apache.shardingsphere.sql.parser.mysql.parser.MySQLLexer",
   "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.CharStream"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.SQLParserFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.parser.SQLParserExecutor"},
   "name":"org.apache.shardingsphere.sql.parser.mysql.parser.MySQLParser",
   "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.TokenStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
+  "name":"org.apache.shardingsphere.sql.parser.mysql.parser.MySQLParserFacade"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
@@ -1594,7 +2500,17 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
+  "name":"org.apache.shardingsphere.sql.parser.mysql.visitor.statement.type.MySQLDALStatementVisitor",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
+  "name":"org.apache.shardingsphere.sql.parser.mysql.visitor.statement.type.MySQLDDLStatementVisitor",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
   "name":"org.apache.shardingsphere.sql.parser.mysql.visitor.statement.type.MySQLDDLStatementVisitor",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -1604,14 +2520,33 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.SQLParserFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
+  "name":"org.apache.shardingsphere.sql.parser.mysql.visitor.statement.type.MySQLTCLStatementVisitor",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
   "name":"org.apache.shardingsphere.sql.parser.opengauss.parser.OpenGaussLexer",
   "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.CharStream"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.SQLParserFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"},
+  "name":"org.apache.shardingsphere.sql.parser.opengauss.parser.OpenGaussLexer",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.CharStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
   "name":"org.apache.shardingsphere.sql.parser.opengauss.parser.OpenGaussParser",
   "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.TokenStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"},
+  "name":"org.apache.shardingsphere.sql.parser.opengauss.parser.OpenGaussParser",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.TokenStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
+  "name":"org.apache.shardingsphere.sql.parser.opengauss.parser.OpenGaussParserFacade"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
@@ -1624,9 +2559,18 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
   "name":"org.apache.shardingsphere.sql.parser.opengauss.visitor.statement.type.OpenGaussDMLStatementVisitor",
   "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"},
+  "name":"org.apache.shardingsphere.sql.parser.opengauss.visitor.statement.type.OpenGaussDMLStatementVisitor",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
+  "name":"org.apache.shardingsphere.sql.parser.oracle.parser.OracleParserFacade"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
@@ -1634,14 +2578,28 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.SQLParserFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
   "name":"org.apache.shardingsphere.sql.parser.postgresql.parser.PostgreSQLLexer",
   "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.CharStream"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.SQLParserFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"},
+  "name":"org.apache.shardingsphere.sql.parser.postgresql.parser.PostgreSQLLexer",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.CharStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
   "name":"org.apache.shardingsphere.sql.parser.postgresql.parser.PostgreSQLParser",
   "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.TokenStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"},
+  "name":"org.apache.shardingsphere.sql.parser.postgresql.parser.PostgreSQLParser",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.TokenStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
+  "name":"org.apache.shardingsphere.sql.parser.postgresql.parser.PostgreSQLParserFacade"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
@@ -1654,9 +2612,18 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
   "name":"org.apache.shardingsphere.sql.parser.postgresql.visitor.statement.type.PostgreSQLDMLStatementVisitor",
   "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"},
+  "name":"org.apache.shardingsphere.sql.parser.postgresql.visitor.statement.type.PostgreSQLDMLStatementVisitor",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
+  "name":"org.apache.shardingsphere.sql.parser.sql92.parser.SQL92ParserFacade"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
@@ -1664,14 +2631,28 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.SQLParserFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
   "name":"org.apache.shardingsphere.sql.parser.sqlserver.parser.SQLServerLexer",
   "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.CharStream"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.SQLParserFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"},
+  "name":"org.apache.shardingsphere.sql.parser.sqlserver.parser.SQLServerLexer",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.CharStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
   "name":"org.apache.shardingsphere.sql.parser.sqlserver.parser.SQLServerParser",
   "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.TokenStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"},
+  "name":"org.apache.shardingsphere.sql.parser.sqlserver.parser.SQLServerParser",
+  "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.TokenStream"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
+  "name":"org.apache.shardingsphere.sql.parser.sqlserver.parser.SQLServerParserFacade"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
@@ -1684,13 +2665,13 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.core.database.visitor.SQLStatementVisitorFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
   "name":"org.apache.shardingsphere.sql.parser.sqlserver.visitor.statement.type.SQLServerDMLStatementVisitor",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.DeleteStatementBinder"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.clickhouse.dml.ClickHouseDeleteStatement",
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"},
+  "name":"org.apache.shardingsphere.sql.parser.sqlserver.visitor.statement.type.SQLServerDMLStatementVisitor",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -1701,11 +2682,6 @@
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"},
   "name":"org.apache.shardingsphere.sql.parser.statement.clickhouse.dml.ClickHouseSelectStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.DeleteStatementBinder"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.hive.dml.HiveDeleteStatement",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -1729,49 +2705,53 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.DeleteStatementBinder"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.opengauss.dml.OpenGaussDeleteStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.InsertStatementBinder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"},
   "name":"org.apache.shardingsphere.sql.parser.statement.opengauss.dml.OpenGaussInsertStatement",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.SelectStatementBinder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"},
   "name":"org.apache.shardingsphere.sql.parser.statement.opengauss.dml.OpenGaussSelectStatement",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.DeleteStatementBinder"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.postgresql.dml.PostgreSQLDeleteStatement",
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
+  "name":"org.apache.shardingsphere.sql.parser.statement.opengauss.dml.OpenGaussSelectStatement",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.InsertStatementBinder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"},
   "name":"org.apache.shardingsphere.sql.parser.statement.postgresql.dml.PostgreSQLInsertStatement",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.SelectStatementBinder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"},
   "name":"org.apache.shardingsphere.sql.parser.statement.postgresql.dml.PostgreSQLSelectStatement",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.DeleteStatementBinder"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.sqlserver.dml.SQLServerDeleteStatement",
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
+  "name":"org.apache.shardingsphere.sql.parser.statement.postgresql.dml.PostgreSQLSelectStatement",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.InsertStatementBinder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"},
   "name":"org.apache.shardingsphere.sql.parser.statement.sqlserver.dml.SQLServerInsertStatement",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.SelectStatementBinder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"},
   "name":"org.apache.shardingsphere.sql.parser.statement.sqlserver.dml.SQLServerSelectStatement",
   "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
+  "name":"org.apache.shardingsphere.sql.parser.statement.sqlserver.dml.SQLServerSelectStatement",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.sqlfederation.distsql.parser.facade.SQLFederationDistSQLParserFacade"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.optimizer.context.parser.dialect.OptimizerSQLPropertiesBuilder"},
@@ -1802,11 +2782,11 @@
   "name":"org.apache.shardingsphere.sqlfederation.optimizer.context.parser.dialect.impl.SQLServerOptimizerBuilder"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.sqlfederation.rule.builder.DefaultSQLFederationRuleConfigurationBuilder"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.sqlfederation.rule.builder.SQLFederationRuleBuilder"
 },
 {
@@ -1820,28 +2800,32 @@
   "methods":[{"name":"getExecutionPlanCache","parameterTypes":[] }, {"name":"isAllQueryUseSQLFederation","parameterTypes":[] }, {"name":"isSqlFederationEnabled","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration",
   "queryAllPublicMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationBeanInfo"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationCustomizer"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.sqltranslator.distsql.parser.facade.SQLTranslatorDistSQLParserFacade"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sqltranslator.rule.SQLTranslatorRule"},
   "name":"org.apache.shardingsphere.sqltranslator.natived.NativeSQLTranslator"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.sqltranslator.rule.builder.DefaultSQLTranslatorRuleConfigurationBuilder"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.sqltranslator.rule.builder.SQLTranslatorRuleBuilder"
 },
 {
@@ -1855,24 +2839,24 @@
   "methods":[{"name":"getProps","parameterTypes":[] }, {"name":"getType","parameterTypes":[] }, {"name":"isUseOriginalSQLWhenTranslatingFailed","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfiguration",
   "queryAllPublicMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationBeanInfo"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationCustomizer"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.timeservice.core.rule.builder.DefaultTimestampServiceConfigurationBuilder"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.timeservice.core.rule.builder.TimestampServiceRuleBuilder"
 },
 {
@@ -1891,11 +2875,15 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+  "name":"org.apache.shardingsphere.transaction.distsql.parser.facade.TransactionDistSQLParserFacade"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.transaction.rule.builder.DefaultTransactionRuleConfigurationBuilder"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.transaction.rule.builder.TransactionRuleBuilder"
 },
 {
@@ -1930,16 +2918,16 @@
   "methods":[{"name":"getDefaultType","parameterTypes":[] }, {"name":"getProps","parameterTypes":[] }, {"name":"getProviderType","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration",
   "queryAllPublicMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationBeanInfo"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
   "name":"org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationCustomizer"
 }
 ]

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/resource-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/resource-config.json
@@ -13,7 +13,7 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"},
     "pattern":"\\QMETA-INF/maven/com.atomikos/atomikos-util/pom.properties\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.cluster.etcd.EtcdRepository"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"},
     "pattern":"\\QMETA-INF/native/libnetty_transport_native_epoll_x86_64.so\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"},
@@ -76,16 +76,16 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"},
     "pattern":"\\QMETA-INF/services/com.atomikos.recovery.OltpLogFactory\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\QMETA-INF/services/com.clickhouse.client.ClickHouseClient\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\QMETA-INF/services/com.clickhouse.client.ClickHouseRequestManager\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\QMETA-INF/services/com.clickhouse.data.ClickHouseDataStreamFactory\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\QMETA-INF/services/com.clickhouse.jdbc.JdbcTypeMapping\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.cluster.etcd.EtcdRepository"},
@@ -115,10 +115,13 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.cluster.etcd.EtcdRepository"},
     "pattern":"\\QMETA-INF/services/io.vertx.core.spi.VertxServiceProvider\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.db.protocol.mysql.constant.MySQLCharacterSet"},
+    "pattern":"\\QMETA-INF/services/java.nio.charset.spi.CharsetProvider\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
     "pattern":"\\QMETA-INF/services/java.time.zone.ZoneRulesProvider\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\QMETA-INF/services/javax.xml.datatype.DatatypeFactory\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.standalone.jdbc.sql.JDBCRepositorySQLLoader"},
@@ -163,14 +166,47 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.authority.rule.AuthorityRule"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.authority.spi.PrivilegeProvider\\E"
   }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.data.pipeline.distsql.handler.migration.update.RegisterMigrationSourceStorageUnitExecutor"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.data.pipeline.core.job.api.TransmissionJobAPI\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.db.protocol.constant.DatabaseProtocolServerInfo"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.db.protocol.constant.DatabaseProtocolDefaultVersionProvider\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.distsql.handler.engine.update.AdvancedDistSQLUpdateExecutor\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecutor\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.database.DatabaseRuleDefinitionExecutor\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.distsql.parser.engine.spi.DistSQLParserFacade\\E"
+  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.driver.executor.engine.facade.DriverExecutorFacadeFactory\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.algorithm.keygen.core.KeyGenerateAlgorithm\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ColumnProjection"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.binder.context.segment.select.projection.extractor.DialectProjectionIdentifierExtractor\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.checker.SupportedSQLCheckersBuilder\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.spi.type.ordered.OrderedSPILoader"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.config.rule.checker.RuleConfigurationChecker\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.persist.MetaDataPersistService"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.config.rule.decorator.RuleConfigurationDecorator\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.database.core.checker.DialectDatabasePrivilegeChecker\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.database.core.connector.ConnectionPropertiesParser\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.database.core.keygen.GeneratedKeyColumnProvider\\E"
@@ -184,17 +220,26 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.metadata.database.system.SystemDatabase"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.database.core.metadata.database.system.DialectSystemDatabase\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.core.type.DatabaseTypeFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.infra.props.TypedPropertyValue"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.database.core.type.DatabaseType\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.datanode.DataNodes"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.datanode.DataNodeBuilder\\E"
   }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.destroyer.DataSourcePoolDestroyer"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.datasource.pool.destroyer.DataSourcePoolActiveDetector\\E"
+  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.datasource.pool.metadata.DataSourcePoolMetaData\\E"
   }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesContentValidator\\E"
+  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.executor.audit.SQLAuditEngine"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.executor.audit.SQLAuditor\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.executor.checker.SQLExecutionChecker\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.executor.kernel.ExecutorEngine"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.executor.sql.hook.SQLExecutionHook\\E"
@@ -205,11 +250,20 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.executor.sql.prepare.driver.DriverExecutionPrepareEngine"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.executor.sql.prepare.driver.SQLExecutionUnitBuilder\\E"
   }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.sharding.distsql.handler.checker.ShardingTableRuleStatementChecker"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.expr.spi.InlineExpressionParser\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.instance.metadata.InstanceMetaDataBuilder\\E"
+  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.merge.MergeEngine"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.merge.engine.ResultProcessEngine\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.metadata.database.schema.reviser.MetaDataReviseEntry\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.metadata.statistics.builder.ShardingSphereStatisticsBuilder\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.rewrite.SQLRewriteEntry"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.rewrite.context.SQLRewriteContextDecorator\\E"
@@ -217,35 +271,89 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.route.engine.impl.PartialSQLRouteExecutor"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.route.SQLRouter\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.rule.builder.database.DatabaseRuleBuilder\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.rule.builder.database.DefaultDatabaseRuleConfigurationBuilder\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.rule.builder.global.DefaultGlobalRuleConfigurationBuilder\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.rule.builder.global.GlobalRuleBuilder\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.url.core.ShardingSphereURLLoadEngine"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.url.spi.ShardingSphereURLLoader\\E"
   }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.util.yaml.constructor.ShardingSphereYamlConstruct\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.yaml.YamlEngine"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.util.yaml.shortcuts.ShardingSphereYamlShortcuts\\E"
+  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.config.swapper.mode.YamlModeConfigurationSwapper"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.yaml.config.swapper.mode.YamlPersistRepositoryConfigurationSwapper\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.logging.rule.builder.DefaultLoggingRuleConfigurationBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.logging.spi.ShardingSphereLogBuilder\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.manager.ContextManagerBuilder\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.manager.listener.ContextManagerLifecycleListener\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.metadata.refresher.MetaDataRefresher\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.persist.service.PersistServiceBuilder\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.cluster.lock.holder.DistributedLockHolder"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.repository.cluster.lock.creator.DistributedLockCreator\\E"
   }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.repository.standalone.StandalonePersistRepository\\E"
+  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.decorator.RuleConfigurationPersistDecorateEngine"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.spi.RuleConfigurationPersistDecorator\\E"
   }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.RuleItemManager"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.spi.RuleItemConfigurationChangedProcessor\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.StandaloneMetaDataManagerPersistService"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.spi.RuleNodePathProvider\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.DatabaseConnector"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.proxy.backend.connector.AdvancedProxySQLExecutor\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.jdbc.statement.JDBCBackendStatement"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.proxy.backend.connector.jdbc.statement.StatementMemoryStrictlyFetchSizeSetter\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.admin.DatabaseAdminBackendHandlerFactory"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.proxy.backend.handler.admin.executor.DatabaseAdminExecutorCreator\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetSetExecutor"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetVariableProvider\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.session.SessionVariableRecordExecutor"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.session.ReplayedSessionVariableProvider\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilderEngine"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilder\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.netty.ServerHandlerInitializer"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngine\\E"
+  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.readwritesplitting.route.standard.StandardReadwriteSplittingDataSourceRouter"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.readwritesplitting.route.standard.filter.ReadDataSourcesFilter\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.sql.parser.spi.DialectSQLParserFacade\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.sql.parser.spi.SQLStatementVisitorFacade\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.optimizer.context.parser.dialect.OptimizerSQLPropertiesBuilder"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.sqlfederation.optimizer.context.parser.dialect.OptimizerSQLDialectBuilder\\E"
@@ -256,13 +364,19 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.sqltranslator.rule.SQLTranslatorRule"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.sqltranslator.spi.SQLTranslator\\E"
   }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.timeservice.spi.TimestampService\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.transaction.spi.TransactionHook\\E"
+  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"},
     "pattern":"\\QMETA-INF/services/org.codehaus.groovy.runtime.ExtensionModule\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\QMETA-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\QMETA-INF/services/org.testcontainers.core.CreateContainerCmdModifier\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"},
@@ -277,11 +391,14 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"},
     "pattern":"\\Qcom/atomikos/icatch/provider/imp/transactions.properties\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\Qcom/clickhouse/client/internal/jpountz/util/linux/amd64/liblz4-java.so\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\Qcontainer-license-acceptance.txt\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.infra.autogen.version.ShardingSphereVersion"},
+    "pattern":"\\Qcurrent-git-commit.properties\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"},
     "pattern":"\\Qjta.properties\\E"
@@ -289,19 +406,19 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"},
     "pattern":"\\Qlib/sqlparser/druid.jar\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\Qorg/apache/hc/core5/version.properties\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
     "pattern":"\\Qorg/h2/util/data.zip\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\Qorg/postgresql/driverconfig.properties\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"},
     "pattern":"\\Qregistry.conf\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.optimizer.context.parser.dialect.impl.H2OptimizerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.optimizer.context.parser.dialect.impl.MySQLOptimizerBuilder"},
     "pattern":"\\Qsaffron.properties\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
@@ -1216,1533 +1333,6 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase"},
     "pattern":"\\Qschema/mysql/sys/waits_global_by_latency.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/_pg_foreign_data_wrappers.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/_pg_foreign_servers.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/_pg_foreign_table_columns.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/_pg_foreign_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/_pg_user_mappings.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/administrable_role_authorizations.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/applicable_roles.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/attributes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/character_sets.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/check_constraint_routine_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/check_constraints.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/collation_character_set_applicability.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/collations.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/column_domain_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/column_options.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/column_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/column_udt_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/columns.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/constraint_column_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/constraint_table_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/data_type_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/domain_constraints.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/domain_udt_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/domains.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/element_types.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/enabled_roles.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/foreign_data_wrapper_options.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/foreign_data_wrappers.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/foreign_server_options.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/foreign_servers.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/foreign_table_options.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/foreign_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/information_schema_catalog_name.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/key_column_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/parameters.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/referential_constraints.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/role_column_grants.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/role_routine_grants.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/role_table_grants.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/role_udt_grants.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/role_usage_grants.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/routine_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/routines.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/schemata.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/sequences.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/sql_features.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/sql_implementation_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/sql_languages.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/sql_packages.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/sql_parts.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/sql_sizing.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/sql_sizing_profiles.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/table_constraints.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/table_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/triggered_update_columns.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/triggers.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/udt_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/usage_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/user_defined_types.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/user_mapping_options.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/user_mappings.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/view_column_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/view_routine_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/view_table_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/information_schema/views.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/get_global_prepared_xacts.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_all_control_group_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_asp.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_auditing.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_auditing_access.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_auditing_policy.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_auditing_policy_access.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_auditing_policy_filters.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_auditing_policy_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_auditing_privilege.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_client_global_keys.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_client_global_keys_args.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_cluster_resource_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_column_keys.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_column_keys_args.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_comm_proxy_thread_status.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_db_privilege.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_db_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_encrypted_columns.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_encrypted_proc.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_file_stat.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_get_control_group_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_global_chain.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_global_config.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_gsc_memory_detail.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_instance_time.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_job_argument.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_job_attribute.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_labels.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_lsc_memory_detail.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_masking.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_masking_policy.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_masking_policy_actions.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_masking_policy_filters.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_matview.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_matview_dependency.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_matviews.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_model_warehouse.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_obsscaninfo.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_opt_model.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_os_run_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_package.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_policy_label.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_recyclebin.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_redo_stat.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_session_cpu_statistics.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_session_memory.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_session_memory_context.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_session_memory_detail.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_session_memory_statistics.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_session_stat.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_session_time.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_shared_memory_detail.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_sql_count.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_stat_session_cu.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_thread_memory_context.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_total_memory_detail.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_total_nodegroup_memory_detail.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_txn_snapshot.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_uid.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_cgroup_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_ec_operator_history.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_ec_operator_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_ec_operator_statistics.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_instance_history.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_operator_history.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_operator_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_operator_statistics.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_plan_encoding_table.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_plan_operator_history.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_plan_operator_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_rebuild_user_resource_pool.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_resource_pool.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_session_history.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_session_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_session_info_all.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_session_query_info_all.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_session_statistics.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_user_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_user_resource_history.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/gs_wlm_workload_records.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/mpp_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_aggregate.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_am.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_amop.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_amproc.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_app_workloadgroup_mapping.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_attrdef.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_attribute.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_auth_history.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_auth_members.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_authid.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_available_extension_versions.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_available_extensions.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_cast.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_class.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_collation.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_comm_delay.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_comm_recv_stream.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_comm_send_stream.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_comm_status.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_constraint.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_control_group_config.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_conversion.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_cursors.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_database.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_db_role_setting.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_default_acl.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_depend.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_description.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_directory.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_enum.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_ext_stats.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_extension.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_extension_data_source.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_foreign_data_wrapper.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_foreign_server.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_foreign_table.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_get_invalid_backends.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_get_senders_catchup_time.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_group.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_gtt_attached_pids.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_gtt_relstats.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_gtt_stats.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_hashbucket.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_index.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_inherits.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_job.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_job_proc.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_language.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_largeobject.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_largeobject_metadata.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_locks.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_namespace.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_node_env.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_object.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_obsscaninfo.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_opclass.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_operator.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_opfamily.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_os_threads.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_partition.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_pltemplate.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_prepared_statements.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_prepared_xacts.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_proc.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_publication.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_publication_rel.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_publication_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_range.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_replication_origin.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_replication_origin_status.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_replication_slots.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_resource_pool.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_rewrite.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_rlspolicies.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_rlspolicy.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_roles.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_rules.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_running_xacts.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_seclabel.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_seclabels.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_session_iostat.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_session_wlmstat.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_settings.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_shadow.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_shdepend.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_shdescription.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_shseclabel.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_activity.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_activity_ng.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_all_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_all_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_bad_block.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_bgwriter.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_database.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_database_conflicts.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_replication.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_subscription.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_sys_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_sys_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_user_functions.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_user_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_user_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_xact_all_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_xact_sys_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_xact_user_functions.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stat_xact_user_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_statio_all_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_statio_all_sequences.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_statio_all_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_statio_sys_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_statio_sys_sequences.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_statio_sys_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_statio_user_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_statio_user_sequences.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_statio_user_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_statistic.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_statistic_ext.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_stats.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_subscription.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_synonym.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_tablespace.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_tde_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_thread_wait_status.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_timezone_abbrevs.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_timezone_names.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_total_memory_detail.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_total_user_resource_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_total_user_resource_info_oid.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_trigger.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_ts_config.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_ts_config_map.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_ts_dict.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_ts_parser.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_ts_template.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_type.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_user.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_user_mapping.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_user_mappings.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_user_status.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_variable_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_views.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_wlm_statistics.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pg_workload_group.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pgxc_class.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pgxc_group.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pgxc_node.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pgxc_prepared_xacts.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pgxc_slice.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/pgxc_thread_wait_status.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/plan_table.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/plan_table_data.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/statement_history.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/streaming_cont_query.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/streaming_reaper_status.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/streaming_stream.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/opengauss/pg_catalog/sys_dummy.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/_pg_foreign_data_wrappers.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/_pg_foreign_servers.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/_pg_foreign_table_columns.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/_pg_foreign_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/_pg_user_mappings.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/administrable_role_authorizations.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/applicable_roles.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/attributes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/character_sets.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/check_constraint_routine_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/check_constraints.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/collation_character_set_applicability.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/collations.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/column_column_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/column_domain_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/column_options.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/column_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/column_udt_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/columns.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/constraint_column_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/constraint_table_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/data_type_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/domain_constraints.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/domain_udt_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/domains.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/element_types.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/enabled_roles.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/foreign_data_wrapper_options.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/foreign_data_wrappers.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/foreign_server_options.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/foreign_servers.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/foreign_table_options.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/foreign_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/information_schema_catalog_name.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/key_column_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/parameters.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/referential_constraints.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/role_column_grants.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/role_routine_grants.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/role_table_grants.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/role_udt_grants.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/role_usage_grants.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/routine_column_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/routine_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/routine_routine_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/routine_sequence_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/routine_table_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/routines.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/schemata.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/sequences.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/sql_features.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/sql_implementation_info.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/sql_parts.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/sql_sizing.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/table_constraints.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/table_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/transforms.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/triggered_update_columns.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/triggers.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/udt_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/usage_privileges.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/user_defined_types.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/user_mapping_options.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/user_mappings.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/view_column_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/view_routine_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/view_table_usage.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/information_schema/views.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_aggregate.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_am.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_amop.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_amproc.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_attrdef.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_attribute.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_auth_members.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_authid.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_available_extension_versions.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_available_extensions.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_backend_memory_contexts.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_cast.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_class.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_collation.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_config.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_constraint.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_conversion.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_cursors.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_database.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_db_role_setting.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_default_acl.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_depend.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_description.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_enum.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_event_trigger.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_extension.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_file_settings.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_foreign_data_wrapper.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_foreign_server.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_foreign_table.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_group.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_hba_file_rules.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_index.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_inherits.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_init_privs.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_language.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_largeobject.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_largeobject_metadata.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_locks.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_matviews.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_namespace.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_opclass.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_operator.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_opfamily.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_partitioned_table.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_policies.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_policy.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_prepared_statements.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_prepared_xacts.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_proc.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_publication.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_publication_rel.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_publication_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_range.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_replication_origin.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_replication_origin_status.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_replication_slots.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_rewrite.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_roles.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_rules.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_seclabel.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_seclabels.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_sequence.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_sequences.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_settings.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_shadow.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_shdepend.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_shdescription.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_shmem_allocations.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_shseclabel.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_activity.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_all_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_all_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_archiver.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_bgwriter.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_database.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_database_conflicts.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_gssapi.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_progress_analyze.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_progress_basebackup.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_progress_cluster.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_progress_copy.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_progress_create_index.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_progress_vacuum.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_replication.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_replication_slots.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_slru.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_ssl.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_subscription.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_sys_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_sys_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_user_functions.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_user_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_user_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_wal.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_wal_receiver.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_xact_all_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_xact_sys_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_xact_user_functions.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stat_xact_user_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_statio_all_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_statio_all_sequences.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_statio_all_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_statio_sys_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_statio_sys_sequences.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_statio_sys_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_statio_user_indexes.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_statio_user_sequences.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_statio_user_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_statistic.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_statistic_ext.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_statistic_ext_data.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stats.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stats_ext.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_stats_ext_exprs.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_subscription.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_subscription_rel.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_tables.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_tablespace.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_timezone_abbrevs.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_timezone_names.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_transform.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_trigger.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_ts_config.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_ts_config_map.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_ts_dict.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_ts_parser.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_ts_template.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_type.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_user.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_user_mapping.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_user_mappings.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/postgresql/pg_catalog/pg_views.yaml\\E"
-  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.directory.ClasspathResourceDirectoryReader"},
     "pattern":"\\Qschema\\E"
   }, {
@@ -2770,10 +1360,10 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.standalone.jdbc.sql.JDBCRepositorySQLLoader"},
     "pattern":"\\Qsql\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\Qtest-native/sql/seata-script-client-at-postgresql.sql\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"\\Qtest-native/sql/test-native-databases-clickhouse.sql\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"},
@@ -2833,7 +1423,7 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.cluster.etcd.EtcdRepository"},
     "pattern":"\\Qvertx-default-jul-logging.properties\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
     "pattern":"java.base:\\Qjdk/internal/icu/impl/data/icudt74b/nfkc.nrm\\E"
   }]},
   "bundles":[{

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reflect-config.json
@@ -61,6 +61,11 @@
   "methods":[{"name":"getDefaultType","parameterTypes":[] }, {"name":"getProps","parameterTypes":[] }, {"name":"getProviderType","parameterTypes":[] }]
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.authority.yaml.config.YamlUserConfiguration"},
+  "name":"org.apache.shardingsphere.authority.yaml.config.YamlUserConfiguration",
+  "allPublicMethods":true
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.hive.parser.HiveLexer"},
   "name":"org.apache.shardingsphere.sql.parser.hive.parser.HiveLexer",
   "methods":[{"name":"<init>","parameterTypes":["org.antlr.v4.runtime.CharStream"] }]
@@ -78,6 +83,31 @@
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.statement.hive.dml.HiveInsertStatement"},
   "name":"org.apache.shardingsphere.sql.parser.statement.hive.dml.HiveInsertStatement",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.DeleteStatementBinder"},
+  "name":"org.apache.shardingsphere.sql.parser.statement.postgresql.dml.PostgreSQLDeleteStatement",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.DeleteStatementBinder"},
+  "name":"org.apache.shardingsphere.sql.parser.statement.hive.dml.HiveDeleteStatement",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.DeleteStatementBinder"},
+  "name":"org.apache.shardingsphere.sql.parser.statement.opengauss.dml.OpenGaussDeleteStatement",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.DeleteStatementBinder"},
+  "name":"org.apache.shardingsphere.sql.parser.statement.sqlserver.dml.SQLServerDeleteStatement",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.DeleteStatementBinder"},
+  "name":"org.apache.shardingsphere.sql.parser.statement.clickhouse.dml.ClickHouseDeleteStatement",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 }
 ]

--- a/test/native/native-image-filter/extra-filter.json
+++ b/test/native/native-image-filter/extra-filter.json
@@ -8,6 +8,7 @@
     {"excludeClasses": "groovy.**"},
     {"excludeClasses": "io.**"},
     {"excludeClasses": "java.**"},
+    {"includeClasses": "java.util.LinkedHashSet"},
     {"includeClasses": "java.util.Properties"},
     {"includeClasses": "java.util.ServiceLoader"},
     {"excludeClasses": "javax.**"},

--- a/test/native/pom.xml
+++ b/test/native/pom.xml
@@ -35,6 +35,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-proxy-bootstrap</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-infra-database-testcontainers</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/commons/ProxyTestingServer.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/commons/ProxyTestingServer.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.natived.proxy.commons;
+
+import lombok.Getter;
+import org.apache.curator.test.InstanceSpec;
+import org.apache.shardingsphere.proxy.Bootstrap;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This class is designed to start ShardingSphere Proxy directly in the current process,
+ * whether it is HotSpot VM or GraalVM Native Image,
+ * so this class intentionally uses fewer than a few dozen JVM parameters.
+ */
+@Getter
+public final class ProxyTestingServer {
+    
+    private final int proxyPort = InstanceSpec.getRandomPort();
+    
+    private final CompletableFuture<Void> completableFuture;
+    
+    /**
+     * Call this method to start the Server side of ShardingSphere Proxy in a separate thread.
+     *
+     * @param configAbsolutePath The absolute path to the directory where {@code global.yaml} is located.
+     */
+    public ProxyTestingServer(final String configAbsolutePath) {
+        completableFuture = CompletableFuture.runAsync(() -> {
+            try {
+                Bootstrap.main(new String[]{String.valueOf(proxyPort), configAbsolutePath, "0.0.0.0", "false"});
+            } catch (final IOException | SQLException ex) {
+                throw new RuntimeException(ex);
+            }
+        });
+    }
+    
+    /**
+     * Force close ShardingSphere Proxy.
+     */
+    public void close() {
+        completableFuture.cancel(true);
+    }
+}

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/features/ShardingTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/features/ShardingTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.natived.proxy.features;
+
+import com.mysql.cj.jdbc.exceptions.CommunicationsException;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.shardingsphere.test.natived.jdbc.commons.TestShardingService;
+import org.apache.shardingsphere.test.natived.proxy.commons.ProxyTestingServer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledInNativeImage;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.sql.DataSource;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Properties;
+
+@SuppressWarnings({"SqlNoDataSourceInspection", "SameParameterValue", "resource"})
+@EnabledInNativeImage
+@Testcontainers
+class ShardingTest {
+    
+    @Container
+    public static final GenericContainer<?> MYSQL_CONTAINER = new GenericContainer<>("mysql:9.0.1-oraclelinux9")
+            .withEnv("MYSQL_ROOT_PASSWORD", "yourStrongPassword123!")
+            .withExposedPorts(3306);
+    
+    private static ProxyTestingServer proxyTestingServer;
+    
+    private TestShardingService testShardingService;
+    
+    @BeforeAll
+    static void beforeAll() throws SQLException {
+        Awaitility.await().atMost(Duration.ofMinutes(30L)).ignoreExceptionsMatching(e -> e instanceof CommunicationsException).until(() -> {
+            openConnection("root", "yourStrongPassword123!", "jdbc:mysql://127.0.0.1:" + MYSQL_CONTAINER.getMappedPort(3306))
+                    .close();
+            return true;
+        });
+        try (
+                Connection connection = openConnection("root", "yourStrongPassword123!", "jdbc:mysql://127.0.0.1:" + MYSQL_CONTAINER.getMappedPort(3306));
+                Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE DATABASE demo_ds_0");
+            statement.executeUpdate("CREATE DATABASE demo_ds_1");
+            statement.executeUpdate("CREATE DATABASE demo_ds_2");
+        }
+        String absolutePath = Paths.get("src/test/resources/test-native/yaml/proxy/features").toAbsolutePath().normalize().toString();
+        proxyTestingServer = new ProxyTestingServer(absolutePath);
+        Awaitility.await().atMost(Duration.ofMinutes(30L)).ignoreExceptionsMatching(e -> e instanceof CommunicationsException).until(() -> {
+            openConnection("root", "root", "jdbc:mysql://127.0.0.1:" + proxyTestingServer.getProxyPort()).close();
+            return true;
+        });
+    }
+    
+    @AfterAll
+    static void afterAll() {
+        proxyTestingServer.close();
+    }
+    
+    /**
+     * {@link groovy.lang.Closure} related classes are not available on GraalVM Native Image.
+     * This CLASS_BASE algorithm class is designed to emulate INLINE's {@code ds_${user_id % 2}}.
+     * See <a href="https://github.com/oracle/graal/issues/5522">oracle/graal#5522</a> .
+     *
+     * @throws SQLException SQL Exception
+     */
+    @Test
+    void assertShardingInLocalTransactions() throws SQLException {
+        try (
+                Connection connection = openConnection("root", "root", "jdbc:mysql://127.0.0.1:" + proxyTestingServer.getProxyPort());
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE DATABASE sharding_db");
+            statement.execute("USE sharding_db");
+            statement.execute("REGISTER STORAGE UNIT ds_0 (\n"
+                    + "  URL=\"jdbc:mysql://127.0.0.1:" + MYSQL_CONTAINER.getMappedPort(3306) + "/demo_ds_0\",\n"
+                    + "  USER=\"root\",\n"
+                    + "  PASSWORD=\"yourStrongPassword123!\"\n"
+                    + "),ds_1 (\n"
+                    + "  URL=\"jdbc:mysql://127.0.0.1:" + MYSQL_CONTAINER.getMappedPort(3306) + "/demo_ds_1\",\n"
+                    + "  USER=\"root\",\n"
+                    + "  PASSWORD=\"yourStrongPassword123!\"\n"
+                    + "),ds_2 (\n"
+                    + "  URL=\"jdbc:mysql://127.0.0.1:" + MYSQL_CONTAINER.getMappedPort(3306) + "/demo_ds_2\",\n"
+                    + "  USER=\"root\",\n"
+                    + "  PASSWORD=\"yourStrongPassword123!\"\n"
+                    + ")");
+            statement.execute("CREATE DEFAULT SHARDING DATABASE STRATEGY (\n"
+                    + "  TYPE=\"standard\", \n"
+                    + "  SHARDING_COLUMN=user_id, \n"
+                    + "  SHARDING_ALGORITHM(\n"
+                    + "    TYPE(\n"
+                    + "      NAME=CLASS_BASED, \n"
+                    + "      PROPERTIES(\n"
+                    + "        \"strategy\"=\"STANDARD\",\n"
+                    + "        \"algorithmClassName\"=\"org.apache.shardingsphere.test.natived.jdbc.commons.algorithm.ClassBasedInlineShardingAlgorithmFixture\"\n"
+                    + "      )\n"
+                    + "    )\n"
+                    + "  )\n"
+                    + ")");
+            statement.execute("CREATE SHARDING TABLE RULE t_order (\n"
+                    + "  DATANODES(\"<LITERAL>ds_0.t_order, ds_1.t_order, ds_2.t_order\"),\n"
+                    + "  KEY_GENERATE_STRATEGY(COLUMN=order_id,TYPE(NAME=\"SNOWFLAKE\"))\n"
+                    + "), t_order_item (\n"
+                    + "  DATANODES(\"<LITERAL>ds_0.t_order_item, ds_1.t_order_item, ds_2.t_order_item\"),\n"
+                    + "  KEY_GENERATE_STRATEGY(COLUMN=order_item_id,TYPE(NAME=\"SNOWFLAKE\"))\n"
+                    + ")");
+            statement.execute("CREATE BROADCAST TABLE RULE t_address");
+        }
+        HikariConfig config = new HikariConfig();
+        config.setDriverClassName("com.mysql.cj.jdbc.Driver");
+        config.setJdbcUrl("jdbc:mysql://127.0.0.1:" + proxyTestingServer.getProxyPort() + "/sharding_db");
+        config.setUsername("root");
+        config.setPassword("root");
+        DataSource dataSource = new HikariDataSource(config);
+        testShardingService = new TestShardingService(dataSource);
+        initEnvironment();
+        testShardingService.processSuccess();
+        testShardingService.cleanEnvironment();
+    }
+    
+    private void initEnvironment() throws SQLException {
+        testShardingService.getOrderRepository().createTableIfNotExistsInMySQL();
+        testShardingService.getOrderItemRepository().createTableIfNotExistsInMySQL();
+        testShardingService.getAddressRepository().createTableIfNotExistsInMySQL();
+        testShardingService.getOrderRepository().truncateTable();
+        testShardingService.getOrderItemRepository().truncateTable();
+        testShardingService.getAddressRepository().truncateTable();
+    }
+    
+    private static Connection openConnection(final String username, final String password, final String jdbcUrl) throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("user", username);
+        props.setProperty("password", password);
+        return DriverManager.getConnection(jdbcUrl, props);
+    }
+}

--- a/test/native/src/test/resources/test-native/yaml/proxy/features/global.yaml
+++ b/test/native/src/test/resources/test-native/yaml/proxy/features/global.yaml
@@ -14,9 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM oraclelinux:9-slim
-LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache.org"
-ENV LOCAL_PATH=/opt/shardingsphere-proxy-native-bin
-ARG OUTPUT_DIRECTORY_NAME
-COPY target/${OUTPUT_DIRECTORY_NAME} ${LOCAL_PATH}
-ENTRYPOINT ["${LOCAL_PATH}/proxy-native", "3307", "${LOCAL_PATH}/conf", "0.0.0.0", "false"]
+
+mode:
+  type: Standalone
+  repository:
+    type: JDBC
+authority:
+  users:
+    - user: root@%
+      password: root
+  privilege:
+    type: ALL_PERMITTED
+props:
+  sql-show: false
+  proxy-frontend-database-protocol-type: MySQL


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Support running DistSQL under Proxy Native in the form of GraalVM Native Image.
  - In order to directly collect the GraalVM Reachability Metadata of ShardingSphere Proxy through unit testing, we must directly start ShardingSphere Proxy without using the Docker Image.
  - The most embarrassing part is that ShardingSphere Proxy cannot actually connect to H2database, which requires starting a MySQL container.
  - The most awkward part of this PR is the splicing of DistSQL in `org.apache.shardingsphere.test.natived.proxy.features.ShardingTest`. Since we need to use the MySQL port of the MySQL container obtained from the testcontainers-java API, we always need to manually splice DistSQL instead of directly reading the `.sql` file. But the problem is that JDK8 does not have the concept of multi-line strings, which makes the related unit tests quite difficult to maintain. Maybe there is a way to write these unit tests under JDK 21.
  - `java.util.LinkedHashSet` is a magical exception. Running ShardingSphere Proxy under GraalVM Native Image requires its constructor. Add it to `extra-filter.json`.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
