### PR TITLE
Implement DistSQLDatabaseRuleQueryExecutorAssert on ShowMaskRuleExecutorTest

### DIFF
--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/query/ShowMaskRuleExecutorTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/query/ShowMaskRuleExecutorTest.java
@@ -18,55 +18,27 @@
 package org.apache.shardingsphere.mask.distsql.handler.query;
 
 import org.apache.shardingsphere.distsql.statement.DistSQLStatement;
-import org.apache.shardingsphere.infra.algorithm.core.config.AlgorithmConfiguration;
-import org.apache.shardingsphere.infra.config.rule.scope.DatabaseRuleConfiguration;
 import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.mask.config.MaskRuleConfiguration;
-import org.apache.shardingsphere.mask.config.rule.MaskColumnRuleConfiguration;
-import org.apache.shardingsphere.mask.config.rule.MaskTableRuleConfiguration;
-import org.apache.shardingsphere.mask.distsql.statement.ShowMaskRulesStatement;
 import org.apache.shardingsphere.mask.rule.MaskRule;
-import org.apache.shardingsphere.test.it.distsql.handler.engine.query.DistSQLDatabaseRuleQueryExecutorTest;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.apache.shardingsphere.test.it.distsql.handler.engine.query.DistSQLDatabaseRuleQueryExecutorAssert;
+import org.apache.shardingsphere.test.it.distsql.handler.engine.query.DistSQLRuleQueryExecutorSettings;
+import org.apache.shardingsphere.test.it.distsql.handler.engine.query.DistSQLRuleQueryExecutorTestCaseArgumentsProvider;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Properties;
-import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
 
-class ShowMaskRuleExecutorTest extends DistSQLDatabaseRuleQueryExecutorTest {
+@DistSQLRuleQueryExecutorSettings("cases/show-mask-rules.xml")
+class ShowMaskRuleExecutorTest {
     
-    ShowMaskRuleExecutorTest() {
-        super(mock(MaskRule.class));
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @ArgumentsSource(TestCaseArgumentsProvider.class)
-    void assertExecuteQuery(final String name, final DatabaseRuleConfiguration ruleConfig, final DistSQLStatement sqlStatement,
-                            final Collection<LocalDataQueryResultRow> expected) throws SQLException {
-        assertQueryResultRows(ruleConfig, sqlStatement, expected);
-    }
-    
-    private static class TestCaseArgumentsProvider implements ArgumentsProvider {
-        
-        @Override
-        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
-            return Stream.of(Arguments.arguments("normal", createRuleConfiguration(), new ShowMaskRulesStatement("T_MASK", null),
-                    Collections.singleton(new LocalDataQueryResultRow("t_mask", "user_id", "md5", ""))));
-        }
-        
-        private MaskRuleConfiguration createRuleConfiguration() {
-            MaskColumnRuleConfiguration maskColumnRuleConfig = new MaskColumnRuleConfiguration("user_id", "t_mask_user_id_md5");
-            MaskTableRuleConfiguration maskTableRuleConfig = new MaskTableRuleConfiguration("t_mask", Collections.singleton(maskColumnRuleConfig));
-            AlgorithmConfiguration algorithmConfig = new AlgorithmConfiguration("md5", new Properties());
-            return new MaskRuleConfiguration(Collections.singleton(maskTableRuleConfig), Collections.singletonMap("t_mask_user_id_md5", algorithmConfig));
-        }
+    @ParameterizedTest(name = "DistSQL -> {0}")
+    @ArgumentsSource(DistSQLRuleQueryExecutorTestCaseArgumentsProvider.class)
+    void assertExecuteQuery(@SuppressWarnings("unused") final String distSQL, final DistSQLStatement sqlStatement,
+                            final MaskRuleConfiguration currentRuleConfig, final Collection<LocalDataQueryResultRow> expected) throws SQLException {
+        new DistSQLDatabaseRuleQueryExecutorAssert(mock(MaskRule.class)).assertQueryResultRows(currentRuleConfig, sqlStatement, expected);
     }
 }

--- a/features/mask/distsql/handler/src/test/resources/cases/show-mask-rules-current-config.yaml
+++ b/features/mask/distsql/handler/src/test/resources/cases/show-mask-rules-current-config.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+rules:
+  - !MASK
+    tables:
+      t_mask:
+        columns:
+          user_id:
+            maskAlgorithm: t_mask_user_id_md5
+    maskAlgorithms:
+      t_mask_user_id_md5:
+        type: MD5

--- a/features/mask/distsql/handler/src/test/resources/cases/show-mask-rules.xml
+++ b/features/mask/distsql/handler/src/test/resources/cases/show-mask-rules.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<distsql-rule-query-executor-test-cases>
+    <test-case dist-sql="SHOW MASK RULES" current-rule-config-yaml-file="cases/show-mask-rules-current-config.yaml">
+        <expected-query-result-rows>
+            <expected-query-result-row>
+                t_mask|user_id|MD5|
+            </expected-query-result-row>
+        </expected-query-result-rows>
+    </test-case>
+</distsql-rule-query-executor-test-cases>


### PR DESCRIPTION
For #33142.


Changes proposed in this pull request:
  - Use parameterized DistSQLDatabaseRuleQueryExecutorAssert to instead of DistSQLDatabaseRuleQueryExecutorTest

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
