### PR TITLE
Optimize loader options config of YAML, change maxAliasesForCollections from by default 50 to 1000

### DIFF
--- a/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/yaml/swapper/YamlReadwriteSplittingRuleConfigurationSwapper.java
+++ b/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/yaml/swapper/YamlReadwriteSplittingRuleConfigurationSwapper.java
@@ -56,7 +56,9 @@ public final class YamlReadwriteSplittingRuleConfigurationSwapper implements Yam
     private YamlReadwriteSplittingDataSourceGroupRuleConfiguration swapToYamlConfiguration(final ReadwriteSplittingDataSourceGroupRuleConfiguration dataSourceGroupRuleConfig) {
         YamlReadwriteSplittingDataSourceGroupRuleConfiguration result = new YamlReadwriteSplittingDataSourceGroupRuleConfiguration();
         result.setWriteDataSourceName(dataSourceGroupRuleConfig.getWriteDataSourceName());
-        result.setReadDataSourceNames(dataSourceGroupRuleConfig.getReadDataSourceNames());
+        if (null != dataSourceGroupRuleConfig.getReadDataSourceNames() && !dataSourceGroupRuleConfig.getReadDataSourceNames().isEmpty()) {
+            result.setReadDataSourceNames(dataSourceGroupRuleConfig.getReadDataSourceNames());
+        }
         result.setTransactionalReadQueryStrategy(dataSourceGroupRuleConfig.getTransactionalReadQueryStrategy().name());
         result.setLoadBalancerName(dataSourceGroupRuleConfig.getLoadBalancerName());
         return result;

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlEngine.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlEngine.java
@@ -53,7 +53,8 @@ public final class YamlEngine {
     @SneakyThrows(ReflectiveOperationException.class)
     public static <T extends YamlConfiguration> T unmarshal(final File yamlFile, final Class<T> classType) throws IOException {
         try (BufferedReader inputStreamReader = Files.newBufferedReader(Paths.get(yamlFile.toURI()))) {
-            T result = new Yaml(new ShardingSphereYamlConstructor(classType)).loadAs(inputStreamReader, classType);
+            T result = new Yaml(new ShardingSphereYamlConstructor(classType), new Representer(new DumperOptions()), new DumperOptions(),
+                    ShardingSphereYamlConstructor.createLoaderOptions()).loadAs(inputStreamReader, classType);
             return null == result ? classType.getConstructor().newInstance() : result;
         }
     }
@@ -70,7 +71,8 @@ public final class YamlEngine {
     @SneakyThrows(ReflectiveOperationException.class)
     public static <T extends YamlConfiguration> T unmarshal(final byte[] yamlBytes, final Class<T> classType) throws IOException {
         try (InputStream inputStream = new ByteArrayInputStream(yamlBytes)) {
-            T result = new Yaml(new ShardingSphereYamlConstructor(classType)).loadAs(inputStream, classType);
+            T result = new Yaml(new ShardingSphereYamlConstructor(classType), new Representer(new DumperOptions()), new DumperOptions(),
+                    ShardingSphereYamlConstructor.createLoaderOptions()).loadAs(inputStream, classType);
             return null == result ? classType.getConstructor().newInstance() : result;
         }
     }
@@ -85,7 +87,8 @@ public final class YamlEngine {
      */
     @SneakyThrows(ReflectiveOperationException.class)
     public static <T> T unmarshal(final String yamlContent, final Class<T> classType) {
-        T result = new Yaml(new ShardingSphereYamlConstructor(classType)).loadAs(yamlContent, classType);
+        T result = new Yaml(new ShardingSphereYamlConstructor(classType), new Representer(new DumperOptions()), new DumperOptions(),
+                ShardingSphereYamlConstructor.createLoaderOptions()).loadAs(yamlContent, classType);
         return null == result ? classType.getConstructor().newInstance() : result;
     }
     
@@ -102,7 +105,8 @@ public final class YamlEngine {
     public static <T> T unmarshal(final String yamlContent, final Class<T> classType, final boolean skipMissingProps) {
         Representer representer = new Representer(new DumperOptions());
         representer.getPropertyUtils().setSkipMissingProperties(skipMissingProps);
-        T result = new Yaml(new ShardingSphereYamlConstructor(classType), representer).loadAs(yamlContent, classType);
+        T result = new Yaml(new ShardingSphereYamlConstructor(classType), representer, new DumperOptions(),
+                ShardingSphereYamlConstructor.createLoaderOptions()).loadAs(yamlContent, classType);
         return null == result ? classType.getConstructor().newInstance() : result;
     }
     

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/constructor/ShardingSphereYamlConstructor.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/constructor/ShardingSphereYamlConstructor.java
@@ -47,7 +47,12 @@ public class ShardingSphereYamlConstructor extends Constructor {
         this.rootClass = rootClass;
     }
     
-    private static LoaderOptions createLoaderOptions() {
+    /**
+     * Create loader options.
+     *
+     * @return loader options
+     */
+    public static LoaderOptions createLoaderOptions() {
         LoaderOptions result = new LoaderOptions();
         result.setMaxAliasesForCollections(1000);
         result.setCodePointLimit(Integer.MAX_VALUE);


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Optimize loader options config of YAML, change maxAliasesForCollections from by default 50 to 1000

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
