### PR TITLE
Support connecting to HiveServer2 with ZooKeeper Service Discovery enabled in GraalVM Native Image

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@
 1. DistSQL: Check inline expression when create sharding table rule with inline sharding algorithm - [#33735](https://github.com/apache/shardingsphere/pull/33735)
 1. Infra: Support setting `hive_conf_list`, `hive_var_list` and `sess_var_list` for jdbcURL when connecting to HiveServer2 - [#33749](https://github.com/apache/shardingsphere/pull/33749)
 1. Infra: Support connecting to HiveServer2 through database connection pools other than HikariCP - [#33762](https://github.com/apache/shardingsphere/pull/33762)
+1. Proxy Native: Support connecting to HiveServer2 with ZooKeeper Service Discovery enabled in GraalVM Native Image - [#33768](https://github.com/apache/shardingsphere/pull/33768)
 
 ### Bug Fixes
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/testcontainers/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/testcontainers/_index.cn.md
@@ -25,6 +25,11 @@ ShardingSphere 默认情况下不提供对 `org.testcontainers.jdbc.ContainerDat
         <version>${shardingsphere.version}</version>
     </dependency>
     <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>42.7.2</version>
+    </dependency>
+    <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>postgresql</artifactId>
         <version>1.20.3</version>

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/testcontainers/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/testcontainers/_index.en.md
@@ -25,6 +25,11 @@ the possible Maven dependencies are as follows,
         <version>${shardingsphere.version}</version>
     </dependency>
     <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>42.7.2</version>
+    </dependency>
+    <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>postgresql</artifactId>
         <version>1.20.3</version>

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/com.github.docker-java/docker-java-api/3.4.0/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/com.github.docker-java/docker-java-api/3.4.0/reflect-config.json
@@ -244,6 +244,7 @@
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
+  "allPublicMethods": true,
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
@@ -16,6 +16,10 @@
   "name":"[Lcom.github.dockerjava.api.model.VolumesFrom;"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager$$Lambda/0x00007f428fce11f0"},
+  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.database.DatabaseTypeEngine"},
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
@@ -60,15 +64,15 @@
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.metadata.persist.service.version.MetaDataVersionPersistService"},
-  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.SchemaMetaDataManager"},
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"},
+  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.jdbc.datasource.JDBCBackendDataSource"},
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
@@ -691,6 +695,11 @@
   "name":"java.util.concurrent.atomic.LongAdder",
   "queryAllPublicConstructors":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"add","parameterTypes":["long"] }, {"name":"sum","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.command.CommandExecutorTask"},
+  "name":"java.util.concurrent.atomic.Striped64$Cell",
+  "fields":[{"name":"value"}]
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"},
@@ -2070,7 +2079,7 @@
   "queryAllDeclaredMethods":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.listener.DatabaseMetaDataChangedListener$$Lambda/0x00007f47f3b26e30"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.listener.DatabaseMetaDataChangedListener$$Lambda/0x00007f428fb277d8"},
   "name":"org.apache.shardingsphere.mode.manager.cluster.event.subscriber.dispatch.MetaDataChangedSubscriber"
 },
 {

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/resource-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/resource-config.json
@@ -229,7 +229,7 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.executor.checker.SQLExecutionChecker\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.executor.kernel.ExecutorEngine"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.executor.sql.hook.SQLExecutionHook\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.executor.sql.prepare.AbstractExecutionPrepareEngine"},
@@ -1961,7 +1961,10 @@
     "pattern":"\\Qtest-native/yaml/jdbc/databases/clickhouse.yaml\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"},
-    "pattern":"\\Qtest-native/yaml/jdbc/databases/hive.yaml\\E"
+    "pattern":"\\Qtest-native/yaml/jdbc/databases/hive/simple.yaml\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"},
+    "pattern":"\\Qtest-native/yaml/jdbc/databases/hive/zookeeper-sde.yaml\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"},
     "pattern":"\\Qtest-native/yaml/jdbc/databases/mysql.yaml\\E"

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/resource-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/resource-config.json
@@ -13,5 +13,11 @@
     "condition":{"typeReachable":"javax.xml.parsers.FactoryFinder"},
     "pattern":"\\QMETA-INF/services/javax.xml.parsers.SAXParserFactory\\E"
   }]},
-  "bundles":[]
+  "bundles":[{
+    "name":"com.microsoft.sqlserver.jdbc.SQLServerResource",
+    "locales":["en"]
+  }, {
+    "name":"org.postgresql.translation.messages",
+    "locales":["en"]
+  }]
 }

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.testcontainers/junit-jupiter/1.20.1/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.testcontainers/junit-jupiter/1.20.1/reflect-config.json
@@ -164,5 +164,32 @@
   "condition":{"typeReachable":"org.testcontainers.junit.jupiter.Testcontainers"},
   "name":"org.testcontainers.junit.jupiter.Testcontainers",
   "allPublicMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl$NetworkingConfig",
+  "allDeclaredFields": true,
+  "allDeclaredMethods": true,
+  "allDeclaredConstructors": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.Network"},
+  "name":"com.github.dockerjava.api.model.Network",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.Network"},
+  "name":"com.github.dockerjava.api.model.Network$Ipam",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.Network"},
+  "name":"com.github.dockerjava.api.model.Network$Ipam$Config",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.Network"},
+  "name":"com.github.dockerjava.api.model.Network$ContainerNetworkConfig",
+  "allDeclaredMethods": true
 }
 ]

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/hive/HiveSimpleTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/hive/HiveSimpleTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.natived.jdbc.databases;
+package org.apache.shardingsphere.test.natived.jdbc.databases.hive;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -45,15 +45,15 @@ import static org.hamcrest.Matchers.nullValue;
 @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
 @EnabledInNativeImage
 @Testcontainers
-class HiveTest {
+class HiveSimpleTest {
     
     @SuppressWarnings("resource")
     @Container
     public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
             .withEnv("SERVICE_NAME", "hiveserver2")
-            .withExposedPorts(10000, 10002);
+            .withExposedPorts(10000);
     
-    private static final String SYSTEM_PROP_KEY_PREFIX = "fixture.test-native.yaml.database.hive.";
+    private static final String SYSTEM_PROP_KEY_PREFIX = "fixture.test-native.yaml.database.hive.simple.";
     
     // Due to https://issues.apache.org/jira/browse/HIVE-28317 , the `initFile` parameter of HiveServer2 JDBC Driver must be an absolute path.
     private static final String ABSOLUTE_PATH = Paths.get("src/test/resources/test-native/sql/test-native-databases-hive.sql").toAbsolutePath().normalize().toString();
@@ -124,7 +124,7 @@ class HiveTest {
         }
         HikariConfig config = new HikariConfig();
         config.setDriverClassName("org.apache.shardingsphere.driver.ShardingSphereDriver");
-        config.setJdbcUrl("jdbc:shardingsphere:classpath:test-native/yaml/jdbc/databases/hive.yaml?placeholder-type=system_props");
+        config.setJdbcUrl("jdbc:shardingsphere:classpath:test-native/yaml/jdbc/databases/hive/simple.yaml?placeholder-type=system_props");
         System.setProperty(SYSTEM_PROP_KEY_PREFIX + "ds0.jdbc-url", jdbcUrlPrefix + "demo_ds_0" + ";initFile=" + ABSOLUTE_PATH);
         System.setProperty(SYSTEM_PROP_KEY_PREFIX + "ds1.jdbc-url", jdbcUrlPrefix + "demo_ds_1" + ";initFile=" + ABSOLUTE_PATH);
         System.setProperty(SYSTEM_PROP_KEY_PREFIX + "ds2.jdbc-url", jdbcUrlPrefix + "demo_ds_2" + ";initFile=" + ABSOLUTE_PATH);

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/hive/HiveZookeeperServiceDiscoveryTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/hive/HiveZookeeperServiceDiscoveryTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.natived.jdbc.databases.hive;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.InstanceSpec;
+import org.apache.shardingsphere.test.natived.commons.TestShardingService;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledInNativeImage;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.sql.DataSource;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection", "resource", "deprecation"})
+@EnabledInNativeImage
+@Testcontainers
+class HiveZookeeperServiceDiscoveryTest {
+    
+    private static final int RANDOM_PORT_FIRST = InstanceSpec.getRandomPort();
+    
+    private static final Network NETWORK = Network.newNetwork();
+    
+    @Container
+    private static final GenericContainer<?> ZOOKEEPER_CONTAINER = new GenericContainer<>("zookeeper:3.9.3-jre-17")
+            .withNetwork(NETWORK)
+            .withNetworkAliases("foo")
+            .withExposedPorts(2181);
+    
+    /**
+     * TODO Maybe we should be able to find a better solution than {@link InstanceSpec#getRandomPort()} to use a random available port on the host.
+     *  It is not a good practice to use {@link FixedHostPortGenericContainer}.
+     */
+    @SuppressWarnings("unused")
+    @Container
+    private static final GenericContainer<?> HIVE_SERVER2_1_CONTAINER = new FixedHostPortGenericContainer<>("apache/hive:4.0.1")
+            .withNetwork(NETWORK)
+            .withEnv("SERVICE_NAME", "hiveserver2")
+            .withEnv("SERVICE_OPTS", "-Dhive.server2.support.dynamic.service.discovery=true" + " "
+                    + "-Dhive.zookeeper.quorum=" + ZOOKEEPER_CONTAINER.getNetworkAliases().get(0) + ":2181" + " "
+                    + "-Dhive.server2.thrift.bind.host=0.0.0.0" + " "
+                    + "-Dhive.server2.thrift.port=" + RANDOM_PORT_FIRST)
+            .withFixedExposedPort(RANDOM_PORT_FIRST, RANDOM_PORT_FIRST)
+            .dependsOn(ZOOKEEPER_CONTAINER);
+    
+    private static final String SYSTEM_PROP_KEY_PREFIX = "fixture.test-native.yaml.database.hive.zookeeper.sde.";
+    
+    // Due to https://issues.apache.org/jira/browse/HIVE-28317 , the `initFile` parameter of HiveServer2 JDBC Driver must be an absolute path.
+    private static final String ABSOLUTE_PATH = Paths.get("src/test/resources/test-native/sql/test-native-databases-hive.sql").toAbsolutePath().normalize().toString();
+    
+    private final String jdbcUrlSuffix = ";serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=hiveserver2";
+    
+    private String jdbcUrlPrefix;
+    
+    private TestShardingService testShardingService;
+    
+    @BeforeAll
+    static void beforeAll() {
+        assertThat(System.getProperty(SYSTEM_PROP_KEY_PREFIX + "ds0.jdbc-url"), is(nullValue()));
+        assertThat(System.getProperty(SYSTEM_PROP_KEY_PREFIX + "ds1.jdbc-url"), is(nullValue()));
+        assertThat(System.getProperty(SYSTEM_PROP_KEY_PREFIX + "ds2.jdbc-url"), is(nullValue()));
+    }
+    
+    @AfterAll
+    static void afterAll() {
+        NETWORK.close();
+        System.clearProperty(SYSTEM_PROP_KEY_PREFIX + "ds0.jdbc-url");
+        System.clearProperty(SYSTEM_PROP_KEY_PREFIX + "ds1.jdbc-url");
+        System.clearProperty(SYSTEM_PROP_KEY_PREFIX + "ds2.jdbc-url");
+    }
+    
+    /**
+     * TODO Need to fix `shardingsphere-parser-sql-hive` module to use {@link TestShardingService#cleanEnvironment()}
+     *      after {@link TestShardingService#processSuccessInHive()}.
+     * TODO Same problem {@link InstanceSpec#getRandomPort()} as {@code HIVE_SERVER2_1_CONTAINER}.
+     *
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    @Test
+    void assertShardingInLocalTransactions() throws SQLException {
+        jdbcUrlPrefix = "jdbc:hive2://" + ZOOKEEPER_CONTAINER.getHost() + ":" + ZOOKEEPER_CONTAINER.getMappedPort(2181) + "/";
+        DataSource dataSource = createDataSource();
+        testShardingService = new TestShardingService(dataSource);
+        testShardingService.processSuccessInHive();
+        HIVE_SERVER2_1_CONTAINER.stop();
+        int randomPortSecond = InstanceSpec.getRandomPort();
+        try (
+                GenericContainer<?> hiveServer2SecondContainer = new FixedHostPortGenericContainer<>("apache/hive:4.0.1")
+                        .withNetwork(NETWORK)
+                        .withEnv("SERVICE_NAME", "hiveserver2")
+                        .withEnv("SERVICE_OPTS", "-Dhive.server2.support.dynamic.service.discovery=true" + " "
+                                + "-Dhive.zookeeper.quorum=" + ZOOKEEPER_CONTAINER.getNetworkAliases().get(0) + ":2181" + " "
+                                + "-Dhive.server2.thrift.bind.host=0.0.0.0" + " "
+                                + "-Dhive.server2.thrift.port=" + randomPortSecond)
+                        .withFixedExposedPort(randomPortSecond, randomPortSecond)
+                        .dependsOn(ZOOKEEPER_CONTAINER)) {
+            hiveServer2SecondContainer.start();
+            extracted(hiveServer2SecondContainer.getMappedPort(randomPortSecond));
+            testShardingService.processSuccessInHive();
+        }
+    }
+    
+    /**
+     * TODO Need to fix `shardingsphere-parser-sql-hive` module to use `initEnvironment()` before {@link TestShardingService#processSuccessInHive()}.
+     *
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    @SuppressWarnings("unused")
+    private void initEnvironment() throws SQLException {
+        testShardingService.getOrderRepository().createTableIfNotExistsInHive();
+        testShardingService.getOrderItemRepository().createTableIfNotExistsInHive();
+        testShardingService.getAddressRepository().createTableIfNotExistsInHive();
+        testShardingService.getOrderRepository().truncateTable();
+        testShardingService.getOrderItemRepository().truncateTable();
+        testShardingService.getAddressRepository().truncateTable();
+    }
+    
+    private Connection openConnection() throws SQLException {
+        Properties props = new Properties();
+        return DriverManager.getConnection(jdbcUrlPrefix + jdbcUrlSuffix, props);
+    }
+    
+    private DataSource createDataSource() throws SQLException {
+        extracted(HIVE_SERVER2_1_CONTAINER.getMappedPort(RANDOM_PORT_FIRST));
+        HikariConfig config = new HikariConfig();
+        config.setDriverClassName("org.apache.shardingsphere.driver.ShardingSphereDriver");
+        config.setJdbcUrl("jdbc:shardingsphere:classpath:test-native/yaml/jdbc/databases/hive/zookeeper-sde.yaml?placeholder-type=system_props");
+        System.setProperty(SYSTEM_PROP_KEY_PREFIX + "ds0.jdbc-url", jdbcUrlPrefix + "demo_ds_0" + ";initFile=" + ABSOLUTE_PATH + jdbcUrlSuffix);
+        System.setProperty(SYSTEM_PROP_KEY_PREFIX + "ds1.jdbc-url", jdbcUrlPrefix + "demo_ds_1" + ";initFile=" + ABSOLUTE_PATH + jdbcUrlSuffix);
+        System.setProperty(SYSTEM_PROP_KEY_PREFIX + "ds2.jdbc-url", jdbcUrlPrefix + "demo_ds_2" + ";initFile=" + ABSOLUTE_PATH + jdbcUrlSuffix);
+        return new HikariDataSource(config);
+    }
+    
+    private void extracted(final int hiveServer2Port) throws SQLException {
+        String connectionString = ZOOKEEPER_CONTAINER.getHost() + ":" + ZOOKEEPER_CONTAINER.getMappedPort(2181);
+        Awaitility.await().atMost(Duration.ofMinutes(2L)).ignoreExceptions().until(() -> {
+            try (
+                    CuratorFramework client = CuratorFrameworkFactory.builder().connectString(connectionString)
+                            .retryPolicy(new ExponentialBackoffRetry(1000, 3)).build()) {
+                client.start();
+                List<String> children = client.getChildren().forPath("/hiveserver2");
+                assertThat(children.size(), is(1));
+                return children.get(0).contains(":" + hiveServer2Port + ";version=");
+            }
+        });
+        Awaitility.await().atMost(Duration.ofMinutes(1L)).ignoreExceptions().until(() -> {
+            openConnection().close();
+            return true;
+        });
+        try (
+                Connection connection = openConnection();
+                Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE DATABASE demo_ds_0");
+            statement.executeUpdate("CREATE DATABASE demo_ds_1");
+            statement.executeUpdate("CREATE DATABASE demo_ds_2");
+        }
+    }
+}

--- a/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native-test-metadata/reflect-config.json
+++ b/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native-test-metadata/reflect-config.json
@@ -106,14 +106,6 @@
   "allDeclaredFields": true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.test.natived.jdbc.databases.HiveTest"},
-  "name":"org.apache.shardingsphere.test.natived.jdbc.databases.HiveTest",
-  "allDeclaredConstructors": true,
-  "allDeclaredMethods": true,
-  "allPublicMethods": true,
-  "allDeclaredFields": true
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.test.natived.jdbc.databases.PostgresTest"},
   "name":"org.apache.shardingsphere.test.natived.jdbc.databases.PostgresTest",
   "allDeclaredConstructors": true,
@@ -152,5 +144,21 @@
   "allDeclaredMethods": true,
   "allPublicMethods": true,
   "allDeclaredFields": true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.test.natived.jdbc.databases.hive.HiveZookeeperServiceDiscoveryTest"},
+  "name":"org.apache.shardingsphere.test.natived.jdbc.databases.hive.HiveZookeeperServiceDiscoveryTest",
+  "allDeclaredFields": true,
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true,
+  "allPublicMethods": true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.test.natived.jdbc.databases.hive.HiveSimpleTest"},
+  "name":"org.apache.shardingsphere.test.natived.jdbc.databases.hive.HiveSimpleTest",
+  "allDeclaredFields": true,
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true,
+  "allPublicMethods": true
 }
 ]

--- a/test/native/src/test/resources/test-native/yaml/jdbc/databases/hive/simple.yaml
+++ b/test/native/src/test/resources/test-native/yaml/jdbc/databases/hive/simple.yaml
@@ -24,15 +24,15 @@ dataSources:
   ds_0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.apache.hive.jdbc.HiveDriver
-    jdbcUrl: $${fixture.test-native.yaml.database.hive.ds0.jdbc-url::}
+    jdbcUrl: $${fixture.test-native.yaml.database.hive.simple.ds0.jdbc-url::}
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.apache.hive.jdbc.HiveDriver
-    jdbcUrl: $${fixture.test-native.yaml.database.hive.ds1.jdbc-url::}
+    jdbcUrl: $${fixture.test-native.yaml.database.hive.simple.ds1.jdbc-url::}
   ds_2:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.apache.hive.jdbc.HiveDriver
-    jdbcUrl: $${fixture.test-native.yaml.database.hive.ds2.jdbc-url::}
+    jdbcUrl: $${fixture.test-native.yaml.database.hive.simple.ds2.jdbc-url::}
 
 rules:
 - !SHARDING

--- a/test/native/src/test/resources/test-native/yaml/jdbc/databases/hive/zookeeper-sde.yaml
+++ b/test/native/src/test/resources/test-native/yaml/jdbc/databases/hive/zookeeper-sde.yaml
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mode:
+  type: Standalone
+  repository:
+    type: JDBC
+
+dataSources:
+  ds_0:
+    dataSourceClassName: com.zaxxer.hikari.HikariDataSource
+    driverClassName: org.apache.hive.jdbc.HiveDriver
+    jdbcUrl: $${fixture.test-native.yaml.database.hive.zookeeper.sde.ds0.jdbc-url::}
+  ds_1:
+    dataSourceClassName: com.zaxxer.hikari.HikariDataSource
+    driverClassName: org.apache.hive.jdbc.HiveDriver
+    jdbcUrl: $${fixture.test-native.yaml.database.hive.zookeeper.sde.ds1.jdbc-url::}
+  ds_2:
+    dataSourceClassName: com.zaxxer.hikari.HikariDataSource
+    driverClassName: org.apache.hive.jdbc.HiveDriver
+    jdbcUrl: $${fixture.test-native.yaml.database.hive.zookeeper.sde.ds2.jdbc-url::}
+
+rules:
+- !SHARDING
+  tables:
+    t_order:
+      actualDataNodes: <LITERAL>ds_0.t_order, ds_1.t_order, ds_2.t_order
+      keyGenerateStrategy:
+        column: order_id
+        keyGeneratorName: snowflake
+    t_order_item:
+      actualDataNodes: <LITERAL>ds_0.t_order_item, ds_1.t_order_item, ds_2.t_order_item
+      keyGenerateStrategy:
+        column: order_item_id
+        keyGeneratorName: snowflake
+  defaultDatabaseStrategy:
+    standard:
+      shardingColumn: user_id
+      shardingAlgorithmName: inline
+  shardingAlgorithms:
+    inline:
+      type: CLASS_BASED
+      props:
+        strategy: STANDARD
+        algorithmClassName: org.apache.shardingsphere.test.natived.commons.algorithm.ClassBasedInlineShardingAlgorithmFixture
+  keyGenerators:
+    snowflake:
+      type: SNOWFLAKE
+  auditors:
+    sharding_key_required_auditor:
+      type: DML_SHARDING_CONDITIONS
+
+- !BROADCAST
+  tables:
+    - t_address
+
+props:
+  sql-show: false


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Support connecting to HiveServer2 with ZooKeeper Service Discovery enabled in GraalVM Native Image.
  - The testcontainers java documentation was missing a reference to the postgresql jdbc driver. This PR adds it.
  - Simplifies the description of Docker Compose in HiveServer2 documentation to improve focus.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
