### PR TITLE
Avoid using `-proc:full` when compiling ShardingSphere with OpenJDK23

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,6 +17,7 @@
 1. SQL Parser: Support parsing Doris STRRIGHT - [#33393](https://github.com/apache/shardingsphere/pull/33393)
 1. JDBC: Add show database name for JDBC when execute SHOW COMPUTE NODES - [#33437](https://github.com/apache/shardingsphere/pull/33437)
 1. Kernel: Add binding to owner table - [#33533](https://github.com/apache/shardingsphere/pull/33533)
+1. Build: Avoid using `-proc:full` when compiling ShardingSphere with OpenJDK23 - [#33681](https://github.com/apache/shardingsphere/pull/33681)
 
 ### Bug Fixes
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -46,7 +46,7 @@
         <h2.version>2.2.224</h2.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.2.13</logback.version>
-        <lombok.version>1.18.34</lombok.version>
+        <lombok.version>1.18.36</lombok.version>
         <mybatis.version>3.5.9</mybatis.version>
         <mybatis-spring.version>2.0.5</mybatis-spring.version>
         <mybatis-spring-boot.version>2.1.3</mybatis-spring-boot.version>
@@ -340,27 +340,10 @@
         <profile>
             <id>jdk11-22</id>
             <activation>
-                <jdk>[11,23)</jdk>
+                <jdk>[11,)</jdk>
             </activation>
             <properties>
                 <annotation-api.version>1.3.2</annotation-api.version>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                    <version>${annotation-api.version}</version>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>jdk23+</id>
-            <activation>
-                <jdk>[23,)</jdk>
-            </activation>
-            <properties>
-                <annotation-api.version>1.3.2</annotation-api.version>
-                <maven.compiler.proc>full</maven.compiler.proc>
             </properties>
             <dependencies>
                 <dependency>
@@ -381,6 +364,13 @@
                     <target>${java.version}</target>
                     <testSource>${java.version}</testSource>
                     <testTarget>${java.version}</testTarget>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
                 <version>${maven-compiler-plugin.version}</version>
             </plugin>

--- a/kernel/sql-federation/optimizer/pom.xml
+++ b/kernel/sql-federation/optimizer/pom.xml
@@ -28,7 +28,6 @@
     
     <properties>
         <calcite.version>1.38.0</calcite.version>
-        <immutables.version>2.9.3</immutables.version>
     </properties>
     
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,8 @@
         <logback.version>1.2.13</logback.version>
         <commons-logging.version>1.2</commons-logging.version>
         
-        <lombok.version>1.18.34</lombok.version>
+        <lombok.version>1.18.36</lombok.version>
+        <immutables.version>2.9.3</immutables.version>
         
         <postgresql.version>42.7.2</postgresql.version>
         <mysql-connector-java.version>8.3.0</mysql-connector-java.version>
@@ -692,6 +693,18 @@
                         <target>${java.version}</target>
                         <testSource>${java.version}</testSource>
                         <testTarget>${java.version}</testTarget>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                                <version>${lombok.version}</version>
+                            </path>
+                            <path>
+                                <groupId>org.immutables</groupId>
+                                <artifactId>value</artifactId>
+                                <version>${immutables.version}</version>
+                            </path>
+                        </annotationProcessorPaths>
                     </configuration>
                 </plugin>
                 <!-- TODO nianjun should remove after test container is used in agent e2e -->
@@ -990,38 +1003,10 @@
         <profile>
             <id>jdk11-22</id>
             <activation>
-                <jdk>[11,23)</jdk>
+                <jdk>[11,)</jdk>
             </activation>
             <properties>
                 <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <configuration>
-                                <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/sun.net=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED</argLine>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <artifactId>maven-failsafe-plugin</artifactId>
-                            <configuration>
-                                <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/sun.net=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED</argLine>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
-            <id>jdk23+</id>
-            <activation>
-                <jdk>[23,)</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-                <maven.compiler.proc>full</maven.compiler.proc>
             </properties>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
For #32927.

Changes proposed in this pull request:
  - Avoid using `-proc:full` when compiling ShardingSphere with OpenJDK23. This is mostly to align the behavior of https://github.com/apache/shardingsphere-elasticjob/pull/2454. Changing the default value of `-proc` on JDK23 is probably not a good idea.
  - Since `org.apache.shardingsphere.sqlfederation.optimizer.planner.rule.transformation.PushProjectIntoScanRule` is generating **`org.apache.shardingsphere.sqlfederation.optimizer.planner.rule.transformation.ImmutablePushProjectIntoScanRule`** through `org.immutables.processor.ProxyProcessor`, the scope of `annotationProcessorPaths` is quite scattered. See https://github.com/immutables/immutables/issues/713 .
  - Bump Lombok to 1.18.36 for further support of JDK23. See https://projectlombok.org/changelog and https://github.com/projectlombok/lombok/issues/3722 .
  - It is hard to explain why ShardingSphere uses `org.immutables:value:2.9.3`. Calcite actually always uses `org.immutables:value:2.8.8`.🤔
  - JDK 23 and JDK 23.0.1 have a lot of bugs so far, and they continue to break unit tests related to GraalVM Tracing Agent. See https://github.com/oracle/graal/issues/9929 .
  - Feel free to test the current PR.
```shell
sdk install java 23-open
sdk use java 23-open
./mvnw clean install -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e
./mvnw clean package -f examples/pom.xml -T1C
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
