### PR TITLE
Rename wrong typo sharing to sharding in sharding feature related class and document

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1343,7 +1343,7 @@
 
 ### Enhancement
 
-1. Optimization for Sharing Parser with ANTLR Visitor improving the parsing performance of long SQL by 100%~1000%
+1. Optimization for Sharding Parser with ANTLR Visitor improving the parsing performance of long SQL by 100%~1000%
 1. Use multiple threads to load metadata for different data sources
 1. Support `allow.range.query.with.inline.sharding` option
 1. The docker of ShardingSphere-Proxy supports loading external lib packages

--- a/docs/blog/content/material/2022_04_06_A_Holistic_Pluggable_Platform_for_Data_Sharding_ICDE_2022_Understanding_Apache_ShardingSphere.en.md
+++ b/docs/blog/content/material/2022_04_06_A_Holistic_Pluggable_Platform_for_Data_Sharding_ICDE_2022_Understanding_Apache_ShardingSphere.en.md
@@ -84,7 +84,7 @@ Vertical sharding alters the table structure, and therefore the structure has to
 
 Combining Figure 1 and Figure 4, let’s explain some data sharding concepts: the `uid` in Figure 1 is used to determine the database sharding field, known as the sharding key. `uid%2` in Figure 1 is used to distribute data to different tables, which is the sharding algorithm. ShardingSphere has over ten built-in sharding algorithms, and also allows clients to customize algorithms through interfaces.
 
-ShardingSphere provides different types of tables for different data sharding demands. For example in Figure 4, `t_user` is a schema, while `t_user_h0` and `t_user_h1` are physical tables. The actual tables stored in the database are the physical tables, but the tables seen by application developers are un-sharded schemas. Data sharing operation is transparent to application developers.
+ShardingSphere provides different types of tables for different data sharding demands. For example in Figure 4, `t_user` is a schema, while `t_user_h0` and `t_user_h1` are physical tables. The actual tables stored in the database are the physical tables, but the tables seen by application developers are un-sharded schemas. Data sharding operation is transparent to application developers.
 
 In Figure 4, if `t_user` and `t_order` share the same sharding algorithm, data source and sharding key, they are binding tables with each other, which is very helpful in related queries. In addition, we use data nodes to map schema to physical tables. It is the smallest unit of sharding, consisting of a data source name and an actual table name, such as `DSO.t_user_h1`.
 

--- a/docs/blog/content/material/Feb_18_Apache_ShardingSphere_5.1.0_Now_Avaliable.en.md
+++ b/docs/blog/content/material/Feb_18_Apache_ShardingSphere_5.1.0_Now_Avaliable.en.md
@@ -187,7 +187,7 @@ Read/write-splitting supports static and dynamic configuration
 
 18. Support to use `instance_id` to perform operations when `enable/disable` a proxy instance
 
-19. Support auto creative algorithm when `CREATE SHARING TABLE RULE`, reducing the steps of creating rule
+19. Support auto creative algorithm when `CREATE SHARDING TABLE RULE`, reducing the steps of creating rule
 
 20. Support specifying an existing KeyGenerator when `CREATE SHARDING TABLE RULE`
 

--- a/docs/blog/content/material/Jan_28_Blog_Apache_ShardingSphere_Enterprise_Applications.en.md
+++ b/docs/blog/content/material/Jan_28_Blog_Apache_ShardingSphere_Enterprise_Applications.en.md
@@ -24,7 +24,7 @@ Keep engineers expressed great interest in Apache ShardingSphere 5.0. At the eve
 
 ## Database Plus: Freeing DBAs and Developers
 
