### PR TITLE
Support building Example module with OpenJDK 23

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,6 +44,7 @@
 1. Infra: Enable Safe Composition of Metadata for ShardingSphere Proxy Native - [#33179](https://github.com/apache/shardingsphere/pull/33179)
 1. Infra: Support compiling and using ShardingSphere under OpenJDK 23 - [#33025](https://github.com/apache/shardingsphere/pull/33025)
 1. Hive: Support Hive integration module to connect to HiveServer2 4.0.1 - [#33212](https://github.com/apache/shardingsphere/pull/33212)
+1. Infra: Support building Example module with OpenJDK 23 - [#33224](https://github.com/apache/shardingsphere/pull/33224)
 
 ### Bug Fix
 

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/expr.cn.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/expr.cn.md
@@ -90,18 +90,13 @@ Truffle 与 JDK 的向后兼容性矩阵位于 https://medium.com/graalvm/40027a
     <dependency>
         <groupId>org.graalvm.polyglot</groupId>
         <artifactId>polyglot</artifactId>
-        <version>24.0.2</version>
+        <version>24.1.0</version>
     </dependency>
     <dependency>
         <groupId>org.graalvm.polyglot</groupId>
-        <artifactId>java-community</artifactId>
-        <version>24.0.2</version>
+        <artifactId>java</artifactId>
+        <version>24.1.0</version>
         <type>pom</type>
-    </dependency>
-    <dependency>
-        <groupId>org.graalvm.espresso</groupId>
-        <artifactId>espresso-runtime-resources-linux-amd64</artifactId>
-        <version>24.0.2</version>
     </dependency>
 </dependencies>
 ```

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/expr.en.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/expr.en.md
@@ -100,18 +100,13 @@ Truffle's backward compatibility matrix with the JDK is located at https://mediu
     <dependency>
         <groupId>org.graalvm.polyglot</groupId>
         <artifactId>polyglot</artifactId>
-        <version>24.0.2</version>
+        <version>24.1.0</version>
     </dependency>
     <dependency>
         <groupId>org.graalvm.polyglot</groupId>
-        <artifactId>java-community</artifactId>
-        <version>24.0.2</version>
+        <artifactId>java</artifactId>
+        <version>24.1.0</version>
         <type>pom</type>
-    </dependency>
-    <dependency>
-        <groupId>org.graalvm.espresso</groupId>
-        <artifactId>espresso-runtime-resources-linux-amd64</artifactId>
-        <version>24.0.2</version>
     </dependency>
 </dependencies>
 ```

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -46,7 +46,7 @@
         <h2.version>2.2.224</h2.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.2.13</logback.version>
-        <lombok.version>1.18.30</lombok.version>
+        <lombok.version>1.18.34</lombok.version>
         <mybatis.version>3.5.9</mybatis.version>
         <mybatis-spring.version>2.0.5</mybatis-spring.version>
         <mybatis-spring-boot.version>2.1.3</mybatis-spring-boot.version>
@@ -60,7 +60,7 @@
         <seata.version>1.6.1</seata.version>
         
         <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
-        <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <freemarker.version>2.3.31</freemarker.version>
@@ -338,12 +338,29 @@
     
     <profiles>
         <profile>
-            <id>jdk11+</id>
+            <id>jdk11-22</id>
             <activation>
-                <jdk>[11,)</jdk>
+                <jdk>[11,23)</jdk>
             </activation>
             <properties>
                 <annotation-api.version>1.3.2</annotation-api.version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>${annotation-api.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk23+</id>
+            <activation>
+                <jdk>[23,)</jdk>
+            </activation>
+            <properties>
+                <annotation-api.version>1.3.2</annotation-api.version>
+                <maven.compiler.proc>full</maven.compiler.proc>
             </properties>
             <dependencies>
                 <dependency>

--- a/infra/expr/type/espresso/pom.xml
+++ b/infra/expr/type/espresso/pom.xml
@@ -51,15 +51,9 @@
         </dependency>
         <dependency>
             <groupId>org.graalvm.polyglot</groupId>
-            <artifactId>java-community</artifactId>
+            <artifactId>java</artifactId>
             <version>${graal-sdk.version}</version>
             <type>pom</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.graalvm.espresso</groupId>
-            <artifactId>espresso-runtime-resources-linux-amd64</artifactId>
-            <version>${graal-sdk.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <testcontainers.version>1.20.1</testcontainers.version>
         <commons-csv.version>1.9.0</commons-csv.version>
         
-        <graal-sdk.version>24.0.2</graal-sdk.version>
+        <graal-sdk.version>24.1.0</graal-sdk.version>
         <jedis.version>4.4.6</jedis.version>
         
         <!-- 3rd party library plugin versions -->
@@ -988,9 +988,36 @@
     
     <profiles>
         <profile>
-            <id>jdk11+</id>
+            <id>jdk11-22</id>
             <activation>
-                <jdk>[11,)</jdk>
+                <jdk>[11,23)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/sun.net=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED</argLine>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <artifactId>maven-failsafe-plugin</artifactId>
+                            <configuration>
+                                <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/sun.net=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED</argLine>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk23+</id>
+            <activation>
+                <jdk>[23,)</jdk>
             </activation>
             <properties>
                 <maven.compiler.release>8</maven.compiler.release>


### PR DESCRIPTION
For #32927.

Changes proposed in this pull request:
  - Support building Example module with OpenJDK 23. Fixes https://github.com/apache/shardingsphere/actions/runs/11297151161/job/31423492593 .
  - Due to the ongoing dispute at https://github.com/oracle/graal/issues/9382 , GraalVM Truffle's Espresso implementation currently does not have a GPL V2 LICENSE JAR. Cross-compiling GraalVM Truffle's Espresso implementation JAR via LLVM would only cause annoyance to contributors in the shardingsphere. Therefore, I need to import the non-OSI approved LICENSE `org.graalvm.polyglot:java:24.1.0` in the unit test. 

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
