### PR TITLE
Add Doris grammar rules for RECOVER and tests

### DIFF
--- a/parser/sql/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
+++ b/parser/sql/dialect/doris/src/main/antlr4/imports/doris/BaseRule.g4
@@ -664,6 +664,14 @@ databaseName
     : identifier
     ;
 
+newDatabaseName
+    : identifier
+    ;
+
+databaseId
+    : identifier
+    ;
+
 databaseNames
     : databaseName (COMMA_ databaseName)*
     ;
@@ -682,6 +690,10 @@ databasePair
 
 tableName
     : (owner DOT_)? name
+    ;
+
+tableId
+    : identifier
     ;
 
 columnName
@@ -837,6 +849,15 @@ userOrRole
     ;
 
 partitionName
+    : identifier
+    ;
+
+newPartitionName
+    : identifier
+    ;
+
+
+partitionId
     : identifier
     ;
 

--- a/parser/sql/dialect/doris/src/main/antlr4/imports/doris/DALStatement.g4
+++ b/parser/sql/dialect/doris/src/main/antlr4/imports/doris/DALStatement.g4
@@ -411,6 +411,18 @@ restart
     : RESTART
     ;
 
+recoverDatabase
+    : RECOVER DATABASE databaseName (databaseId | AS newDatabaseName)?
+    ;
+
+recoverPartition
+    : RECOVER PARTITION partitionName partitionId? (AS newPartitionName)? FROM tableName
+    ;
+
+recoverTable
+    : RECOVER TABLE tableName tableId? (AS newDatabaseName)?
+    ;
+
 shutdown
     : SHUTDOWN
     ;

--- a/parser/sql/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
+++ b/parser/sql/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
@@ -31,6 +31,7 @@ execute
     | repairTable
     | dropTable
     | truncateTable
+    | recoverTable
     | createIndex
     | dropIndex
     | createProcedure
@@ -39,6 +40,7 @@ execute
     | dropFunction
     | createDatabase
     | dropDatabase
+    | recoverDatabase
     | createEvent
     | dropEvent
     | createLogfileGroup
@@ -128,6 +130,7 @@ execute
     | dropTablespace
     | delimiter
     | startReplica
+    | recoverPartition
     // TODO consider refactor following sytax to SEMI_? EOF
     ) (SEMI_ EOF? | EOF)
     | EOF