-Database Plus is a design concept of the distributed database system. By building a standard layer and ecosystem for use and interaction above fragmented heterogeneous databases, and by multiplying and expanding computing capabilities (e.g. data sharing, data encryption and decryption), all the interaction between applications and databases is oriented to the standard layer built by Database Plus. This results in shielding the differentiated impact of database fragmentation on upper layer transactions.
+Database Plus is a design concept of the distributed database system. By building a standard layer and ecosystem for use and interaction above fragmented heterogeneous databases, and by multiplying and expanding computing capabilities (e.g. data sharding, data encryption and decryption), all the interaction between applications and databases is oriented to the standard layer built by Database Plus. This results in shielding the differentiated impact of database fragmentation on upper layer transactions.
 
 Pan believes that the global database industry has boomed thanks in large to the following two reasons:
 

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/sharding.en.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/sharding.en.md
@@ -119,7 +119,7 @@ Type: COMPLEX_INLINE
 
 | *Name*                                     | *DataType* | *Description*                                                                                            | *Default Value* |
 |--------------------------------------------|------------|----------------------------------------------------------------------------------------------------------|-----------------|
-| sharding-columns (?)                       | String     | sharing column names                                                                                     | -               |
+| sharding-columns (?)                       | String     | sharding column names                                                                                    | -               |
 | algorithm-expression                       | String     | Inline expression sharding algorithm                                                                     | -               |
 | allow-range-query-with-inline-sharding (?) | boolean    | Whether range query is allowed. Note: range query will ignore sharding strategy and conduct full routing | false           |
 

--- a/docs/document/content/user-manual/error-code/sql-error-code.cn.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.cn.md
@@ -178,7 +178,7 @@ SQL 错误码以标准的 SQL State，Vendor Code 和详细错误信息提供，
 | 20050       | HY000     | Sharding algorithm class '%s' should be implement '%s'.                                                                             |
 | 20051       | HY000     | Routed target '%s' does not exist, available targets are '%s'.                                                                      |
 | 20052       | 44000     | Inline sharding algorithms expression '%s' and sharding column '%s' do not match.                                                   |
-| 20053       | 44000     | Complex inline algorithm need %d sharing columns, but only found %d.                                                                |
+| 20053       | 44000     | Complex inline algorithm need %d sharding columns, but only found %d.                                                               |
 | 20054       | 44000     | No sharding database route info.                                                                                                    |
 | 20055       | 44000     | Some routed data sources do not belong to configured data sources. routed data sources '%s', configured data sources '%s'.          |
 | 20056       | 44000     | Please check your sharding conditions '%s' to avoid same record in table '%s' routing to multiple data nodes.                       |

--- a/docs/document/content/user-manual/error-code/sql-error-code.en.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.en.md
@@ -178,7 +178,7 @@ SQL error codes provide by standard `SQL State`, `Vendor Code` and `Reason`, whi
 | 20050       | HY000     | Sharding algorithm class '%s' should be implement '%s'.                                                                             |
 | 20051       | HY000     | Routed target '%s' does not exist, available targets are '%s'.                                                                      |
 | 20052       | 44000     | Inline sharding algorithms expression '%s' and sharding column '%s' do not match.                                                   |
-| 20053       | 44000     | Complex inline algorithm need %d sharing columns, but only found %d.                                                                |
+| 20053       | 44000     | Complex inline algorithm need %d sharding columns, but only found %d.                                                               |
 | 20054       | 44000     | No sharding database route info.                                                                                                    |
 | 20055       | 44000     | Some routed data sources do not belong to configured data sources. routed data sources '%s', configured data sources '%s'.          |
 | 20056       | 44000     | Please check your sharding conditions '%s' to avoid same record in table '%s' routing to multiple data nodes.                       |

--- a/docs/document/content/user-manual/shardingsphere-proxy/cdc/build.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/cdc/build.cn.md
@@ -12,7 +12,7 @@ ShardingSphere CDC 分为两个部分，一个是 CDC Server，另一个是 CDC 
 ## 约束条件
 
 - 纯 JAVA 开发，JDK 建议 1.8 或以上版本。
