### PR TITLE
Support connecting to HiveServer2 through database connection pools other than HikariCP

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 1. Doc: Adds documentation for HiveServer2 support - [#33717](https://github.com/apache/shardingsphere/pull/33717)
 1. DistSQL: Check inline expression when create sharding table rule with inline sharding algorithm - [#33735](https://github.com/apache/shardingsphere/pull/33735)
 1. Infra: Support setting `hive_conf_list`, `hive_var_list` and `sess_var_list` for jdbcURL when connecting to HiveServer2 - [#33749](https://github.com/apache/shardingsphere/pull/33749)
+1. Infra: Support connecting to HiveServer2 through database connection pools other than HikariCP - [#33762](https://github.com/apache/shardingsphere/pull/33762)
 
 ### Bug Fixes
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.cn.md
@@ -128,6 +128,17 @@ cd ./shardingsphere/
 COPY --from=ghcr.io/apache/shardingsphere-agent:latest /usr/agent/ /shardingsphere-agent/
 ```
 
+#### 社区构建
+
+自 ShardingSphere 5.5.2 开始，ShardingSphere Agent 在 https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-agent 发布社区构建。
+此 Docker Image 不属于 ASF 分发产物之一，只是为了方便而提供。
+
+若在自定义 `Dockerfile` 中添加以下语句，这会将 ShardingSphere Agent 的目录复制到 `/shardingsphere-agent/` 。
+
+```dockerfile
+COPY --from=ghcr.io/apache/shardingsphere-agent:5.5.2 /usr/agent/ /shardingsphere-agent/
+```
+
 #### 夜间构建
 
 ShardingSphere Agent 在 https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-agent 存在夜间构建的 Docker Image。

--- a/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/observability/_index.en.md
@@ -130,6 +130,17 @@ If you add the following statement in your custom `Dockerfile`, it will copy the
 COPY --from=ghcr.io/apache/shardingsphere-agent:latest /usr/agent/ /shardingsphere-agent/
 ```
 
+#### Community Build
+
+Since ShardingSphere 5.5.2, ShardingSphere Agent has released community builds at https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-agent .
+This Docker Image is not part of the ASF distribution, but is provided for convenience.
+
+If you add the following statement in a custom `Dockerfile`, it will copy the ShardingSphere Agent directory to `/shardingsphere-agent/`.
+
+```dockerfile
+COPY --from=ghcr.io/apache/shardingsphere-agent:5.5.2 /usr/agent/ /shardingsphere-agent/
+```
+
 #### Nightly Build
 
 ShardingSphere Agent has a nightly built Docker Image at https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-agent .

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/hiveserver2/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/hiveserver2/_index.cn.md
@@ -233,16 +233,6 @@ ShardingSphere 仅针对 HiveServer2 `4.0.1` 进行集成测试。
 HiveServer2 JDBC Driver `4.0.1` 不支持 Hadoop `3.4.1`，
 参考 https://github.com/apache/hive/pull/5500 。
 
-### 数据库连接池限制
-
-由于 `org.apache.hive.jdbc.DatabaseMetaData` 未实现 `java.sql.DatabaseMetaData#getURL()`， 
-ShardingSphere 在`org.apache.shardingsphere.infra.database.DatabaseTypeEngine#getStorageType(javax.sql.DataSource)`处做了模糊处理，
-因此用户暂时仅可通过 `com.zaxxer.hikari.HikariDataSource` 的数据库连接池连接 HiveServer2。
-
-若用户需要通过 `com.alibaba.druid.pool.DruidDataSource` 的数据库连接池连接 HiveServer2，
-用户应当考虑在 Hive 的主分支实现 `java.sql.DatabaseMetaData#getURL()`，
-而不是尝试修改 ShardingSphere 的内部类。
-
 ### SQL 限制
 
 ShardingSphere JDBC DataSource 尚不支持执行 HiveServer2 的 `SET` 语句，`CREATE TABLE` 语句和 `TRUNCATE TABLE` 语句。

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/hiveserver2/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/hiveserver2/_index.en.md
@@ -237,16 +237,6 @@ Users can only use Hadoop `3.3.6` as the underlying Hadoop dependency of HiveSer
 HiveServer2 JDBC Driver `4.0.1` does not support Hadoop `3.4.1`,
 Reference https://github.com/apache/hive/pull/5500.
 
-### Database connection pool limitation
-
-Since `org.apache.hive.jdbc.DatabaseMetaData` does not implement `java.sql.DatabaseMetaData#getURL()`,
-ShardingSphere has done fuzzy processing at `org.apache.shardingsphere.infra.database.DatabaseTypeEngine#getStorageType(javax.sql.DataSource)`,
-so users can only connect to HiveServer2 through the database connection pool of `com.zaxxer.hikari.HikariDataSource` for the time being.
-
-If users need to connect to HiveServer2 through the database connection pool of `com.alibaba.druid.pool.DruidDataSource`,
-users should consider implementing `java.sql.DatabaseMetaData#getURL()` in the main branch of Hive,
-rather than trying to modify the internal classes of ShardingSphere.
-
 ### SQL Limitations
 
 ShardingSphere JDBC DataSource does not yet support executing HiveServer2's `SET` statement, 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/testcontainers/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/testcontainers/_index.cn.md
@@ -3,8 +3,13 @@ title = "Testcontainers"
 weight = 6
 +++
 
+## 背景信息
+
 ShardingSphere 默认情况下不提供对 `org.testcontainers.jdbc.ContainerDatabaseDriver` 的 `driverClassName` 的支持。
-要在 ShardingSphere 的配置文件为数据节点使用类似 `jdbc:tc:postgresql:17.1-bookworm://test-databases-postgres/demo_ds_0` 的 `jdbcUrl`，
+
+## 前提条件
+
+要在 ShardingSphere 的配置文件为数据节点使用类似 `jdbc:tc:postgresql:17.1-bookworm://test/demo_ds_0` 的 `jdbcUrl`，
 可能的 Maven 依赖关系如下，
 
 ```xml
@@ -28,6 +33,8 @@ ShardingSphere 默认情况下不提供对 `org.testcontainers.jdbc.ContainerDat
 </dependencies>
 ```
 
+## 配置示例
+
 要使用 `org.apache.shardingsphere:shardingsphere-infra-database-testcontainers` 模块，
 用户设备总是需要安装 Docker Engine 或符合 https://java.testcontainers.org/supported_docker_environment/ 要求的 alternative container runtimes。
 此时可在 ShardingSphere 的 YAML 配置文件正常使用 `jdbc:tc:postgresql:` 前缀的 jdbcURL。
@@ -37,15 +44,15 @@ dataSources:
   ds_0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:17.1-bookworm://test-databases-postgres/demo_ds_0
+    jdbcUrl: jdbc:tc:postgresql:17.1-bookworm://test/demo_ds_0
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:17.1-bookworm://test-databases-postgres/demo_ds_1
+    jdbcUrl: jdbc:tc:postgresql:17.1-bookworm://test/demo_ds_1
   ds_2:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:17.1-bookworm://test-databases-postgres/demo_ds_2
+    jdbcUrl: jdbc:tc:postgresql:17.1-bookworm://test/demo_ds_2
 ```
 
 `org.apache.shardingsphere:shardingsphere-infra-database-testcontainers` 为 testcontainers-java 风格的 jdbcURL 提供支持，
@@ -58,3 +65,34 @@ dataSources:
 5. 为 `jdbc:tc:mysql:` 的 jdbcURL 前缀提供支持的 Maven 模块 `org.testcontainers:mysql:1.20.3`
 6. 为 `jdbc:tc:oracle:` 的 jdbcURL 前缀提供支持的 Maven 模块 `org.testcontainers:oracle-xe:1.20.3` 和 `org.testcontainers:oracle-free:1.20.3`
 7. 为 `jdbc:tc:tidb:` 的 jdbcURL 前缀提供支持的 Maven 模块 `org.testcontainers:tidb:1.20.3`
+
+## 使用限制
+
+### 生命周期限制
+
+如果像如下所示在 ShardingSphere 配置文件内定义通过 testcontainers-java 创建 Docker Container 的逻辑，
+
+```yaml
+dataSources:
+  ds_0:
+    dataSourceClassName: com.zaxxer.hikari.HikariDataSource
+    driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
+    jdbcUrl: jdbc:tc:postgresql:17.1-bookworm://test/demo_ds_0
+```
+
+testcontainers 默认情况下仅在对 `jdbc:tc:postgresql:17.1-bookworm://test/demo_ds_0` 的最后一个 `java.sql.Connection` 关闭后，
+停止`jdbc:tc:postgresql:17.1-bookworm://test/demo_ds_0`创建的 Docker Container。
+但 ShardingSphere 的内部类会缓存 `java.sql.Connection`。这导致直到 JVM 关闭，
+`jdbc:tc:postgresql:17.1-bookworm://test/demo_ds_0` 创建的 Docker Container 才会被关闭。
+若有避免 Container 被长期开启的必要，
+`org.testcontainers.jdbc.ContainerDatabaseDriver` 存在可用方法来在单元测试中快速关闭相关 Container，
+示例如下，
+
+```java
+import org.testcontainers.jdbc.ContainerDatabaseDriver;
+public class ExampleUtils {
+    void test() {
+        ContainerDatabaseDriver.killContainers();
+    }
+}
+```

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
@@ -693,11 +693,6 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"add","parameterTypes":["long"] }, {"name":"sum","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.command.CommandExecutorTask"},
-  "name":"java.util.concurrent.atomic.Striped64$Cell",
-  "fields":[{"name":"value"}]
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"},
   "name":"java.util.function.DoubleFunction",
   "queryAllPublicMethods":true
@@ -2075,7 +2070,7 @@
   "queryAllDeclaredMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.listener.DatabaseMetaDataChangedListener$$Lambda/0x00007f401fb273a8"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.listener.DatabaseMetaDataChangedListener$$Lambda/0x00007f47f3b26e30"},
   "name":"org.apache.shardingsphere.mode.manager.cluster.event.subscriber.dispatch.MetaDataChangedSubscriber"
 },
 {

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/PostgresTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/PostgresTest.java
@@ -20,8 +20,10 @@ package org.apache.shardingsphere.test.natived.jdbc.databases;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.shardingsphere.test.natived.commons.TestShardingService;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledInNativeImage;
+import org.testcontainers.jdbc.ContainerDatabaseDriver;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -30,6 +32,11 @@ import java.sql.SQLException;
 class PostgresTest {
     
     private TestShardingService testShardingService;
+    
+    @AfterAll
+    static void afterAll() {
+        ContainerDatabaseDriver.killContainers();
+    }
     
     @Test
     void assertShardingInLocalTransactions() throws SQLException {

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/SQLServerTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/SQLServerTest.java
@@ -20,8 +20,10 @@ package org.apache.shardingsphere.test.natived.jdbc.databases;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.shardingsphere.test.natived.commons.TestShardingService;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledInNativeImage;
+import org.testcontainers.jdbc.ContainerDatabaseDriver;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -30,6 +32,11 @@ import java.sql.SQLException;
 class SQLServerTest {
     
     private TestShardingService testShardingService;
+    
+    @AfterAll
+    static void afterAll() {
+        ContainerDatabaseDriver.killContainers();
+    }
     
     @Test
     void assertShardingInLocalTransactions() throws SQLException {


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Support connecting to HiveServer2 through database connection pools other than HikariCP. HiveServer2 JDBC Driver seems to deliberately bypass all the convenient ways to implement JDBC specification. There are simple public methods to use in https://github.com/apache/hive/blob/rel/release-4.0.1/jdbc/src/java/org/apache/hive/jdbc/HiveDriver.java and https://github.com/apache/hive/blob/rel/release-4.0.1/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java . What I am referring to is exactly `org.apache.hive.jdbc.HiveConnection#getConnectedUrl()`. This creates an easy access.
  - ![image](https://github.com/user-attachments/assets/87b894a0-d464-40c3-865a-3e1d2a5bbcfc)
  - As a successor to #33377 , add description of shardingsphere agent docker image for 5.5.2.
  - A very suspicious thing is that the shardingsphere jdbc datasource is not closed normally in the unit test, which leads to,
1. The database started by testcontainers-java is not closed immediately. This only affects unit tests that use the testcontainers java style jdbcurl, and there are only 3 unit tests that use testcontainers like this. This does break testcontainers-java's best practices a bit, as connections created for testcontainers-java are not explicitly handled. The design of testcontainers-java's JDBC support is to retain Docker Containers until the last connection is closed, but shardingsphere caches connections. As part of this, the documentation for unit tests and testcontainers-java integration has been updated to use the utility class `org.testcontainers.jdbc.ContainerDatabaseDriver` which is part of `org.testcontainers.jdbc.AbstractJDBCDriverTest`.
2. `org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager#close()` is never called normally. This leads to a large number of logs in https://github.com/apache/shardingsphere/actions/runs/11953880634/job/33322727601 due to the failure of seata client to close normally. Maybe we can find a simpler way to avoid using `connection.unwrap(ShardingSphereConnection.class).getContextManager().close();`.
```shell
Error:  2024-11-21 13:26:47.684 [timeoutChecker_2_1] o.a.s.c.r.n.NettyClientChannelManager - connect server failed. can not connect to [127.0.0.1:32771]
org.apache.seata.common.exception.FrameworkException: can not connect to [127.0.0.1:32771]
	at org.apache.seata.core.rpc.netty.NettyClientChannelManager.doReconnect(NettyClientChannelManager.java:251)
	at org.apache.seata.core.rpc.netty.NettyClientChannelManager.doReconnect(NettyClientChannelManager.java:212)
	at org.apache.seata.core.rpc.netty.NettyClientChannelManager.reconnect(NettyClientChannelManager.java:167)
	at org.apache.seata.core.rpc.netty.AbstractNettyRemotingClient.lambda$init$0(AbstractNettyRemotingClient.java:109)
	at java.base@22.0.2/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base@22.0.2/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358)
	at java.base@22.0.2/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base@22.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base@22.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base@22.0.2/java.lang.Thread.runWith(Thread.java:1583)
	at java.base@22.0.2/java.lang.Thread.run(Thread.java:1570)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:853)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:829)
```


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
