### PR TITLE
Update JDBCStreamQueryResult.java

### DIFF
--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResult.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResult.java
@@ -104,7 +104,7 @@ public final class JDBCStreamQueryResult extends AbstractStreamQueryResult {
         if (Array.class == type) {
             return resultSet.getArray(columnIndex);
         }
-        return resultSet.getObject(columnIndex);
+        return resultSet.getObject(columnIndex, type);
     }
     
     @Override


### PR DESCRIPTION
DateTime column support prased as ZonedDatetime

Fixes #33660.

Changes proposed in this pull request:
  -  Support Sharding-JDBC to parse dateTime as ZonedDateTime.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