-- CDC Server 要求 SharingSphere-Proxy 使用集群模式，目前支持 ZooKeeper 作为注册中心。
+- CDC Server 要求 ShardingSphere-Proxy 使用集群模式，目前支持 ZooKeeper 作为注册中心。
 - CDC 只同步数据，不会同步表结构，目前也不支持 DDL 的语句同步。
 - CDC 增量阶段会按照分库事务的维度输出数据， 如果要开启 XA 事务的兼容，则 openGauss 和 ShardingSphere-Proxy 都需要 GLT 模块
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/cdc/build.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/cdc/build.en.md
@@ -12,7 +12,7 @@ Users can introduce the CDC Client into their own projects to implement data con
 ## Constraints
 
 - Pure JAVA development, JDK recommended 1.8 or above.
-- CDC Server requires SharingSphere-Proxy to use cluster mode, currently supports ZooKeeper as the registry center.
+- CDC Server requires ShardingSphere-Proxy to use cluster mode, currently supports ZooKeeper as the registry center.
 - CDC only synchronizes data, does not synchronize table structure, and currently does not support DDL statement synchronization.
 - CDC incremental task will not split transaction data of the database shards. If you want to enable XA transaction compatibility, both openGauss and ShardingSphere-Proxy need the GLT module.
 

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/inline/ComplexInlineShardingAlgorithm.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/inline/ComplexInlineShardingAlgorithm.java
@@ -43,7 +43,7 @@ public final class ComplexInlineShardingAlgorithm implements ComplexKeysSharding
     
     private static final String ALGORITHM_EXPRESSION_KEY = "algorithm-expression";
     
-    private static final String SHARING_COLUMNS_KEY = "sharding-columns";
+    private static final String SHARDING_COLUMNS_KEY = "sharding-columns";
     
     private static final String ALLOW_RANGE_QUERY_KEY = "allow-range-query-with-inline-sharding";
     
