### PR TITLE
Support ALL PRIVILEGES ON `DB`.* in MySQLDatabasePrivilegeChecker

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -54,6 +54,7 @@
 1. Sharding: Fixes avg, sum, min, max function return empty data when no query result return - [#33449](https://github.com/apache/shardingsphere/pull/33449)
 1. Encrypt: Fixes merge exception without encrypt rule in database - [#33708](https://github.com/apache/shardingsphere/pull/33708)
 1. SQL Binder: Fixes the expression segment cannot find the outer table when binding - [#34015](https://github.com/apache/shardingsphere/pull/34015)
+1. Proxy: Fixes "ALL PRIVILEGES ON `DB`.*" is not recognized during SELECT privilege verification for MySQL - [#34037](https://github.com/apache/shardingsphere/pull/34037)
 
 ### Change Logs
 

--- a/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/checker/MySQLDatabasePrivilegeChecker.java
+++ b/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/checker/MySQLDatabasePrivilegeChecker.java
@@ -98,7 +98,8 @@ public final class MySQLDatabasePrivilegeChecker implements DialectDatabasePrivi
     }
     
     private String[][] getSelectRequiredPrivilege(final Connection connection) throws SQLException {
-        return new String[][]{{"ALL PRIVILEGES", "ON *.*"}, {"SELECT", "ON *.*"}, {"SELECT", String.format("ON `%s`.*", connection.getCatalog()).toUpperCase()}};
+        String onCatalog = String.format("ON `%s`.*", connection.getCatalog().toUpperCase());
+        return new String[][]{{"ALL PRIVILEGES", "ON *.*"}, {"SELECT", "ON *.*"}, {"ALL PRIVILEGES", onCatalog}, {"SELECT", onCatalog}};
     }
     
     private boolean matchPrivileges(final String grantedPrivileges, final String[][] requiredPrivileges) {


### PR DESCRIPTION
Fixes #34036.

- User privilege
<img width="436" alt="image" src="https://github.com/user-attachments/assets/82c4e295-8876-42ed-a38f-3afee83055b3" />

- Register storage unit
<img width="1382" alt="image" src="https://github.com/user-attachments/assets/cf3b14f8-1e8f-4f94-a098-bb09f5f3f12a" />
