### PR TITLE
Partial support for connecting to embedded ClickHouse `chDB`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,7 @@
 1. DistSQL: Check inline expression when create sharding table rule with inline sharding algorithm - [#33735](https://github.com/apache/shardingsphere/pull/33735)
 1. Infra: Support setting `hive_conf_list`, `hive_var_list` and `sess_var_list` for jdbcURL when connecting to HiveServer2 - [#33749](https://github.com/apache/shardingsphere/pull/33749)
 1. Infra: Support connecting to HiveServer2 through database connection pools other than HikariCP - [#33762](https://github.com/apache/shardingsphere/pull/33762)
+1. Infra: Partial support for connecting to embedded ClickHouse `chDB` - [#33786](https://github.com/apache/shardingsphere/pull/33786)
 1. Proxy Native: Support connecting to HiveServer2 with ZooKeeper Service Discovery enabled in GraalVM Native Image - [#33768](https://github.com/apache/shardingsphere/pull/33768)
 
 ### Bug Fixes

--- a/infra/database/type/clickhouse/src/main/java/org/apache/shardingsphere/infra/database/clickhouse/type/ClickHouseDatabaseType.java
+++ b/infra/database/type/clickhouse/src/main/java/org/apache/shardingsphere/infra/database/clickhouse/type/ClickHouseDatabaseType.java
@@ -29,7 +29,7 @@ public final class ClickHouseDatabaseType implements DatabaseType {
     
     @Override
     public Collection<String> getJdbcUrlPrefixes() {
-        return Arrays.asList("jdbc:ch:", "jdbc:clickhouse:");
+        return Arrays.asList("jdbc:ch:", "jdbc:clickhouse:", "jdbc:chdb");
     }
     
     @Override

--- a/infra/database/type/clickhouse/src/test/java/org/apache/shardingsphere/infra/database/clickhouse/type/ClickHouseDatabaseTypeTest.java
+++ b/infra/database/type/clickhouse/src/test/java/org/apache/shardingsphere/infra/database/clickhouse/type/ClickHouseDatabaseTypeTest.java
@@ -30,6 +30,6 @@ class ClickHouseDatabaseTypeTest {
     
     @Test
     void assertGetJdbcUrlPrefixes() {
-        assertThat(TypedSPILoader.getService(DatabaseType.class, "ClickHouse").getJdbcUrlPrefixes(), is(Arrays.asList("jdbc:ch:", "jdbc:clickhouse:")));
+        assertThat(TypedSPILoader.getService(DatabaseType.class, "ClickHouse").getJdbcUrlPrefixes(), is(Arrays.asList("jdbc:ch:", "jdbc:clickhouse:", "jdbc:chdb")));
     }
 }


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Partial support for connecting to embedded ClickHouse `chDB`. See https://clickhouse.com/docs/en/chdb .
  - There is apparently controversy in https://github.com/chdb-io/chdb/issues/243 , and it is a big question whether embedded ClickHouse should only use FFM on JDK22+. Corresponding to https://github.com/linux-china/chdb-java-ffm/issues/1, it seems that the result of merging the projects is nothing.
  - But whether it is https://github.com/chdb-io/chdb-java or https://github.com/linux-china/chdb-java-ffm , the two different chDB JDBC Drivers use `jdbc:chdb` as the jdbcUrl prefix. At the ShardingSphere level, it is not a problem to support 4 drivers for a single database dialect parsing module at the same time.
  - Since this is a standalone project, the unit tests under GraalVM Native Image obviously need to be rewritten to cover GRM.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
