### PR TITLE
Move tableless sql route in sharding to TablelessRouteEngineFactory

### DIFF
--- a/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/route/BroadcastSQLRouter.java
+++ b/features/broadcast/core/src/main/java/org/apache/shardingsphere/broadcast/route/BroadcastSQLRouter.java
@@ -68,13 +68,13 @@ public final class BroadcastSQLRouter implements EntranceSQLRouter<BroadcastRule
     
     @Override
     public RouteContext createRouteContext(final QueryContext queryContext, final RuleMetaData globalRuleMetaData,
-                                           final ShardingSphereDatabase database, final BroadcastRule rule, final ConfigurationProperties props) {
+                                           final ShardingSphereDatabase database, final BroadcastRule rule, final Collection<String> tableNames, final ConfigurationProperties props) {
         return BroadcastRouteEngineFactory.newInstance(rule, database, queryContext).route(new RouteContext(), rule);
     }
     
     @Override
     public void decorateRouteContext(final RouteContext routeContext, final QueryContext queryContext,
-                                     final ShardingSphereDatabase database, final BroadcastRule rule, final ConfigurationProperties props) {
+                                     final ShardingSphereDatabase database, final BroadcastRule rule, final Collection<String> tableNames, final ConfigurationProperties props) {
         SQLStatementContext sqlStatementContext = queryContext.getSqlStatementContext();
         SQLStatement sqlStatement = sqlStatementContext.getSqlStatement();
         if (sqlStatement instanceof TCLStatement) {

--- a/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/route/BroadcastSQLRouterTest.java
+++ b/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/route/BroadcastSQLRouterTest.java
@@ -74,7 +74,7 @@ class BroadcastSQLRouterTest {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
         BroadcastRouteEngine routeEngine = mock(BroadcastRouteEngine.class);
         when(BroadcastRouteEngineFactory.newInstance(rule, database, queryContext)).thenReturn(routeEngine);
-        getSQLRouter(rule).createRouteContext(queryContext, mock(RuleMetaData.class), database, rule, new ConfigurationProperties(new Properties()));
+        getSQLRouter(rule).createRouteContext(queryContext, mock(RuleMetaData.class), database, rule, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         verify(routeEngine).route(any(), eq(rule));
     }
     
@@ -86,7 +86,7 @@ class BroadcastSQLRouterTest {
         RouteContext routeContext = new RouteContext();
         routeContext.getRouteUnits().add(new RouteUnit(new RouteMapper("foo_ds", "foo_ds"), Lists.newArrayList()));
         BroadcastSQLRouter sqlRouter = getSQLRouter(rule);
-        sqlRouter.decorateRouteContext(routeContext, createQueryContext(), mockSingleDatabase(), rule, new ConfigurationProperties(new Properties()));
+        sqlRouter.decorateRouteContext(routeContext, createQueryContext(), mockSingleDatabase(), rule, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         Iterator<String> routedDataSourceNames = routeContext.getActualDataSourceNames().iterator();
         assertThat(routedDataSourceNames.next(), is("foo_ds"));
     }

--- a/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/route/ReadwriteSplittingSQLRouter.java
+++ b/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/route/ReadwriteSplittingSQLRouter.java
@@ -40,7 +40,7 @@ public final class ReadwriteSplittingSQLRouter implements DecorateSQLRouter<Read
     
     @Override
     public void decorateRouteContext(final RouteContext routeContext, final QueryContext queryContext, final ShardingSphereDatabase database,
-                                     final ReadwriteSplittingRule rule, final ConfigurationProperties props) {
+                                     final ReadwriteSplittingRule rule, final Collection<String> tableNames, final ConfigurationProperties props) {
         Collection<RouteUnit> toBeRemoved = new LinkedList<>();
         Collection<RouteUnit> toBeAdded = new LinkedList<>();
         for (RouteUnit each : routeContext.getRouteUnits()) {

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/route/ReadwriteSplittingSQLRouterTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/route/ReadwriteSplittingSQLRouterTest.java
@@ -93,7 +93,7 @@ class ReadwriteSplittingSQLRouterTest {
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(staticRule));
         ShardingSphereDatabase database = new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME,
                 mock(DatabaseType.class), mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, Collections.emptyMap());
-        sqlRouter.decorateRouteContext(actual, queryContext, database, staticRule, new ConfigurationProperties(new Properties()));
+        sqlRouter.decorateRouteContext(actual, queryContext, database, staticRule, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         Iterator<String> routedDataSourceNames = actual.getActualDataSourceNames().iterator();
         assertThat(routedDataSourceNames.next(), is(NONE_READWRITE_SPLITTING_DATASOURCE_NAME));
         assertThat(routedDataSourceNames.next(), is(WRITE_DATASOURCE));
@@ -111,7 +111,7 @@ class ReadwriteSplittingSQLRouterTest {
         ShardingSphereDatabase database = new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME,
                 mock(DatabaseType.class), mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, Collections.emptyMap());
         RouteContext actual = mockRouteContext();
-        sqlRouter.decorateRouteContext(actual, queryContext, database, staticRule, new ConfigurationProperties(new Properties()));
+        sqlRouter.decorateRouteContext(actual, queryContext, database, staticRule, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         assertThat(actual.getActualDataSourceNames(), is(new HashSet<>(Arrays.asList(NONE_READWRITE_SPLITTING_DATASOURCE_NAME, READ_DATASOURCE))));
     }
     
@@ -125,7 +125,7 @@ class ReadwriteSplittingSQLRouterTest {
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(staticRule));
         ShardingSphereDatabase database = new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME,
                 mock(DatabaseType.class), mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, Collections.emptyMap());
-        sqlRouter.decorateRouteContext(actual, queryContext, database, staticRule, new ConfigurationProperties(new Properties()));
+        sqlRouter.decorateRouteContext(actual, queryContext, database, staticRule, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         Iterator<String> routedDataSourceNames = actual.getActualDataSourceNames().iterator();
         assertThat(routedDataSourceNames.next(), is(NONE_READWRITE_SPLITTING_DATASOURCE_NAME));
         assertThat(routedDataSourceNames.next(), is(WRITE_DATASOURCE));

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/ShadowSQLRouter.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/ShadowSQLRouter.java
@@ -43,7 +43,7 @@ public final class ShadowSQLRouter implements DecorateSQLRouter<ShadowRule>, Dat
     
     @Override
     public void decorateRouteContext(final RouteContext routeContext, final QueryContext queryContext, final ShardingSphereDatabase database,
-                                     final ShadowRule rule, final ConfigurationProperties props) {
+                                     final ShadowRule rule, final Collection<String> tableNames, final ConfigurationProperties props) {
         Collection<RouteUnit> toBeRemovedRouteUnit = new LinkedList<>();
         Collection<RouteUnit> toBeAddedRouteUnit = new LinkedList<>();
         Map<String, String> shadowDataSourceMappings = ShadowDataSourceMappingsRetrieverFactory.newInstance(queryContext).retrieve(rule);

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/ShardingSQLRouter.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/ShardingSQLRouter.java
@@ -64,8 +64,8 @@ public final class ShardingSQLRouter implements EntranceSQLRouter<ShardingRule>,
     
     private RouteContext createRouteContext0(final QueryContext queryContext, final RuleMetaData globalRuleMetaData, final ShardingSphereDatabase database, final ShardingRule rule,
                                              final Collection<String> tableNames, final ConfigurationProperties props) {
-        Collection<String> shardingTableNames = rule.getShardingLogicTableNames(tableNames);
-        if (shardingTableNames.isEmpty()) {
+        Collection<String> logicTableNames = rule.getShardingLogicTableNames(tableNames);
+        if (logicTableNames.isEmpty()) {
             return new RouteContext();
         }
         SQLStatement sqlStatement = queryContext.getSqlStatementContext().getSqlStatement();
@@ -75,7 +75,7 @@ public final class ShardingSQLRouter implements EntranceSQLRouter<ShardingRule>,
         if (sqlStatement instanceof DMLStatement && shardingConditions.isNeedMerge()) {
             shardingConditions.merge();
         }
-        RouteContext result = ShardingRouteEngineFactory.newInstance(rule, database, queryContext, shardingConditions, props).route(rule);
+        RouteContext result = ShardingRouteEngineFactory.newInstance(rule, database, queryContext, shardingConditions, logicTableNames, props).route(rule);
         validator.ifPresent(optional -> optional.postValidate(rule, queryContext.getSqlStatementContext(), queryContext.getHintValueContext(), queryContext.getParameters(), database, props, result));
         return result;
     }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingRule.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingRule.java
@@ -56,12 +56,12 @@ import org.apache.shardingsphere.sharding.rule.attribute.ShardingTableNamesRuleA
 import org.apache.shardingsphere.sharding.rule.checker.ShardingRuleChecker;
 import org.apache.shardingsphere.sharding.spi.ShardingAlgorithm;
 import org.apache.shardingsphere.sharding.spi.ShardingAuditAlgorithm;
+import org.apache.shardingsphere.sql.parser.statement.core.extractor.ExpressionExtractor;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.AndPredicate;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.extractor.ExpressionExtractor;
 
 import javax.sql.DataSource;
 import java.util.Arrays;
@@ -541,16 +541,6 @@ public final class ShardingRule implements DatabaseRule {
             }
         }
         return result;
-    }
-    
-    /**
-     * Get sharding rule table names.
-     *
-     * @param logicTableNames logic table names
-     * @return sharding rule table names
-     */
-    public Collection<String> getShardingRuleTableNames(final Collection<String> logicTableNames) {
-        return logicTableNames.stream().filter(this::isShardingTable).collect(Collectors.toList());
     }
     
     /**

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/ShardingRouteEngineFactoryTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/ShardingRouteEngineFactoryTest.java
@@ -49,21 +49,15 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.DALStat
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dcl.DCLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dcl.GrantStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DDLStatement;
-import org.apache.shardingsphere.sql.parser.statement.core.statement.tcl.TCLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
-import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLCreateResourceGroupStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLOptimizeTableStatement;
-import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLSetResourceGroupStatement;
-import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLSetStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLShowColumnsStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLShowCreateTableStatement;
-import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLShowDatabasesStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.dcl.MySQLGrantStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.dml.MySQLSelectStatement;
 import org.apache.shardingsphere.sql.parser.statement.opengauss.ddl.OpenGaussCloseStatement;
 import org.apache.shardingsphere.sql.parser.statement.opengauss.ddl.OpenGaussCursorStatement;
 import org.apache.shardingsphere.sql.parser.statement.oracle.dcl.OracleGrantStatement;
-import org.apache.shardingsphere.sql.parser.statement.postgresql.dal.PostgreSQLSetStatement;
 import org.apache.shardingsphere.sql.parser.statement.postgresql.dcl.PostgreSQLGrantStatement;
 import org.apache.shardingsphere.sql.parser.statement.sql92.dcl.SQL92GrantStatement;
 import org.apache.shardingsphere.sql.parser.statement.sqlserver.dcl.SQLServerGrantStatement;
@@ -121,16 +115,6 @@ class ShardingRouteEngineFactoryTest {
         when(tablesContext.getTableNames()).thenReturn(tableNames);
     }
     
-    @Test
-    void assertNewInstanceForTCL() {
-        TCLStatement tclStatement = mock(TCLStatement.class);
-        when(sqlStatementContext.getSqlStatement()).thenReturn(tclStatement);
-        QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
-        ShardingRouteEngine actual =
-                ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props);
-        assertThat(actual, instanceOf(ShardingDatabaseBroadcastRouteEngine.class));
-    }
-    
     private ConnectionContext mockConnectionContext() {
         ConnectionContext result = mock(ConnectionContext.class);
         when(result.getCurrentDatabaseName()).thenReturn(Optional.of(DefaultDatabase.LOGIC_NAME));
@@ -148,7 +132,7 @@ class ShardingRouteEngineFactoryTest {
     @Test
     void assertNewInstanceForDALWithTables() {
         tableNames.add("tbl");
-        when(shardingRule.getShardingRuleTableNames(tableNames)).thenReturn(tableNames);
+        when(shardingRule.getShardingLogicTableNames(tableNames)).thenReturn(tableNames);
         DALStatement dalStatement = mock(DALStatement.class);
         when(sqlStatementContext.getSqlStatement()).thenReturn(dalStatement);
         QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
@@ -165,34 +149,6 @@ class ShardingRouteEngineFactoryTest {
         ShardingRouteEngine actual =
                 ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props);
         assertThat(actual, instanceOf(ShardingDataSourceGroupBroadcastRouteEngine.class));
-    }
-    
-    @Test
-    void assertNewInstanceForDALShow() {
-        DALStatement dalStatement = mock(MySQLShowDatabasesStatement.class);
-        when(sqlStatementContext.getSqlStatement()).thenReturn(dalStatement);
-        QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
-        ShardingRouteEngine actual =
-                ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props);
-        assertThat(actual, instanceOf(ShardingDatabaseBroadcastRouteEngine.class));
-    }
-    
-    @Test
-    void assertNewInstanceForDALSetForMySQL() {
-        assertNewInstanceForDALSet(mock(MySQLSetStatement.class));
-    }
-    
-    @Test
-    void assertNewInstanceForDALSetForPostgreSQL() {
-        assertNewInstanceForDALSet(mock(PostgreSQLSetStatement.class));
-    }
-    
-    private void assertNewInstanceForDALSet(final DALStatement dalStatement) {
-        when(sqlStatementContext.getSqlStatement()).thenReturn(dalStatement);
-        QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
-        ShardingRouteEngine actual =
-                ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props);
-        assertThat(actual, instanceOf(ShardingDatabaseBroadcastRouteEngine.class));
     }
     
     @Test
@@ -314,7 +270,7 @@ class ShardingRouteEngineFactoryTest {
         DALStatement dalStatement = mock(MySQLShowCreateTableStatement.class);
         when(sqlStatementContext.getSqlStatement()).thenReturn(dalStatement);
         tableNames.add("table_1");
-        when(shardingRule.getShardingRuleTableNames(tableNames)).thenReturn(tableNames);
+        when(shardingRule.getShardingLogicTableNames(tableNames)).thenReturn(tableNames);
         QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
         ShardingRouteEngine actual =
                 ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props);
@@ -326,7 +282,7 @@ class ShardingRouteEngineFactoryTest {
         DALStatement dalStatement = mock(MySQLShowColumnsStatement.class);
         when(sqlStatementContext.getSqlStatement()).thenReturn(dalStatement);
         tableNames.add("table_1");
-        when(shardingRule.getShardingRuleTableNames(tableNames)).thenReturn(tableNames);
+        when(shardingRule.getShardingLogicTableNames(tableNames)).thenReturn(tableNames);
         QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
         ShardingRouteEngine actual =
                 ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props);
@@ -349,31 +305,11 @@ class ShardingRouteEngineFactoryTest {
     }
     
     @Test
-    void assertNewInstanceForCreateResourceGroup() {
-        MySQLCreateResourceGroupStatement resourceGroupStatement = mock(MySQLCreateResourceGroupStatement.class);
-        when(sqlStatementContext.getSqlStatement()).thenReturn(resourceGroupStatement);
-        QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
-        ShardingRouteEngine actual =
-                ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props);
-        assertThat(actual, instanceOf(ShardingInstanceBroadcastRouteEngine.class));
-    }
-    
-    @Test
-    void assertNewInstanceForSetResourceGroup() {
-        MySQLSetResourceGroupStatement resourceGroupStatement = mock(MySQLSetResourceGroupStatement.class);
-        when(sqlStatementContext.getSqlStatement()).thenReturn(resourceGroupStatement);
-        QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
-        ShardingRouteEngine actual =
-                ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props);
-        assertThat(actual, instanceOf(ShardingInstanceBroadcastRouteEngine.class));
-    }
-    
-    @Test
     void assertNewInstanceForOptimizeTableWithShardingTable() {
         MySQLOptimizeTableStatement optimizeTableStatement = mock(MySQLOptimizeTableStatement.class);
         when(sqlStatementContext.getSqlStatement()).thenReturn(optimizeTableStatement);
         tableNames.add("table_1");
-        when(shardingRule.getShardingRuleTableNames(tableNames)).thenReturn(tableNames);
+        when(shardingRule.getShardingLogicTableNames(tableNames)).thenReturn(tableNames);
         QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
         ShardingRouteEngine actual =
                 ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props);
@@ -385,7 +321,7 @@ class ShardingRouteEngineFactoryTest {
         MySQLOptimizeTableStatement optimizeTableStatement = mock(MySQLOptimizeTableStatement.class);
         when(sqlStatementContext.getSqlStatement()).thenReturn(optimizeTableStatement);
         tableNames.add("table_1");
-        when(shardingRule.getShardingRuleTableNames(tableNames)).thenReturn(Collections.emptyList());
+        when(shardingRule.getShardingLogicTableNames(tableNames)).thenReturn(Collections.emptyList());
         QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
         ShardingRouteEngine actual =
                 ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props);
@@ -403,7 +339,6 @@ class ShardingRouteEngineFactoryTest {
         when(cursorStatementContext.getTablesContext().getTableNames()).thenReturn(tableNames);
         when(cursorStatementContext.getTablesContext().getDatabaseName()).thenReturn(Optional.empty());
         when(shardingRule.isAllShardingTables(tableNames)).thenReturn(true);
-        when(shardingRule.getShardingRuleTableNames(tableNames)).thenReturn(tableNames);
         when(shardingRule.getShardingLogicTableNames(tableNames)).thenReturn(tableNames);
         QueryContext queryContext = new QueryContext(cursorStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
         ShardingRouteEngine actual =
@@ -434,7 +369,7 @@ class ShardingRouteEngineFactoryTest {
         when(closeStatementContext.getTablesContext().getTableNames()).thenReturn(tableNames);
         when(closeStatementContext.getTablesContext().getDatabaseName()).thenReturn(Optional.empty());
         when(closeStatementContext.getSqlStatement()).thenReturn(closeStatement);
-        when(shardingRule.getShardingRuleTableNames(tableNames)).thenReturn(tableNames);
+        when(shardingRule.getShardingLogicTableNames(tableNames)).thenReturn(tableNames);
         QueryContext queryContext = new QueryContext(closeStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
         ShardingRouteEngine actual =
                 ShardingRouteEngineFactory.newInstance(shardingRule, database, queryContext, shardingConditions, props);

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
@@ -790,7 +790,7 @@ class ShardingRuleTest {
     @Test
     void assertGetShardingRuleTableNames() {
         ShardingRule actual = createMaximumShardingRule();
-        Collection<String> shardingRuleTableNames = actual.getShardingRuleTableNames(Collections.singleton("Logic_Table"));
+        Collection<String> shardingRuleTableNames = actual.getShardingLogicTableNames(Collections.singleton("Logic_Table"));
         assertTrue(shardingRuleTableNames.contains("Logic_Table"));
     }
     

--- a/infra/route/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/TablelessRouteEngineFactory.java
+++ b/infra/route/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/TablelessRouteEngineFactory.java
@@ -21,7 +21,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.route.engine.tableless.type.broadcast.DataSourceBroadcastRouteEngine;
-import org.apache.shardingsphere.infra.route.engine.tableless.type.broadcast.DatabaseInstanceBroadcastRouteEngine;
+import org.apache.shardingsphere.infra.route.engine.tableless.type.broadcast.InstanceBroadcastRouteEngine;
 import org.apache.shardingsphere.infra.route.engine.tableless.type.ignore.IgnoreRouteEngine;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
@@ -70,10 +70,10 @@ public final class TablelessRouteEngineFactory {
             return new DataSourceBroadcastRouteEngine();
         }
         if (sqlStatement instanceof CreateTablespaceStatement || sqlStatement instanceof AlterTablespaceStatement || sqlStatement instanceof DropTablespaceStatement) {
-            return new DatabaseInstanceBroadcastRouteEngine();
+            return new InstanceBroadcastRouteEngine();
         }
         if (isResourceGroupStatement(sqlStatement)) {
-            return new DatabaseInstanceBroadcastRouteEngine();
+            return new InstanceBroadcastRouteEngine();
         }
         return new IgnoreRouteEngine();
     }

--- a/infra/route/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/TablelessRouteEngineFactory.java
+++ b/infra/route/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/TablelessRouteEngineFactory.java
@@ -21,11 +21,25 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.route.engine.tableless.type.broadcast.DataSourceBroadcastRouteEngine;
+import org.apache.shardingsphere.infra.route.engine.tableless.type.broadcast.DatabaseInstanceBroadcastRouteEngine;
 import org.apache.shardingsphere.infra.route.engine.tableless.type.ignore.IgnoreRouteEngine;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.CreateResourceGroupStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.LoadStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.ResetParameterStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.SetResourceGroupStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.SetStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.ShowDatabasesStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.ShowTableStatusStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.ShowTablesStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.AlterFunctionStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.AlterTablespaceStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.CreateFunctionStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.CreateTablespaceStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DropFunctionStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DropTablespaceStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.tcl.TCLStatement;
 
 /**
  * Tableless route engine factory.
@@ -45,6 +59,27 @@ public final class TablelessRouteEngineFactory {
         if (sqlStatement instanceof ShowTablesStatement || sqlStatement instanceof ShowTableStatusStatement) {
             return new DataSourceBroadcastRouteEngine();
         }
+        if (sqlStatement instanceof TCLStatement) {
+            return new DataSourceBroadcastRouteEngine();
+        }
+        if (sqlStatement instanceof SetStatement || sqlStatement instanceof ResetParameterStatement || sqlStatement instanceof ShowDatabasesStatement || sqlStatement instanceof LoadStatement) {
+            return new DataSourceBroadcastRouteEngine();
+        }
+        boolean functionStatement = sqlStatement instanceof CreateFunctionStatement || sqlStatement instanceof AlterFunctionStatement || sqlStatement instanceof DropFunctionStatement;
+        if (functionStatement) {
+            return new DataSourceBroadcastRouteEngine();
+        }
+        if (sqlStatement instanceof CreateTablespaceStatement || sqlStatement instanceof AlterTablespaceStatement || sqlStatement instanceof DropTablespaceStatement) {
+            return new DatabaseInstanceBroadcastRouteEngine();
+        }
+        if (isResourceGroupStatement(sqlStatement)) {
+            return new DatabaseInstanceBroadcastRouteEngine();
+        }
         return new IgnoreRouteEngine();
+    }
+    
+    private static boolean isResourceGroupStatement(final SQLStatement sqlStatement) {
+        // TODO add dropResourceGroupStatement, alterResourceGroupStatement
+        return sqlStatement instanceof CreateResourceGroupStatement || sqlStatement instanceof SetResourceGroupStatement;
     }
 }

--- a/infra/route/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/type/broadcast/DatabaseInstanceBroadcastRouteEngine.java
+++ b/infra/route/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/type/broadcast/DatabaseInstanceBroadcastRouteEngine.java
@@ -15,35 +15,30 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.route.type;
+package org.apache.shardingsphere.infra.route.engine.tableless.type.broadcast;
 
-import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
-import org.apache.shardingsphere.infra.route.SQLRouter;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
-import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
-import org.apache.shardingsphere.infra.session.query.QueryContext;
+import org.apache.shardingsphere.infra.route.context.RouteMapper;
+import org.apache.shardingsphere.infra.route.context.RouteUnit;
+import org.apache.shardingsphere.infra.route.engine.tableless.TablelessRouteEngine;
 
-import java.util.Collection;
+import java.util.Collections;
 
 /**
- * Entrance SQL Router.
- * 
- * @param <T> type of rule
+ * Database instance broadcast route engine.
  */
-public interface EntranceSQLRouter<T extends ShardingSphereRule> extends SQLRouter<T> {
+@RequiredArgsConstructor
+public final class DatabaseInstanceBroadcastRouteEngine implements TablelessRouteEngine {
     
-    /**
-     * Create route context.
-     *
-     * @param queryContext query context
-     * @param globalRuleMetaData global rule meta data
-     * @param database database
-     * @param rule rule
-     * @param tableNames table names
-     * @param props configuration properties
-     * @return route context
-     */
-    RouteContext createRouteContext(QueryContext queryContext, RuleMetaData globalRuleMetaData, ShardingSphereDatabase database, T rule, Collection<String> tableNames, ConfigurationProperties props);
+    @Override
+    public RouteContext route(final RuleMetaData globalRuleMetaData, final ShardingSphereDatabase database) {
+        RouteContext result = new RouteContext();
+        for (String each : database.getResourceMetaData().getAllInstanceDataSourceNames()) {
+            result.getRouteUnits().add(new RouteUnit(new RouteMapper(each, each), Collections.emptyList()));
+        }
+        return result;
+    }
 }

--- a/infra/route/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/type/broadcast/InstanceBroadcastRouteEngine.java
+++ b/infra/route/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/type/broadcast/InstanceBroadcastRouteEngine.java
@@ -28,10 +28,10 @@ import org.apache.shardingsphere.infra.route.engine.tableless.TablelessRouteEngi
 import java.util.Collections;
 
 /**
- * Database instance broadcast route engine.
+ * Instance broadcast route engine.
  */
 @RequiredArgsConstructor
-public final class DatabaseInstanceBroadcastRouteEngine implements TablelessRouteEngine {
+public final class InstanceBroadcastRouteEngine implements TablelessRouteEngine {
     
     @Override
     public RouteContext route(final RuleMetaData globalRuleMetaData, final ShardingSphereDatabase database) {

--- a/infra/route/src/main/java/org/apache/shardingsphere/infra/route/type/DecorateSQLRouter.java
+++ b/infra/route/src/main/java/org/apache/shardingsphere/infra/route/type/DecorateSQLRouter.java
@@ -24,6 +24,8 @@ import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
 
+import java.util.Collection;
+
 /**
  * Decorate SQL Router.
  * 
@@ -38,7 +40,8 @@ public interface DecorateSQLRouter<T extends ShardingSphereRule> extends SQLRout
      * @param queryContext query context
      * @param database database
      * @param rule rule
+     * @param tableNames table names
      * @param props configuration properties
      */
-    void decorateRouteContext(RouteContext routeContext, QueryContext queryContext, ShardingSphereDatabase database, T rule, ConfigurationProperties props);
+    void decorateRouteContext(RouteContext routeContext, QueryContext queryContext, ShardingSphereDatabase database, T rule, Collection<String> tableNames, ConfigurationProperties props);
 }

--- a/infra/route/src/test/java/org/apache/shardingsphere/infra/route/engine/tableless/TablelessRouteEngineFactoryTest.java
+++ b/infra/route/src/test/java/org/apache/shardingsphere/infra/route/engine/tableless/TablelessRouteEngineFactoryTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.route.engine.tableless;
+
+import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
+import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
+import org.apache.shardingsphere.infra.binder.context.type.TableAvailable;
+import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
+import org.apache.shardingsphere.infra.hint.HintValueContext;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.route.engine.tableless.type.broadcast.DataSourceBroadcastRouteEngine;
+import org.apache.shardingsphere.infra.route.engine.tableless.type.broadcast.InstanceBroadcastRouteEngine;
+import org.apache.shardingsphere.infra.session.connection.ConnectionContext;
+import org.apache.shardingsphere.infra.session.query.QueryContext;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.DALStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.tcl.TCLStatement;
+import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLCreateResourceGroupStatement;
+import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLSetResourceGroupStatement;
+import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLSetStatement;
+import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLShowDatabasesStatement;
+import org.apache.shardingsphere.sql.parser.statement.postgresql.dal.PostgreSQLSetStatement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TablelessRouteEngineFactoryTest {
+    
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private ShardingSphereDatabase database;
+    
+    @Mock(extraInterfaces = TableAvailable.class)
+    private SQLStatementContext sqlStatementContext;
+    
+    @Mock
+    private TablesContext tablesContext;
+    
+    @BeforeEach
+    void setUp() {
+        when(((TableAvailable) sqlStatementContext).getTablesContext()).thenReturn(tablesContext);
+        when(database.getSchema(DefaultDatabase.LOGIC_NAME)).thenReturn(mock(ShardingSphereSchema.class));
+        Collection<String> tableNames = new ArrayList<>();
+        when(tablesContext.getTableNames()).thenReturn(tableNames);
+    }
+    
+    private ConnectionContext mockConnectionContext() {
+        ConnectionContext result = mock(ConnectionContext.class);
+        when(result.getCurrentDatabaseName()).thenReturn(Optional.of(DefaultDatabase.LOGIC_NAME));
+        return result;
+    }
+    
+    @Test
+    void assertNewInstanceForSetResourceGroup() {
+        MySQLSetResourceGroupStatement resourceGroupStatement = mock(MySQLSetResourceGroupStatement.class);
+        when(sqlStatementContext.getSqlStatement()).thenReturn(resourceGroupStatement);
+        QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
+        TablelessRouteEngine actual = TablelessRouteEngineFactory.newInstance(queryContext);
+        assertThat(actual, instanceOf(InstanceBroadcastRouteEngine.class));
+    }
+    
+    @Test
+    void assertNewInstanceForDALShow() {
+        DALStatement dalStatement = mock(MySQLShowDatabasesStatement.class);
+        when(sqlStatementContext.getSqlStatement()).thenReturn(dalStatement);
+        QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
+        TablelessRouteEngine actual = TablelessRouteEngineFactory.newInstance(queryContext);
+        assertThat(actual, instanceOf(DataSourceBroadcastRouteEngine.class));
+    }
+    
+    @Test
+    void assertNewInstanceForDALSetForPostgreSQL() {
+        assertNewInstanceForDALSet(mock(PostgreSQLSetStatement.class));
+    }
+    
+    @Test
+    void assertNewInstanceForTCL() {
+        TCLStatement tclStatement = mock(TCLStatement.class);
+        when(sqlStatementContext.getSqlStatement()).thenReturn(tclStatement);
+        QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
+        TablelessRouteEngine actual = TablelessRouteEngineFactory.newInstance(queryContext);
+        assertThat(actual, instanceOf(DataSourceBroadcastRouteEngine.class));
+    }
+    
+    
+    @Test
+    void assertNewInstanceForDALSetForMySQL() {
+        assertNewInstanceForDALSet(mock(MySQLSetStatement.class));
+    }
+    
+    private void assertNewInstanceForDALSet(final DALStatement dalStatement) {
+        when(sqlStatementContext.getSqlStatement()).thenReturn(dalStatement);
+        QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
+        TablelessRouteEngine actual = TablelessRouteEngineFactory.newInstance(queryContext);
+        assertThat(actual, instanceOf(DataSourceBroadcastRouteEngine.class));
+    }
+    
+    @Test
+    void assertNewInstanceForCreateResourceGroup() {
+        MySQLCreateResourceGroupStatement resourceGroupStatement = mock(MySQLCreateResourceGroupStatement.class);
+        when(sqlStatementContext.getSqlStatement()).thenReturn(resourceGroupStatement);
+        QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
+        TablelessRouteEngine actual = TablelessRouteEngineFactory.newInstance(queryContext);
+        assertThat(actual, instanceOf(InstanceBroadcastRouteEngine.class));
+    }
+}

--- a/infra/route/src/test/java/org/apache/shardingsphere/infra/route/engine/tableless/TablelessRouteEngineFactoryTest.java
+++ b/infra/route/src/test/java/org/apache/shardingsphere/infra/route/engine/tableless/TablelessRouteEngineFactoryTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.route.engine.tableless;
 
 import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
+import org.apache.shardingsphere.infra.binder.context.statement.ddl.CloseStatementContext;
 import org.apache.shardingsphere.infra.binder.context.type.TableAvailable;
 import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
@@ -35,6 +36,7 @@ import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLCreateResou
 import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLSetResourceGroupStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLSetStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLShowDatabasesStatement;
+import org.apache.shardingsphere.sql.parser.statement.opengauss.ddl.OpenGaussCloseStatement;
 import org.apache.shardingsphere.sql.parser.statement.postgresql.dal.PostgreSQLSetStatement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,6 +54,7 @@ import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -114,7 +117,6 @@ class TablelessRouteEngineFactoryTest {
         assertThat(actual, instanceOf(DataSourceBroadcastRouteEngine.class));
     }
     
-    
     @Test
     void assertNewInstanceForDALSetForMySQL() {
         assertNewInstanceForDALSet(mock(MySQLSetStatement.class));
@@ -134,5 +136,17 @@ class TablelessRouteEngineFactoryTest {
         QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
         TablelessRouteEngine actual = TablelessRouteEngineFactory.newInstance(queryContext);
         assertThat(actual, instanceOf(InstanceBroadcastRouteEngine.class));
+    }
+    
+    @Test
+    void assertNewInstanceForCloseAllStatement() {
+        CloseStatementContext closeStatementContext = mock(CloseStatementContext.class, RETURNS_DEEP_STUBS);
+        OpenGaussCloseStatement closeStatement = mock(OpenGaussCloseStatement.class);
+        when(closeStatement.isCloseAll()).thenReturn(true);
+        when(closeStatementContext.getTablesContext().getDatabaseName()).thenReturn(Optional.empty());
+        when(closeStatementContext.getSqlStatement()).thenReturn(closeStatement);
+        QueryContext queryContext = new QueryContext(closeStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
+        TablelessRouteEngine actual = TablelessRouteEngineFactory.newInstance(queryContext);
+        assertThat(actual, instanceOf(DataSourceBroadcastRouteEngine.class));
     }
 }

--- a/infra/route/src/test/java/org/apache/shardingsphere/infra/route/fixture/router/DataSourceSQLRouterFixture.java
+++ b/infra/route/src/test/java/org/apache/shardingsphere/infra/route/fixture/router/DataSourceSQLRouterFixture.java
@@ -29,13 +29,14 @@ import org.apache.shardingsphere.infra.route.type.DecorateSQLRouter;
 import org.apache.shardingsphere.infra.route.type.EntranceSQLRouter;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
 
+import java.util.Collection;
 import java.util.Collections;
 
 public final class DataSourceSQLRouterFixture implements EntranceSQLRouter<DataSourceRouteRuleFixture>, DecorateSQLRouter<DataSourceRouteRuleFixture>, DataSourceSQLRouter<DataSourceRouteRuleFixture> {
     
     @Override
     public RouteContext createRouteContext(final QueryContext queryContext, final RuleMetaData globalRuleMetaData, final ShardingSphereDatabase database, final DataSourceRouteRuleFixture rule,
-                                           final ConfigurationProperties props) {
+                                           final Collection<String> tableNames, final ConfigurationProperties props) {
         RouteContext result = new RouteContext();
         result.getRouteUnits().add(new RouteUnit(new RouteMapper("ds", "ds_0"), Collections.emptyList()));
         return result;
@@ -43,7 +44,7 @@ public final class DataSourceSQLRouterFixture implements EntranceSQLRouter<DataS
     
     @Override
     public void decorateRouteContext(final RouteContext routeContext, final QueryContext queryContext, final ShardingSphereDatabase database, final DataSourceRouteRuleFixture rule,
-                                     final ConfigurationProperties props) {
+                                     final Collection<String> tableNames, final ConfigurationProperties props) {
         routeContext.getRouteUnits().add(new RouteUnit(new RouteMapper("ds", "ds_0"), Collections.emptyList()));
     }
     

--- a/infra/route/src/test/java/org/apache/shardingsphere/infra/route/fixture/router/TableSQLRouterFailureFixture.java
+++ b/infra/route/src/test/java/org/apache/shardingsphere/infra/route/fixture/router/TableSQLRouterFailureFixture.java
@@ -25,11 +25,13 @@ import org.apache.shardingsphere.infra.route.type.DecorateSQLRouter;
 import org.apache.shardingsphere.infra.route.type.TableSQLRouter;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
 
+import java.util.Collection;
+
 public final class TableSQLRouterFailureFixture implements DecorateSQLRouter<RouteFailureRuleFixture>, TableSQLRouter<RouteFailureRuleFixture> {
     
     @Override
     public void decorateRouteContext(final RouteContext routeContext, final QueryContext queryContext, final ShardingSphereDatabase database,
-                                     final RouteFailureRuleFixture rule, final ConfigurationProperties props) {
+                                     final RouteFailureRuleFixture rule, final Collection<String> tableNames, final ConfigurationProperties props) {
         throw new UnsupportedOperationException("Route failure.");
     }
     

--- a/infra/route/src/test/java/org/apache/shardingsphere/infra/route/fixture/router/TableSQLRouterFixture.java
+++ b/infra/route/src/test/java/org/apache/shardingsphere/infra/route/fixture/router/TableSQLRouterFixture.java
@@ -29,13 +29,14 @@ import org.apache.shardingsphere.infra.route.fixture.rule.TableRouteRuleFixture;
 import org.apache.shardingsphere.infra.route.type.TableSQLRouter;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
 
+import java.util.Collection;
 import java.util.Collections;
 
 public final class TableSQLRouterFixture implements EntranceSQLRouter<TableRouteRuleFixture>, DecorateSQLRouter<TableRouteRuleFixture>, TableSQLRouter<TableRouteRuleFixture> {
     
     @Override
     public RouteContext createRouteContext(final QueryContext queryContext, final RuleMetaData globalRuleMetaData, final ShardingSphereDatabase database, final TableRouteRuleFixture rule,
-                                           final ConfigurationProperties props) {
+                                           final Collection<String> tableNames, final ConfigurationProperties props) {
         RouteContext result = new RouteContext();
         result.getRouteUnits().add(new RouteUnit(new RouteMapper("ds", "ds_0"), Collections.emptyList()));
         return result;
@@ -43,7 +44,7 @@ public final class TableSQLRouterFixture implements EntranceSQLRouter<TableRoute
     
     @Override
     public void decorateRouteContext(final RouteContext routeContext, final QueryContext queryContext, final ShardingSphereDatabase database, final TableRouteRuleFixture rule,
-                                     final ConfigurationProperties props) {
+                                     final Collection<String> tableNames, final ConfigurationProperties props) {
         routeContext.getRouteUnits().add(new RouteUnit(new RouteMapper("ds", "ds_0"), Collections.emptyList()));
     }
     

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/route/SingleSQLRouter.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/route/SingleSQLRouter.java
@@ -49,7 +49,7 @@ public final class SingleSQLRouter implements EntranceSQLRouter<SingleRule>, Dec
     
     @Override
     public RouteContext createRouteContext(final QueryContext queryContext, final RuleMetaData globalRuleMetaData, final ShardingSphereDatabase database,
-                                           final SingleRule rule, final ConfigurationProperties props) {
+                                           final SingleRule rule, final Collection<String> tableNames, final ConfigurationProperties props) {
         if (1 == database.getResourceMetaData().getStorageUnits().size()) {
             return createSingleDataSourceRouteContext(rule, database, queryContext);
         }
@@ -68,7 +68,7 @@ public final class SingleSQLRouter implements EntranceSQLRouter<SingleRule>, Dec
     
     @Override
     public void decorateRouteContext(final RouteContext routeContext, final QueryContext queryContext, final ShardingSphereDatabase database,
-                                     final SingleRule rule, final ConfigurationProperties props) {
+                                     final SingleRule rule, final Collection<String> tableNames, final ConfigurationProperties props) {
         SQLStatementContext sqlStatementContext = queryContext.getSqlStatementContext();
         Collection<QualifiedTable> singleTables = getSingleTables(database, rule, routeContext, sqlStatementContext);
         SingleRouteEngineFactory.newInstance(singleTables, sqlStatementContext.getSqlStatement(), queryContext.getHintValueContext()).ifPresent(optional -> optional.route(routeContext, rule));

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/SingleSQLRouterTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/SingleSQLRouterTest.java
@@ -83,7 +83,7 @@ class SingleSQLRouterTest {
         rule.getAttributes().getAttribute(DataNodeRuleAttribute.class).getAllDataNodes().put("t_order", Collections.singleton(createDataNode("foo_ds")));
         ShardingSphereDatabase database = mockSingleDatabase();
         RouteContext actual = new SingleSQLRouter().createRouteContext(
-                createQueryContext(), mock(RuleMetaData.class), database, rule, new ConfigurationProperties(new Properties()));
+                createQueryContext(), mock(RuleMetaData.class), database, rule, Collections.singletonList("t_order"), new ConfigurationProperties(new Properties()));
         assertThat(actual.getRouteUnits().size(), is(1));
         RouteUnit routeUnit = actual.getRouteUnits().iterator().next();
         assertThat(routeUnit.getDataSourceMapper().getLogicName(), is("foo_ds"));
@@ -104,7 +104,7 @@ class SingleSQLRouterTest {
         rule.getAttributes().getAttribute(DataNodeRuleAttribute.class).getAllDataNodes().put("t_order", Collections.singletonList(createDataNode("write_ds")));
         ShardingSphereDatabase database = mockReadwriteSplittingDatabase();
         RouteContext actual = new SingleSQLRouter().createRouteContext(
-                createQueryContext(), mock(RuleMetaData.class), database, rule, new ConfigurationProperties(new Properties()));
+                createQueryContext(), mock(RuleMetaData.class), database, rule, Collections.singletonList("t_order"), new ConfigurationProperties(new Properties()));
         assertThat(actual.getRouteUnits().size(), is(1));
         RouteUnit routeUnit = actual.getRouteUnits().iterator().next();
         assertThat(routeUnit.getDataSourceMapper().getLogicName(), is("readwrite_ds"));
@@ -124,7 +124,7 @@ class SingleSQLRouterTest {
         SingleRule rule = new SingleRule(new SingleRuleConfiguration(), DefaultDatabase.LOGIC_NAME, new H2DatabaseType(), createMultiDataSourceMap(), Collections.emptyList());
         ShardingSphereDatabase database = mockDatabaseWithMultipleResources();
         RouteContext actual = new SingleSQLRouter().createRouteContext(
-                createQueryContext(), mock(RuleMetaData.class), database, rule, new ConfigurationProperties(new Properties()));
+                createQueryContext(), mock(RuleMetaData.class), database, rule, Collections.singletonList("t_order"), new ConfigurationProperties(new Properties()));
         List<RouteUnit> routeUnits = new ArrayList<>(actual.getRouteUnits());
         assertThat(actual.getRouteUnits().size(), is(1));
         assertThat(routeUnits.get(0).getDataSourceMapper().getLogicName(), is(routeUnits.get(0).getDataSourceMapper().getActualName()));
@@ -179,7 +179,7 @@ class SingleSQLRouterTest {
         routeContext.getRouteUnits().add(new RouteUnit(new RouteMapper("foo_ds", "foo_ds"), Collections.singletonList(new RouteMapper("t_order", "t_order"))));
         SingleSQLRouter sqlRouter = (SingleSQLRouter) OrderedSPILoader.getServices(SQLRouter.class, Collections.singleton(rule)).get(rule);
         sqlRouter.decorateRouteContext(
-                routeContext, createQueryContext(), mockReadwriteSplittingDatabase(), rule, new ConfigurationProperties(new Properties()));
+                routeContext, createQueryContext(), mockReadwriteSplittingDatabase(), rule, Collections.singletonList("t_order"), new ConfigurationProperties(new Properties()));
         Iterator<String> routedDataSourceNames = routeContext.getActualDataSourceNames().iterator();
         assertThat(routedDataSourceNames.next(), is("foo_ds"));
     }
@@ -196,7 +196,7 @@ class SingleSQLRouterTest {
         SingleSQLRouter sqlRouter = (SingleSQLRouter) OrderedSPILoader.getServices(SQLRouter.class, Collections.singleton(rule)).get(rule);
         ShardingSphereDatabase database = new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME, mock(DatabaseType.class), mock(ResourceMetaData.class, RETURNS_DEEP_STUBS),
                 new RuleMetaData(Collections.singleton(rule)), Collections.emptyMap());
-        sqlRouter.decorateRouteContext(routeContext, createQueryContext(), database, rule, new ConfigurationProperties(new Properties()));
+        sqlRouter.decorateRouteContext(routeContext, createQueryContext(), database, rule, Collections.singletonList("t_order"), new ConfigurationProperties(new Properties()));
         assertThat(routeContext.getActualDataSourceNames(), is(new HashSet<>(Arrays.asList("write_ds", "readwrite_ds"))));
     }
     
@@ -208,7 +208,7 @@ class SingleSQLRouterTest {
         routeContext.getRouteUnits().add(new RouteUnit(new RouteMapper("ds_1", "ds_1"), Collections.emptyList()));
         SingleSQLRouter sqlRouter = (SingleSQLRouter) OrderedSPILoader.getServices(SQLRouter.class, Collections.singleton(rule)).get(rule);
         sqlRouter.decorateRouteContext(
-                routeContext, createQueryContext(), mockDatabaseWithMultipleResources(), rule, new ConfigurationProperties(new Properties()));
+                routeContext, createQueryContext(), mockDatabaseWithMultipleResources(), rule, Collections.singletonList("t_order"), new ConfigurationProperties(new Properties()));
         Iterator<String> routedDataSourceNames = routeContext.getActualDataSourceNames().iterator();
         assertThat(routedDataSourceNames.next(), is("ds_1"));
         assertThat(routedDataSourceNames.next(), is("ds_0"));

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/AbstractMigrationE2EIT.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/AbstractMigrationE2EIT.java
@@ -76,7 +76,7 @@ public abstract class AbstractMigrationE2EIT {
                 .replace("${ds3}", containerComposer.getActualJdbcUrlTemplate(PipelineContainerComposer.DS_3, true))
                 .replace("${ds4}", containerComposer.getActualJdbcUrlTemplate(PipelineContainerComposer.DS_4, true));
         containerComposer.proxyExecuteWithLog(addTargetResource, 0);
-        Awaitility.await().ignoreExceptions().atMost(15L, TimeUnit.SECONDS).pollInterval(3L, TimeUnit.SECONDS).until(() -> 3 == containerComposer.showStorageUnitsName().size());
+        Awaitility.await().ignoreExceptions().atMost(60L, TimeUnit.SECONDS).pollInterval(3L, TimeUnit.SECONDS).until(() -> 3 == containerComposer.showStorageUnitsName().size());
     }
     
     protected void createSourceSchema(final PipelineContainerComposer containerComposer, final String schemaName) throws SQLException {


### PR DESCRIPTION
Ref #33811.

Changes proposed in this pull request:
  - Move tableless sql route in sharding to TablelessRouteEngineFactory

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
