### PR TITLE
Added INSTR to Doris parsing support (#31508)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -62,6 +62,8 @@
 1. Infra: Support compiling and using ShardingSphere under OpenJDK 23 - [#33025](https://github.com/apache/shardingsphere/pull/33025)
 1. Hive: Support Hive integration module to connect to HiveServer2 4.0.1 - [#33212](https://github.com/apache/shardingsphere/pull/33212)
 1. Infra: Support building Example module with OpenJDK 23 - [#33224](https://github.com/apache/shardingsphere/pull/33224)
+1. SQL Parser: Support parsing Doris BITXOR - [#33258](https://github.com/apache/shardingsphere/pull/33258)
+
 
 ### Bug Fix
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -63,7 +63,7 @@
 1. Hive: Support Hive integration module to connect to HiveServer2 4.0.1 - [#33212](https://github.com/apache/shardingsphere/pull/33212)
 1. Infra: Support building Example module with OpenJDK 23 - [#33224](https://github.com/apache/shardingsphere/pull/33224)
 1. SQL Parser: Support parsing Doris BITXOR - [#33258](https://github.com/apache/shardingsphere/pull/33258)
-
+1. SQL Parser: Support parsing Doris INSTR - [#33289](3325://github.com/apache/shardingsphere/pull/33289)
 
 ### Bug Fix
 

--- a/parser/sql/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
+++ b/parser/sql/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
@@ -261,6 +261,7 @@ identifierKeywordsUnambiguous
     | INITIAL_SIZE
     | INSERT_METHOD
     | INSTANCE
+    | INSTR
     | INVISIBLE
     | INVOKER
     | IO
@@ -1037,6 +1038,7 @@ specialFunction
     | charFunction
     | extractFunction
     | groupConcatFunction
+    | instrFunction
     | positionFunction
     | substringFunction
     | trimFunction
@@ -1062,6 +1064,10 @@ timeStampDiffFunction
 
 groupConcatFunction
     : GROUP_CONCAT LP_ distinct? (expr (COMMA_ expr)* | ASTERISK_)? (orderByClause)? (SEPARATOR expr)? RP_
+    ;
+
+instrFunction
+    : INSTR LP_ expr COMMA_ expr RP_
     ;
 
 windowFunction

--- a/parser/sql/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
+++ b/parser/sql/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
@@ -263,7 +263,9 @@ identifierKeywordsUnambiguous
     | INITIAL_SIZE
     | INSERT_METHOD
     | INSTANCE
+    // DORIS ADDED BEGIN
     | INSTR
+    // DORIS ADDED END
     | INVISIBLE
     | INVOKER
     | IO

--- a/parser/sql/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
+++ b/parser/sql/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
@@ -150,7 +150,9 @@ identifierKeywordsUnambiguous
     | BEFORE
     | BINLOG
     | BIT
+    // DORIS ADDED BEGIN
     | BITXOR
+    // DORIS ADDED END
     | BLOCK
     | BOOLEAN
     | BOOL
@@ -962,9 +964,11 @@ aggregationFunction
     : aggregationFunctionName LP_ distinct? (expr (COMMA_ expr)* | ASTERISK_)? collateClause? RP_ overClause?
     ;
 
+// DORIS ADDED BEGIN
 bitwiseFunction
     : bitwiseBinaryFunctionName LP_ expr COMMA_ expr RP_
     ;
+// DORIS ADDED END
 
 jsonFunction
     : jsonTableFunction
@@ -999,9 +1003,11 @@ aggregationFunctionName
     : MAX | MIN | SUM | COUNT | AVG | BIT_XOR | GROUP_CONCAT
     ;
 
+// DORIS ADDED BEGIN
 bitwiseBinaryFunctionName
     : BITXOR
     ;
+// DORIS ADDED END
 
 distinct
     : DISTINCT
@@ -1034,11 +1040,16 @@ frameBetween
 specialFunction
     : castFunction
     | convertFunction
+    // DORIS ADDED BEGIN
+    | bitwiseFunction
+    // DORIS ADDED END
     | currentUserFunction
     | charFunction
     | extractFunction
     | groupConcatFunction
+    // DORIS ADDED BEGIN
     | instrFunction
+    // DORIS ADDED END
     | positionFunction
     | substringFunction
     | trimFunction
@@ -1047,7 +1058,6 @@ specialFunction
     | windowFunction
     | groupingFunction
     | timeStampDiffFunction
-    | bitwiseFunction
     ;
 
 currentUserFunction
@@ -1066,9 +1076,11 @@ groupConcatFunction
     : GROUP_CONCAT LP_ distinct? (expr (COMMA_ expr)* | ASTERISK_)? (orderByClause)? (SEPARATOR expr)? RP_
     ;
 
+// DORIS ADDED BEGIN
 instrFunction
     : INSTR LP_ expr COMMA_ expr RP_
     ;
+// DORIS ADDED END
 
 windowFunction
     : funcName = (ROW_NUMBER | RANK | DENSE_RANK | CUME_DIST | PERCENT_RANK) LP_ RP_ windowingClause

--- a/parser/sql/dialect/doris/src/main/antlr4/imports/doris/DorisKeyword.g4
+++ b/parser/sql/dialect/doris/src/main/antlr4/imports/doris/DorisKeyword.g4
@@ -127,9 +127,11 @@ ASSIGN_GTIDS_TO_ANONYMOUS_TRANSACTIONS
     : A S S I G N UL_ G T I D S UL_ T O UL_ A N O N Y M O U S UL_ T R A N S A C T I O N S
     ;
 
+// DORIS ADDED BEGIN
 BITXOR
     : B I T X O R
     ;
+// DORIS ADDED END
 
 BIT_XOR
     : B I T UL_ X O R
@@ -1071,9 +1073,12 @@ INSTANCE
     : I N S T A N C E
     ;
 
+// DORIS ADDED BEOIM
 INSTR
     : I N S T R
     ;
+// DORIS ADDED END
+
 
 INT
     : I N T

--- a/parser/sql/dialect/doris/src/main/antlr4/imports/doris/DorisKeyword.g4
+++ b/parser/sql/dialect/doris/src/main/antlr4/imports/doris/DorisKeyword.g4
@@ -1071,6 +1071,10 @@ INSTANCE
     : I N S T A N C E
     ;
 
+INSTR
+    : I N S T R
+    ;
+
 INT
     : I N T
     ;

--- a/parser/sql/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/doris/visitor/statement/DorisStatementVisitor.java
+++ b/parser/sql/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/doris/visitor/statement/DorisStatementVisitor.java
@@ -1001,6 +1001,9 @@ public abstract class DorisStatementVisitor extends DorisStatementBaseVisitor<AS
         if (null != ctx.convertFunction()) {
             return visit(ctx.convertFunction());
         }
+        if (null != ctx.instrFunction()) {
+            return visit(ctx.instrFunction());
+        }
         if (null != ctx.positionFunction()) {
             return visit(ctx.positionFunction());
         }
@@ -1185,6 +1188,15 @@ public abstract class DorisStatementVisitor extends DorisStatementBaseVisitor<AS
     @Override
     public final ASTNode visitBitwiseFunction(final BitwiseFunctionContext ctx) {
         FunctionSegment result = new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.bitwiseBinaryFunctionName().getText(), getOriginalText(ctx));
+        for (ExprContext each : ctx.expr()) {
+            result.getParameters().add(new LiteralExpressionSegment(each.getStart().getStartIndex(), each.getStop().getStopIndex(), each.getText()));
+        }
+        return result;
+    }
+    
+    @Override
+    public final ASTNode visitInstrFunction(final InstrFunctionContext ctx) {
+        FunctionSegment result = new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.INSTR().getText(), getOriginalText(ctx));
         for (ExprContext each : ctx.expr()) {
             result.getParameters().add(new LiteralExpressionSegment(each.getStart().getStartIndex(), each.getStop().getStopIndex(), each.getText()));
         }

--- a/parser/sql/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/doris/visitor/statement/DorisStatementVisitor.java
+++ b/parser/sql/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/doris/visitor/statement/DorisStatementVisitor.java
@@ -74,6 +74,7 @@ import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.InsertC
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.InsertIdentifierContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.InsertSelectClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.InsertValuesClauseContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.InstrFunctionContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.IntervalExpressionContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.JoinSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.JoinedTableContext;
@@ -995,15 +996,22 @@ public abstract class DorisStatementVisitor extends DorisStatementBaseVisitor<AS
         if (null != ctx.windowFunction()) {
             return visit(ctx.windowFunction());
         }
+        // DORIS ADDED BEGIN
+        if (null != ctx.bitwiseFunction()) {
+            return visit(ctx.bitwiseFunction());
+        }
+        // DORIS ADDED END
         if (null != ctx.castFunction()) {
             return visit(ctx.castFunction());
         }
         if (null != ctx.convertFunction()) {
             return visit(ctx.convertFunction());
         }
+        // DORIS ADDED BEGIN
         if (null != ctx.instrFunction()) {
             return visit(ctx.instrFunction());
         }
+        // DORIS ADDED END
         if (null != ctx.positionFunction()) {
             return visit(ctx.positionFunction());
         }
@@ -1031,9 +1039,6 @@ public abstract class DorisStatementVisitor extends DorisStatementBaseVisitor<AS
         if (null != ctx.timeStampDiffFunction()) {
             return visit(ctx.timeStampDiffFunction());
         }
-        if (null != ctx.bitwiseFunction()) {
-            return visit(ctx.bitwiseFunction());
-        }
         return new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), getOriginalText(ctx), getOriginalText(ctx));
     }
     
@@ -1046,6 +1051,28 @@ public abstract class DorisStatementVisitor extends DorisStatementBaseVisitor<AS
         }
         return result;
     }
+    
+    // DORIS ADDED BEGIN
+    @Override
+    public final ASTNode visitBitwiseFunction(final BitwiseFunctionContext ctx) {
+        FunctionSegment result = new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.bitwiseBinaryFunctionName().getText(), getOriginalText(ctx));
+        for (ExprContext each : ctx.expr()) {
+            result.getParameters().add(new LiteralExpressionSegment(each.getStart().getStartIndex(), each.getStop().getStopIndex(), each.getText()));
+        }
+        return result;
+    }
+    // DORIS ADDED END
+    
+    // DORIS ADDED BEGIN
+    @Override
+    public final ASTNode visitInstrFunction(final InstrFunctionContext ctx) {
+        FunctionSegment result = new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.INSTR().getText(), getOriginalText(ctx));
+        for (ExprContext each : ctx.expr()) {
+            result.getParameters().add(new LiteralExpressionSegment(each.getStart().getStartIndex(), each.getStop().getStopIndex(), each.getText()));
+        }
+        return result;
+    }
+    // DORIS ADDED END
     
     @Override
     public final ASTNode visitCastFunction(final CastFunctionContext ctx) {
@@ -1182,24 +1209,6 @@ public abstract class DorisStatementVisitor extends DorisStatementBaseVisitor<AS
     public ASTNode visitTimeStampDiffFunction(final TimeStampDiffFunctionContext ctx) {
         FunctionSegment result = new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.TIMESTAMPDIFF().getText(), getOriginalText(ctx));
         result.getParameters().addAll(getExpressions(ctx.expr()));
-        return result;
-    }
-    
-    @Override
-    public final ASTNode visitBitwiseFunction(final BitwiseFunctionContext ctx) {
-        FunctionSegment result = new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.bitwiseBinaryFunctionName().getText(), getOriginalText(ctx));
-        for (ExprContext each : ctx.expr()) {
-            result.getParameters().add(new LiteralExpressionSegment(each.getStart().getStartIndex(), each.getStop().getStopIndex(), each.getText()));
-        }
-        return result;
-    }
-    
-    @Override
-    public final ASTNode visitInstrFunction(final InstrFunctionContext ctx) {
-        FunctionSegment result = new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.INSTR().getText(), getOriginalText(ctx));
-        for (ExprContext each : ctx.expr()) {
-            result.getParameters().add(new LiteralExpressionSegment(each.getStart().getStartIndex(), each.getStop().getStopIndex(), each.getText()));
-        }
         return result;
     }
     

