### PR TITLE
Refactor AbstractSQLBuilder logic and add getStopIndex in SQLToken

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/comparator/InsertSelectColumnsEncryptorComparator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/comparator/InsertSelectColumnsEncryptorComparator.java
@@ -23,7 +23,11 @@ import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ColumnProjection;
+import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ExpressionProjection;
+import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ParameterMarkerProjection;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.ColumnSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
@@ -52,6 +56,9 @@ public final class InsertSelectColumnsEncryptorComparator {
             EncryptAlgorithm insertColumnEncryptor = encryptRule.findQueryEncryptor(
                     insertColumnSegment.getColumnBoundInfo().getOriginalTable().getValue(), insertColumnSegment.getColumnBoundInfo().getOriginalColumn().getValue()).orElse(null);
             Projection projection = projectionIterator.next();
+            if (isLiteralOrParameterMarker(projection)) {
+                continue;
+            }
             ColumnSegmentBoundInfo projectionColumnBoundInfo = getColumnSegmentBoundInfo(projection);
             EncryptAlgorithm projectionEncryptor =
                     encryptRule.findQueryEncryptor(projectionColumnBoundInfo.getOriginalTable().getValue(), projectionColumnBoundInfo.getOriginalColumn().getValue()).orElse(null);
@@ -60,6 +67,14 @@ public final class InsertSelectColumnsEncryptorComparator {
             }
         }
         return true;
+    }
+    
+    private static boolean isLiteralOrParameterMarker(final Projection projection) {
+        if (projection instanceof ExpressionProjection) {
+            ExpressionSegment expressionSegment = ((ExpressionProjection) projection).getExpressionSegment().getExpr();
+            return expressionSegment instanceof LiteralExpressionSegment;
+        }
+        return projection instanceof ParameterMarkerProjection;
     }
     
     private static ColumnSegmentBoundInfo getColumnSegmentBoundInfo(final Projection projection) {

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/insert/EncryptInsertCipherNameTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/insert/EncryptInsertCipherNameTokenGenerator.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.infra.binder.context.segment.select.projection.
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ColumnProjection;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.InsertStatementContext;
+import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.CollectionSQLTokenGenerator;
@@ -66,10 +67,7 @@ public final class EncryptInsertCipherNameTokenGenerator implements CollectionSQ
         Preconditions.checkState(insertColumnsSegment.isPresent());
         Collection<ColumnSegment> insertColumns = insertColumnsSegment.get().getColumns();
         if (null != insertStatementContext.getInsertSelectContext()) {
-            Collection<Projection> projections = insertStatementContext.getInsertSelectContext().getSelectStatementContext().getProjectionsContext().getExpandProjections();
-            ShardingSpherePreconditions.checkState(insertColumns.size() == projections.size(), () -> new UnsupportedSQLOperationException("Column count doesn't match value count."));
-            ShardingSpherePreconditions.checkState(InsertSelectColumnsEncryptorComparator.isSame(insertColumns, projections, encryptRule),
-                    () -> new UnsupportedSQLOperationException("Can not use different encryptor in insert select columns"));
+            checkInsertSelectEncryptor(insertStatementContext.getInsertSelectContext().getSelectStatementContext(), insertColumns);
         }
         EncryptTable encryptTable = encryptRule.getEncryptTable(insertStatementContext.getSqlStatement().getTable().map(optional -> optional.getTableName().getIdentifier().getValue()).orElse(""));
         Collection<SQLToken> result = new LinkedList<>();
@@ -82,5 +80,13 @@ public final class EncryptInsertCipherNameTokenGenerator implements CollectionSQ
             }
         }
         return result;