--- a/parser/sql/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/doris/visitor/statement/type/DorisDALStatementVisitor.java
+++ b/parser/sql/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/doris/visitor/statement/type/DorisDALStatementVisitor.java
@@ -160,6 +160,7 @@ import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisInstallPlug
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisKillStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisLoadIndexInfoStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisOptimizeTableStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisRecoverPartitionStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisRepairTableStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisResetPersistStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisResetStatement;
@@ -215,10 +216,14 @@ import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisUseStatemen
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.ResetMasterOptionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.ResetOptionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.ResetSlaveOptionSegment;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisRecoverDatabaseStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisRecoverTableStatement;
 
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+
+import static org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.*;
 
 /**
  * DAL statement visitor for Doris.
@@ -1068,6 +1073,46 @@ public final class DorisDALStatementVisitor extends DorisStatementVisitor implem
     public ASTNode visitHelp(final HelpContext ctx) {
         DorisHelpStatement result = new DorisHelpStatement();
         result.setSearchString(ctx.textOrIdentifier().getText());
+        return result;
+    }
+    
+    @Override
+    public ASTNode visitRecoverDatabase(final RecoverDatabaseContext ctx) {
+        DorisRecoverDatabaseStatement result = new DorisRecoverDatabaseStatement();
+        result.setDatabaseName(new IdentifierValue(ctx.databaseName().getText()).getValue());
+        if (null != ctx.databaseId()) {
+            result.setDatabaseId(new IdentifierValue(ctx.databaseId().getText()).getValue());
+        }
+        if (null != ctx.newDatabaseName()) {
+            result.setDatabaseName(new IdentifierValue(ctx.newDatabaseName().getText()).getValue());
+        }
+        return result;
+    }
+    
+    @Override
+    public ASTNode visitRecoverPartition(final RecoverPartitionContext ctx) {
+        DorisRecoverPartitionStatement result = new DorisRecoverPartitionStatement();
+        result.setPartitionName(new IdentifierValue(ctx.partitionName().getText()).getValue());
+        if (null != ctx.partitionId()) {
+            result.setPartitionId(new IdentifierValue(ctx.partitionId().getText()).getValue());
+        }
+        if (null != ctx.newPartitionName()) {
+            result.setNewPartitionName(new IdentifierValue(ctx.newPartitionName().getText()).getValue());
+        }
+        if (null != ctx.tableName().owner()) {
+            result.setOwner(new IdentifierValue(ctx.tableName().owner().getText()).getValue());
+        }
+        result.setTableName(new IdentifierValue(ctx.tableName().name().getText()).getValue());
+        return result;
+    }
+    
+    @Override
+    public ASTNode visitRecoverTable(final RecoverTableContext ctx) {
+        DorisRecoverTableStatement result = new DorisRecoverTableStatement();
+        result.setTableName(new IdentifierValue(ctx.tableName().getText()).getValue());
+        if (null != ctx.tableId()) {
+            result.setTableName(new IdentifierValue(ctx.tableId().getText()).getValue());
+        }
         return result;
     }
 }

--- a/parser/sql/engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
+++ b/parser/sql/engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
@@ -85,6 +85,8 @@ public enum SQLVisitorRule {
     
     DROP_TABLE("DropTable", SQLStatementType.DDL),
     
+    RECOVER_TABLE("RecoverTable", SQLStatementType.DAL),
+    
     TRUNCATE_TABLE("TruncateTable", SQLStatementType.DDL),
     
     CREATE_INDEX("CreateIndex", SQLStatementType.DDL),
@@ -136,6 +138,8 @@ public enum SQLVisitorRule {
     ALTER_DATABASE_LINK("AlterDatabaseLink", SQLStatementType.DDL),
     
     DROP_DATABASE("DropDatabase", SQLStatementType.DDL),
+    
+    RECOVER_DATABASE("RecoverDatabase", SQLStatementType.DAL),
     
     DROP_DATABASE_LINK("DropDatabaseLink", SQLStatementType.DDL),
     
@@ -711,7 +715,9 @@ public enum SQLVisitorRule {
     
     START_REPLICA("StartReplica", SQLStatementType.RL),
     
-    OPEN("Open", SQLStatementType.DDL);
+    OPEN("Open", SQLStatementType.DDL),
+    
+    RECOVER_PARTITION("RecoverPartition", SQLStatementType.DAL);
     
     private final String name;
     

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/dal/RecoverDatabaseStatement.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/dal/RecoverDatabaseStatement.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.core.statement.dal;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.AbstractSQLStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DDLStatement;
+
+/**
+ * Create database statement.
+ */
+@Getter
+@Setter
+public abstract class RecoverDatabaseStatement extends AbstractSQLStatement implements DDLStatement {
+    
+    private String databaseName;
+    
+    private String databaseId;
+    
+}

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/dal/RecoverPartitionStatement.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/dal/RecoverPartitionStatement.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.core.statement.dal;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.AbstractSQLStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DDLStatement;
+
+/**
+ * Create database statement.
+ */
+@Getter
+@Setter
+public abstract class RecoverPartitionStatement extends AbstractSQLStatement implements DDLStatement {
+    
+    private String partitionName;
+    
+    private String partitionId;
+    
+    private String databaseName;
+    
+    private String newPartitionName;
+    
+    private String owner;
+    
+    private String tableName;
+    
+}

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/dal/RecoverTableStatement.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/dal/RecoverTableStatement.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.core.statement.dal;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.AbstractSQLStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DDLStatement;
+
+/**
+ * Create database statement.
+ */
+@Getter
+@Setter
+public abstract class RecoverTableStatement extends AbstractSQLStatement implements DDLStatement {
+    
+    private String tableName;
+    
+    private String tableId;
+    
+}

--- a/parser/sql/statement/type/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisRecoverDatabaseStatement.java
+++ b/parser/sql/statement/type/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisRecoverDatabaseStatement.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.doris.dal;
+
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.RecoverDatabaseStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.DorisStatement;
+
+/**
+ * Doris create database statement.
+ */
+public final class DorisRecoverDatabaseStatement extends RecoverDatabaseStatement implements DorisStatement {
+}

--- a/parser/sql/statement/type/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisRecoverPartitionStatement.java
+++ b/parser/sql/statement/type/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisRecoverPartitionStatement.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.doris.dal;
+
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.RecoverPartitionStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.DorisStatement;
+
+/**
+ * Doris create database statement.
+ */
+public final class DorisRecoverPartitionStatement extends RecoverPartitionStatement implements DorisStatement {
+}