--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -4145,7 +4145,7 @@
             </function-table>
         </from>
     </select>
-        <select sql-case-id="select_bitxor" db-types="Doris">
+    <select sql-case-id="select_bitxor" db-types="Doris">
         <projections start-index="7" stop-index="17">
             <expression-projection text="BITXOR(3,5)" start-index="7" stop-index="17">
                 <expr>
@@ -4155,6 +4155,22 @@
                         </parameter>
                         <parameter>
                             <literal-expression value="5" start-index="16" stop-index="16" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+    <select sql-case-id="select_instr" db-types="Doris">
+        <projections start-index="7" stop-index="27">
+            <expression-projection text="INSTR('foobar','bar')" start-index="7" stop-index="27">
+                <expr>
+                    <function function-name="INSTR" start-index="7" stop-index="27" text="INSTR('foobar','bar')">
+                        <parameter>
+                            <literal-expression value="'foobar'" start-index="13" stop-index="20" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="'bar'" start-index="22" stop-index="26" />
                         </parameter>
                     </function>
                 </expr>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
@@ -240,4 +240,5 @@
     <sql-case id="select_st_convexhull" value="SELECT ST_ConvexHull(ST_GeomFromText('MULTIPOINT(5 0,25 0,15 10,15 25)'))" db-types="MySQL,Doris" />
     <sql-case id="select_st_crosses" value="SELECT ST_Crosses(ST_GeomFromText('POINT(1 1)'), ST_GeomFromText('POINT(2 2)'))" db-types="MySQL,Doris" />
     <sql-case id="select_bitxor" value="SELECT BITXOR(3,5)" db-types="Doris" />
