### PR TITLE
Remove redundant null check of directoryUrlEnumeration in ClasspathResourceDirectoryReader

### DIFF
--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/directory/ClasspathResourceDirectoryReader.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/directory/ClasspathResourceDirectoryReader.java
@@ -116,9 +116,6 @@ public final class ClasspathResourceDirectoryReader {
     @SneakyThrows(IOException.class)
     public static Stream<String> read(final ClassLoader classLoader, final String directory) {
         Enumeration<URL> directoryUrlEnumeration = classLoader.getResources(directory);
-        if (null == directoryUrlEnumeration) {
-            return Stream.empty();
-        }
         return Collections.list(directoryUrlEnumeration).stream().flatMap(directoryUrl -> {
             if (JAR_URL_PROTOCOLS.contains(directoryUrl.getProtocol())) {
                 return readDirectoryInJar(directory, directoryUrl);


### PR DESCRIPTION
Fixes #33640

### Before
<img width="1116" alt="image" src="https://github.com/user-attachments/assets/7191f691-d32e-4bc0-b934-549805d8892c">


### After 
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/f67edef5-cf6a-4e35-9d89-299d48eb7c1c">