@@ -67,7 +67,7 @@ public final class ComplexInlineShardingAlgorithm implements ComplexKeysSharding
     }
     
     private Collection<String> getShardingColumns(final Properties props) {
-        String shardingColumns = props.getProperty(SHARING_COLUMNS_KEY, "");
+        String shardingColumns = props.getProperty(SHARDING_COLUMNS_KEY, "");
         return shardingColumns.isEmpty() ? Collections.emptyList() : Arrays.asList(shardingColumns.split(","));
     }
     

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/exception/algorithm/MismatchedComplexInlineShardingAlgorithmColumnAndValueSizeException.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/exception/algorithm/MismatchedComplexInlineShardingAlgorithmColumnAndValueSizeException.java
@@ -28,6 +28,6 @@ public final class MismatchedComplexInlineShardingAlgorithmColumnAndValueSizeExc
     private static final long serialVersionUID = -3667110081810167498L;
     
     public MismatchedComplexInlineShardingAlgorithmColumnAndValueSizeException(final int shardingColumnSize, final int shardingValueSize) {
-        super(XOpenSQLState.CHECK_OPTION_VIOLATION, 53, "Complex inline algorithm need %d sharing columns, but only found %d.", shardingColumnSize, shardingValueSize);
+        super(XOpenSQLState.CHECK_OPTION_VIOLATION, 53, "Complex inline algorithm need %d sharding columns, but only found %d.", shardingColumnSize, shardingValueSize);
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/exception/metadata/DuplicateShardingActualDataNodeException.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/exception/metadata/DuplicateShardingActualDataNodeException.java
@@ -23,11 +23,11 @@ import org.apache.shardingsphere.sharding.exception.ShardingSQLException;
 /**
  * Duplicate sharding actual data node exception.
  */
-public final class DuplicateSharingActualDataNodeException extends ShardingSQLException {
+public final class DuplicateShardingActualDataNodeException extends ShardingSQLException {
     
     private static final long serialVersionUID = 3503761639898230998L;
     
-    public DuplicateSharingActualDataNodeException(final String logicalTableName, final String dataSourceName, final String tableName) {
+    public DuplicateShardingActualDataNodeException(final String logicalTableName, final String dataSourceName, final String tableName) {
         super(XOpenSQLState.DUPLICATE, 12,
                 "Same actual data node cannot be configured in multiple logic tables in same database, logical table '%s', actual data node '%s.%s'.", logicalTableName, dataSourceName, tableName);
     }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/checker/ShardingRuleChecker.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/checker/ShardingRuleChecker.java
@@ -30,7 +30,7 @@ import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ComplexSh
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.StandardShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
-import org.apache.shardingsphere.sharding.exception.metadata.DuplicateSharingActualDataNodeException;
+import org.apache.shardingsphere.sharding.exception.metadata.DuplicateShardingActualDataNodeException;
 import org.apache.shardingsphere.sharding.exception.metadata.InvalidBindingTablesException;
 import org.apache.shardingsphere.sharding.exception.metadata.ShardingTableRuleNotFoundException;
 import org.apache.shardingsphere.sharding.rule.BindingTableCheckedConfiguration;
@@ -68,7 +68,7 @@ public class ShardingRuleChecker {
         shardingRule.getShardingTables().forEach((key, value) -> {
             DataNode sampleActualDataNode = value.getActualDataNodes().iterator().next();
             ShardingSpherePreconditions.checkNotContains(uniqueActualDataNodes, sampleActualDataNode,
-                    () -> new DuplicateSharingActualDataNodeException(key, sampleActualDataNode.getDataSourceName(), sampleActualDataNode.getTableName()));
+                    () -> new DuplicateShardingActualDataNodeException(key, sampleActualDataNode.getDataSourceName(), sampleActualDataNode.getTableName()));
             uniqueActualDataNodes.add(sampleActualDataNode);
         });
     }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/yaml/config/strategy/audit/YamlShardingAuditStrategyConfiguration.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/yaml/config/strategy/audit/YamlShardingAuditStrategyConfiguration.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.infra.util.yaml.YamlConfiguration;
 import java.util.Collection;
 
 /**
- * Sharing audit strategy configuration for YAML.
+ * Sharding audit strategy configuration for YAML.
  */
 @Getter
 @Setter

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
@@ -46,7 +46,7 @@ import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ComplexSh
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.NoneShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.StandardShardingStrategyConfiguration;
-import org.apache.shardingsphere.sharding.exception.metadata.DuplicateSharingActualDataNodeException;
+import org.apache.shardingsphere.sharding.exception.metadata.DuplicateShardingActualDataNodeException;
 import org.apache.shardingsphere.sharding.exception.metadata.InvalidBindingTablesException;
 import org.apache.shardingsphere.sharding.exception.metadata.ShardingTableRuleNotFoundException;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
@@ -172,7 +172,7 @@ class ShardingRuleTest {
         duplicateTableRuleConfig.setTableShardingStrategy(new StandardShardingStrategyConfiguration("order_id", "MOD"));
         ruleConfig.getTables().add(duplicateTableRuleConfig);
         ruleConfig.getShardingAlgorithms().put("INLINE", new AlgorithmConfiguration("INLINE", PropertiesBuilder.build(new Property("algorithm-expression", "t_order_%{order_id % 2}"))));
-        assertThrows(DuplicateSharingActualDataNodeException.class, () -> new ShardingRule(ruleConfig, Collections.emptyMap(), mock(ComputeNodeInstanceContext.class)));
+        assertThrows(DuplicateShardingActualDataNodeException.class, () -> new ShardingRule(ruleConfig, Collections.emptyMap(), mock(ComputeNodeInstanceContext.class)));
     }
     
     @Test

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/checker/ShardingTableRuleStatementChecker.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/checker/ShardingTableRuleStatementChecker.java
@@ -87,7 +87,7 @@ public final class ShardingTableRuleStatementChecker {
     private static final String DELIMITER = ".";
     
     /**
-     * Check create sharing table rule statement.
+     * Check create sharding table rule statement.
      *
      * @param database database
      * @param rules rules
@@ -100,7 +100,7 @@ public final class ShardingTableRuleStatementChecker {
     }
     
     /**
-     * Check alter sharing table rule statement.
+     * Check alter sharding table rule statement.
      *
      * @param database database
      * @param rules rules


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Rename wrong typo sharing to sharding in sharding feature related class and document

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
