### PR TITLE
Simplify the use of Agent's Docker Image

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,7 @@
 1. Proxy Native: Change the Base Docker Image of ShardingSphere Proxy Native - [#33263](https://github.com/apache/shardingsphere/issues/33263)
 1. Proxy: Add query parameters and check for mysql kill processId - [#33274](https://github.com/apache/shardingsphere/pull/33274)
 1. SQL Parser: Support parsing Doris INSTR - [#33289](https://github.com/apache/shardingsphere/pull/33289)
+1. Agent: Simplify the use of Agent's Docker Image - [#33356](https://github.com/apache/shardingsphere/pull/33356)
 
 ### Bug Fixes
 

--- a/distribution/agent/Dockerfile
+++ b/distribution/agent/Dockerfile
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM eclipse-temurin:22-jdk
+FROM eclipse-temurin:23-jdk
 LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache.org"
-ARG APP_NAME
-ADD target/${APP_NAME} /usr
+ARG DIRECTORY_NAME
+ARG JAR_NAME
+ADD target/${DIRECTORY_NAME} /usr
+RUN mv /usr/agent/${JAR_NAME} /usr/agent/shardingsphere-agent.jar

--- a/distribution/agent/pom.xml
+++ b/distribution/agent/pom.xml
@@ -120,7 +120,9 @@
                                     <arguments>
                                         <argument>build</argument>
                                         <argument>--build-arg</argument>
-                                        <argument>APP_NAME=apache-shardingsphere-${project.version}-shardingsphere-agent-bin</argument>
+                                        <argument>DIRECTORY_NAME=apache-shardingsphere-${project.version}-shardingsphere-agent-bin</argument>
+                                        <argument>--build-arg</argument>
+                                        <argument>JAR_NAME=shardingsphere-agent-${project.version}.jar</argument>
                                         <argument>.</argument>
                                         <argument>-t</argument>
                                         <argument>apache/shardingsphere-agent:${project.version}</argument>
@@ -184,7 +186,9 @@
                                         <argument>--platform</argument>
                                         <argument>linux/amd64,linux/arm64</argument>
                                         <argument>--build-arg</argument>
-                                        <argument>APP_NAME=apache-shardingsphere-${project.version}-shardingsphere-agent-bin</argument>
+                                        <argument>DIRECTORY_NAME=apache-shardingsphere-${project.version}-shardingsphere-agent-bin</argument>
+                                        <argument>--build-arg</argument>
+                                        <argument>JAR_NAME=shardingsphere-agent-${project.version}.jar</argument>
                                         <argument>.</argument>
                                         <argument>-t</argument>
                                         <argument>${agent.image.repository}:${agent.image.tag}</argument>

--- a/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.cn.md
@@ -149,12 +149,8 @@ docker network create example-net
 docker run --rm -d \
   --name jaeger \
   -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
-  -p 16686:16686 \
-  -p 4317:4317 \
-  -p 4318:4318 \
-  -p 9411:9411 \
   --network example-net \
-  jaegertracing/all-in-one:1.60.0
+  jaegertracing/all-in-one:1.62.0
 ```
 
 2. 假设 `./custom-agent.yaml` 包含 ShardingSphere Agent 的配置，内容可能如下，
@@ -175,7 +171,7 @@ plugins:
 FROM ghcr.io/apache/shardingsphere-agent:latest
 COPY ./target/example.jar /app.jar
 COPY ./custom-agent.yaml /usr/agent/conf/agent.yaml
-ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent-5.5.2-SNAPSHOT.jar","-jar","/app.jar"]
+ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent.jar","-jar","/app.jar"]
 ```
 
 如果是通过本地构建 `apache/shardingsphere-agent:latest` 的 Docker Image，`Dockerfile` 可能如下，
@@ -184,7 +180,7 @@ ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent-5.5.2-SNAPSHOT.ja
 FROM apache/shardingsphere-agent:latest
 COPY ./target/example.jar /app.jar
 COPY ./custom-agent.yaml /usr/agent/conf/agent.yaml
-ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent-5.5.2-SNAPSHOT.jar","-jar","/app.jar"]
+ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent.jar","-jar","/app.jar"]
 ```
 
 4. 享受它，

--- a/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.en.md
@@ -151,12 +151,8 @@ docker network create example-net
 docker run --rm -d \
   --name jaeger \
   -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
-  -p 16686:16686 \
-  -p 4317:4317 \
-  -p 4318:4318 \
-  -p 9411:9411 \
   --network example-net \
-  jaegertracing/all-in-one:1.60.0
+  jaegertracing/all-in-one:1.62.0
 ```
 
 2. Assume `./custom-agent.yaml` contains the configuration of ShardingSphere Agent, and the content may be as follows,
@@ -177,7 +173,7 @@ you can use the ShardingSphere Agent in the nightly built Docker Image for a JAR
 FROM ghcr.io/apache/shardingsphere-agent:latest
 COPY ./target/example.jar /app.jar
 COPY ./custom-agent.yaml /usr/agent/conf/agent.yaml
-ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent-5.5.2-SNAPSHOT.jar","-jar","/app.jar "]
+ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent.jar","-jar","/app.jar"]
 ```
 
 If you build the Docker Image of `apache/shardingsphere-agent:latest` locally, the `Dockerfile` may be as follows,
@@ -186,7 +182,7 @@ If you build the Docker Image of `apache/shardingsphere-agent:latest` locally, t
 FROM apache/shardingsphere-agent:latest
 COPY ./target/example.jar /app.jar
 COPY ./custom-agent.yaml /usr/agent/conf/agent.yaml
-ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent-5.5.2-SNAPSHOT.jar","-jar","/app.jar"]
+ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent.jar","-jar","/app.jar"]
 ```
 
 4. Enjoy it,


### PR DESCRIPTION
For #33350.

Changes proposed in this pull request:
  - Simplify the use of Agent's Docker Image. This properly aligns with the sidecar image processing of the skywalking agent. See https://hub.docker.com/r/apache/skywalking-java-agent .
  - Bump Base Image to JDK23.
  - I've verified this helps with https://github.com/apache/shardingsphere/issues/32793 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
