### PR TITLE
Fix Windows startup script runs in the background and outputs log files

### DIFF
--- a/distribution/proxy/src/main/resources/bin/start.bat
+++ b/distribution/proxy/src/main/resources/bin/start.bat
@@ -89,7 +89,7 @@ if %int_version% == 8 (
 
 echo Starting the %SERVER_NAME% ...
 
-javaw -server -Xmx2g -Xms2g -Xmn1g -Xss1m -XX:AutoBoxCacheMax=4096 -XX:+DisableExplicitGC -XX:LargePageSizeInBytes=128m %VERSION_OPTS% -Dfile.encoding=UTF-8 -Dio.netty.leakDetection.level=DISABLED -classpath %CLASS_PATH% %MAIN_CLASS% >> %STDOUT_FILE%
+javaw -server -Xmx2g -Xms2g -Xmn1g -Xss1m -XX:AutoBoxCacheMax=4096 -XX:+DisableExplicitGC -XX:LargePageSizeInBytes=128m %VERSION_OPTS% -Dfile.encoding=UTF-8 -Dio.netty.leakDetection.level=DISABLED -classpath %CLASS_PATH% %MAIN_CLASS% >> %STDOUT_FILE% 2>&1
 
 goto exit
 

--- a/distribution/proxy/src/main/resources/bin/start.bat
+++ b/distribution/proxy/src/main/resources/bin/start.bat
@@ -19,6 +19,14 @@
 
 cd %~dp0
 
+set LOGS_DIR=..\logs
+
+if not exist %LOGS_DIR% (
+    mkdir %LOGS_DIR%
+)
+
+set STDOUT_FILE=%LOGS_DIR%\stdout.log
+
 set SERVER_NAME=ShardingSphere-Proxy
 
 set CLASS_PATH="..;..\lib\*;..\ext-lib\*"
@@ -81,7 +89,7 @@ if %int_version% == 8 (
 
 echo Starting the %SERVER_NAME% ...
 
-java -server -Xmx2g -Xms2g -Xmn1g -Xss1m -XX:AutoBoxCacheMax=4096 -XX:+DisableExplicitGC -XX:LargePageSizeInBytes=128m %VERSION_OPTS% -Dfile.encoding=UTF-8 -Dio.netty.leakDetection.level=DISABLED -classpath %CLASS_PATH% %MAIN_CLASS%
+javaw -server -Xmx2g -Xms2g -Xmn1g -Xss1m -XX:AutoBoxCacheMax=4096 -XX:+DisableExplicitGC -XX:LargePageSizeInBytes=128m %VERSION_OPTS% -Dfile.encoding=UTF-8 -Dio.netty.leakDetection.level=DISABLED -classpath %CLASS_PATH% %MAIN_CLASS% >> %STDOUT_FILE%
 
 goto exit
 


### PR DESCRIPTION
Fixes #34018.

Changes proposed in this pull request:
  1. windows start.bat uses javaw to run in the background
  2. redirect the output log file
---

