### PR TITLE
Fix BatchUpdateException when execute INSERT INTO ON DUPLICATE KEY UPDATE in proxy adapter

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,6 +41,7 @@
 1. Sharding: Fix avg, sum, min, max function return empty data when no query result return - [#33449](https://github.com/apache/shardingsphere/pull/33449)
 1. Encrypt: Fix merge exception without encrypt rule in database - [#33708](https://github.com/apache/shardingsphere/pull/33708)
 1. SQL Parser: Fix mysql parse zone unreserved keyword error - [#33720](https://github.com/apache/shardingsphere/pull/33720)
+1. Proxy: Fix BatchUpdateException when execute INSERT INTO ON DUPLICATE KEY UPDATE in proxy adapter - [#33796](https://github.com/apache/shardingsphere/pull/33796)
 
 ### Change Logs
 

--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/constant/MySQLCapabilityFlag.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/constant/MySQLCapabilityFlag.java
@@ -97,7 +97,7 @@ public enum MySQLCapabilityFlag {
      * @return handshake capability flags upper bit
      */
     public static int calculateHandshakeCapabilityFlagsUpper() {
-        return calculateCapabilityFlags(CLIENT_MULTI_STATEMENTS, CLIENT_PLUGIN_AUTH) >> 16;
+        return calculateCapabilityFlags(CLIENT_MULTI_STATEMENTS, CLIENT_PLUGIN_AUTH, CLIENT_MULTI_RESULTS, CLIENT_PS_MULTI_RESULTS) >> 16;
     }
     
     /**

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/executor/engine/batch/preparedstatement/BatchPreparedStatementExecutor.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/executor/engine/batch/preparedstatement/BatchPreparedStatementExecutor.java
@@ -178,7 +178,7 @@ public final class BatchPreparedStatementExecutor {
     
     private void accumulate(final int[] executeResult, final int[] addBatchCounts, final JDBCExecutionUnit executionUnit) {
         for (Entry<Integer, Integer> entry : getJDBCAndActualAddBatchCallTimesMap(executionUnit).entrySet()) {
-            int value = null == executeResult ? 0 : executeResult[entry.getValue()];
+            int value = null == executeResult || 0 == executeResult.length ? 0 : executeResult[entry.getValue()];
             addBatchCounts[entry.getKey()] += value;
         }
     }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/response/header/update/MultiStatementsUpdateResponseHeader.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/response/header/update/MultiStatementsUpdateResponseHeader.java
@@ -15,27 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.db.protocol.mysql.constant;
+package org.apache.shardingsphere.proxy.backend.response.header.update;
 
-import org.junit.jupiter.api.Test;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import java.util.Collection;
 
-class MySQLCapabilityFlagTest {
+/**
+ * Multi statements update response header.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class MultiStatementsUpdateResponseHeader implements ResponseHeader {
     
-    @Test
-    void assertGetValue() {
-        assertThat(MySQLCapabilityFlag.CLIENT_LONG_PASSWORD.getValue(), is(0x00000001));
-    }
-    
-    @Test
-    void assertCalculateHandshakeCapabilityFlagsLower() {
-        assertThat(MySQLCapabilityFlag.calculateHandshakeCapabilityFlagsLower(), is(46927));
-    }
-    
-    @Test
-    void assertCalculateHandshakeCapabilityFlagsUpper() {
-        assertThat(MySQLCapabilityFlag.calculateHandshakeCapabilityFlagsUpper(), is(0x000f));
-    }
+    private final Collection<UpdateResponseHeader> updateResponseHeaders;
 }

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/ServerStatusFlagCalculator.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/ServerStatusFlagCalculator.java
@@ -35,9 +35,21 @@ public final class ServerStatusFlagCalculator {
      * @return server status flag
      */
     public static int calculateFor(final ConnectionSession connectionSession) {
+        return calculateFor(connectionSession, true);
+    }
+    
+    /**
+     * Calculate server status flag for specified connection.
+     *
+     * @param connectionSession connection session
+     * @param lastPacket last packet
+     * @return server status flag
+     */
+    public static int calculateFor(final ConnectionSession connectionSession, final boolean lastPacket) {
         int result = 0;
         result |= connectionSession.isAutoCommit() ? MySQLStatusFlag.SERVER_STATUS_AUTOCOMMIT.getValue() : 0;
         result |= connectionSession.getTransactionStatus().isInTransaction() ? MySQLStatusFlag.SERVER_STATUS_IN_TRANS.getValue() : 0;
+        result |= lastPacket ? 0 : MySQLStatusFlag.SERVER_MORE_RESULTS_EXISTS.getValue();
         return result;
     }
 }

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareParameterMarkerExtractor.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareParameterMarkerExtractor.java
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.ColumnAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.InsertValuesSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
@@ -64,6 +65,16 @@ public final class MySQLComStmtPrepareParameterMarkerExtractor {
                     continue;
                 }
                 String columnName = columnNamesOfInsert.get(columnIndex);
+                ShardingSphereColumn column = table.getColumn(columnName);
+                result.add(column);
+            }
+        }
+        if (insertStatement.getOnDuplicateKeyColumns().isPresent()) {
+            for (ColumnAssignmentSegment each : insertStatement.getOnDuplicateKeyColumns().get().getColumns()) {
+                if (!(each.getValue() instanceof ParameterMarkerExpressionSegment)) {
+                    continue;
+                }
+                String columnName = each.getColumns().iterator().next().getIdentifier().getValue();
                 ShardingSphereColumn column = table.getColumn(columnName);
                 result.add(column);
             }

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareParameterMarkerExtractor.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareParameterMarkerExtractor.java
@@ -30,6 +30,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatemen
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.InsertStatement;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
@@ -69,20 +70,23 @@ public final class MySQLComStmtPrepareParameterMarkerExtractor {
                 result.add(column);
             }
         }
-        if (insertStatement.getOnDuplicateKeyColumns().isPresent()) {
-            for (ColumnAssignmentSegment each : insertStatement.getOnDuplicateKeyColumns().get().getColumns()) {
-                if (!(each.getValue() instanceof ParameterMarkerExpressionSegment)) {
-                    continue;
-                }
-                String columnName = each.getColumns().iterator().next().getIdentifier().getValue();
-                ShardingSphereColumn column = table.getColumn(columnName);
-                result.add(column);
-            }
-        }
+        insertStatement.getOnDuplicateKeyColumns().ifPresent(optional -> appendOnDuplicateKeyParameterMarkers(optional.getColumns(), table, result));
         return result;
     }
     
     private static List<String> getColumnNamesOfInsertStatement(final InsertStatement insertStatement, final ShardingSphereTable table) {
         return insertStatement.getColumns().isEmpty() ? table.getColumnNames() : insertStatement.getColumns().stream().map(each -> each.getIdentifier().getValue()).collect(Collectors.toList());
+    }
+    
+    private static void appendOnDuplicateKeyParameterMarkers(final Collection<ColumnAssignmentSegment> onDuplicateKeyColumns,
+                                                             final ShardingSphereTable table, final List<ShardingSphereColumn> result) {
+        for (ColumnAssignmentSegment each : onDuplicateKeyColumns) {
+            if (!(each.getValue() instanceof ParameterMarkerExpressionSegment)) {
+                continue;
+            }
+            String columnName = each.getColumns().iterator().next().getIdentifier().getValue();
+            ShardingSphereColumn column = table.getColumn(columnName);
+            result.add(column);
+        }
     }
 }

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutor.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutor.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactor
 import org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.query.QueryResponseHeader;
