### PR TITLE
Change the Base Docker Image of ShardingSphere Proxy Native

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -45,6 +45,7 @@
 1. Infra: Support compiling and using ShardingSphere under OpenJDK 23 - [#33025](https://github.com/apache/shardingsphere/pull/33025)
 1. Hive: Support Hive integration module to connect to HiveServer2 4.0.1 - [#33212](https://github.com/apache/shardingsphere/pull/33212)
 1. Infra: Support building Example module with OpenJDK 23 - [#33224](https://github.com/apache/shardingsphere/pull/33224)
+1. Proxy Native: Change the Base Docker Image of ShardingSphere Proxy Native - [#33263](https://github.com/apache/shardingsphere/issues/33263)
 
 ### Bug Fix
 

--- a/distribution/proxy-native/Dockerfile
+++ b/distribution/proxy-native/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM oraclelinux:9-slim
+FROM container-registry.oracle.com/os/oraclelinux:9-slim
 LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache.org"
 ENV LOCAL_PATH=/opt/shardingsphere-proxy-native-bin
 ARG OUTPUT_DIRECTORY_NAME

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -149,7 +149,8 @@ services:
       - "3307:3307"
 ```
 
-如果用户不对 Git Source 做任何更改，上文提及的命令将使用 `oraclelinux:9-slim` 作为 Base Docker Image。
+如果用户不对 Git Source 做任何更改，
+上文提及的命令将使用 https://container-registry.oracle.com/ords/ocr/ba/os/oraclelinux 中的 `container-registry.oracle.com/os/oraclelinux:9-slim` 作为 Base Docker Image。
 但如果用户希望使用 `scratch`，`alpine:3`，`gcr.io/distroless/base-debian12`，
 `gcr.io/distroless/java-base-debian12` 或 `gcr.io/distroless/static-debian12` 等更小体积的 Docker Image 作为 Base Docker Image，
 用户可能需要根据 https://www.graalvm.org/jdk23/reference-manual/native-image/guides/build-static-executables/ 的要求，

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -153,7 +153,8 @@ services:
       - "3307:3307"
 ```
 
-If the user does not make any changes to the Git Source, the command mentioned above will use `oraclelinux:9-slim` as the Base Docker Image.
+If the user does not make any changes to the Git Source, 
+the above mentioned command will use `container-registry.oracle.com/os/oraclelinux:9-slim` in https://container-registry.oracle.com/ords/ocr/ba/os/oraclelinux as the Base Docker Image.
 But if the user wants to use a smaller Docker Image such as `scratch`, `alpine:3`, `gcr.io/distroless/base-debian12`,
 `gcr.io/distroless/java-base-debian12` or `gcr.io/distroless/static-debian12` as the Base Docker Image,
 the user may need to add `--static`, 

--- a/infra/expr/type/espresso/src/test/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParserTest.java
+++ b/infra/expr/type/espresso/src/test/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParserTest.java
@@ -22,7 +22,9 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledOnJre;
 import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 
 import java.util.Arrays;
@@ -35,6 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@EnabledOnJre(value = {JRE.JAVA_21, JRE.JAVA_23}, disabledReason = "This is used to match the requirement of `org.graalvm.polyglot:polyglot:24.1.0`")
 @EnabledIfSystemProperty(named = "java.vm.vendor", matches = "GraalVM Community", disabledReason = "Github Actions device performance is too low")
 @EnabledOnOs(value = OS.LINUX, architectures = "amd64", disabledReason = "See https://www.graalvm.org/jdk21/reference-manual/java-on-truffle/faq/#does-java-running-on-truffle-run-on-hotspot-too")
 class EspressoInlineExpressionParserTest {


### PR DESCRIPTION
Fixes #33263.

Changes proposed in this pull request:
  - Change the Base Docker Image of ShardingSphere Proxy Native.
  - Change `org.apache.shardingsphere.infra.expr.espresso.EspressoInlineExpressionParserTest` to restrict it from running on JDK22. See https://shardingsphere.apache.org/document/current/en/user-manual/common-config/builtin-algorithm/expr/#row-value-expressions-that-uses-the-groovy-syntax-based-on-graalvm-truffles-espresso-implementation for the Truffle API compatibility table https://medium.com/graalvm/40027a59c401 .
  - ![image](https://github.com/user-attachments/assets/b7c02cca-ce27-453b-94ef-6de673b1f01c)
  - ![image](https://github.com/user-attachments/assets/d7e74cd2-c583-462e-a267-faa821a477b3)


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
