### PR TITLE
ResultSet support ZonedDateTime(#33660)

### DIFF
--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResult.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResult.java
@@ -104,7 +104,7 @@ public final class JDBCStreamQueryResult extends AbstractStreamQueryResult {
         if (Array.class == type) {
             return resultSet.getArray(columnIndex);
         }
-        return resultSet.getObject(columnIndex);
+        return resultSet.getObject(columnIndex, type);
     }
     
     @Override

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResult.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResult.java
@@ -34,6 +34,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 
 /**
@@ -104,7 +105,10 @@ public final class JDBCStreamQueryResult extends AbstractStreamQueryResult {
         if (Array.class == type) {
             return resultSet.getArray(columnIndex);
         }
-        return resultSet.getObject(columnIndex, type);
+        if (ZonedDateTime.class == type) {
+            return resultSet.getObject(columnIndex, type);
+        }
+        return resultSet.getObject(columnIndex);
     }
     
     @Override

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResultTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResultTest.java
@@ -28,6 +28,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -163,6 +166,13 @@ class JDBCStreamQueryResultTest {
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.getTimestamp(1)).thenReturn(new Timestamp(0L));
         assertThat(new JDBCStreamQueryResult(resultSet).getValue(1, Timestamp.class), is(new Timestamp(0L)));
+    }
+
+    @Test
+    void assertGetValueByZonedDateTime() throws SQLException {
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getObject(1, ZonedDateTime.class)).thenReturn(ZonedDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneId.systemDefault()));
+        assertThat(new JDBCStreamQueryResult(resultSet).getValue(1, ZonedDateTime.class), is(ZonedDateTime.ofInstant(Instant.ofEpochSecond(1), ZoneId.systemDefault())));
     }
     
     @Test

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResultTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResultTest.java
@@ -167,7 +167,7 @@ class JDBCStreamQueryResultTest {
         when(resultSet.getTimestamp(1)).thenReturn(new Timestamp(0L));
         assertThat(new JDBCStreamQueryResult(resultSet).getValue(1, Timestamp.class), is(new Timestamp(0L)));
     }
-
+    
     @Test
     void assertGetValueByZonedDateTime() throws SQLException {
         ResultSet resultSet = mock(ResultSet.class);


### PR DESCRIPTION
Fixes #33660 

Changes proposed in this pull request:
  - Support Sharding-JDBC to parse dateTime as ZonedDateTime.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
