### PR TITLE
Added support to TestContainers JDBC URL of Firebird

### DIFF
--- a/infra/database/type/testcontainers/src/main/java/org/apache/shardingsphere/infra/database/testcontainers/type/TcFirebirdDatabaseType.java
+++ b/infra/database/type/testcontainers/src/main/java/org/apache/shardingsphere/infra/database/testcontainers/type/TcFirebirdDatabaseType.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 /**
- * Database type of MariaDB in testcontainers-java.
+ * Database type of Firebird in testcontainers-java.
  */
 public final class TcFirebirdDatabaseType implements TestcontainersDatabaseType {
 

--- a/infra/database/type/testcontainers/src/main/java/org/apache/shardingsphere/infra/database/testcontainers/type/TcFirebirdDatabaseType.java
+++ b/infra/database/type/testcontainers/src/main/java/org/apache/shardingsphere/infra/database/testcontainers/type/TcFirebirdDatabaseType.java
@@ -25,9 +25,10 @@ import java.util.Collections;
 import java.util.Optional;
 
 /**
- * Database type of Firebird in testcontainers-java.
+ * Database type of MariaDB in testcontainers-java.
  */
 public final class TcFirebirdDatabaseType implements TestcontainersDatabaseType {
+
     @Override
     public Collection<String> getJdbcUrlPrefixes() {
         return Collections.singleton("jdbc:tc:firebird:");

--- a/infra/database/type/testcontainers/src/main/java/org/apache/shardingsphere/infra/database/testcontainers/type/TcFirebirdDatabaseType.java
+++ b/infra/database/type/testcontainers/src/main/java/org/apache/shardingsphere/infra/database/testcontainers/type/TcFirebirdDatabaseType.java
@@ -28,17 +28,17 @@ import java.util.Optional;
  * Database type of Firebird in testcontainers-java.
  */
 public final class TcFirebirdDatabaseType implements TestcontainersDatabaseType {
-
+    
     @Override
     public Collection<String> getJdbcUrlPrefixes() {
         return Collections.singleton("jdbc:tc:firebird:");
     }
-
+    
     @Override
     public Optional<DatabaseType> getTrunkDatabaseType() {
         return Optional.of(TypedSPILoader.getService(DatabaseType.class, "Firebird"));
     }
-
+    
     @Override
     public String getType() {
         return "TC-Firebird";

--- a/infra/database/type/testcontainers/src/main/java/org/apache/shardingsphere/infra/database/testcontainers/type/TcFirebirdDatabaseType.java
+++ b/infra/database/type/testcontainers/src/main/java/org/apache/shardingsphere/infra/database/testcontainers/type/TcFirebirdDatabaseType.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.testcontainers.type;
+
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Database type of Firebird in testcontainers-java.
+ */
+public final class TcFirebirdDatabaseType implements TestcontainersDatabaseType {
+    @Override
+    public Collection<String> getJdbcUrlPrefixes() {
+        return Collections.singleton("jdbc:tc:firebird:");
+    }
+
+    @Override
+    public Optional<DatabaseType> getTrunkDatabaseType() {
+        return Optional.of(TypedSPILoader.getService(DatabaseType.class, "Firebird"));
+    }
+
+    @Override
+    public String getType() {
+        return "TC-Firebird";
+    }
+}

--- a/infra/database/type/testcontainers/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.database.core.type.DatabaseType
+++ b/infra/database/type/testcontainers/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.database.core.type.DatabaseType
@@ -22,3 +22,4 @@ org.apache.shardingsphere.infra.database.testcontainers.type.TcOracleDatabaseTyp
 org.apache.shardingsphere.infra.database.testcontainers.type.TcPostgreSQLDatabaseType
 org.apache.shardingsphere.infra.database.testcontainers.type.TcSQLServerDatabaseType
 org.apache.shardingsphere.infra.database.testcontainers.type.TcTiDBDatabaseType
+org.apache.shardingsphere.infra.database.testcontainers.type.TcFirebirdDatabaseType

--- a/infra/database/type/testcontainers/src/test/java/org/apache/shardingsphere/infra/database/testcontainers/type/TestcontainersDatabaseTypeTest.java
+++ b/infra/database/type/testcontainers/src/test/java/org/apache/shardingsphere/infra/database/testcontainers/type/TestcontainersDatabaseTypeTest.java
@@ -37,5 +37,6 @@ class TestcontainersDatabaseTypeTest {
         assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-PostgreSQL").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:postgresql:")));
         assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-SQLServer").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:sqlserver:")));
         assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-TiDB").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:tidb:")));
+        assertThat(TypedSPILoader.getService(DatabaseType.class, "TC-Firebird").getJdbcUrlPrefixes(), is(Collections.singleton("jdbc:tc:firebird:")));
     }
 }


### PR DESCRIPTION
Fixes #33782.

Changes proposed in this pull request:
  -  Add support to TestContainers JDBC URL of Firebird to the optional module

---

Before committing this PR, I'm sure that I have checked the following options:
- [X] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [X] I have self-reviewed the commit code.
- [X] I have (or in comment I request) added corresponding labels for the pull request.
- [X] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [X] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
