### PR TITLE
Implement DistSQLDatabaseRuleQueryExecutorAssert on ShowBroadcastTableRuleExecutorTest

### DIFF
--- a/features/broadcast/distsql/handler/src/test/java/org/apache/shardingsphere/broadcast/distsql/handler/query/ShowBroadcastTableRuleExecutorTest.java
+++ b/features/broadcast/distsql/handler/src/test/java/org/apache/shardingsphere/broadcast/distsql/handler/query/ShowBroadcastTableRuleExecutorTest.java
@@ -17,45 +17,36 @@
 
 package org.apache.shardingsphere.broadcast.distsql.handler.query;
 
-import org.apache.shardingsphere.broadcast.config.BroadcastRuleConfiguration;
-import org.apache.shardingsphere.broadcast.distsql.statement.ShowBroadcastTableRulesStatement;
 import org.apache.shardingsphere.broadcast.rule.BroadcastRule;
 import org.apache.shardingsphere.distsql.statement.DistSQLStatement;
 import org.apache.shardingsphere.infra.config.rule.scope.DatabaseRuleConfiguration;
 import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
-import org.apache.shardingsphere.test.it.distsql.handler.engine.query.DistSQLDatabaseRuleQueryExecutorTest;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.apache.shardingsphere.test.it.distsql.handler.engine.query.DistSQLDatabaseRuleQueryExecutorAssert;
+import org.apache.shardingsphere.test.it.distsql.handler.engine.query.DistSQLRuleQueryExecutorSettings;
+import org.apache.shardingsphere.test.it.distsql.handler.engine.query.DistSQLRuleQueryExecutorTestCaseArgumentsProvider;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-class ShowBroadcastTableRuleExecutorTest extends DistSQLDatabaseRuleQueryExecutorTest {
+@DistSQLRuleQueryExecutorSettings("cases/show-broadcast-table-rules.xml")
+class ShowBroadcastTableRuleExecutorTest {
     
-    ShowBroadcastTableRuleExecutorTest() {
-        super(mock(BroadcastRule.class));
+    @ParameterizedTest(name = "DistSQL -> {0}")
+    @ArgumentsSource(DistSQLRuleQueryExecutorTestCaseArgumentsProvider.class)
+    void assertExecuteQuery(@SuppressWarnings("unused") final String distSQL, final DistSQLStatement sqlStatement,
+                            final DatabaseRuleConfiguration currentRuleConfig, final Collection<LocalDataQueryResultRow> expected) throws SQLException {
+        new DistSQLDatabaseRuleQueryExecutorAssert(mockRule()).assertQueryResultRows(currentRuleConfig, sqlStatement, expected);
     }
     
-    @ParameterizedTest(name = "{0}")
-    @ArgumentsSource(TestCaseArgumentsProvider.class)
-    void assertExecuteQuery(final String name, final DatabaseRuleConfiguration ruleConfig, final DistSQLStatement sqlStatement,
-                            final Collection<LocalDataQueryResultRow> expected) throws SQLException {
-        assertQueryResultRows(ruleConfig, sqlStatement, expected);
-    }
-    
-    private static class TestCaseArgumentsProvider implements ArgumentsProvider {
-        
-        @Override
-        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
-            return Stream.of(Arguments.arguments("normal", new BroadcastRuleConfiguration(Collections.singleton("t_address")), new ShowBroadcastTableRulesStatement(null),
-                    Collections.singleton(new LocalDataQueryResultRow("t_address"))));
-        }
+    private BroadcastRule mockRule() {
+        BroadcastRule result = mock(BroadcastRule.class);
+        when(result.getTables()).thenReturn(Collections.singleton("t_address"));
+        return result;
     }
 }

--- a/features/broadcast/distsql/handler/src/test/resources/cases/show-broadcast-table-rules-current-config.yaml
+++ b/features/broadcast/distsql/handler/src/test/resources/cases/show-broadcast-table-rules-current-config.yaml
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+rules:
+  - !BROADCAST
+    tables:
+      - t_address

--- a/features/broadcast/distsql/handler/src/test/resources/cases/show-broadcast-table-rules.xml
+++ b/features/broadcast/distsql/handler/src/test/resources/cases/show-broadcast-table-rules.xml
@@ -17,7 +17,7 @@
   -->
 
 <distsql-rule-query-executor-test-cases>
-    <test-case dist-sql="SHOW BROADCAST TABLE RULES" current-rule-config-yaml-file="cases/show-broadcast-table-rule-current-config.yaml">
+    <test-case dist-sql="SHOW BROADCAST TABLE RULES" current-rule-config-yaml-file="cases/show-broadcast-table-rules-current-config.yaml">
         <expected-query-result-rows>
             <expected-query-result-row>t_address</expected-query-result-row>
         </expected-query-result-rows>

--- a/features/broadcast/distsql/handler/src/test/resources/cases/show-broadcast-table-rules.xml
+++ b/features/broadcast/distsql/handler/src/test/resources/cases/show-broadcast-table-rules.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<distsql-rule-query-executor-test-cases>
+    <test-case dist-sql="SHOW BROADCAST TABLE RULES" current-rule-config-yaml-file="cases/show-broadcast-table-rule-current-config.yaml">
+        <expected-query-result-rows>
+            <expected-query-result-row>t_address</expected-query-result-row>
+        </expected-query-result-rows>
+    </test-case>
+</distsql-rule-query-executor-test-cases>

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/route/ReadwriteSplittingSQLRouterTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/route/ReadwriteSplittingSQLRouterTest.java
@@ -47,7 +47,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.Properties;
@@ -110,9 +112,7 @@ class ReadwriteSplittingSQLRouterTest {
                 mock(DatabaseType.class), mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, Collections.emptyMap());
         RouteContext actual = mockRouteContext();
         sqlRouter.decorateRouteContext(actual, queryContext, database, staticRule, new ConfigurationProperties(new Properties()));
-        Iterator<String> routedDataSourceNames = actual.getActualDataSourceNames().iterator();
-        assertThat(routedDataSourceNames.next(), is(NONE_READWRITE_SPLITTING_DATASOURCE_NAME));
-        assertThat(routedDataSourceNames.next(), is(READ_DATASOURCE));
+        assertThat(actual.getActualDataSourceNames(), is(new HashSet<>(Arrays.asList(NONE_READWRITE_SPLITTING_DATASOURCE_NAME, READ_DATASOURCE))));
     }
     
     @Test

--- a/test/it/distsql/src/main/java/org/apache/shardingsphere/test/it/distsql/handler/engine/query/DistSQLDatabaseRuleQueryExecutorAssert.java
+++ b/test/it/distsql/src/main/java/org/apache/shardingsphere/test/it/distsql/handler/engine/query/DistSQLDatabaseRuleQueryExecutorAssert.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.distsql.handler.engine.query;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.distsql.handler.engine.DistSQLConnectionContext;
+import org.apache.shardingsphere.distsql.handler.engine.query.DistSQLQueryExecuteEngine;
+import org.apache.shardingsphere.distsql.statement.DistSQLStatement;
+import org.apache.shardingsphere.infra.config.rule.scope.DatabaseRuleConfiguration;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
+import org.apache.shardingsphere.infra.rule.scope.DatabaseRule;
+import org.apache.shardingsphere.mode.manager.ContextManager;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.shardingsphere.test.matcher.ShardingSphereAssertionMatchers.deepEqual;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * DistSQL database rule query executor assert.
+ */
+@RequiredArgsConstructor
+public class DistSQLDatabaseRuleQueryExecutorAssert {
+    
+    private final DatabaseRule mockedRule;
+    
+    /**
+     * Assert query result rows.
+     *
+     * @param ruleConfig   rule configuration
+     * @param sqlStatement SQL statement
+     * @param expected     expected query result rows
+     * @throws SQLException SQL exception
+     */
+    public void assertQueryResultRows(final DatabaseRuleConfiguration ruleConfig, final DistSQLStatement sqlStatement, final Collection<LocalDataQueryResultRow> expected) throws SQLException {
+        DistSQLQueryExecuteEngine engine = new DistSQLQueryExecuteEngine(sqlStatement, "foo_db", mockContextManager(ruleConfig), mock(DistSQLConnectionContext.class));
+        engine.executeQuery();
+        Collection<LocalDataQueryResultRow> actual = new ArrayList<>(engine.getRows());
+        assertThat(actual, deepEqual(new ArrayList<>(expected)));
+    }
+    
+    private ContextManager mockContextManager(final DatabaseRuleConfiguration ruleConfig) {
+        ContextManager result = mock(ContextManager.class, RETURNS_DEEP_STUBS);
+        when(mockedRule.getConfiguration()).thenReturn(ruleConfig);
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        when(database.getRuleMetaData()).thenReturn(new RuleMetaData(Collections.singleton(mockedRule)));
+        when(result.getDatabase("foo_db")).thenReturn(database);
+        return result;
+    }
+}


### PR DESCRIPTION
For #33142.

Changes proposed in this pull request:
  - Use parameterized `DistSQLDatabaseRuleQueryExecutorAssert` to instead of `DistSQLDatabaseRuleQueryExecutorTest`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
