### PR TITLE
Fix NPE error when MySQLComStmtExecuteExecutor and MySQLComFieldListPacketExecutor executing close

### DIFF
--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutor.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutor.java
@@ -126,6 +126,8 @@ public final class MySQLComStmtExecuteExecutor implements QueryCommandExecutor {
     
     @Override
     public void close() throws SQLException {
-        proxyBackendHandler.close();
+        if (null != proxyBackendHandler) {
+            proxyBackendHandler.close();
+        }
     }
 }

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/fieldlist/MySQLComFieldListPacketExecutor.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/fieldlist/MySQLComFieldListPacketExecutor.java
@@ -91,6 +91,8 @@ public final class MySQLComFieldListPacketExecutor implements CommandExecutor {
     
     @Override
     public void close() throws SQLException {
-        databaseConnector.close();
+        if (null != databaseConnector) {
+            databaseConnector.close();
+        }
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.
Ref: #33766

Changes proposed in this pull request:
  - Fix NPE error when MySQLComStmtExecuteExecutor and MySQLComFieldListPacketExecutor executing close

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