+    }
+    
+    private void checkInsertSelectEncryptor(final SelectStatementContext selectStatementContext, final Collection<ColumnSegment> insertColumns) {
+        Collection<Projection> projections = selectStatementContext.getProjectionsContext().getExpandProjections();
+        ShardingSpherePreconditions.checkState(insertColumns.size() == projections.size(), () -> new UnsupportedSQLOperationException("Column count doesn't match value count."));
+        ShardingSpherePreconditions.checkState(InsertSelectColumnsEncryptorComparator.isSame(insertColumns, projections, encryptRule),
+                () -> new UnsupportedSQLOperationException("Can not use different encryptor in insert select columns"));
+        selectStatementContext.getSubqueryContexts().values().forEach(each -> checkInsertSelectEncryptor(each, insertColumns));
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/DistinctProjectionPrefixToken.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/DistinctProjectionPrefixToken.java
@@ -33,4 +33,9 @@ public final class DistinctProjectionPrefixToken extends SQLToken implements Att
     public String toString() {
         return "DISTINCT ";
     }
+    
+    @Override
+    public int getStopIndex() {
+        return getStartIndex();
+    }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/OrderByToken.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/OrderByToken.java
@@ -53,4 +53,9 @@ public final class OrderByToken extends SQLToken implements Attachable {
         result.append(' ');
         return result.toString();
     }
+    
+    @Override
+    public int getStopIndex() {
+        return getStartIndex();
+    }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/ProjectionsToken.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/ProjectionsToken.java
@@ -46,4 +46,9 @@ public final class ProjectionsToken extends SQLToken implements Attachable, Rout
         }
         return result.toString();
     }
+    
+    @Override
+    public int getStopIndex() {
+        return getStartIndex();
+    }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/InsertStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/InsertStatementContext.java
@@ -41,6 +41,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignmen
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.SetAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.OnDuplicateKeyColumnsSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.combine.CombineSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubquerySegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
@@ -137,6 +138,13 @@ public final class InsertStatementContext extends CommonSQLStatementContext impl
         SubquerySegment insertSelectSegment = getSqlStatement().getInsertSelect().get();
         SelectStatementContext selectStatementContext = new SelectStatementContext(metaData, params, insertSelectSegment.getSelect(), currentDatabaseName, Collections.emptyList());
         selectStatementContext.setSubqueryType(SubqueryType.INSERT_SELECT);
+        if (selectStatementContext.getSqlStatement().getCombine().isPresent()) {
+            CombineSegment combineSegment = selectStatementContext.getSqlStatement().getCombine().get();
+            Optional.ofNullable(selectStatementContext.getSubqueryContexts().get(combineSegment.getLeft().getStartIndex()))
+                    .ifPresent(optional -> optional.setSubqueryType(SubqueryType.INSERT_SELECT));
+            Optional.ofNullable(selectStatementContext.getSubqueryContexts().get(combineSegment.getRight().getStartIndex()))
+                    .ifPresent(optional -> optional.setSubqueryType(SubqueryType.INSERT_SELECT));
+        }
         InsertSelectContext insertSelectContext = new InsertSelectContext(selectStatementContext, params, paramsOffset.get());
         paramsOffset.addAndGet(insertSelectContext.getParameterCount());
         return Optional.of(insertSelectContext);

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/SQLToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/SQLToken.java
@@ -33,4 +33,11 @@ public abstract class SQLToken implements Comparable<SQLToken> {
     public final int compareTo(final SQLToken sqlToken) {
         return startIndex - sqlToken.startIndex;
     }
+    
+    /**
+     * Get stop index.
+     *
+     * @return stop index
+     */
+    public abstract int getStopIndex();
 }

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/generic/ColumnDefinitionToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/generic/ColumnDefinitionToken.java
@@ -47,4 +47,9 @@ public final class ColumnDefinitionToken extends SQLToken {
         }
         return columnName + " " + dataType;
     }
+    
+    @Override
+    public int getStopIndex() {
+        return getStartIndex();
+    }
 }

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/generic/InsertColumnsToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/generic/InsertColumnsToken.java
@@ -44,4 +44,9 @@ public final class InsertColumnsToken extends SQLToken implements Attachable {
         columns.forEach(result::add);
         return result.toString();
     }
