### PR TITLE
Add the release process of ShardingSphere Agent's Docker Image to the release guide

### DIFF
--- a/distribution/agent/pom.xml
+++ b/distribution/agent/pom.xml
@@ -27,6 +27,11 @@
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     
+    <properties>
+        <agent.image.repository>ghcr.io/apache/shardingsphere-agent</agent.image.repository>
+        <agent.image.tag>${project.version}</agent.image.tag>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
@@ -125,9 +130,9 @@
                                         <argument>JAR_NAME=shardingsphere-agent-${project.version}.jar</argument>
                                         <argument>.</argument>
                                         <argument>-t</argument>
-                                        <argument>apache/shardingsphere-agent:${project.version}</argument>
+                                        <argument>${agent.image.repository}:${agent.image.tag}</argument>
                                         <argument>-t</argument>
-                                        <argument>apache/shardingsphere-agent:latest</argument>
+                                        <argument>${agent.image.repository}:latest</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -138,10 +143,6 @@
         </profile>
         <profile>
             <id>docker.buildx.push</id>
-            <properties>
-                <agent.image.repository>apache/shardingsphere-agent</agent.image.repository>
-                <agent.image.tag>${project.version}</agent.image.tag>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/docs/community/content/involved/release/shardingsphere.cn.md
+++ b/docs/community/content/involved/release/shardingsphere.cn.md
@@ -579,6 +579,28 @@ git checkout ${RELEASE.VERSION}
 docker logout
 ```
 
+3.5 登录 GitHub Packages Container Registry
+
+```shell
+docker login ghcr.io/apache/shardingsphere
+```
+
+3.6 构建并推送 ShardingSphere Agent Docker image
+
+```shell
+cd ~/shardingsphere
+git checkout ${RELEASE.VERSION}
+./mvnw -am -pl distribution/agent -Prelease,docker.buildx.push -T 1C -DskipTests clean package
+```
+
+3.7 确认发布成功
+
+查看 [GitHub Packages](https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-agent) 是否有发布的镜像，确保镜像同时支持 `linux/amd64` 和 `linux/arm64`。
+
+```shell
+docker logout
+```
+
 ### 4. GitHub 版本发布
 
 在 [GitHub Releases](https://github.com/apache/shardingsphere/releases) 页面创建新版本。

--- a/docs/community/content/involved/release/shardingsphere.en.md
+++ b/docs/community/content/involved/release/shardingsphere.en.md
@@ -584,6 +584,28 @@ Go to [Docker Hub](https://hub.docker.com/r/apache/shardingsphere-proxy/) and ch
 docker logout
 ```
 
+3.5 Log in to GitHub Packages Container Registry
+
+```shell
+docker login ghcr.io/apache/shardingsphere
+```
+
+3.6 Build and push ShardingSphere Agent Docker image
+
+```shell
+cd ~/shardingsphere
+git checkout ${RELEASE.VERSION}
+./mvnw -am -pl distribution/agent -Prelease,docker.buildx.push -T 1C -DskipTests clean package
+```
+
+3.7 Confirm the successful release
+
+Check [GitHub Packages](https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-agent) for released images, and make sure that the image supports both `linux/amd64` and `linux/arm64`.
+
+```shell
+docker logout
+```
+
 ### 4. Publish release on GitHub
 
 Click `Draft a new release` in [GitHub Releases](https://github.com/apache/shardingsphere/releases).

--- a/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.cn.md
@@ -125,7 +125,7 @@ cd ./shardingsphere/
 此后若在自定义 `Dockerfile` 中添加以下语句，这会将 ShardingSphere Agent 的目录复制到 `/shardingsphere-agent/` 。
 
 ```dockerfile
-COPY --from=apache/shardingsphere-agent:latest /usr/agent/ /shardingsphere-agent/
+COPY --from=ghcr.io/apache/shardingsphere-agent:latest /usr/agent/ /shardingsphere-agent/
 ```
 
 #### 夜间构建
@@ -174,10 +174,10 @@ COPY ./custom-agent.yaml /usr/agent/conf/agent.yaml
 ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent.jar","-jar","/app.jar"]
 ```
 
-如果是通过本地构建 `apache/shardingsphere-agent:latest` 的 Docker Image，`Dockerfile` 可能如下，
+如果是通过本地构建 `ghcr.io/apache/shardingsphere-agent:latest` 的 Docker Image，`Dockerfile` 可能如下，
 
 ```dockerfile
-FROM apache/shardingsphere-agent:latest
+FROM ghcr.io/apache/shardingsphere-agent:latest
 COPY ./target/example.jar /app.jar
 COPY ./custom-agent.yaml /usr/agent/conf/agent.yaml
 ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent.jar","-jar","/app.jar"]

--- a/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.en.md
@@ -127,7 +127,7 @@ cd ./shardingsphere/
 If you add the following statement in your custom `Dockerfile`, it will copy the ShardingSphere Agent directory to `/shardingsphere-agent/`.
 
 ```dockerfile
-COPY --from=apache/shardingsphere-agent:latest /usr/agent/ /shardingsphere-agent/
+COPY --from=ghcr.io/apache/shardingsphere-agent:latest /usr/agent/ /shardingsphere-agent/
 ```
 
 #### Nightly Build
@@ -176,10 +176,10 @@ COPY ./custom-agent.yaml /usr/agent/conf/agent.yaml
 ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent.jar","-jar","/app.jar"]
 ```
 
-If you build the Docker Image of `apache/shardingsphere-agent:latest` locally, the `Dockerfile` may be as follows,
+If you build the Docker Image of `ghcr.io/apache/shardingsphere-agent:latest` locally, the `Dockerfile` may be as follows,
 
 ```dockerfile
-FROM apache/shardingsphere-agent:latest
+FROM ghcr.io/apache/shardingsphere-agent:latest
 COPY ./target/example.jar /app.jar
 COPY ./custom-agent.yaml /usr/agent/conf/agent.yaml
 ENTRYPOINT ["java","-javaagent:/usr/agent/shardingsphere-agent.jar","-jar","/app.jar"]

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -57,7 +57,7 @@ please enable LLVM backend according to the content of https://medium.com/graalv
 Users must build the different GraalVM Native Image for each target operating system and target architecture that they need to run the GraalVM Native Image on.
 Users can consider partially circumventing this limitation by using Docker Image.
 
-This section is still limited by the documented content of the [GraalVM Native Image](/us/user-manual/shardingsphere-jdbc/graalvm-native-image) on the ShardingSphere JDBC side.
+This section is still limited by the documented content of the [GraalVM Native Image](/en/user-manual/shardingsphere-jdbc/graalvm-native-image) on the ShardingSphere JDBC side.
 
 ## Premise
 


### PR DESCRIPTION
Fixes #33350 .

Changes proposed in this pull request:
  - Add the release process of ShardingSphere Agent's Docker Image to the release guide.
  - Neither Github Packages nor Docker Hub are actually official distribution channels for ASF, so I thought publishing only to Github Packages would simplify the communication process with ASF Infra.
  - Publishing to Github Packages also avoids issues like #33263. Even ASF is limited by Docker Hub's rate limiting policy, which is not conducive to unit testing.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
