### PR TITLE
Added support to TestContainers JDBC URL of Firebird

### DIFF
--- a/infra/database/type/testcontainers/src/main/java/org/apache/shardingsphere/infra/database/testcontainers/type/TcFirebirdDatabaseType.java
+++ b/infra/database/type/testcontainers/src/main/java/org/apache/shardingsphere/infra/database/testcontainers/type/TcFirebirdDatabaseType.java
@@ -1,0 +1,27 @@
+package org.apache.shardingsphere.infra.database.testcontainers.type;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Database type of Firebird in testcontainers-java.
+ */
+public final class TcFirebirdDatabaseType implements TestcontainersDatabaseType {
+    @Override
+    public Collection<String> getJdbcUrlPrefixes() {
+        return Collections.singleton("jdbc:tc:firebird:");
+    }
+
+    @Override
+    public Optional<DatabaseType> getTrunkDatabaseType() {
+        return Optional.of(TypedSPILoader.getService(DatabaseType.class, "Firebird"));
+    }
+
+    @Override
+    public String getType() {
+        return "TC-Firebird";
+    }
+}

--- a/infra/database/type/testcontainers/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.database.core.type.DatabaseType
+++ b/infra/database/type/testcontainers/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.database.core.type.DatabaseType
@@ -22,3 +22,4 @@ org.apache.shardingsphere.infra.database.testcontainers.type.TcOracleDatabaseTyp
 org.apache.shardingsphere.infra.database.testcontainers.type.TcPostgreSQLDatabaseType
 org.apache.shardingsphere.infra.database.testcontainers.type.TcSQLServerDatabaseType
 org.apache.shardingsphere.infra.database.testcontainers.type.TcTiDBDatabaseType
+org.apache.shardingsphere.infra.database.testcontainers.type.TcFirebirdDatabaseType

--- a/infra/database/type/testcontainers/src/test/java/org/apache/shardingsphere/infra/database/testcontainers/type/TestcontainersDatabaseTypeTest.java
+++ b/infra/database/type/testcontainers/src/test/java/org/apache/shardingsphere/infra/database/testcontainers/type/TestcontainersDatabaseTypeTest.java
@@ -35,6 +35,7 @@ class TestcontainersDatabaseTypeTest {
         assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-MySQL").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:mysql:")));
         assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-Oracle").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:oracle:")));
         assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-PostgreSQL").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:postgresql:")));
+        assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-Firebird").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:firebird:")));
         assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-SQLServer").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:sqlserver:")));
         assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-TiDB").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:tidb:")));
     }


### PR DESCRIPTION
Changes proposed in this pull request:
  -  Add support to TestContainers JDBC URL of Firebird to the optional module

---

Before committing this PR, I'm sure that I have checked the following options:
- [X] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [X] I have self-reviewed the commit code.
- [X] I have (or in comment I request) added corresponding labels for the pull request.
- [X] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [X] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