+    <sql-case id="select_instr" value="SELECT INSTR('foobar','bar')" db-types="Doris" />
 </sql-cases>


### PR DESCRIPTION
As part of hacktoberfest, this is a POC for adding more parsing logic to Doris support. If this is successful, I will look at the other Doris SQL keywords in subsequent PRs. Continues to address #31508.

Note that
- Doris: `SELECT INSTR('foobar','bar')`
- MySQL: `SELECT POSITION('bar' IN 'foobar')` and `SELECT LOCATE('bar','foobar')` are the equivalent

I understand that I cannot add the labels to the PR and maintainers have to do it.

### Changes proposed in this pull request:

- Made g4 changes
- Includes test case additions to XML
- Added  `// DORIS ADDED BEGIN|END` markers to code for both this change and #33258
- Moved related code around to better reflect order in the g4
- Added to release notes

### Next
---


Before committing this PR, I'm sure that I have checked the following options:
- [✅] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [✅] I have self-reviewed the commit code.
- [✅] I have (or in comment I request) added corresponding labels for the pull request.
- [✅] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [✅ ] I have made corresponding changes to the documentation (release notes)
- [✅] I have added corresponding unit tests for my changes.
- [✅] `mvn spotless:apply -Pcheck`
- [✅] `mvn test -Dtest=InternalDorisParserIT` in shardingsphere/parser/sql/dialect/doris
- [✅] Executed test case in Doris v2.0.3 – `SELECT INSTR('foobar','bar')`