### PR TITLE
Refactor : refactor the exclude jacoco exec files

### DIFF
--- a/.github/workflows/resources/scripts/unit-test-coverage-merge/code-coverage-merge.sh
+++ b/.github/workflows/resources/scripts/unit-test-coverage-merge/code-coverage-merge.sh
@@ -89,8 +89,7 @@ done
 # delete useless packages or files to avoid useless packages analysis
 # delete the build/libs/groovy.jar file, this will include useless packages
 find . -type f -regex '.*/groovy.jar' -exec rm -f {} +
-find . -type d -regex '.*/parser/autogen/*' -exec rm -rf {} +
-find . -type d -regex '.*/src/main/templates/*' -exec rm -rf {} +
+find . -type d -regex '.*/autogen/*' -exec rm -rf {} +
 
 echo "Copy Success, the compilation merge output folder is located at: $classOutPutDir"
 echo "Start generating overall coverage reports"


### PR DESCRIPTION
Changes proposed in this pull request:
  - refactor the exclude jacoco exec files

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
