### PR TITLE
Support setting `hive_conf_list`, `hive_var_list` and `sess_var_list` for jdbcURL when connecting to HiveServer2

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 1. Build: Avoid using `-proc:full` when compiling ShardingSphere with OpenJDK23 - [#33681](https://github.com/apache/shardingsphere/pull/33681)
 1. Doc: Adds documentation for HiveServer2 support - [#33717](https://github.com/apache/shardingsphere/pull/33717)
 1. DistSQL: Check inline expression when create sharding table rule with inline sharding algorithm - [#33735](https://github.com/apache/shardingsphere/pull/33735)
+1. Infra: Support setting `hive_conf_list`, `hive_var_list` and `sess_var_list` for jdbcURL when connecting to HiveServer2 - [#33749](https://github.com/apache/shardingsphere/pull/33749)
 
 ### Bug Fixes
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/hiveserver2/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/hiveserver2/_index.cn.md
@@ -88,14 +88,18 @@ ShardingSphere 对 HiveServer2 JDBC Driver 的支持位于可选模块中。
 
 ```yaml
 services:
-    hive-server2:
-        image: apache/hive:4.0.1
-        environment:
-          SERVICE_NAME: hiveserver2
-        ports:
-          - "10000:10000"
-        expose:
-          - 10002
+  hive-server2:
+    image: apache/hive:4.0.1
+    environment:
+      SERVICE_NAME: hiveserver2
+    ports:
+      - "10000:10000"
+    expose:
+      - 10002
+    volumes:
+      - warehouse:/opt/hive/data/warehouse
+volumes:
+  warehouse:
 ```
 
 ### 创建业务表
@@ -244,14 +248,6 @@ ShardingSphere 在`org.apache.shardingsphere.infra.database.DatabaseTypeEngine#g
 ShardingSphere JDBC DataSource 尚不支持执行 HiveServer2 的 `SET` 语句，`CREATE TABLE` 语句和 `TRUNCATE TABLE` 语句。
 
 用户应考虑为 ShardingSphere 提交包含单元测试的 PR。
-
-### jdbcURL 限制
-
-对于 ShardingSphere 的配置文件，对 HiveServer2 的 jdbcURL 存在限制。引入前提，
-HiveServer2 的 jdbcURL 格式为 `jdbc:hive2://<host1>:<port1>,<host2>:<port2>/dbName;initFile=<file>;sess_var_list?hive_conf_list#hive_var_list`。
-ShardingSphere 当前对参数的解析仅支持以`jdbc:hive2://localhost:10000/demo_ds_1;initFile=/tmp/init.sql`为代表的`;hive_conf_list`部分。
-
-若用户需使用`;sess_var_list`或`#hive_var_list`的 jdbcURL 参数，考虑为 ShardingSphere 提交包含单元测试的 PR。
 
 ### 在 ShardingSphere 数据源上使用 DML SQL 语句的前提条件
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/hiveserver2/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/hiveserver2/_index.en.md
@@ -90,14 +90,18 @@ Write a Docker Compose file to start HiveServer2.
 
 ```yaml
 services:
-    hive-server2:
-        image: apache/hive:4.0.1
-        environment:
-          SERVICE_NAME: hiveserver2
-        ports:
-          - "10000:10000"
-        expose:
-          - 10002
+  hive-server2:
+    image: apache/hive:4.0.1
+    environment:
+      SERVICE_NAME: hiveserver2
+    ports:
+      - "10000:10000"
+    expose:
+      - 10002
+    volumes:
+      - warehouse:/opt/hive/data/warehouse
+volumes:
+  warehouse:
 ```
 
 ### Create business tables
@@ -249,16 +253,6 @@ ShardingSphere JDBC DataSource does not yet support executing HiveServer2's `SET
 `CREATE TABLE` statement, and `TRUNCATE TABLE` statement.
 
 Users should consider submitting a PR containing unit tests for ShardingSphere.
-
-### jdbcURL Restrictions
-
-For ShardingSphere configuration files, there are restrictions on HiveServer2's jdbcURL. Introduction premise,
-HiveServer2's jdbcURL format is `jdbc:hive2://<host1>:<port1>,<host2>:<port2>/dbName;initFile=<file>;sess_var_list?hive_conf_list#hive_var_list`.
-
-ShardingSphere currently only supports the `;hive_conf_list` part represented by `jdbc:hive2://localhost:10000/demo_ds_1;initFile=/tmp/init.sql`.
-
-If users need to use the jdbcURL parameters of `;sess_var_list` or `#hive_var_list`, 
-consider submitting a PR containing unit tests for ShardingSphere.
 
 ### Prerequisites for using DML SQL statements on ShardingSphere data sources
 

--- a/infra/database/type/hive/src/main/java/org/apache/shardingsphere/infra/database/hive/metadata/data/loader/HiveMetaDataLoader.java
+++ b/infra/database/type/hive/src/main/java/org/apache/shardingsphere/infra/database/hive/metadata/data/loader/HiveMetaDataLoader.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.database.hive.metadata.data.loader;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.GetTableRequest;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.shardingsphere.infra.database.core.metadata.data.loader.DialectMetaDataLoader;
 import org.apache.shardingsphere.infra.database.core.metadata.data.loader.MetaDataLoaderMaterial;
@@ -85,7 +86,8 @@ public final class HiveMetaDataLoader implements DialectMetaDataLoader {
         Map<String, Integer> dataTypes = getDataType(material.getDataSource());
         Collection<TableMetaData> result = new LinkedList<>();
         for (String each : tables) {
-            result.add(new TableMetaData(each, getColumnMetaData(storeClient.getTable(material.getDefaultSchemaName(), each), dataTypes), Collections.emptyList(), Collections.emptyList()));
+            GetTableRequest req = new GetTableRequest(material.getDefaultSchemaName(), each);
+            result.add(new TableMetaData(each, getColumnMetaData(storeClient.getTable(req), dataTypes), Collections.emptyList(), Collections.emptyList()));
         }
         return result;
     }


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Support setting `hive_conf_list`, `hive_var_list` and `sess_var_list` for jdbcURL when connecting to HiveServer2. This is actually a prerequisite for the nativeTest test under GraalVM Native Image to connect to HiveServer2 with Zookeeper service discovery enabled.
  - Due to the change in https://github.com/apache/hive/pull/2153, `org.apache.hadoop.hive.metastore.HiveMetaStoreClient#(String, String)` has been replaced by `org.apache.hadoop.hive.metastore.HiveMetaStoreClient#(org.apache.hadoop.hive.metastore.api.GetTableRequest)`. Considering that shardingsphere do not test HiveServer2 for `2.x` and `3.x` like DBeaver, this will not break any unit tests.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