+import org.apache.shardingsphere.proxy.backend.response.header.update.MultiStatementsUpdateResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.frontend.command.executor.QueryCommandExecutor;
@@ -39,10 +40,12 @@ import org.apache.shardingsphere.proxy.frontend.mysql.command.ServerStatusFlagCa
 import org.apache.shardingsphere.proxy.frontend.mysql.command.query.builder.ResponsePacketBuilder;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.DeleteStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.InsertStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.UpdateStatement;
 
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.LinkedList;
 
 /**
  * COM_QUERY command packet executor for MySQL.
@@ -78,7 +81,11 @@ public final class MySQLComQueryPacketExecutor implements QueryCommandExecutor {
     }
     
     private boolean isSuitableMultiStatementsSQLStatement(final SQLStatement sqlStatement) {
-        return sqlStatement instanceof UpdateStatement || sqlStatement instanceof DeleteStatement;
+        return containsInsertOnDuplicateKey(sqlStatement) || sqlStatement instanceof UpdateStatement || sqlStatement instanceof DeleteStatement;
+    }
+    
+    private boolean containsInsertOnDuplicateKey(final SQLStatement sqlStatement) {
+        return sqlStatement instanceof InsertStatement && ((InsertStatement) sqlStatement).getOnDuplicateKeyColumns().isPresent();
     }
     
     @Override
@@ -88,16 +95,29 @@ public final class MySQLComQueryPacketExecutor implements QueryCommandExecutor {
             return processQuery((QueryResponseHeader) responseHeader);
         }
         responseType = ResponseType.UPDATE;
+        if (responseHeader instanceof MultiStatementsUpdateResponseHeader) {
+            return processMultiStatementsUpdate((MultiStatementsUpdateResponseHeader) responseHeader);
+        }
         return processUpdate((UpdateResponseHeader) responseHeader);
     }
     
     private Collection<DatabasePacket> processQuery(final QueryResponseHeader queryResponseHeader) {
         responseType = ResponseType.QUERY;
-        return ResponsePacketBuilder.buildQueryResponsePackets(queryResponseHeader, characterSet, ServerStatusFlagCalculator.calculateFor(connectionSession));
+        return ResponsePacketBuilder.buildQueryResponsePackets(queryResponseHeader, characterSet, ServerStatusFlagCalculator.calculateFor(connectionSession, true));
     }
     
     private Collection<DatabasePacket> processUpdate(final UpdateResponseHeader updateResponseHeader) {
-        return ResponsePacketBuilder.buildUpdateResponsePackets(updateResponseHeader, ServerStatusFlagCalculator.calculateFor(connectionSession));
+        return ResponsePacketBuilder.buildUpdateResponsePackets(updateResponseHeader, ServerStatusFlagCalculator.calculateFor(connectionSession, true));
+    }
+    
+    private Collection<DatabasePacket> processMultiStatementsUpdate(final MultiStatementsUpdateResponseHeader responseHeader) {
+        Collection<DatabasePacket> result = new LinkedList<>();
+        int index = 0;
+        for (UpdateResponseHeader each : responseHeader.getUpdateResponseHeaders()) {
+            boolean lastPacket = ++index == responseHeader.getUpdateResponseHeaders().size();
+            result.addAll(ResponsePacketBuilder.buildUpdateResponsePackets(each, ServerStatusFlagCalculator.calculateFor(connectionSession, lastPacket)));
+        }
+        return result;
     }
     
     @Override

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutor.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutor.java
@@ -103,11 +103,11 @@ public final class MySQLComQueryPacketExecutor implements QueryCommandExecutor {
     
     private Collection<DatabasePacket> processQuery(final QueryResponseHeader queryResponseHeader) {
         responseType = ResponseType.QUERY;
-        return ResponsePacketBuilder.buildQueryResponsePackets(queryResponseHeader, characterSet, ServerStatusFlagCalculator.calculateFor(connectionSession, true));
+        return ResponsePacketBuilder.buildQueryResponsePackets(queryResponseHeader, characterSet, ServerStatusFlagCalculator.calculateFor(connectionSession));
     }
     
     private Collection<DatabasePacket> processUpdate(final UpdateResponseHeader updateResponseHeader) {
-        return ResponsePacketBuilder.buildUpdateResponsePackets(updateResponseHeader, ServerStatusFlagCalculator.calculateFor(connectionSession, true));
+        return ResponsePacketBuilder.buildUpdateResponsePackets(updateResponseHeader, ServerStatusFlagCalculator.calculateFor(connectionSession));
     }
     
     private Collection<DatabasePacket> processMultiStatementsUpdate(final MultiStatementsUpdateResponseHeader responseHeader) {

--- a/proxy/frontend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/ServerStatusFlagCalculatorTest.java
+++ b/proxy/frontend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/ServerStatusFlagCalculatorTest.java
@@ -58,4 +58,10 @@ class ServerStatusFlagCalculatorTest {
         when(connectionSession.getTransactionStatus().isInTransaction()).thenReturn(true);
         assertThat(ServerStatusFlagCalculator.calculateFor(connectionSession), is(MySQLStatusFlag.SERVER_STATUS_IN_TRANS.getValue()));
     }
+    
+    @Test
+    void assertCalculateForWithMultiStatements() {
+        assertThat(ServerStatusFlagCalculator.calculateFor(connectionSession, false), is(MySQLStatusFlag.SERVER_MORE_RESULTS_EXISTS.getValue()));
+        assertThat(ServerStatusFlagCalculator.calculateFor(connectionSession, true), is(0));
+    }
 }

--- a/proxy/frontend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLMultiStatementsHandlerTest.java
+++ b/proxy/frontend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLMultiStatementsHandlerTest.java
@@ -35,6 +35,7 @@ import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnection
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.statement.JDBCBackendStatement;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
+import org.apache.shardingsphere.proxy.backend.response.header.update.MultiStatementsUpdateResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.sql.parser.statement.mysql.dml.MySQLUpdateStatement;
@@ -53,6 +54,7 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -78,11 +80,22 @@ class MySQLMultiStatementsHandlerTest {
         ContextManager contextManager = mockContextManager();
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         ResponseHeader actual = new MySQLMultiStatementsHandler(connectionSession, expectedStatement, sql).execute();
-        assertThat(actual, instanceOf(UpdateResponseHeader.class));
-        UpdateResponseHeader actualHeader = (UpdateResponseHeader) actual;
-        assertThat(actualHeader.getUpdateCount(), is(3L));
-        assertThat(actualHeader.getLastInsertId(), is(0L));
-        assertThat(actualHeader.getSqlStatement(), is(expectedStatement));
+        assertThat(actual, instanceOf(MultiStatementsUpdateResponseHeader.class));
+        MultiStatementsUpdateResponseHeader actualHeader = (MultiStatementsUpdateResponseHeader) actual;
+        assertThat(actualHeader.getUpdateResponseHeaders().size(), is(3));
+        Iterator<UpdateResponseHeader> iterator = actualHeader.getUpdateResponseHeaders().iterator();
+        UpdateResponseHeader responseHeader = iterator.next();
+        assertThat(responseHeader.getUpdateCount(), is(1L));
+        assertThat(responseHeader.getLastInsertId(), is(0L));
+        assertThat(responseHeader.getSqlStatement(), is(expectedStatement));
+        responseHeader = iterator.next();
+        assertThat(responseHeader.getUpdateCount(), is(1L));
+        assertThat(responseHeader.getLastInsertId(), is(0L));
+        assertThat(responseHeader.getSqlStatement(), is(expectedStatement));
+        responseHeader = iterator.next();
+        assertThat(responseHeader.getUpdateCount(), is(1L));
+        assertThat(responseHeader.getLastInsertId(), is(0L));
+        assertThat(responseHeader.getSqlStatement(), is(expectedStatement));
     }
     
     @Test
@@ -93,11 +106,50 @@ class MySQLMultiStatementsHandlerTest {
         ContextManager contextManager = mockContextManager();
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         ResponseHeader actual = new MySQLMultiStatementsHandler(connectionSession, expectedStatement, sql).execute();
-        assertThat(actual, instanceOf(UpdateResponseHeader.class));
-        UpdateResponseHeader actualHeader = (UpdateResponseHeader) actual;
-        assertThat(actualHeader.getUpdateCount(), is(3L));
-        assertThat(actualHeader.getLastInsertId(), is(0L));
-        assertThat(actualHeader.getSqlStatement(), is(expectedStatement));
+        assertThat(actual, instanceOf(MultiStatementsUpdateResponseHeader.class));
+        MultiStatementsUpdateResponseHeader actualHeader = (MultiStatementsUpdateResponseHeader) actual;
+        assertThat(actualHeader.getUpdateResponseHeaders().size(), is(3));
+        Iterator<UpdateResponseHeader> iterator = actualHeader.getUpdateResponseHeaders().iterator();
+        UpdateResponseHeader responseHeader = iterator.next();
+        assertThat(responseHeader.getUpdateCount(), is(1L));
+        assertThat(responseHeader.getLastInsertId(), is(0L));
+        assertThat(responseHeader.getSqlStatement(), is(expectedStatement));
+        responseHeader = iterator.next();
+        assertThat(responseHeader.getUpdateCount(), is(1L));
+        assertThat(responseHeader.getLastInsertId(), is(0L));
+        assertThat(responseHeader.getSqlStatement(), is(expectedStatement));
+        responseHeader = iterator.next();
+        assertThat(responseHeader.getUpdateCount(), is(1L));
+        assertThat(responseHeader.getLastInsertId(), is(0L));
+        assertThat(responseHeader.getSqlStatement(), is(expectedStatement));
+    }
+    
+    @Test
+    void assertExecuteWithMultiInsertOnDuplicateKey() throws SQLException {
+        String sql =
+                "insert into t (id, v) values(1,1) on duplicate key update v=2;insert into t (id, v) values(2,1) "
+                        + "on duplicate key update v=3;insert into t (id, v) values(2,1) on duplicate key update v=3";
+        ConnectionSession connectionSession = mockConnectionSession();
+        MySQLUpdateStatement expectedStatement = mock(MySQLUpdateStatement.class);
+        ContextManager contextManager = mockContextManager();
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        ResponseHeader actual = new MySQLMultiStatementsHandler(connectionSession, expectedStatement, sql).execute();
+        assertThat(actual, instanceOf(MultiStatementsUpdateResponseHeader.class));
+        MultiStatementsUpdateResponseHeader actualHeader = (MultiStatementsUpdateResponseHeader) actual;
+        assertThat(actualHeader.getUpdateResponseHeaders().size(), is(3));
+        Iterator<UpdateResponseHeader> iterator = actualHeader.getUpdateResponseHeaders().iterator();
+        UpdateResponseHeader responseHeader = iterator.next();
+        assertThat(responseHeader.getUpdateCount(), is(1L));
+        assertThat(responseHeader.getLastInsertId(), is(0L));
+        assertThat(responseHeader.getSqlStatement(), is(expectedStatement));
+        responseHeader = iterator.next();
+        assertThat(responseHeader.getUpdateCount(), is(1L));
+        assertThat(responseHeader.getLastInsertId(), is(0L));
+        assertThat(responseHeader.getSqlStatement(), is(expectedStatement));
+        responseHeader = iterator.next();
+        assertThat(responseHeader.getUpdateCount(), is(1L));
+        assertThat(responseHeader.getLastInsertId(), is(0L));
+        assertThat(responseHeader.getSqlStatement(), is(expectedStatement));
     }
     
     private ConnectionSession mockConnectionSession() throws SQLException {

--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/cases/dataset/row/DataSetRow.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/cases/dataset/row/DataSetRow.java
@@ -45,6 +45,9 @@ public final class DataSetRow {
     @XmlAttribute(required = true)
     private String values;
     
+    @XmlAttribute
+    private boolean updated;
+    
     /**
      * Split values with vertical bar.
      *

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_multiple.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_multiple.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<dataset update-count="38">
+<dataset update-count="1">
     <metadata data-nodes="db_${0..9}.t_order">
         <column name="order_id" type="numeric" />
         <column name="user_id" type="numeric" />

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_1.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_1.xml
@@ -1,0 +1,66 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="db_${0..9}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2000, 20, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1100, 11, init, 5, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1101, 11, init, 6, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2100, 21, init, 7, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2101, 21, init, 8, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1200, 12, init, 9, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1201, 12, init, 10, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2200, 22, init, 11, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2201, 22, init, 12, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1300, 13, init, 13, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1301, 13, init, 14, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2300, 23, init, 15, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2301, 23, init, 16, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1400, 14, init, 17, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1401, 14, init, 18, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2400, 24, init, 19, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2401, 24, init, 20, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1500, 15, init, 1, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1501, 15, init, 2, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2500, 25, init, null, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2501, 25, init, 4, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1600, 16, init, 5, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1601, 16, init, 6, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2600, 26, init, 7, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2601, 26, init, 8, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1700, 17, init, 9, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1701, 17, init, 10, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2700, 27, init, 11, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2701, 27, init, 12, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1800, 18, init, 13, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1801, 18, init, 14, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2800, 28, init, null, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2801, 28, init, 16, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1900, 19, init, 17, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1901, 19, init, 18, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2900, 29, init, 19, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2901, 29, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_2.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_2.xml
@@ -24,7 +24,7 @@
         <column name="remark" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
-    <row data-node="db_0.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="1000, 10, init, null, test, 2017-08-08" />
     <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
     <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />
     <row data-node="db_1.t_order" values="1100, 11, init, 5, test, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_2.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_2.xml
@@ -1,0 +1,66 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="db_${0..9}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="db_0.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1100, 11, init, 5, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1101, 11, init, 6, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2100, 21, init, 7, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2101, 21, init, 8, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1200, 12, init, 9, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1201, 12, init, 10, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2200, 22, init, 11, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2201, 22, init, 12, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1300, 13, init, 13, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1301, 13, init, 14, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2300, 23, init, 15, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2301, 23, init, 16, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1400, 14, init, 17, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1401, 14, init, 18, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2400, 24, init, 19, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2401, 24, init, 20, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1500, 15, init, 1, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1501, 15, init, 2, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2500, 25, init, null, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2501, 25, init, 4, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1600, 16, init, 5, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1601, 16, init, 6, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2600, 26, init, 7, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2601, 26, init, 8, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1700, 17, init, 9, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1701, 17, init, 10, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2700, 27, init, 11, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2701, 27, init, 12, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1800, 18, init, 13, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1801, 18, init, 14, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2800, 28, init, null, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2801, 28, init, 16, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1900, 19, init, 17, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1901, 19, init, 18, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2900, 29, init, 19, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2901, 29, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_3.xml
@@ -24,7 +24,7 @@
         <column name="remark" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
-    <row data-node="db_0.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="1000, 10, init, null, test, 2017-08-08" />
     <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
     <row data-node="db_0.t_order" values="2000, 20, init, null, test, 2017-08-08" />
     <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_3.xml
@@ -1,0 +1,66 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="db_${0..9}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="db_0.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2000, 20, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1100, 11, init, 5, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1101, 11, init, 6, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2100, 21, init, 7, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2101, 21, init, 8, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1200, 12, init, 9, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1201, 12, init, 10, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2200, 22, init, 11, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2201, 22, init, 12, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1300, 13, init, 13, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1301, 13, init, 14, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2300, 23, init, 15, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2301, 23, init, 16, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1400, 14, init, 17, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1401, 14, init, 18, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2400, 24, init, 19, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2401, 24, init, 20, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1500, 15, init, 1, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1501, 15, init, 2, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2500, 25, init, null, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2501, 25, init, 4, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1600, 16, init, 5, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1601, 16, init, 6, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2600, 26, init, 7, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2601, 26, init, 8, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1700, 17, init, 9, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1701, 17, init, 10, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2700, 27, init, 11, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2701, 27, init, 12, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1800, 18, init, 13, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1801, 18, init, 14, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2801, 28, init, 16, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1900, 19, init, 17, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1901, 19, init, 18, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2900, 29, init, 19, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2901, 29, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_4.xml
@@ -24,7 +24,7 @@
         <column name="remark" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
-    <row data-node="db_0.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="1000, 10, init, null, test, 2017-08-08" />
     <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
     <row data-node="db_0.t_order" values="2000, 20, init, null, test, 2017-08-08" />
     <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/delete_with_sharding_value_batch_4.xml
@@ -1,0 +1,66 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="db_${0..9}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="db_0.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2000, 20, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1100, 11, init, 5, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1101, 11, init, 6, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2100, 21, init, 7, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2101, 21, init, 8, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1200, 12, init, 9, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1201, 12, init, 10, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2200, 22, init, 11, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2201, 22, init, 12, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1300, 13, init, 13, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1301, 13, init, 14, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2300, 23, init, 15, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2301, 23, init, 16, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1400, 14, init, 17, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1401, 14, init, 18, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2400, 24, init, 19, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2401, 24, init, 20, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1500, 15, init, 1, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1501, 15, init, 2, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2500, 25, init, null, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2501, 25, init, 4, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1600, 16, init, 5, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1601, 16, init, 6, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2600, 26, init, 7, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2601, 26, init, 8, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1700, 17, init, 9, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1701, 17, init, 10, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2700, 27, init, 11, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2701, 27, init, 12, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1800, 18, init, 13, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1801, 18, init, 14, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2800, 28, init, null, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2801, 28, init, 16, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1900, 19, init, 17, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1901, 19, init, 18, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2901, 29, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/insert_for_order_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/insert_for_order_3.xml
@@ -1,0 +1,68 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="db_${0..9}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="db_0.t_order" values="1000, 10, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2000, 20, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1100, 11, init, 5, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1101, 11, init, 6, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2100, 21, init, 7, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2101, 21, init, 8, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1200, 12, init, 9, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1201, 12, init, 10, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2200, 22, init, 11, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2201, 22, init, 12, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="3, 3, insert, 1, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1300, 13, init, 13, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1301, 13, init, 14, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2300, 23, init, 15, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2301, 23, init, 16, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1400, 14, init, 17, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1401, 14, init, 18, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2400, 24, init, 19, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2401, 24, init, 20, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1500, 15, init, 1, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1501, 15, init, 2, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2500, 25, init, null, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2501, 25, init, 4, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1600, 16, init, 5, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1601, 16, init, 6, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2600, 26, init, 7, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2601, 26, init, 8, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1700, 17, init, 9, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1701, 17, init, 10, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2700, 27, init, 11, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2701, 27, init, 12, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1800, 18, init, 13, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1801, 18, init, 14, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2800, 28, init, null, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2801, 28, init, 16, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1900, 19, init, 17, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1901, 19, init, 18, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2900, 29, init, 19, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2901, 29, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/insert_for_order_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/insert_for_order_4.xml
@@ -1,0 +1,68 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="db_${0..9}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="db_0.t_order" values="1000, 10, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2000, 20, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1100, 11, init, 5, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1101, 11, init, 6, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2100, 21, init, 7, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2101, 21, init, 8, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1200, 12, init, 9, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1201, 12, init, 10, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2200, 22, init, 11, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2201, 22, init, 12, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1300, 13, init, 13, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1301, 13, init, 14, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2300, 23, init, 15, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2301, 23, init, 16, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="4, 4, insert, 1, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1400, 14, init, 17, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1401, 14, init, 18, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2400, 24, init, 19, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2401, 24, init, 20, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1500, 15, init, 1, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1501, 15, init, 2, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2500, 25, init, null, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2501, 25, init, 4, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1600, 16, init, 5, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1601, 16, init, 6, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2600, 26, init, 7, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2601, 26, init, 8, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1700, 17, init, 9, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1701, 17, init, 10, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2700, 27, init, 11, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2701, 27, init, 12, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1800, 18, init, 13, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1801, 18, init, 14, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2800, 28, init, null, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2801, 28, init, 16, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1900, 19, init, 17, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1901, 19, init, 18, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2900, 29, init, 19, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2901, 29, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/update_batch_1.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/update_batch_1.xml
@@ -1,0 +1,67 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="db_${0..9}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="db_0.t_order" values="1000, 10, update, null, test, 2017-08-08" updated="true" />
+    <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2000, 20, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1100, 11, init, 5, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1101, 11, init, 6, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2100, 21, init, 7, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2101, 21, init, 8, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1200, 12, init, 9, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1201, 12, init, 10, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2200, 22, init, 11, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2201, 22, init, 12, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1300, 13, init, 13, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1301, 13, init, 14, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2300, 23, init, 15, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2301, 23, init, 16, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1400, 14, init, 17, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1401, 14, init, 18, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2400, 24, init, 19, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2401, 24, init, 20, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1500, 15, init, 1, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1501, 15, init, 2, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2500, 25, init, null, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2501, 25, init, 4, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1600, 16, init, 5, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1601, 16, init, 6, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2600, 26, init, 7, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2601, 26, init, 8, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1700, 17, init, 9, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1701, 17, init, 10, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2700, 27, init, 11, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2701, 27, init, 12, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1800, 18, init, 13, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1801, 18, init, 14, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2800, 28, init, null, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2801, 28, init, 16, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1900, 19, init, 17, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1901, 19, init, 18, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2900, 29, init, 19, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2901, 29, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/update_batch_2.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/update_batch_2.xml
@@ -1,0 +1,67 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="db_${0..9}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="db_0.t_order" values="1000, 10, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2000, 20, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1100, 11, init, 5, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1101, 11, update, 6, test, 2017-08-08" updated="true" />
+    <row data-node="db_1.t_order" values="2100, 21, init, 7, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2101, 21, init, 8, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1200, 12, init, 9, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1201, 12, init, 10, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2200, 22, init, 11, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2201, 22, init, 12, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1300, 13, init, 13, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1301, 13, init, 14, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2300, 23, init, 15, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2301, 23, init, 16, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1400, 14, init, 17, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1401, 14, init, 18, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2400, 24, init, 19, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2401, 24, init, 20, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1500, 15, init, 1, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1501, 15, init, 2, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2500, 25, init, null, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2501, 25, init, 4, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1600, 16, init, 5, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1601, 16, init, 6, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2600, 26, init, 7, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2601, 26, init, 8, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1700, 17, init, 9, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1701, 17, init, 10, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2700, 27, init, 11, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2701, 27, init, 12, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1800, 18, init, 13, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1801, 18, init, 14, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2800, 28, init, null, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2801, 28, init, 16, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1900, 19, init, 17, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1901, 19, init, 18, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2900, 29, init, 19, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2901, 29, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/update_batch_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/update_batch_3.xml
@@ -1,0 +1,67 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="db_${0..9}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="db_0.t_order" values="1000, 10, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2000, 20, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1100, 11, init, 5, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1101, 11, init, 6, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2100, 21, init, 7, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2101, 21, init, 8, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1200, 12, init, 9, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1201, 12, init, 10, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2200, 22, init, 11, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2201, 22, init, 12, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1300, 13, init, 13, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1301, 13, init, 14, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2300, 23, init, 15, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2301, 23, init, 16, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1400, 14, init, 17, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1401, 14, init, 18, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2400, 24, update, 19, test, 2017-08-08" updated="true" />
+    <row data-node="db_4.t_order" values="2401, 24, init, 20, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1500, 15, init, 1, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1501, 15, init, 2, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2500, 25, init, null, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2501, 25, init, 4, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1600, 16, init, 5, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1601, 16, init, 6, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2600, 26, init, 7, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2601, 26, init, 8, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1700, 17, init, 9, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1701, 17, init, 10, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2700, 27, init, 11, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2701, 27, init, 12, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1800, 18, init, 13, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1801, 18, init, 14, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2800, 28, init, null, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2801, 28, init, 16, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1900, 19, init, 17, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1901, 19, init, 18, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2900, 29, init, 19, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2901, 29, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/db/update_batch_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/db/update_batch_4.xml
@@ -1,0 +1,67 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="db_${0..9}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="db_0.t_order" values="1000, 10, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2000, 20, init, null, test, 2017-08-08" />
+    <row data-node="db_0.t_order" values="2001, 20, init, 4, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1100, 11, init, 5, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="1101, 11, init, 6, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2100, 21, init, 7, test, 2017-08-08" />
+    <row data-node="db_1.t_order" values="2101, 21, init, 8, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1200, 12, init, 9, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="1201, 12, init, 10, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2200, 22, init, 11, test, 2017-08-08" />
+    <row data-node="db_2.t_order" values="2201, 22, init, 12, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1300, 13, init, 13, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="1301, 13, init, 14, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2300, 23, init, 15, test, 2017-08-08" />
+    <row data-node="db_3.t_order" values="2301, 23, init, 16, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1400, 14, init, 17, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="1401, 14, init, 18, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2400, 24, init, 19, test, 2017-08-08" />
+    <row data-node="db_4.t_order" values="2401, 24, init, 20, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1500, 15, init, 1, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="1501, 15, init, 2, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2500, 25, init, null, test, 2017-08-08" />
+    <row data-node="db_5.t_order" values="2501, 25, init, 4, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1600, 16, init, 5, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="1601, 16, init, 6, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2600, 26, init, 7, test, 2017-08-08" />
+    <row data-node="db_6.t_order" values="2601, 26, init, 8, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1700, 17, init, 9, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="1701, 17, init, 10, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2700, 27, init, 11, test, 2017-08-08" />
+    <row data-node="db_7.t_order" values="2701, 27, init, 12, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1800, 18, init, 13, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="1801, 18, init, 14, test, 2017-08-08" />
+    <row data-node="db_8.t_order" values="2800, 28, update, null, test, 2017-08-08" updated="true" />
+    <row data-node="db_8.t_order" values="2801, 28, init, 16, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1900, 19, init, 17, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="1901, 19, init, 18, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2900, 29, init, 19, test, 2017-08-08" />
+    <row data-node="db_9.t_order" values="2901, 29, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_1.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_1.xml
@@ -1,0 +1,226 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds_${0..9}.t_order_${0..9},read_ds_${0..9}.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_0" values="1200, 12, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_1" values="1201, 12, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_2" values="1202, 12, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_3" values="1203, 12, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_4" values="1204, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_5" values="1205, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_6" values="1206, 12, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_7" values="1207, 12, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_8" values="1208, 12, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_9" values="1209, 12, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_0" values="1300, 13, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_1" values="1301, 13, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_2" values="1302, 13, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_3" values="1303, 13, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_4" values="1304, 13, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_5" values="1305, 13, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_6" values="1306, 13, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_7" values="1307, 13, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_8" values="1308, 13, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_9" values="1309, 13, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_0" values="1400, 14, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_1" values="1401, 14, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_2" values="1402, 14, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_3" values="1403, 14, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_4" values="1404, 14, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_5" values="1405, 14, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_6" values="1406, 14, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_7" values="1407, 14, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_8" values="1408, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_9" values="1409, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_0" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_1" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_2" values="1502, 15, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_3" values="1503, 15, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_4" values="1504, 15, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_5" values="1505, 15, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_6" values="1506, 15, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_7" values="1507, 15, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_8" values="1508, 15, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_9" values="1509, 15, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_0" values="1600, 16, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_1" values="1601, 16, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_2" values="1602, 16, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_3" values="1603, 16, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_4" values="1604, 16, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_5" values="1605, 16, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_6" values="1606, 16, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_7" values="1607, 16, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_8" values="1608, 16, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_9" values="1609, 16, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_0" values="1700, 17, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_1" values="1701, 17, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_2" values="1702, 17, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_3" values="1703, 17, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_4" values="1704, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_5" values="1705, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_6" values="1706, 17, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_7" values="1707, 17, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_8" values="1708, 17, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_9" values="1709, 17, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_0" values="1800, 18, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_1" values="1801, 18, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_2" values="1802, 18, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_3" values="1803, 18, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_4" values="1804, 18, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_5" values="1805, 18, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_6" values="1806, 18, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_7" values="1807, 18, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_8" values="1808, 18, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_9" values="1809, 18, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_0" values="1900, 19, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_1" values="1901, 19, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_2" values="1902, 19, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_3" values="1903, 19, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_4" values="1904, 19, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_5" values="1905, 19, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_6" values="1906, 19, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_7" values="1907, 19, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_8" values="1908, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_9" values="1909, 19, init, 20, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_0" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_1" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_2" values="1002, 10, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_3" values="1003, 10, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_4" values="1004, 10, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_5" values="1005, 10, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_6" values="1006, 10, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_7" values="1007, 10, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_8" values="1008, 10, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_9" values="1009, 10, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_0" values="1100, 11, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_1" values="1101, 11, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_2" values="1102, 11, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_3" values="1103, 11, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_4" values="1104, 11, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_5" values="1105, 11, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_6" values="1106, 11, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_7" values="1107, 11, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_8" values="1108, 11, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_9" values="1109, 11, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_0" values="1200, 12, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_1" values="1201, 12, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_2" values="1202, 12, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_3" values="1203, 12, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_4" values="1204, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_5" values="1205, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_6" values="1206, 12, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_7" values="1207, 12, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_8" values="1208, 12, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_9" values="1209, 12, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_0" values="1300, 13, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_1" values="1301, 13, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_2" values="1302, 13, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_3" values="1303, 13, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_4" values="1304, 13, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_5" values="1305, 13, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_6" values="1306, 13, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_7" values="1307, 13, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_8" values="1308, 13, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_9" values="1309, 13, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_0" values="1400, 14, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_1" values="1401, 14, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_2" values="1402, 14, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_3" values="1403, 14, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_4" values="1404, 14, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_5" values="1405, 14, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_6" values="1406, 14, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_7" values="1407, 14, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_8" values="1408, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_9" values="1409, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_0" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_1" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_2" values="1502, 15, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_3" values="1503, 15, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_4" values="1504, 15, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_5" values="1505, 15, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_6" values="1506, 15, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_7" values="1507, 15, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_8" values="1508, 15, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_9" values="1509, 15, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_0" values="1600, 16, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_1" values="1601, 16, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_2" values="1602, 16, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_3" values="1603, 16, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_4" values="1604, 16, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_5" values="1605, 16, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_6" values="1606, 16, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_7" values="1607, 16, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_8" values="1608, 16, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_9" values="1609, 16, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_0" values="1700, 17, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_1" values="1701, 17, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_2" values="1702, 17, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_3" values="1703, 17, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_4" values="1704, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_5" values="1705, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_6" values="1706, 17, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_7" values="1707, 17, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_8" values="1708, 17, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_9" values="1709, 17, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_0" values="1800, 18, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_1" values="1801, 18, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_2" values="1802, 18, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_3" values="1803, 18, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_4" values="1804, 18, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_5" values="1805, 18, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_6" values="1806, 18, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_7" values="1807, 18, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_8" values="1808, 18, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_9" values="1809, 18, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_0" values="1900, 19, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_1" values="1901, 19, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_2" values="1902, 19, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_3" values="1903, 19, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_4" values="1904, 19, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_5" values="1905, 19, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_6" values="1906, 19, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_7" values="1907, 19, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_8" values="1908, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_9" values="1909, 19, init_read, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_2.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_2.xml
@@ -24,7 +24,7 @@
         <column name="remark" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
-    <row data-node="write_ds_0.t_order_1" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
     <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
     <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
     <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_2.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_2.xml
@@ -1,0 +1,227 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="0">
+    <metadata data-nodes="write_ds_${0..9}.t_order_${0..9},read_ds_${0..9}.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds_0.t_order_1" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_0" values="1200, 12, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_1" values="1201, 12, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_2" values="1202, 12, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_3" values="1203, 12, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_4" values="1204, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_5" values="1205, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_6" values="1206, 12, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_7" values="1207, 12, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_8" values="1208, 12, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_9" values="1209, 12, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_0" values="1300, 13, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_1" values="1301, 13, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_2" values="1302, 13, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_3" values="1303, 13, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_4" values="1304, 13, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_5" values="1305, 13, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_6" values="1306, 13, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_7" values="1307, 13, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_8" values="1308, 13, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_9" values="1309, 13, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_0" values="1400, 14, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_1" values="1401, 14, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_2" values="1402, 14, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_3" values="1403, 14, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_4" values="1404, 14, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_5" values="1405, 14, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_6" values="1406, 14, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_7" values="1407, 14, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_8" values="1408, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_9" values="1409, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_0" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_1" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_2" values="1502, 15, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_3" values="1503, 15, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_4" values="1504, 15, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_5" values="1505, 15, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_6" values="1506, 15, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_7" values="1507, 15, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_8" values="1508, 15, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_9" values="1509, 15, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_0" values="1600, 16, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_1" values="1601, 16, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_2" values="1602, 16, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_3" values="1603, 16, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_4" values="1604, 16, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_5" values="1605, 16, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_6" values="1606, 16, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_7" values="1607, 16, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_8" values="1608, 16, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_9" values="1609, 16, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_0" values="1700, 17, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_1" values="1701, 17, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_2" values="1702, 17, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_3" values="1703, 17, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_4" values="1704, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_5" values="1705, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_6" values="1706, 17, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_7" values="1707, 17, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_8" values="1708, 17, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_9" values="1709, 17, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_0" values="1800, 18, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_1" values="1801, 18, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_2" values="1802, 18, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_3" values="1803, 18, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_4" values="1804, 18, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_5" values="1805, 18, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_6" values="1806, 18, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_7" values="1807, 18, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_8" values="1808, 18, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_9" values="1809, 18, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_0" values="1900, 19, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_1" values="1901, 19, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_2" values="1902, 19, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_3" values="1903, 19, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_4" values="1904, 19, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_5" values="1905, 19, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_6" values="1906, 19, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_7" values="1907, 19, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_8" values="1908, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_9" values="1909, 19, init, 20, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_0" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_1" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_2" values="1002, 10, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_3" values="1003, 10, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_4" values="1004, 10, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_5" values="1005, 10, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_6" values="1006, 10, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_7" values="1007, 10, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_8" values="1008, 10, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_9" values="1009, 10, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_0" values="1100, 11, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_1" values="1101, 11, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_2" values="1102, 11, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_3" values="1103, 11, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_4" values="1104, 11, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_5" values="1105, 11, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_6" values="1106, 11, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_7" values="1107, 11, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_8" values="1108, 11, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_9" values="1109, 11, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_0" values="1200, 12, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_1" values="1201, 12, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_2" values="1202, 12, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_3" values="1203, 12, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_4" values="1204, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_5" values="1205, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_6" values="1206, 12, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_7" values="1207, 12, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_8" values="1208, 12, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_9" values="1209, 12, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_0" values="1300, 13, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_1" values="1301, 13, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_2" values="1302, 13, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_3" values="1303, 13, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_4" values="1304, 13, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_5" values="1305, 13, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_6" values="1306, 13, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_7" values="1307, 13, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_8" values="1308, 13, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_9" values="1309, 13, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_0" values="1400, 14, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_1" values="1401, 14, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_2" values="1402, 14, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_3" values="1403, 14, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_4" values="1404, 14, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_5" values="1405, 14, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_6" values="1406, 14, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_7" values="1407, 14, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_8" values="1408, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_9" values="1409, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_0" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_1" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_2" values="1502, 15, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_3" values="1503, 15, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_4" values="1504, 15, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_5" values="1505, 15, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_6" values="1506, 15, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_7" values="1507, 15, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_8" values="1508, 15, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_9" values="1509, 15, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_0" values="1600, 16, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_1" values="1601, 16, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_2" values="1602, 16, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_3" values="1603, 16, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_4" values="1604, 16, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_5" values="1605, 16, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_6" values="1606, 16, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_7" values="1607, 16, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_8" values="1608, 16, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_9" values="1609, 16, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_0" values="1700, 17, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_1" values="1701, 17, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_2" values="1702, 17, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_3" values="1703, 17, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_4" values="1704, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_5" values="1705, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_6" values="1706, 17, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_7" values="1707, 17, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_8" values="1708, 17, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_9" values="1709, 17, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_0" values="1800, 18, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_1" values="1801, 18, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_2" values="1802, 18, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_3" values="1803, 18, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_4" values="1804, 18, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_5" values="1805, 18, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_6" values="1806, 18, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_7" values="1807, 18, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_8" values="1808, 18, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_9" values="1809, 18, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_0" values="1900, 19, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_1" values="1901, 19, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_2" values="1902, 19, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_3" values="1903, 19, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_4" values="1904, 19, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_5" values="1905, 19, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_6" values="1906, 19, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_7" values="1907, 19, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_8" values="1908, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_9" values="1909, 19, init_read, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_3.xml
@@ -24,7 +24,7 @@
         <column name="remark" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
-    <row data-node="write_ds_0.t_order_1" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
     <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
     <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
     <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_3.xml
@@ -1,0 +1,227 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="0">
+    <metadata data-nodes="write_ds_${0..9}.t_order_${0..9},read_ds_${0..9}.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds_0.t_order_1" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_0" values="1200, 12, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_1" values="1201, 12, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_2" values="1202, 12, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_3" values="1203, 12, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_4" values="1204, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_5" values="1205, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_6" values="1206, 12, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_7" values="1207, 12, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_8" values="1208, 12, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_9" values="1209, 12, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_0" values="1300, 13, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_1" values="1301, 13, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_2" values="1302, 13, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_3" values="1303, 13, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_4" values="1304, 13, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_5" values="1305, 13, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_6" values="1306, 13, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_7" values="1307, 13, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_8" values="1308, 13, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_9" values="1309, 13, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_0" values="1400, 14, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_1" values="1401, 14, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_2" values="1402, 14, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_3" values="1403, 14, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_4" values="1404, 14, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_5" values="1405, 14, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_6" values="1406, 14, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_7" values="1407, 14, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_8" values="1408, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_9" values="1409, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_0" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_1" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_2" values="1502, 15, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_3" values="1503, 15, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_4" values="1504, 15, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_5" values="1505, 15, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_6" values="1506, 15, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_7" values="1507, 15, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_8" values="1508, 15, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_9" values="1509, 15, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_0" values="1600, 16, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_1" values="1601, 16, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_2" values="1602, 16, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_3" values="1603, 16, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_4" values="1604, 16, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_5" values="1605, 16, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_6" values="1606, 16, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_7" values="1607, 16, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_8" values="1608, 16, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_9" values="1609, 16, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_0" values="1700, 17, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_1" values="1701, 17, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_2" values="1702, 17, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_3" values="1703, 17, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_4" values="1704, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_5" values="1705, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_6" values="1706, 17, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_7" values="1707, 17, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_8" values="1708, 17, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_9" values="1709, 17, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_0" values="1800, 18, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_1" values="1801, 18, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_2" values="1802, 18, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_3" values="1803, 18, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_4" values="1804, 18, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_5" values="1805, 18, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_6" values="1806, 18, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_7" values="1807, 18, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_8" values="1808, 18, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_9" values="1809, 18, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_0" values="1900, 19, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_1" values="1901, 19, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_2" values="1902, 19, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_3" values="1903, 19, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_4" values="1904, 19, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_5" values="1905, 19, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_6" values="1906, 19, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_7" values="1907, 19, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_8" values="1908, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_9" values="1909, 19, init, 20, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_0" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_1" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_2" values="1002, 10, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_3" values="1003, 10, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_4" values="1004, 10, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_5" values="1005, 10, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_6" values="1006, 10, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_7" values="1007, 10, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_8" values="1008, 10, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_9" values="1009, 10, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_0" values="1100, 11, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_1" values="1101, 11, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_2" values="1102, 11, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_3" values="1103, 11, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_4" values="1104, 11, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_5" values="1105, 11, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_6" values="1106, 11, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_7" values="1107, 11, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_8" values="1108, 11, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_9" values="1109, 11, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_0" values="1200, 12, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_1" values="1201, 12, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_2" values="1202, 12, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_3" values="1203, 12, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_4" values="1204, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_5" values="1205, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_6" values="1206, 12, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_7" values="1207, 12, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_8" values="1208, 12, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_9" values="1209, 12, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_0" values="1300, 13, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_1" values="1301, 13, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_2" values="1302, 13, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_3" values="1303, 13, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_4" values="1304, 13, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_5" values="1305, 13, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_6" values="1306, 13, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_7" values="1307, 13, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_8" values="1308, 13, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_9" values="1309, 13, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_0" values="1400, 14, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_1" values="1401, 14, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_2" values="1402, 14, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_3" values="1403, 14, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_4" values="1404, 14, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_5" values="1405, 14, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_6" values="1406, 14, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_7" values="1407, 14, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_8" values="1408, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_9" values="1409, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_0" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_1" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_2" values="1502, 15, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_3" values="1503, 15, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_4" values="1504, 15, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_5" values="1505, 15, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_6" values="1506, 15, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_7" values="1507, 15, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_8" values="1508, 15, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_9" values="1509, 15, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_0" values="1600, 16, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_1" values="1601, 16, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_2" values="1602, 16, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_3" values="1603, 16, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_4" values="1604, 16, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_5" values="1605, 16, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_6" values="1606, 16, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_7" values="1607, 16, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_8" values="1608, 16, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_9" values="1609, 16, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_0" values="1700, 17, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_1" values="1701, 17, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_2" values="1702, 17, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_3" values="1703, 17, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_4" values="1704, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_5" values="1705, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_6" values="1706, 17, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_7" values="1707, 17, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_8" values="1708, 17, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_9" values="1709, 17, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_0" values="1800, 18, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_1" values="1801, 18, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_2" values="1802, 18, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_3" values="1803, 18, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_4" values="1804, 18, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_5" values="1805, 18, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_6" values="1806, 18, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_7" values="1807, 18, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_8" values="1808, 18, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_9" values="1809, 18, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_0" values="1900, 19, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_1" values="1901, 19, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_2" values="1902, 19, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_3" values="1903, 19, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_4" values="1904, 19, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_5" values="1905, 19, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_6" values="1906, 19, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_7" values="1907, 19, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_8" values="1908, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_9" values="1909, 19, init_read, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_4.xml
@@ -24,7 +24,7 @@
         <column name="remark" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
-    <row data-node="write_ds_0.t_order_1" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
     <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
     <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
     <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/delete_with_sharding_value_batch_4.xml
@@ -1,0 +1,227 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="0">
+    <metadata data-nodes="write_ds_${0..9}.t_order_${0..9},read_ds_${0..9}.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds_0.t_order_1" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_0" values="1200, 12, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_1" values="1201, 12, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_2" values="1202, 12, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_3" values="1203, 12, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_4" values="1204, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_5" values="1205, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_6" values="1206, 12, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_7" values="1207, 12, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_8" values="1208, 12, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_9" values="1209, 12, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_0" values="1300, 13, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_1" values="1301, 13, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_2" values="1302, 13, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_3" values="1303, 13, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_4" values="1304, 13, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_5" values="1305, 13, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_6" values="1306, 13, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_7" values="1307, 13, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_8" values="1308, 13, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_9" values="1309, 13, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_0" values="1400, 14, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_1" values="1401, 14, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_2" values="1402, 14, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_3" values="1403, 14, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_4" values="1404, 14, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_5" values="1405, 14, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_6" values="1406, 14, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_7" values="1407, 14, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_8" values="1408, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_9" values="1409, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_0" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_1" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_2" values="1502, 15, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_3" values="1503, 15, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_4" values="1504, 15, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_5" values="1505, 15, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_6" values="1506, 15, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_7" values="1507, 15, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_8" values="1508, 15, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_9" values="1509, 15, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_0" values="1600, 16, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_1" values="1601, 16, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_2" values="1602, 16, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_3" values="1603, 16, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_4" values="1604, 16, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_5" values="1605, 16, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_6" values="1606, 16, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_7" values="1607, 16, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_8" values="1608, 16, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_9" values="1609, 16, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_0" values="1700, 17, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_1" values="1701, 17, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_2" values="1702, 17, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_3" values="1703, 17, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_4" values="1704, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_5" values="1705, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_6" values="1706, 17, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_7" values="1707, 17, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_8" values="1708, 17, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_9" values="1709, 17, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_0" values="1800, 18, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_1" values="1801, 18, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_2" values="1802, 18, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_3" values="1803, 18, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_4" values="1804, 18, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_5" values="1805, 18, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_6" values="1806, 18, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_7" values="1807, 18, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_8" values="1808, 18, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_9" values="1809, 18, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_0" values="1900, 19, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_1" values="1901, 19, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_2" values="1902, 19, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_3" values="1903, 19, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_4" values="1904, 19, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_5" values="1905, 19, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_6" values="1906, 19, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_7" values="1907, 19, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_8" values="1908, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_9" values="1909, 19, init, 20, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_0" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_1" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_2" values="1002, 10, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_3" values="1003, 10, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_4" values="1004, 10, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_5" values="1005, 10, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_6" values="1006, 10, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_7" values="1007, 10, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_8" values="1008, 10, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_9" values="1009, 10, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_0" values="1100, 11, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_1" values="1101, 11, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_2" values="1102, 11, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_3" values="1103, 11, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_4" values="1104, 11, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_5" values="1105, 11, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_6" values="1106, 11, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_7" values="1107, 11, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_8" values="1108, 11, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_9" values="1109, 11, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_0" values="1200, 12, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_1" values="1201, 12, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_2" values="1202, 12, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_3" values="1203, 12, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_4" values="1204, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_5" values="1205, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_6" values="1206, 12, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_7" values="1207, 12, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_8" values="1208, 12, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_9" values="1209, 12, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_0" values="1300, 13, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_1" values="1301, 13, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_2" values="1302, 13, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_3" values="1303, 13, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_4" values="1304, 13, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_5" values="1305, 13, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_6" values="1306, 13, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_7" values="1307, 13, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_8" values="1308, 13, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_9" values="1309, 13, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_0" values="1400, 14, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_1" values="1401, 14, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_2" values="1402, 14, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_3" values="1403, 14, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_4" values="1404, 14, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_5" values="1405, 14, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_6" values="1406, 14, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_7" values="1407, 14, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_8" values="1408, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_9" values="1409, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_0" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_1" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_2" values="1502, 15, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_3" values="1503, 15, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_4" values="1504, 15, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_5" values="1505, 15, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_6" values="1506, 15, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_7" values="1507, 15, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_8" values="1508, 15, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_9" values="1509, 15, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_0" values="1600, 16, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_1" values="1601, 16, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_2" values="1602, 16, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_3" values="1603, 16, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_4" values="1604, 16, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_5" values="1605, 16, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_6" values="1606, 16, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_7" values="1607, 16, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_8" values="1608, 16, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_9" values="1609, 16, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_0" values="1700, 17, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_1" values="1701, 17, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_2" values="1702, 17, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_3" values="1703, 17, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_4" values="1704, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_5" values="1705, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_6" values="1706, 17, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_7" values="1707, 17, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_8" values="1708, 17, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_9" values="1709, 17, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_0" values="1800, 18, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_1" values="1801, 18, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_2" values="1802, 18, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_3" values="1803, 18, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_4" values="1804, 18, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_5" values="1805, 18, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_6" values="1806, 18, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_7" values="1807, 18, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_8" values="1808, 18, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_9" values="1809, 18, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_0" values="1900, 19, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_1" values="1901, 19, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_2" values="1902, 19, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_3" values="1903, 19, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_4" values="1904, 19, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_5" values="1905, 19, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_6" values="1906, 19, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_7" values="1907, 19, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_8" values="1908, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_9" values="1909, 19, init_read, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/insert_for_order_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/insert_for_order_3.xml
@@ -1,0 +1,228 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds_${0..9}.t_order_${0..9},read_ds_${0..9}.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds_0.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_0" values="1200, 12, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_1" values="1201, 12, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_2" values="1202, 12, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_3" values="1203, 12, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_4" values="1204, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_5" values="1205, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_6" values="1206, 12, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_7" values="1207, 12, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_8" values="1208, 12, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_9" values="1209, 12, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_0" values="1300, 13, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_1" values="1301, 13, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_2" values="1302, 13, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_3" values="3, 3, insert, 1, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_3" values="1303, 13, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_4" values="1304, 13, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_5" values="1305, 13, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_6" values="1306, 13, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_7" values="1307, 13, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_8" values="1308, 13, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_9" values="1309, 13, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_0" values="1400, 14, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_1" values="1401, 14, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_2" values="1402, 14, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_3" values="1403, 14, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_4" values="1404, 14, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_5" values="1405, 14, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_6" values="1406, 14, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_7" values="1407, 14, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_8" values="1408, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_9" values="1409, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_0" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_1" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_2" values="1502, 15, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_3" values="1503, 15, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_4" values="1504, 15, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_5" values="1505, 15, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_6" values="1506, 15, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_7" values="1507, 15, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_8" values="1508, 15, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_9" values="1509, 15, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_0" values="1600, 16, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_1" values="1601, 16, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_2" values="1602, 16, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_3" values="1603, 16, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_4" values="1604, 16, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_5" values="1605, 16, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_6" values="1606, 16, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_7" values="1607, 16, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_8" values="1608, 16, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_9" values="1609, 16, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_0" values="1700, 17, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_1" values="1701, 17, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_2" values="1702, 17, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_3" values="1703, 17, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_4" values="1704, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_5" values="1705, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_6" values="1706, 17, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_7" values="1707, 17, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_8" values="1708, 17, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_9" values="1709, 17, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_0" values="1800, 18, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_1" values="1801, 18, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_2" values="1802, 18, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_3" values="1803, 18, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_4" values="1804, 18, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_5" values="1805, 18, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_6" values="1806, 18, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_7" values="1807, 18, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_8" values="1808, 18, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_9" values="1809, 18, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_0" values="1900, 19, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_1" values="1901, 19, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_2" values="1902, 19, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_3" values="1903, 19, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_4" values="1904, 19, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_5" values="1905, 19, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_6" values="1906, 19, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_7" values="1907, 19, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_8" values="1908, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_9" values="1909, 19, init, 20, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_0" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_1" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_2" values="1002, 10, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_3" values="1003, 10, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_4" values="1004, 10, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_5" values="1005, 10, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_6" values="1006, 10, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_7" values="1007, 10, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_8" values="1008, 10, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_9" values="1009, 10, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_0" values="1100, 11, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_1" values="1101, 11, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_2" values="1102, 11, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_3" values="1103, 11, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_4" values="1104, 11, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_5" values="1105, 11, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_6" values="1106, 11, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_7" values="1107, 11, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_8" values="1108, 11, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_9" values="1109, 11, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_0" values="1200, 12, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_1" values="1201, 12, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_2" values="1202, 12, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_3" values="1203, 12, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_4" values="1204, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_5" values="1205, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_6" values="1206, 12, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_7" values="1207, 12, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_8" values="1208, 12, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_9" values="1209, 12, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_0" values="1300, 13, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_1" values="1301, 13, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_2" values="1302, 13, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_3" values="1303, 13, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_4" values="1304, 13, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_5" values="1305, 13, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_6" values="1306, 13, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_7" values="1307, 13, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_8" values="1308, 13, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_9" values="1309, 13, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_0" values="1400, 14, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_1" values="1401, 14, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_2" values="1402, 14, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_3" values="1403, 14, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_4" values="1404, 14, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_5" values="1405, 14, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_6" values="1406, 14, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_7" values="1407, 14, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_8" values="1408, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_9" values="1409, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_0" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_1" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_2" values="1502, 15, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_3" values="1503, 15, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_4" values="1504, 15, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_5" values="1505, 15, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_6" values="1506, 15, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_7" values="1507, 15, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_8" values="1508, 15, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_9" values="1509, 15, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_0" values="1600, 16, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_1" values="1601, 16, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_2" values="1602, 16, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_3" values="1603, 16, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_4" values="1604, 16, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_5" values="1605, 16, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_6" values="1606, 16, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_7" values="1607, 16, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_8" values="1608, 16, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_9" values="1609, 16, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_0" values="1700, 17, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_1" values="1701, 17, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_2" values="1702, 17, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_3" values="1703, 17, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_4" values="1704, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_5" values="1705, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_6" values="1706, 17, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_7" values="1707, 17, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_8" values="1708, 17, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_9" values="1709, 17, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_0" values="1800, 18, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_1" values="1801, 18, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_2" values="1802, 18, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_3" values="1803, 18, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_4" values="1804, 18, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_5" values="1805, 18, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_6" values="1806, 18, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_7" values="1807, 18, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_8" values="1808, 18, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_9" values="1809, 18, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_0" values="1900, 19, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_1" values="1901, 19, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_2" values="1902, 19, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_3" values="1903, 19, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_4" values="1904, 19, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_5" values="1905, 19, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_6" values="1906, 19, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_7" values="1907, 19, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_8" values="1908, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_9" values="1909, 19, init_read, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/insert_for_order_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/insert_for_order_4.xml
@@ -1,0 +1,228 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds_${0..9}.t_order_${0..9},read_ds_${0..9}.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds_0.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_0" values="1200, 12, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_1" values="1201, 12, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_2" values="1202, 12, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_3" values="1203, 12, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_4" values="1204, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_5" values="1205, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_6" values="1206, 12, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_7" values="1207, 12, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_8" values="1208, 12, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_9" values="1209, 12, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_0" values="1300, 13, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_1" values="1301, 13, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_2" values="1302, 13, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_3" values="1303, 13, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_4" values="1304, 13, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_5" values="1305, 13, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_6" values="1306, 13, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_7" values="1307, 13, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_8" values="1308, 13, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_9" values="1309, 13, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_0" values="1400, 14, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_1" values="1401, 14, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_2" values="1402, 14, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_3" values="1403, 14, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_4" values="4, 4, insert, 1, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_4" values="1404, 14, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_5" values="1405, 14, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_6" values="1406, 14, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_7" values="1407, 14, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_8" values="1408, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_9" values="1409, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_0" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_1" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_2" values="1502, 15, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_3" values="1503, 15, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_4" values="1504, 15, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_5" values="1505, 15, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_6" values="1506, 15, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_7" values="1507, 15, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_8" values="1508, 15, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_9" values="1509, 15, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_0" values="1600, 16, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_1" values="1601, 16, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_2" values="1602, 16, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_3" values="1603, 16, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_4" values="1604, 16, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_5" values="1605, 16, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_6" values="1606, 16, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_7" values="1607, 16, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_8" values="1608, 16, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_9" values="1609, 16, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_0" values="1700, 17, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_1" values="1701, 17, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_2" values="1702, 17, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_3" values="1703, 17, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_4" values="1704, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_5" values="1705, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_6" values="1706, 17, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_7" values="1707, 17, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_8" values="1708, 17, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_9" values="1709, 17, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_0" values="1800, 18, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_1" values="1801, 18, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_2" values="1802, 18, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_3" values="1803, 18, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_4" values="1804, 18, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_5" values="1805, 18, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_6" values="1806, 18, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_7" values="1807, 18, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_8" values="1808, 18, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_9" values="1809, 18, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_0" values="1900, 19, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_1" values="1901, 19, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_2" values="1902, 19, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_3" values="1903, 19, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_4" values="1904, 19, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_5" values="1905, 19, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_6" values="1906, 19, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_7" values="1907, 19, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_8" values="1908, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_9" values="1909, 19, init, 20, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_0" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_1" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_2" values="1002, 10, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_3" values="1003, 10, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_4" values="1004, 10, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_5" values="1005, 10, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_6" values="1006, 10, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_7" values="1007, 10, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_8" values="1008, 10, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_9" values="1009, 10, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_0" values="1100, 11, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_1" values="1101, 11, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_2" values="1102, 11, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_3" values="1103, 11, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_4" values="1104, 11, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_5" values="1105, 11, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_6" values="1106, 11, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_7" values="1107, 11, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_8" values="1108, 11, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_9" values="1109, 11, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_0" values="1200, 12, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_1" values="1201, 12, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_2" values="1202, 12, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_3" values="1203, 12, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_4" values="1204, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_5" values="1205, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_6" values="1206, 12, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_7" values="1207, 12, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_8" values="1208, 12, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_9" values="1209, 12, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_0" values="1300, 13, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_1" values="1301, 13, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_2" values="1302, 13, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_3" values="1303, 13, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_4" values="1304, 13, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_5" values="1305, 13, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_6" values="1306, 13, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_7" values="1307, 13, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_8" values="1308, 13, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_9" values="1309, 13, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_0" values="1400, 14, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_1" values="1401, 14, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_2" values="1402, 14, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_3" values="1403, 14, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_4" values="1404, 14, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_5" values="1405, 14, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_6" values="1406, 14, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_7" values="1407, 14, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_8" values="1408, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_9" values="1409, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_0" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_1" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_2" values="1502, 15, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_3" values="1503, 15, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_4" values="1504, 15, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_5" values="1505, 15, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_6" values="1506, 15, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_7" values="1507, 15, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_8" values="1508, 15, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_9" values="1509, 15, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_0" values="1600, 16, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_1" values="1601, 16, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_2" values="1602, 16, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_3" values="1603, 16, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_4" values="1604, 16, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_5" values="1605, 16, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_6" values="1606, 16, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_7" values="1607, 16, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_8" values="1608, 16, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_9" values="1609, 16, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_0" values="1700, 17, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_1" values="1701, 17, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_2" values="1702, 17, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_3" values="1703, 17, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_4" values="1704, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_5" values="1705, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_6" values="1706, 17, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_7" values="1707, 17, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_8" values="1708, 17, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_9" values="1709, 17, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_0" values="1800, 18, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_1" values="1801, 18, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_2" values="1802, 18, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_3" values="1803, 18, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_4" values="1804, 18, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_5" values="1805, 18, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_6" values="1806, 18, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_7" values="1807, 18, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_8" values="1808, 18, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_9" values="1809, 18, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_0" values="1900, 19, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_1" values="1901, 19, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_2" values="1902, 19, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_3" values="1903, 19, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_4" values="1904, 19, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_5" values="1905, 19, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_6" values="1906, 19, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_7" values="1907, 19, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_8" values="1908, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_9" values="1909, 19, init_read, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/update_batch_1.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/update_batch_1.xml
@@ -1,0 +1,227 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds_${0..9}.t_order_${0..9},read_ds_${0..9}.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds_0.t_order_0" values="1000, 10, update, 1, test, 2017-08-08" updated="true" />
+    <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_0" values="1200, 12, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_1" values="1201, 12, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_2" values="1202, 12, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_3" values="1203, 12, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_4" values="1204, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_5" values="1205, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_6" values="1206, 12, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_7" values="1207, 12, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_8" values="1208, 12, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_9" values="1209, 12, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_0" values="1300, 13, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_1" values="1301, 13, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_2" values="1302, 13, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_3" values="1303, 13, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_4" values="1304, 13, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_5" values="1305, 13, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_6" values="1306, 13, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_7" values="1307, 13, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_8" values="1308, 13, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_9" values="1309, 13, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_0" values="1400, 14, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_1" values="1401, 14, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_2" values="1402, 14, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_3" values="1403, 14, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_4" values="1404, 14, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_5" values="1405, 14, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_6" values="1406, 14, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_7" values="1407, 14, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_8" values="1408, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_9" values="1409, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_0" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_1" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_2" values="1502, 15, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_3" values="1503, 15, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_4" values="1504, 15, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_5" values="1505, 15, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_6" values="1506, 15, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_7" values="1507, 15, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_8" values="1508, 15, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_9" values="1509, 15, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_0" values="1600, 16, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_1" values="1601, 16, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_2" values="1602, 16, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_3" values="1603, 16, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_4" values="1604, 16, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_5" values="1605, 16, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_6" values="1606, 16, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_7" values="1607, 16, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_8" values="1608, 16, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_9" values="1609, 16, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_0" values="1700, 17, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_1" values="1701, 17, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_2" values="1702, 17, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_3" values="1703, 17, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_4" values="1704, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_5" values="1705, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_6" values="1706, 17, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_7" values="1707, 17, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_8" values="1708, 17, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_9" values="1709, 17, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_0" values="1800, 18, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_1" values="1801, 18, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_2" values="1802, 18, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_3" values="1803, 18, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_4" values="1804, 18, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_5" values="1805, 18, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_6" values="1806, 18, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_7" values="1807, 18, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_8" values="1808, 18, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_9" values="1809, 18, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_0" values="1900, 19, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_1" values="1901, 19, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_2" values="1902, 19, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_3" values="1903, 19, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_4" values="1904, 19, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_5" values="1905, 19, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_6" values="1906, 19, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_7" values="1907, 19, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_8" values="1908, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_9" values="1909, 19, init, 20, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_0" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_1" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_2" values="1002, 10, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_3" values="1003, 10, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_4" values="1004, 10, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_5" values="1005, 10, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_6" values="1006, 10, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_7" values="1007, 10, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_8" values="1008, 10, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_9" values="1009, 10, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_0" values="1100, 11, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_1" values="1101, 11, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_2" values="1102, 11, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_3" values="1103, 11, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_4" values="1104, 11, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_5" values="1105, 11, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_6" values="1106, 11, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_7" values="1107, 11, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_8" values="1108, 11, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_9" values="1109, 11, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_0" values="1200, 12, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_1" values="1201, 12, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_2" values="1202, 12, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_3" values="1203, 12, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_4" values="1204, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_5" values="1205, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_6" values="1206, 12, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_7" values="1207, 12, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_8" values="1208, 12, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_9" values="1209, 12, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_0" values="1300, 13, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_1" values="1301, 13, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_2" values="1302, 13, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_3" values="1303, 13, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_4" values="1304, 13, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_5" values="1305, 13, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_6" values="1306, 13, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_7" values="1307, 13, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_8" values="1308, 13, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_9" values="1309, 13, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_0" values="1400, 14, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_1" values="1401, 14, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_2" values="1402, 14, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_3" values="1403, 14, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_4" values="1404, 14, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_5" values="1405, 14, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_6" values="1406, 14, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_7" values="1407, 14, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_8" values="1408, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_9" values="1409, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_0" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_1" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_2" values="1502, 15, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_3" values="1503, 15, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_4" values="1504, 15, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_5" values="1505, 15, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_6" values="1506, 15, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_7" values="1507, 15, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_8" values="1508, 15, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_9" values="1509, 15, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_0" values="1600, 16, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_1" values="1601, 16, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_2" values="1602, 16, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_3" values="1603, 16, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_4" values="1604, 16, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_5" values="1605, 16, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_6" values="1606, 16, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_7" values="1607, 16, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_8" values="1608, 16, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_9" values="1609, 16, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_0" values="1700, 17, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_1" values="1701, 17, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_2" values="1702, 17, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_3" values="1703, 17, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_4" values="1704, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_5" values="1705, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_6" values="1706, 17, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_7" values="1707, 17, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_8" values="1708, 17, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_9" values="1709, 17, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_0" values="1800, 18, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_1" values="1801, 18, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_2" values="1802, 18, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_3" values="1803, 18, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_4" values="1804, 18, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_5" values="1805, 18, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_6" values="1806, 18, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_7" values="1807, 18, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_8" values="1808, 18, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_9" values="1809, 18, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_0" values="1900, 19, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_1" values="1901, 19, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_2" values="1902, 19, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_3" values="1903, 19, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_4" values="1904, 19, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_5" values="1905, 19, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_6" values="1906, 19, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_7" values="1907, 19, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_8" values="1908, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_9" values="1909, 19, init_read, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/update_batch_2.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/update_batch_2.xml
@@ -1,0 +1,227 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds_${0..9}.t_order_${0..9},read_ds_${0..9}.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds_0.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_1" values="1101, 11, update, 12, test, 2017-08-08" updated="true" />
+    <row data-node="write_ds_1.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_0" values="1200, 12, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_1" values="1201, 12, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_2" values="1202, 12, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_3" values="1203, 12, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_4" values="1204, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_5" values="1205, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_6" values="1206, 12, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_7" values="1207, 12, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_8" values="1208, 12, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_9" values="1209, 12, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_0" values="1300, 13, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_1" values="1301, 13, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_2" values="1302, 13, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_3" values="1303, 13, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_4" values="1304, 13, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_5" values="1305, 13, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_6" values="1306, 13, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_7" values="1307, 13, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_8" values="1308, 13, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_9" values="1309, 13, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_0" values="1400, 14, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_1" values="1401, 14, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_2" values="1402, 14, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_3" values="1403, 14, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_4" values="1404, 14, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_5" values="1405, 14, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_6" values="1406, 14, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_7" values="1407, 14, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_8" values="1408, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_9" values="1409, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_0" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_1" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_2" values="1502, 15, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_3" values="1503, 15, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_4" values="1504, 15, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_5" values="1505, 15, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_6" values="1506, 15, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_7" values="1507, 15, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_8" values="1508, 15, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_9" values="1509, 15, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_0" values="1600, 16, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_1" values="1601, 16, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_2" values="1602, 16, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_3" values="1603, 16, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_4" values="1604, 16, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_5" values="1605, 16, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_6" values="1606, 16, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_7" values="1607, 16, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_8" values="1608, 16, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_9" values="1609, 16, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_0" values="1700, 17, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_1" values="1701, 17, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_2" values="1702, 17, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_3" values="1703, 17, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_4" values="1704, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_5" values="1705, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_6" values="1706, 17, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_7" values="1707, 17, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_8" values="1708, 17, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_9" values="1709, 17, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_0" values="1800, 18, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_1" values="1801, 18, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_2" values="1802, 18, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_3" values="1803, 18, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_4" values="1804, 18, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_5" values="1805, 18, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_6" values="1806, 18, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_7" values="1807, 18, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_8" values="1808, 18, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_9" values="1809, 18, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_0" values="1900, 19, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_1" values="1901, 19, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_2" values="1902, 19, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_3" values="1903, 19, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_4" values="1904, 19, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_5" values="1905, 19, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_6" values="1906, 19, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_7" values="1907, 19, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_8" values="1908, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_9" values="1909, 19, init, 20, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_0" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_1" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_2" values="1002, 10, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_3" values="1003, 10, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_4" values="1004, 10, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_5" values="1005, 10, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_6" values="1006, 10, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_7" values="1007, 10, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_8" values="1008, 10, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_9" values="1009, 10, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_0" values="1100, 11, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_1" values="1101, 11, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_2" values="1102, 11, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_3" values="1103, 11, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_4" values="1104, 11, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_5" values="1105, 11, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_6" values="1106, 11, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_7" values="1107, 11, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_8" values="1108, 11, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_9" values="1109, 11, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_0" values="1200, 12, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_1" values="1201, 12, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_2" values="1202, 12, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_3" values="1203, 12, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_4" values="1204, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_5" values="1205, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_6" values="1206, 12, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_7" values="1207, 12, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_8" values="1208, 12, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_9" values="1209, 12, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_0" values="1300, 13, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_1" values="1301, 13, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_2" values="1302, 13, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_3" values="1303, 13, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_4" values="1304, 13, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_5" values="1305, 13, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_6" values="1306, 13, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_7" values="1307, 13, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_8" values="1308, 13, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_9" values="1309, 13, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_0" values="1400, 14, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_1" values="1401, 14, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_2" values="1402, 14, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_3" values="1403, 14, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_4" values="1404, 14, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_5" values="1405, 14, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_6" values="1406, 14, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_7" values="1407, 14, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_8" values="1408, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_9" values="1409, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_0" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_1" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_2" values="1502, 15, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_3" values="1503, 15, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_4" values="1504, 15, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_5" values="1505, 15, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_6" values="1506, 15, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_7" values="1507, 15, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_8" values="1508, 15, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_9" values="1509, 15, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_0" values="1600, 16, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_1" values="1601, 16, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_2" values="1602, 16, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_3" values="1603, 16, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_4" values="1604, 16, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_5" values="1605, 16, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_6" values="1606, 16, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_7" values="1607, 16, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_8" values="1608, 16, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_9" values="1609, 16, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_0" values="1700, 17, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_1" values="1701, 17, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_2" values="1702, 17, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_3" values="1703, 17, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_4" values="1704, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_5" values="1705, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_6" values="1706, 17, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_7" values="1707, 17, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_8" values="1708, 17, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_9" values="1709, 17, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_0" values="1800, 18, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_1" values="1801, 18, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_2" values="1802, 18, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_3" values="1803, 18, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_4" values="1804, 18, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_5" values="1805, 18, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_6" values="1806, 18, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_7" values="1807, 18, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_8" values="1808, 18, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_9" values="1809, 18, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_0" values="1900, 19, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_1" values="1901, 19, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_2" values="1902, 19, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_3" values="1903, 19, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_4" values="1904, 19, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_5" values="1905, 19, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_6" values="1906, 19, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_7" values="1907, 19, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_8" values="1908, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_9" values="1909, 19, init_read, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/update_batch_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/update_batch_3.xml
@@ -1,0 +1,227 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="0">
+    <metadata data-nodes="write_ds_${0..9}.t_order_${0..9},read_ds_${0..9}.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds_0.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_1" values="1101, 11, init, 12, test, 2017-08-08"/>
+    <row data-node="write_ds_1.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_0" values="1200, 12, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_1" values="1201, 12, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_2" values="1202, 12, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_3" values="1203, 12, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_4" values="1204, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_5" values="1205, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_6" values="1206, 12, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_7" values="1207, 12, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_8" values="1208, 12, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_9" values="1209, 12, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_0" values="1300, 13, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_1" values="1301, 13, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_2" values="1302, 13, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_3" values="1303, 13, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_4" values="1304, 13, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_5" values="1305, 13, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_6" values="1306, 13, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_7" values="1307, 13, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_8" values="1308, 13, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_9" values="1309, 13, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_0" values="1400, 14, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_1" values="1401, 14, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_2" values="1402, 14, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_3" values="1403, 14, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_4" values="1404, 14, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_5" values="1405, 14, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_6" values="1406, 14, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_7" values="1407, 14, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_8" values="1408, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_9" values="1409, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_0" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_1" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_2" values="1502, 15, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_3" values="1503, 15, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_4" values="1504, 15, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_5" values="1505, 15, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_6" values="1506, 15, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_7" values="1507, 15, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_8" values="1508, 15, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_9" values="1509, 15, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_0" values="1600, 16, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_1" values="1601, 16, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_2" values="1602, 16, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_3" values="1603, 16, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_4" values="1604, 16, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_5" values="1605, 16, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_6" values="1606, 16, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_7" values="1607, 16, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_8" values="1608, 16, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_9" values="1609, 16, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_0" values="1700, 17, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_1" values="1701, 17, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_2" values="1702, 17, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_3" values="1703, 17, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_4" values="1704, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_5" values="1705, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_6" values="1706, 17, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_7" values="1707, 17, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_8" values="1708, 17, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_9" values="1709, 17, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_0" values="1800, 18, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_1" values="1801, 18, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_2" values="1802, 18, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_3" values="1803, 18, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_4" values="1804, 18, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_5" values="1805, 18, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_6" values="1806, 18, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_7" values="1807, 18, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_8" values="1808, 18, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_9" values="1809, 18, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_0" values="1900, 19, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_1" values="1901, 19, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_2" values="1902, 19, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_3" values="1903, 19, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_4" values="1904, 19, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_5" values="1905, 19, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_6" values="1906, 19, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_7" values="1907, 19, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_8" values="1908, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_9" values="1909, 19, init, 20, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_0" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_1" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_2" values="1002, 10, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_3" values="1003, 10, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_4" values="1004, 10, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_5" values="1005, 10, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_6" values="1006, 10, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_7" values="1007, 10, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_8" values="1008, 10, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_9" values="1009, 10, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_0" values="1100, 11, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_1" values="1101, 11, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_2" values="1102, 11, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_3" values="1103, 11, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_4" values="1104, 11, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_5" values="1105, 11, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_6" values="1106, 11, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_7" values="1107, 11, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_8" values="1108, 11, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_9" values="1109, 11, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_0" values="1200, 12, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_1" values="1201, 12, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_2" values="1202, 12, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_3" values="1203, 12, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_4" values="1204, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_5" values="1205, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_6" values="1206, 12, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_7" values="1207, 12, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_8" values="1208, 12, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_9" values="1209, 12, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_0" values="1300, 13, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_1" values="1301, 13, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_2" values="1302, 13, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_3" values="1303, 13, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_4" values="1304, 13, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_5" values="1305, 13, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_6" values="1306, 13, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_7" values="1307, 13, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_8" values="1308, 13, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_9" values="1309, 13, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_0" values="1400, 14, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_1" values="1401, 14, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_2" values="1402, 14, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_3" values="1403, 14, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_4" values="1404, 14, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_5" values="1405, 14, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_6" values="1406, 14, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_7" values="1407, 14, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_8" values="1408, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_9" values="1409, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_0" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_1" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_2" values="1502, 15, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_3" values="1503, 15, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_4" values="1504, 15, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_5" values="1505, 15, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_6" values="1506, 15, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_7" values="1507, 15, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_8" values="1508, 15, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_9" values="1509, 15, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_0" values="1600, 16, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_1" values="1601, 16, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_2" values="1602, 16, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_3" values="1603, 16, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_4" values="1604, 16, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_5" values="1605, 16, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_6" values="1606, 16, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_7" values="1607, 16, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_8" values="1608, 16, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_9" values="1609, 16, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_0" values="1700, 17, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_1" values="1701, 17, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_2" values="1702, 17, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_3" values="1703, 17, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_4" values="1704, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_5" values="1705, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_6" values="1706, 17, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_7" values="1707, 17, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_8" values="1708, 17, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_9" values="1709, 17, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_0" values="1800, 18, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_1" values="1801, 18, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_2" values="1802, 18, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_3" values="1803, 18, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_4" values="1804, 18, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_5" values="1805, 18, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_6" values="1806, 18, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_7" values="1807, 18, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_8" values="1808, 18, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_9" values="1809, 18, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_0" values="1900, 19, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_1" values="1901, 19, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_2" values="1902, 19, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_3" values="1903, 19, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_4" values="1904, 19, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_5" values="1905, 19, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_6" values="1906, 19, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_7" values="1907, 19, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_8" values="1908, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_9" values="1909, 19, init_read, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/update_batch_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/dbtbl_with_readwrite_splitting/update_batch_4.xml
@@ -1,0 +1,227 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="0">
+    <metadata data-nodes="write_ds_${0..9}.t_order_${0..9},read_ds_${0..9}.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds_0.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_0.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_1" values="1101, 11, init, 12, test, 2017-08-08"/>
+    <row data-node="write_ds_1.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_1.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_0" values="1200, 12, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_1" values="1201, 12, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_2" values="1202, 12, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_3" values="1203, 12, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_4" values="1204, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_5" values="1205, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_6" values="1206, 12, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_7" values="1207, 12, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_8" values="1208, 12, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_2.t_order_9" values="1209, 12, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_0" values="1300, 13, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_1" values="1301, 13, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_2" values="1302, 13, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_3" values="1303, 13, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_4" values="1304, 13, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_5" values="1305, 13, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_6" values="1306, 13, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_7" values="1307, 13, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_8" values="1308, 13, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_3.t_order_9" values="1309, 13, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_0" values="1400, 14, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_1" values="1401, 14, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_2" values="1402, 14, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_3" values="1403, 14, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_4" values="1404, 14, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_5" values="1405, 14, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_6" values="1406, 14, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_7" values="1407, 14, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_8" values="1408, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_4.t_order_9" values="1409, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_0" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_1" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_2" values="1502, 15, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_3" values="1503, 15, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_4" values="1504, 15, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_5" values="1505, 15, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_6" values="1506, 15, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_7" values="1507, 15, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_8" values="1508, 15, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_5.t_order_9" values="1509, 15, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_0" values="1600, 16, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_1" values="1601, 16, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_2" values="1602, 16, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_3" values="1603, 16, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_4" values="1604, 16, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_5" values="1605, 16, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_6" values="1606, 16, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_7" values="1607, 16, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_8" values="1608, 16, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_6.t_order_9" values="1609, 16, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_0" values="1700, 17, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_1" values="1701, 17, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_2" values="1702, 17, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_3" values="1703, 17, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_4" values="1704, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_5" values="1705, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_6" values="1706, 17, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_7" values="1707, 17, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_8" values="1708, 17, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_7.t_order_9" values="1709, 17, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_0" values="1800, 18, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_1" values="1801, 18, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_2" values="1802, 18, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_3" values="1803, 18, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_4" values="1804, 18, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_5" values="1805, 18, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_6" values="1806, 18, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_7" values="1807, 18, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_8" values="1808, 18, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds_8.t_order_9" values="1809, 18, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_0" values="1900, 19, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_1" values="1901, 19, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_2" values="1902, 19, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_3" values="1903, 19, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_4" values="1904, 19, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_5" values="1905, 19, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_6" values="1906, 19, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_7" values="1907, 19, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_8" values="1908, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds_9.t_order_9" values="1909, 19, init, 20, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_0" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_1" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_2" values="1002, 10, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_3" values="1003, 10, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_4" values="1004, 10, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_5" values="1005, 10, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_6" values="1006, 10, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_7" values="1007, 10, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_8" values="1008, 10, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_0.t_order_9" values="1009, 10, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_0" values="1100, 11, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_1" values="1101, 11, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_2" values="1102, 11, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_3" values="1103, 11, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_4" values="1104, 11, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_5" values="1105, 11, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_6" values="1106, 11, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_7" values="1107, 11, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_8" values="1108, 11, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_1.t_order_9" values="1109, 11, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_0" values="1200, 12, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_1" values="1201, 12, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_2" values="1202, 12, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_3" values="1203, 12, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_4" values="1204, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_5" values="1205, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_6" values="1206, 12, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_7" values="1207, 12, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_8" values="1208, 12, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_2.t_order_9" values="1209, 12, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_0" values="1300, 13, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_1" values="1301, 13, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_2" values="1302, 13, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_3" values="1303, 13, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_4" values="1304, 13, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_5" values="1305, 13, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_6" values="1306, 13, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_7" values="1307, 13, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_8" values="1308, 13, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_3.t_order_9" values="1309, 13, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_0" values="1400, 14, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_1" values="1401, 14, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_2" values="1402, 14, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_3" values="1403, 14, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_4" values="1404, 14, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_5" values="1405, 14, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_6" values="1406, 14, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_7" values="1407, 14, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_8" values="1408, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_4.t_order_9" values="1409, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_0" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_1" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_2" values="1502, 15, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_3" values="1503, 15, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_4" values="1504, 15, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_5" values="1505, 15, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_6" values="1506, 15, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_7" values="1507, 15, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_8" values="1508, 15, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_5.t_order_9" values="1509, 15, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_0" values="1600, 16, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_1" values="1601, 16, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_2" values="1602, 16, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_3" values="1603, 16, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_4" values="1604, 16, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_5" values="1605, 16, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_6" values="1606, 16, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_7" values="1607, 16, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_8" values="1608, 16, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_6.t_order_9" values="1609, 16, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_0" values="1700, 17, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_1" values="1701, 17, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_2" values="1702, 17, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_3" values="1703, 17, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_4" values="1704, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_5" values="1705, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_6" values="1706, 17, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_7" values="1707, 17, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_8" values="1708, 17, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_7.t_order_9" values="1709, 17, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_0" values="1800, 18, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_1" values="1801, 18, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_2" values="1802, 18, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_3" values="1803, 18, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_4" values="1804, 18, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_5" values="1805, 18, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_6" values="1806, 18, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_7" values="1807, 18, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_8" values="1808, 18, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_ds_8.t_order_9" values="1809, 18, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_0" values="1900, 19, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_1" values="1901, 19, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_2" values="1902, 19, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_3" values="1903, 19, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_4" values="1904, 19, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_5" values="1905, 19, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_6" values="1906, 19, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_7" values="1907, 19, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_8" values="1908, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_ds_9.t_order_9" values="1909, 19, init_read, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/delete_with_sharding_value_batch_1.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/delete_with_sharding_value_batch_1.xml
@@ -1,0 +1,146 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds.t_order,read_${0..1}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1100, 11, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1101, 11, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1200, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1201, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1300, 13, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1301, 13, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1400, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1401, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1600, 16, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1601, 16, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1700, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1701, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1800, 18, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1801, 18, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1900, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1901, 19, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2000, 20, init, 21, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2001, 20, init, 22, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2100, 21, init, 23, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2101, 21, init, 24, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2200, 22, init, 25, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2201, 22, init, 26, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2300, 23, init, 27, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2301, 23, init, 28, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2400, 24, init, 29, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2401, 24, init, 30, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2500, 25, init, 31, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2501, 25, init, 32, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2600, 26, init, 33, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2601, 26, init, 34, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2700, 27, init, 35, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2701, 27, init, 36, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2800, 28, init, 37, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2801, 28, init, 38, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2900, 29, init, 39, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2901, 29, init, 40, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/delete_with_sharding_value_batch_2.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/delete_with_sharding_value_batch_2.xml
@@ -1,0 +1,146 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds.t_order,read_${0..1}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1100, 11, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1101, 11, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1200, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1201, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1300, 13, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1301, 13, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1400, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1401, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1600, 16, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1601, 16, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1700, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1701, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1800, 18, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1801, 18, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1900, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1901, 19, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2001, 20, init, 22, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2100, 21, init, 23, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2101, 21, init, 24, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2200, 22, init, 25, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2201, 22, init, 26, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2300, 23, init, 27, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2301, 23, init, 28, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2400, 24, init, 29, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2401, 24, init, 30, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2500, 25, init, 31, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2501, 25, init, 32, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2600, 26, init, 33, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2601, 26, init, 34, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2700, 27, init, 35, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2701, 27, init, 36, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2800, 28, init, 37, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2801, 28, init, 38, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2900, 29, init, 39, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2901, 29, init, 40, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/delete_with_sharding_value_batch_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/delete_with_sharding_value_batch_3.xml
@@ -1,0 +1,146 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds.t_order,read_${0..1}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1100, 11, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1101, 11, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1200, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1201, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1300, 13, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1301, 13, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1400, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1401, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1600, 16, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1601, 16, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1700, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1701, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1800, 18, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1801, 18, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1900, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1901, 19, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2000, 20, init, 21, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2001, 20, init, 22, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2100, 21, init, 23, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2101, 21, init, 24, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2200, 22, init, 25, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2201, 22, init, 26, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2300, 23, init, 27, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2301, 23, init, 28, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2400, 24, init, 29, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2401, 24, init, 30, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2500, 25, init, 31, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2501, 25, init, 32, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2600, 26, init, 33, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2601, 26, init, 34, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2700, 27, init, 35, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2701, 27, init, 36, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2801, 28, init, 38, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2900, 29, init, 39, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2901, 29, init, 40, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/delete_with_sharding_value_batch_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/delete_with_sharding_value_batch_4.xml
@@ -1,0 +1,146 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds.t_order,read_${0..1}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1100, 11, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1101, 11, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1200, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1201, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1300, 13, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1301, 13, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1400, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1401, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1600, 16, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1601, 16, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1700, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1701, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1800, 18, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1801, 18, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1900, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1901, 19, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2000, 20, init, 21, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2001, 20, init, 22, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2100, 21, init, 23, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2101, 21, init, 24, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2200, 22, init, 25, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2201, 22, init, 26, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2300, 23, init, 27, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2301, 23, init, 28, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2400, 24, init, 29, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2401, 24, init, 30, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2500, 25, init, 31, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2501, 25, init, 32, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2600, 26, init, 33, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2601, 26, init, 34, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2700, 27, init, 35, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2701, 27, init, 36, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2800, 28, init, 37, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2801, 28, init, 38, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2901, 29, init, 40, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/insert_for_order_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/insert_for_order_3.xml
@@ -1,0 +1,148 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds.t_order,read_${0..1}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds.t_order" values="3, 3, insert, 1, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1100, 11, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1101, 11, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1200, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1201, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1300, 13, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1301, 13, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1400, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1401, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1600, 16, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1601, 16, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1700, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1701, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1800, 18, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1801, 18, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1900, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1901, 19, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2000, 20, init, 21, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2001, 20, init, 22, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2100, 21, init, 23, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2101, 21, init, 24, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2200, 22, init, 25, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2201, 22, init, 26, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2300, 23, init, 27, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2301, 23, init, 28, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2400, 24, init, 29, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2401, 24, init, 30, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2500, 25, init, 31, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2501, 25, init, 32, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2600, 26, init, 33, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2601, 26, init, 34, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2700, 27, init, 35, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2701, 27, init, 36, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2800, 28, init, 37, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2801, 28, init, 38, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2900, 29, init, 39, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2901, 29, init, 40, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/insert_for_order_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/insert_for_order_4.xml
@@ -1,0 +1,148 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds.t_order,read_${0..1}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds.t_order" values="4, 4, insert, 1, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1100, 11, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1101, 11, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1200, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1201, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1300, 13, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1301, 13, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1400, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1401, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1600, 16, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1601, 16, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1700, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1701, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1800, 18, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1801, 18, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1900, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1901, 19, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2000, 20, init, 21, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2001, 20, init, 22, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2100, 21, init, 23, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2101, 21, init, 24, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2200, 22, init, 25, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2201, 22, init, 26, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2300, 23, init, 27, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2301, 23, init, 28, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2400, 24, init, 29, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2401, 24, init, 30, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2500, 25, init, 31, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2501, 25, init, 32, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2600, 26, init, 33, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2601, 26, init, 34, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2700, 27, init, 35, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2701, 27, init, 36, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2800, 28, init, 37, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2801, 28, init, 38, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2900, 29, init, 39, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2901, 29, init, 40, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/update_batch_1.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/update_batch_1.xml
@@ -1,0 +1,147 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds.t_order,read_${0..1}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds.t_order" values="1000, 10, update, 1, test, 2017-08-08" updated="true" />
+    <row data-node="write_ds.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1100, 11, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1101, 11, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1200, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1201, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1300, 13, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1301, 13, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1400, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1401, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1600, 16, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1601, 16, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1700, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1701, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1800, 18, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1801, 18, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1900, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1901, 19, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2000, 20, init, 21, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2001, 20, init, 22, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2100, 21, init, 23, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2101, 21, init, 24, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2200, 22, init, 25, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2201, 22, init, 26, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2300, 23, init, 27, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2301, 23, init, 28, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2400, 24, init, 29, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2401, 24, init, 30, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2500, 25, init, 31, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2501, 25, init, 32, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2600, 26, init, 33, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2601, 26, init, 34, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2700, 27, init, 35, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2701, 27, init, 36, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2800, 28, init, 37, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2801, 28, init, 38, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2900, 29, init, 39, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2901, 29, init, 40, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/update_batch_2.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/update_batch_2.xml
@@ -1,0 +1,147 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds.t_order,read_${0..1}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1100, 11, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1101, 11, update, 4, test, 2017-08-08" updated="true" />
+    <row data-node="write_ds.t_order" values="1200, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1201, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1300, 13, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1301, 13, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1400, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1401, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1600, 16, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1601, 16, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1700, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1701, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1800, 18, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1801, 18, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1900, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1901, 19, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2000, 20, init, 21, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2001, 20, init, 22, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2100, 21, init, 23, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2101, 21, init, 24, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2200, 22, init, 25, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2201, 22, init, 26, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2300, 23, init, 27, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2301, 23, init, 28, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2400, 24, init, 29, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2401, 24, init, 30, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2500, 25, init, 31, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2501, 25, init, 32, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2600, 26, init, 33, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2601, 26, init, 34, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2700, 27, init, 35, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2701, 27, init, 36, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2800, 28, init, 37, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2801, 28, init, 38, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2900, 29, init, 39, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2901, 29, init, 40, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/update_batch_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/update_batch_3.xml
@@ -1,0 +1,147 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds.t_order,read_${0..1}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1100, 11, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1101, 11, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1200, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1201, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1300, 13, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1301, 13, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1400, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1401, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1600, 16, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1601, 16, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1700, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1701, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1800, 18, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1801, 18, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1900, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1901, 19, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2000, 20, init, 21, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2001, 20, init, 22, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2100, 21, init, 23, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2101, 21, init, 24, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2200, 22, init, 25, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2201, 22, init, 26, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2300, 23, init, 27, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2301, 23, init, 28, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2400, 24, update, 29, test, 2017-08-08" updated="true" />
+    <row data-node="write_ds.t_order" values="2401, 24, init, 30, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2500, 25, init, 31, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2501, 25, init, 32, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2600, 26, init, 33, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2601, 26, init, 34, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2700, 27, init, 35, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2701, 27, init, 36, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2800, 28, init, 37, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2801, 28, init, 38, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2900, 29, init, 39, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2901, 29, init, 40, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/update_batch_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/readwrite_splitting/update_batch_4.xml
@@ -1,0 +1,147 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="write_ds.t_order,read_${0..1}.t_order">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="write_ds.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1100, 11, init, 3, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1101, 11, init, 4, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1200, 12, init, 5, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1201, 12, init, 6, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1300, 13, init, 7, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1301, 13, init, 8, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1400, 14, init, 9, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1401, 14, init, 10, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1500, 15, init, 11, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1501, 15, init, 12, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1600, 16, init, 13, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1601, 16, init, 14, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1700, 17, init, 15, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1701, 17, init, 16, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1800, 18, init, 17, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1801, 18, init, 18, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1900, 19, init, 19, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="1901, 19, init, 20, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2000, 20, init, 21, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2001, 20, init, 22, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2100, 21, init, 23, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2101, 21, init, 24, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2200, 22, init, 25, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2201, 22, init, 26, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2300, 23, init, 27, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2301, 23, init, 28, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2400, 24, init, 29, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2401, 24, init, 30, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2500, 25, init, 31, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2501, 25, init, 32, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2600, 26, init, 33, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2601, 26, init, 34, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2700, 27, init, 35, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2701, 27, init, 36, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2800, 28, update, 37, test, 2017-08-08" updated="true" />
+    <row data-node="write_ds.t_order" values="2801, 28, init, 38, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2900, 29, init, 39, test, 2017-08-08" />
+    <row data-node="write_ds.t_order" values="2901, 29, init, 40, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_0.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1101, 11, init_read, 4, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1200, 12, init_read, 5, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1201, 12, init_read, 6, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1300, 13, init_read, 7, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1301, 13, init_read, 8, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1400, 14, init_read, 9, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1401, 14, init_read, 10, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1500, 15, init_read, 11, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1501, 15, init_read, 12, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1600, 16, init_read, 13, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1601, 16, init_read, 14, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1700, 17, init_read, 15, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1701, 17, init_read, 16, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1800, 18, init_read, 17, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1801, 18, init_read, 18, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1900, 19, init_read, 19, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="1901, 19, init_read, 20, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2000, 20, init_read, 21, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2001, 20, init_read, 22, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2100, 21, init_read, 23, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2101, 21, init_read, 24, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2200, 22, init_read, 25, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2201, 22, init_read, 26, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2300, 23, init_read, 27, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2301, 23, init_read, 28, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2400, 24, init_read, 29, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2401, 24, init_read, 30, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2500, 25, init_read, 31, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2501, 25, init_read, 32, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2600, 26, init_read, 33, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2601, 26, init_read, 34, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2700, 27, init_read, 35, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2701, 27, init_read, 36, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2800, 28, init_read, 37, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2801, 28, init_read, 38, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2900, 29, init_read, 39, test, 2017-08-08" />
+    <row data-node="read_1.t_order" values="2901, 29, init_read, 40, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_1.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_1.xml
@@ -1,0 +1,46 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="tbl.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_2.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_2.xml
@@ -24,7 +24,7 @@
         <column name="remark" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
-    <row data-node="tbl.t_order_1" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
     <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
     <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
     <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_2.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_2.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="0">
+    <metadata data-nodes="tbl.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="tbl.t_order_1" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_3.xml
@@ -24,7 +24,7 @@
         <column name="remark" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
-    <row data-node="tbl.t_order_1" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
     <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
     <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
     <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_3.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="0">
+    <metadata data-nodes="tbl.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="tbl.t_order_1" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_4.xml
@@ -24,7 +24,7 @@
         <column name="remark" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
-    <row data-node="tbl.t_order_1" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
     <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
     <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
     <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/delete_with_sharding_value_batch_4.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="0">
+    <metadata data-nodes="tbl.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="tbl.t_order_1" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/insert_for_order_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/insert_for_order_3.xml
@@ -1,0 +1,48 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="tbl.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="tbl.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="3, 3, insert, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/insert_for_order_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/insert_for_order_4.xml
@@ -1,0 +1,48 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="tbl.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="tbl.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="4, 4, insert, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/update_batch_1.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/update_batch_1.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="tbl.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="tbl.t_order_0" values="1000, 10, update, 1, test, 2017-08-08" updated="true" />
+    <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/update_batch_2.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/update_batch_2.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="1">
+    <metadata data-nodes="tbl.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="tbl.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1101, 11, update, 12, test, 2017-08-08" updated="true" />
+    <row data-node="tbl.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/update_batch_3.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/update_batch_3.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="0">
+    <metadata data-nodes="tbl.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="tbl.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/update_batch_4.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/dataset/tbl/update_batch_4.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset update-count="0">
+    <metadata data-nodes="tbl.t_order_${0..9}">
+        <column name="order_id" type="numeric" />
+        <column name="user_id" type="numeric" />
+        <column name="status" type="varchar" />
+        <column name="merchant_id" type="numeric" />
+        <column name="remark" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <row data-node="tbl.t_order_0" values="1000, 10, init, 1, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1001, 10, init, 2, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1002, 10, init, 3, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1003, 10, init, 4, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1004, 10, init, 5, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1005, 10, init, 6, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1006, 10, init, 7, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1007, 10, init, 8, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1008, 10, init, 9, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1009, 10, init, 10, test, 2017-08-08" />
+    <row data-node="tbl.t_order_0" values="1100, 11, init, 11, test, 2017-08-08" />
+    <row data-node="tbl.t_order_1" values="1101, 11, init, 12, test, 2017-08-08" />
+    <row data-node="tbl.t_order_2" values="1102, 11, init, 13, test, 2017-08-08" />
+    <row data-node="tbl.t_order_3" values="1103, 11, init, 14, test, 2017-08-08" />
+    <row data-node="tbl.t_order_4" values="1104, 11, init, 15, test, 2017-08-08" />
+    <row data-node="tbl.t_order_5" values="1105, 11, init, 16, test, 2017-08-08" />
+    <row data-node="tbl.t_order_6" values="1106, 11, init, 17, test, 2017-08-08" />
+    <row data-node="tbl.t_order_7" values="1107, 11, init, 18, test, 2017-08-08" />
+    <row data-node="tbl.t_order_8" values="1108, 11, init, 19, test, 2017-08-08" />
+    <row data-node="tbl.t_order_9" values="1109, 11, init, 20, test, 2017-08-08" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-delete.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-delete.xml
@@ -67,9 +67,7 @@
         <assertion parameters="0:int, 4:int, 5:int" expected-data-file="shadow_delete_order_by_user_id.xml" />
     </test-case>
     
-    <test-case
-            sql="DELETE FROM t_order WHERE order_id = 1000 AND user_id = 10;DELETE FROM t_order WHERE order_id = 1001 AND user_id = 11;DELETE FROM t_order WHERE user_id &lt; 29;" db-types="MySQL"
-            scenario-types="db" sql-case-types="LITERAL" adapters="proxy">
+    <test-case sql="DELETE FROM t_order WHERE order_id = 1000 AND user_id = 10;DELETE FROM t_order WHERE order_id = 1001 AND user_id = 11;DELETE FROM t_order WHERE user_id &lt; 29;" db-types="MySQL" scenario-types="db" sql-case-types="LITERAL" adapters="proxy">
         <assertion expected-data-file="delete_with_multiple.xml" />
     </test-case>
 </e2e-test-cases>

--- a/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-delete.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-delete.xml
@@ -20,6 +20,13 @@
     <test-case sql="DELETE FROM t_order WHERE order_id = ? AND user_id = ? AND status= ?" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion parameters="1000:int, 10:int, init:String" expected-data-file="delete_with_sharding_value.xml" />
     </test-case>
+
+    <test-case sql="DELETE FROM t_order WHERE order_id = ? AND user_id = ? AND status= ?" db-types="MySQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+        <assertion parameters="1000:int, 10:int, init:String" expected-data-file="delete_with_sharding_value_batch_1.xml" />
+        <assertion parameters="2000:int, 20:int, init:String" expected-data-file="delete_with_sharding_value_batch_2.xml" />
+        <assertion parameters="2800:int, 28:int, init:String" expected-data-file="delete_with_sharding_value_batch_3.xml" />
+        <assertion parameters="2900:int, 29:int, init:String" expected-data-file="delete_with_sharding_value_batch_4.xml" />
+    </test-case>
     
     <test-case sql="DELETE FROM t_order WHERE status= ?" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion parameters="init:String" expected-data-file="delete_without_sharding_value.xml" />

--- a/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-insert.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-insert.xml
@@ -18,8 +18,17 @@
 
 <e2e-test-cases>
     <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?, ?, ?, 1, 'test', '2017-08-08')" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
-        <assertion parameters="2:int, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />
         <assertion parameters="1:int, 1:int, insert:String" expected-data-file="insert_for_order_1.xml" />
+        <assertion parameters="2:int, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />
+        <assertion parameters="3:int, 3:int, insert:String" expected-data-file="insert_for_order_3.xml" />
+        <assertion parameters="4:int, 4:int, insert:String" expected-data-file="insert_for_order_4.xml" />
+    </test-case>
+
+    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?, ?, ?, 1, 'test', '2017-08-08') ON DUPLICATE KEY UPDATE status = ?" db-types="MySQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+        <assertion parameters="1:int, 1:int, insert:String, test:String" expected-data-file="insert_for_order_1.xml" />
+        <assertion parameters="2:int, 2:int, insert:String, test:String" expected-data-file="insert_for_order_2.xml" />
+        <assertion parameters="3:int, 3:int, insert:String, test:String" expected-data-file="insert_for_order_3.xml" />
+        <assertion parameters="4:int, 4:int, insert:String, test:String" expected-data-file="insert_for_order_4.xml" />
     </test-case>
     
     <!--    TODO Fix https://github.com/apache/shardingsphere/issues/23764 -->

--- a/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-update.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-update.xml
@@ -20,6 +20,13 @@
     <test-case sql="UPDATE t_order SET status = ? WHERE order_id = ? AND user_id = ?" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion parameters="update:String, 1000:int, 10:int" expected-data-file="update.xml" />
     </test-case>
+
+    <test-case sql="UPDATE t_order SET status = ? WHERE order_id = ? AND user_id = ?" db-types="MySQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+        <assertion parameters="update:String, 1000:int, 10:int" expected-data-file="update_batch_1.xml" />
+        <assertion parameters="update:String, 1101:int, 11:int" expected-data-file="update_batch_2.xml" />
+        <assertion parameters="update:String, 2400:int, 24:int" expected-data-file="update_batch_3.xml" />
+        <assertion parameters="update:String, 2800:int, 28:int" expected-data-file="update_batch_4.xml" />
+    </test-case>
     
     <test-case sql="UPDATE t_order AS o SET o.status = ? WHERE o.order_id = ? AND o.user_id = ?" db-types="H2,MySQL,SQLServer,Oracle" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion parameters="update:String, 1000:int, 10:int" expected-data-file="update.xml" />


### PR DESCRIPTION
Fixes #33745.

Changes proposed in this pull request:
  - Fix BatchUpdateException when execute INSERT INTO ON DUPLICATE KEY UPDATE in proxy adapter

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