+    
+    @Override
+    public int getStopIndex() {
+        return getStartIndex();
+    }
 }

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/generic/UseDefaultInsertColumnsToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/generic/UseDefaultInsertColumnsToken.java
@@ -40,4 +40,9 @@ public final class UseDefaultInsertColumnsToken extends SQLToken implements Atta
     public String toString() {
         return columns.isEmpty() ? "" : "(" + String.join(", ", columns) + ")";
     }
+    
+    @Override
+    public int getStopIndex() {
+        return getStartIndex();
+    }
 }

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/keygen/pojo/GeneratedKeyAssignmentToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/keygen/pojo/GeneratedKeyAssignmentToken.java
@@ -38,4 +38,9 @@ public abstract class GeneratedKeyAssignmentToken extends SQLToken implements At
     }
     
     protected abstract String getRightValue();
+    
+    @Override
+    public int getStopIndex() {
+        return getStartIndex();
+    }
 }

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/keygen/pojo/GeneratedKeyInsertColumnToken.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/keygen/pojo/GeneratedKeyInsertColumnToken.java
@@ -36,4 +36,9 @@ public final class GeneratedKeyInsertColumnToken extends SQLToken implements Att
     public String toString() {
         return ", " + column;
     }
+    
+    @Override
+    public int getStopIndex() {
+        return getStartIndex();
+    }
 }

--- a/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/impl/RouteSQLBuilderTest.java
+++ b/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/impl/RouteSQLBuilderTest.java
@@ -39,7 +39,8 @@ class RouteSQLBuilderTest {
     
     @Test
     void assertToSQLWithDuplicateSQLToken() {
-        assertThat(new RouteSQLBuilder("SELECT * FROM tbl WHERE id=?", Arrays.asList(new SQLTokenFixture(14, 16), new SQLTokenFixture(14, 16)), createRouteUnit()).toSQL(), is("SELECT * FROM XXX WHERE id=?"));
+        assertThat(new RouteSQLBuilder("SELECT * FROM tbl WHERE id=?", Arrays.asList(new SQLTokenFixture(14, 16), new SQLTokenFixture(14, 16)), createRouteUnit()).toSQL(),
+                is("SELECT * FROM XXX WHERE id=?"));
     }
     
     @Test

--- a/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/impl/RouteSQLBuilderTest.java
+++ b/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/impl/RouteSQLBuilderTest.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.infra.route.context.RouteMapper;
 import org.apache.shardingsphere.infra.route.context.RouteUnit;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -34,6 +35,11 @@ class RouteSQLBuilderTest {
     @Test
     void assertToSQLWithNormalSQLToken() {
         assertThat(new RouteSQLBuilder("SELECT * FROM tbl WHERE id=?", Collections.singletonList(new SQLTokenFixture(14, 16)), createRouteUnit()).toSQL(), is("SELECT * FROM XXX WHERE id=?"));
+    }
+    
+    @Test
+    void assertToSQLWithDuplicateSQLToken() {
+        assertThat(new RouteSQLBuilder("SELECT * FROM tbl WHERE id=?", Arrays.asList(new SQLTokenFixture(14, 16), new SQLTokenFixture(14, 16)), createRouteUnit()).toSQL(), is("SELECT * FROM XXX WHERE id=?"));
     }
     
     @Test

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
@@ -614,8 +614,11 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
         } else {
             combineType = CombineType.MINUS;
         }
+        OracleSelectStatement right = (OracleSelectStatement) visit(ctx.selectSubquery(1));
         result.setCombine(new CombineSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), createSubquerySegment(ctx.selectSubquery(0), left), combineType,
-                createSubquerySegment(ctx.selectSubquery(1), (OracleSelectStatement) visit(ctx.selectSubquery(1)))));
+                createSubquerySegment(ctx.selectSubquery(1), right)));
+        result.addParameterMarkerSegments(left.getParameterMarkerSegments());
+        result.addParameterMarkerSegments(right.getParameterMarkerSegments());
     }
     
     private SubquerySegment createSubquerySegment(final SelectSubqueryContext ctx, final OracleSelectStatement selectStatement) {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Refactor AbstractSQLBuilder logic and add getStopIndex in SQLToken

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
