### PR TITLE
Improve the parsing of methods in MySQL (#31554)

### DIFF
--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -815,7 +815,7 @@
         </projections>
     </select>
     
-    <select sql-case-id="select_json_array">
+    <select sql-case-id="select_json_object_with_json_array">
         <projections start-index="7" stop-index="58">
             <expression-projection text="JSON_OBJECT('name':'value', 'type':JSON_ARRAY(1, 2))" start-index="7" stop-index="58">
                 <expr>
@@ -846,6 +846,272 @@
                                     </function>
                                 </value>
                             </key-value>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_array">
+        <projections start-index="7" stop-index="49">
+            <expression-projection text="JSON_ARRAY(1, 'abc', NULL, TRUE, CURTIME())" start-index="7" stop-index="49" >
+                <expr>
+                    <function function-name="JSON_ARRAY" text="JSON_ARRAY(1, 'abc', NULL, TRUE, CURTIME())" start-index="7" stop-index="49">
+                        <parameter>
+                            <literal-expression value="1" start-index="18" stop-index="18"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="abc" start-index="21" stop-index="25"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="null" start-index="28" stop-index="31"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="true" start-index="34" stop-index="37"/>
+                        </parameter>
+                        <parameter>
+                            <function function-name="CURTIME" text="CURTIME()" start-index="40" stop-index="48" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_array_append">
+        <projections start-index="7" stop-index="60">
+            <expression-projection text="JSON_ARRAY_APPEND('[&quot;a&quot;, [&quot;b&quot;, &quot;c&quot;], &quot;d&quot;]', '$[1]', 1)" start-index="7" stop-index="60" >
+                <expr>
+                    <function function-name="JSON_ARRAY_APPEND" text="JSON_ARRAY_APPEND('[&quot;a&quot;, [&quot;b&quot;, &quot;c&quot;], &quot;d&quot;]', '$[1]', 1)" start-index="7" stop-index="60">
+                        <parameter>
+                            <literal-expression value="[&quot;a&quot;, [&quot;b&quot;, &quot;c&quot;], &quot;d&quot;]" start-index="25" stop-index="48"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="$[1]" start-index="51" stop-index="56"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="1" start-index="59" stop-index="59"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_array_insert">
+        <projections start-index="7" stop-index="68">
+            <expression-projection text="JSON_ARRAY_INSERT('[&quot;a&quot;, {&quot;b&quot;: [1, 2]}, [3, 4]]', '$[1]', 'x')" start-index="7" stop-index="68" >
+                <expr>
+                    <function function-name="JSON_ARRAY_INSERT" text="JSON_ARRAY_INSERT('[&quot;a&quot;, {&quot;b&quot;: [1, 2]}, [3, 4]]', '$[1]', 'x')" start-index="7" stop-index="68">
+                        <parameter>
+                            <literal-expression value="[&quot;a&quot;, {&quot;b&quot;: [1, 2]}, [3, 4]]" start-index="25" stop-index="54"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="$[1]" start-index="57" stop-index="62"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="x" start-index="65" stop-index="67"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_arrayagg">
+        <projections start-index="7" stop-index="52">
+            <column-projection name="o_id" start-index="7" stop-index="10" />
+            <expression-projection text="JSON_ARRAYAGG(attribute)" alias="attributes" start-index="13" stop-index="52">
+                <expr>
+                    <function function-name="JSON_ARRAYAGG" text="JSON_ARRAYAGG(attribute)" start-index="13" stop-index="36">
+                        <parameter>
+                            <column name="attribute" start-index="27" stop-index="35" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from start-index="59" stop-index="60">
+            <simple-table name="t3" start-index="59" stop-index="60"/>
+        </from>
+        <group-by start-index="62" stop-index="74">
+            <column-item name="o_id" order-direction="ASC" start-index="71" stop-index="74" />
+        </group-by>
+    </select>
+
+    <select sql-case-id="select_json_contains">
+        <projections start-index="7" stop-index="66">
+            <expression-projection text="JSON_CONTAINS('{&quot;a&quot;: 1, &quot;b&quot;: 2, &quot;c&quot;: {&quot;d&quot;: 4}}', '1', '$.a')" start-index="7" stop-index="66">
+                <expr>
+                    <function function-name="JSON_CONTAINS" text="JSON_CONTAINS('{&quot;a&quot;: 1, &quot;b&quot;: 2, &quot;c&quot;: {&quot;d&quot;: 4}}', '1', '$.a')" start-index="7" stop-index="66">
+                        <parameter>
+                            <literal-expression value="{&quot;a&quot;: 1, &quot;b&quot;: 2, &quot;c&quot;: {&quot;d&quot;: 4}}" start-index="21" stop-index="53"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="1" start-index="56" stop-index="58"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="$.a" start-index="61" stop-index="65"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_contains_one">
+        <projections start-index="7" stop-index="80">
+            <expression-projection text="JSON_CONTAINS_PATH('{&quot;a&quot;: 1, &quot;b&quot;: 2, &quot;c&quot;: {&quot;d&quot;: 4}}', 'one', '$.a', '$.e')" start-index="7" stop-index="80">
+                <expr>
+                    <function function-name="JSON_CONTAINS_PATH" text="JSON_CONTAINS_PATH('{&quot;a&quot;: 1, &quot;b&quot;: 2, &quot;c&quot;: {&quot;d&quot;: 4}}', 'one', '$.a', '$.e')" start-index="7" stop-index="80">
+                        <parameter>
+                            <literal-expression value="{&quot;a&quot;: 1, &quot;b&quot;: 2, &quot;c&quot;: {&quot;d&quot;: 4}}" start-index="26" stop-index="58"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="one" start-index="61" stop-index="65"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="$.a" start-index="68" stop-index="72"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="$.e" start-index="75" stop-index="79"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_contains_all">
+        <projections start-index="7" stop-index="80">
+            <expression-projection text="JSON_CONTAINS_PATH('{&quot;a&quot;: 1, &quot;b&quot;: 2, &quot;c&quot;: {&quot;d&quot;: 4}}', 'all', '$.a', '$.e')" start-index="7" stop-index="80">
+                <expr>
+                    <function function-name="JSON_CONTAINS_PATH" text="JSON_CONTAINS_PATH('{&quot;a&quot;: 1, &quot;b&quot;: 2, &quot;c&quot;: {&quot;d&quot;: 4}}', 'all', '$.a', '$.e')" start-index="7" stop-index="80">
+                        <parameter>
+                            <literal-expression value="{&quot;a&quot;: 1, &quot;b&quot;: 2, &quot;c&quot;: {&quot;d&quot;: 4}}" start-index="26" stop-index="58"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="all" start-index="61" stop-index="65"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="$.a" start-index="68" stop-index="72"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="$.e" start-index="75" stop-index="79"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_depth">
+        <projections start-index="7" stop-index="35">
+            <expression-projection text="JSON_DEPTH('[10, {&quot;a&quot;: 20}]')" start-index="7" stop-index="35">
+                <expr>
+                    <function function-name="JSON_DEPTH" text="JSON_DEPTH('[10, {&quot;a&quot;: 20}]')" start-index="7" stop-index="35">
+                        <parameter>
+                            <literal-expression value="[10, {&quot;a&quot;: 20}]" start-index="18" stop-index="34"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_extract">
+        <projections start-index="7" stop-index="56">
+            <expression-projection text="JSON_EXTRACT('[10, 20, [30, 40]]', '$[1]', '$[0]')" start-index="7" stop-index="56">
+                <expr>
+                    <function function-name="JSON_EXTRACT" text="JSON_EXTRACT('[10, 20, [30, 40]]', '$[1]', '$[0]')" start-index="7" stop-index="56">
+                        <parameter>
+                            <literal-expression value="[10, 20, [30, 40]]" start-index="20" stop-index="39"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="$[1]" start-index="42" stop-index="47"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="$[0]" start-index="50" stop-index="55"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_keys">
+        <projections start-index="7" stop-index="43">
+            <expression-projection text="JSON_KEYS('{&quot;a&quot;: 1, &quot;b&quot;: {&quot;c&quot;: 30}}')" start-index="7" stop-index="43">
+                <expr>
+                    <function function-name="JSON_KEYS" text="JSON_KEYS('{&quot;a&quot;: 1, &quot;b&quot;: {&quot;c&quot;: 30}}')" start-index="7" stop-index="43">
+                        <parameter>
+                            <literal-expression value="{&quot;a&quot;: 1, &quot;b&quot;: {&quot;c&quot;: 30}}" start-index="17" stop-index="42"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_length">
+        <projections start-index="7" stop-index="37">
+            <expression-projection text="JSON_LENGTH('[1, 2, {&quot;a&quot;: 3}]')" start-index="7" stop-index="37">
+                <expr>
+                    <function function-name="JSON_LENGTH" text="JSON_LENGTH('[1, 2, {&quot;a&quot;: 3}]')" start-index="7" stop-index="37">
+                        <parameter>
+                            <literal-expression value="[1, 2, {&quot;a&quot;: 3}]" start-index="19" stop-index="36"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_merge">
+        <projections start-index="7" stop-index="43">
+            <expression-projection text="JSON_MERGE('[1, 2]', '[true, false]')" start-index="7" stop-index="43">
+                <expr>
+                    <function function-name="JSON_MERGE" text="JSON_MERGE('[1, 2]', '[true, false]')" start-index="7" stop-index="43">
+                        <parameter>
+                            <literal-expression value="[1, 2]" start-index="18" stop-index="25"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="[true, false]" start-index="28" stop-index="42"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_merge_patch">
+        <projections start-index="7" stop-index="49">
+            <expression-projection text="JSON_MERGE_PATCH('[1, 2]', '[true, false]')" start-index="7" stop-index="49">
+                <expr>
+                    <function function-name="JSON_MERGE_PATCH" text="JSON_MERGE_PATCH('[1, 2]', '[true, false]')" start-index="7" stop-index="49">
+                        <parameter>
+                            <literal-expression value="[1, 2]" start-index="24" stop-index="31"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="[true, false]" start-index="34" stop-index="48"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+
+    <select sql-case-id="select_json_merge_preserve">
+        <projections start-index="7" stop-index="52">
+            <expression-projection text="JSON_MERGE_PRESERVE('[1, 2]', '[true, false]')" start-index="7" stop-index="52">
+                <expr>
+                    <function function-name="JSON_MERGE_PRESERVE" text="JSON_MERGE_PRESERVE('[1, 2]', '[true, false]')" start-index="7" stop-index="52">
+                        <parameter>
+                            <literal-expression value="[1, 2]" start-index="27" stop-index="34"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="[true, false]" start-index="37" stop-index="51"/>
                         </parameter>
                     </function>
                 </expr>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
@@ -52,7 +52,21 @@
     <sql-case id="select_from_open_row_set_with_provider_string" value="SELECT d.* FROM OPENROWSET('SQLNCLI','Server=Seattle1;Trusted_Connection=yes;',AdventureWorks2022.HumanResources.Department) AS d;" db-types="SQLServer"/>
     <sql-case id="select_json_object_simple_key_value" value="SELECT JSON_OBJECT('name':'value', 'type':1)" db-types="SQLServer" />
     <sql-case id="select_json_object_absent_not_null" value="SELECT JSON_OBJECT('name':'value', 'type':NULL ABSENT ON NULL)" db-types="SQLServer" />
-    <sql-case id="select_json_array" value="SELECT JSON_OBJECT('name':'value', 'type':JSON_ARRAY(1, 2))" db-types="SQLServer" />
+    <sql-case id="select_json_object_with_json_array" value="SELECT JSON_OBJECT('name':'value', 'type':JSON_ARRAY(1, 2))" db-types="SQLServer" />
+    <sql-case id="select_json_array" value="SELECT JSON_ARRAY(1, 'abc', NULL, TRUE, CURTIME());" db-types="MySQL" />
+    <sql-case id="select_json_array_append" value="SELECT JSON_ARRAY_APPEND('[&quot;a&quot;, [&quot;b&quot;, &quot;c&quot;], &quot;d&quot;]', '$[1]', 1);" db-types="MySQL" />
+    <sql-case id="select_json_array_insert" value="SELECT JSON_ARRAY_INSERT('[&quot;a&quot;, {&quot;b&quot;: [1, 2]}, [3, 4]]', '$[1]', 'x');" db-types="MySQL" />
+    <sql-case id="select_json_arrayagg" value="SELECT o_id, JSON_ARRAYAGG(attribute) AS 'attributes' FROM t3 GROUP BY o_id" db-types="MySQL" />
+    <sql-case id="select_json_contains" value="SELECT JSON_CONTAINS('{&quot;a&quot;: 1, &quot;b&quot;: 2, &quot;c&quot;: {&quot;d&quot;: 4}}', '1', '$.a')" db-types="MySQL" />
+    <sql-case id="select_json_contains_one" value="SELECT JSON_CONTAINS_PATH('{&quot;a&quot;: 1, &quot;b&quot;: 2, &quot;c&quot;: {&quot;d&quot;: 4}}', 'one', '$.a', '$.e')" db-types="MySQL" />
+    <sql-case id="select_json_contains_all" value="SELECT JSON_CONTAINS_PATH('{&quot;a&quot;: 1, &quot;b&quot;: 2, &quot;c&quot;: {&quot;d&quot;: 4}}', 'all', '$.a', '$.e')" db-types="MySQL" />
+    <sql-case id="select_json_depth" value="SELECT JSON_DEPTH('[10, {&quot;a&quot;: 20}]')" db-types="MySQL" />
+    <sql-case id="select_json_extract" value="SELECT JSON_EXTRACT('[10, 20, [30, 40]]', '$[1]', '$[0]')" db-types="MySQL" />
+    <sql-case id="select_json_keys" value="SELECT JSON_KEYS('{&quot;a&quot;: 1, &quot;b&quot;: {&quot;c&quot;: 30}}')" db-types="MySQL" />
+    <sql-case id="select_json_length" value="SELECT JSON_LENGTH('[1, 2, {&quot;a&quot;: 3}]')" db-types="MySQL" />
+    <sql-case id="select_json_merge" value="SELECT JSON_MERGE('[1, 2]', '[true, false]')" db-types="MySQL" />
+    <sql-case id="select_json_merge_patch" value="SELECT JSON_MERGE_PATCH('[1, 2]', '[true, false]')" db-types="MySQL" />
+    <sql-case id="select_json_merge_preserve" value="SELECT JSON_MERGE_PRESERVE('[1, 2]', '[true, false]')" db-types="MySQL" />
     <sql-case id="select_nest_json_object" value="SELECT JSON_OBJECT('name':'value', 'type':JSON_OBJECT('type_id':1, 'name':'a'))" db-types="SQLServer" />
     <sql-case id="select_json_object_with_subquery" value="SELECT JSON_OBJECT('user_name':USER_NAME(), @id_key:@id_value, 'sid':(SELECT @@SPID))" db-types="SQLServer" />
     <sql-case id="select_dm_exec_sessions_with_json_object_function" value="SELECT s.session_id, JSON_OBJECT('security_id':s.security_id, 'login':s.login_name, 'status':s.status) as info FROM sys.dm_exec_sessions AS s WHERE s.is_user_process = 1" db-types="SQLServer" />


### PR DESCRIPTION
Fixes #31554.

Changes proposed in this pull request:
  - I've verified all sql can be parsed by the parser
  - I've check SQLStatement can correctly capture the params in the method
  - added corresponding test case for each sql, and SQL Parser IT run successfully.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
