### PR TITLE
Fix missing logic db when query information_schema.SCHEMATA with NOT IN clause

### DIFF
--- a/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/information/SelectInformationSchemataExecutor.java
+++ b/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/information/SelectInformationSchemataExecutor.java
@@ -142,7 +142,7 @@ public final class SelectInformationSchemataExecutor extends DefaultDatabaseMeta
     protected void preProcess(final String databaseName, final Map<String, Object> rows, final Map<String, String> alias) throws SQLException {
         ResourceMetaData resourceMetaData = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getDatabase(databaseName).getResourceMetaData();
         Collection<String> catalogs = getCatalogs(resourceMetaData);
-        schemaNameAlias = alias.getOrDefault(SCHEMA_NAME, "");
+        schemaNameAlias = alias.getOrDefault(SCHEMA_NAME, alias.getOrDefault(schemaNameAlias, schemaNameAlias));
         String rowValue = rows.getOrDefault(schemaNameAlias, "").toString();
         queryDatabase = !rowValue.isEmpty();
         if (catalogs.contains(rowValue)) {


### PR DESCRIPTION
Optimize  #33346.

Changes proposed in this pull request:
  - If `originalColumnName` is not SCHEMA_NAME, use alias to get result.