--- a/parser/sql/statement/type/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisRecoverTableStatement.java
+++ b/parser/sql/statement/type/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisRecoverTableStatement.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.doris.dal;
+
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.RecoverTableStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.DorisStatement;
+
+/**
+ * Doris create database statement.
+ */
+public final class DorisRecoverTableStatement extends RecoverTableStatement implements DorisStatement {
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
@@ -41,6 +41,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.KillStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.LoadIndexInfoStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.OptimizeTableStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.RecoverPartitionStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.RepairTableStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.ResetParameterStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.ResetPersistStatementTestCase;
@@ -285,6 +286,8 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.OpenStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.PreparedStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.PurgeStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.RecoverDatabaseStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.RecoverTableStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.RefreshMatViewStmtStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.ReindexStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.RenameStatementTestCase;
@@ -710,6 +713,15 @@ public final class RootSQLParserTestCases {
     
     @XmlElement(name = "create-database")
     private final List<CreateDatabaseStatementTestCase> createDatabaseTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "recover-database")
+    private final List<RecoverDatabaseStatementTestCase> recoverDatabaseTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "recover-table")
+    private final List<RecoverTableStatementTestCase> recoverTableTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "recover-partition")
+    private final List<RecoverPartitionStatementTestCase> recoverPartitionTestCases = new LinkedList<>();
     
     @XmlElement(name = "create-database-link")
     private final List<CreateDatabaseLinkStatementTestCase> createDatabaseLinkTestCases = new LinkedList<>();

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/RecoverDatabaseStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/RecoverDatabaseStatementTestCase.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal;
+
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+
+/**
+ * Create database statement test case.
+ */
+public final class RecoverDatabaseStatementTestCase extends SQLParserTestCase {
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/RecoverPartitionStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/RecoverPartitionStatementTestCase.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal;
+
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+
+/**
+ * Create database statement test case.
+ */
+public final class RecoverPartitionStatementTestCase extends SQLParserTestCase {
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/RecoverTableStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/RecoverTableStatementTestCase.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal;
+
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+
+/**
+ * Create database statement test case.
+ */
+public final class RecoverTableStatementTestCase extends SQLParserTestCase {
+}

--- a/test/it/parser/src/main/resources/case/dal/recover.xml
+++ b/test/it/parser/src/main/resources/case/dal/recover.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <recover-database sql-case-id="recover_database"/>
+    <recover-database sql-case-id="recover_database_with_name_and_id"/>
+    <recover-database sql-case-id="recover_database_with_new_name"/>
+
+    <recover-table sql-case-id="recover_table" />
+    <recover-table sql-case-id="recover_table_with_name_and_id" />
+    <recover-table sql-case-id="recover_table_without_database_name"/>
+    <recover-table sql-case-id="recover_table_with_new_database_name"/>
+
+    <recover-partition sql-case-id="recover_partition"/>
+    <recover-partition sql-case-id="recover_partition_with_partition_name"/>
+    <recover-partition sql-case-id="recover_partition_with_partition_id"/>
+    <recover-partition sql-case-id="recover_partition_with_new_partition_name"/>
+</sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dal/recover-database.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/recover-database.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="recover_database" value="RECOVER DATABASE example_db" db-types="Doris" />
+    <sql-case id="recover_database_with_name_and_id" value="RECOVER DATABASE example_db ex436" db-types="Doris" />
+    <sql-case id="recover_database_with_new_name" value="RECOVER DATABASE example_db AS new_example_db" db-types="Doris" />
+</sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dal/recover-partition.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/recover-partition.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="recover_partition" value="RECOVER PARTITION example_partition FROM example_db.example_table" db-types="Doris" />
+    <sql-case id="recover_partition_with_partition_name" value="RECOVER PARTITION example_partition FROM example_table" db-types="Doris" />
+    <sql-case id="recover_partition_with_partition_id" value="RECOVER PARTITION example_partition sas23_2w FROM example_db.example_table" db-types="Doris" />
+    <sql-case id="recover_partition_with_new_partition_name" value="RECOVER PARTITION example_partition sas23_2w AS new_example_partition FROM example_db.example_table" db-types="Doris" />
+</sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dal/recover-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/recover-table.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="recover_table" value="RECOVER TABLE example_db.example_table" db-types="Doris" />
+    <sql-case id="recover_table_with_name_and_id" value="RECOVER TABLE example_db.example_table bgsf412" db-types="Doris" />
+    <sql-case id="recover_table_without_database_name" value="RECOVER TABLE example_table" db-types="Doris" />
+    <sql-case id="recover_table_with_new_database_name" value="RECOVER TABLE example_db.example_table gshht11 AS new_example_db" db-types="Doris" />
+</sql-cases>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Added changes necessary to parse Doris RECOVER statements including:
    - RECOVER PARTITION
    - RECOVER DATABASE
    - RECOVER TABLE
  - Added tests

---

Before committing this PR, I'm sure that I have checked the following options:
- [ X ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ X ] I have self-reviewed the commit code.
- [ X ] I have (or in comment I request) added corresponding labels for the pull request.
- [ X ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ X ] I have added corresponding unit tests for my changes.
