### PR TITLE
Remove openGauss db-types for group_concat e2e test case

### DIFF
--- a/test/e2e/sql/src/test/resources/cases/dql/e2e-dql-select-aggregate.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/e2e-dql-select-aggregate.xml
@@ -145,11 +145,11 @@
         <assertion parameters="abc:String" expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT GROUP_CONCAT(o.remark) as order_id_group_concat FROM t_order o where o.order_id > 1 - 1" db-types="MySQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting,db_tbl_sql_federation">
+    <test-case sql="SELECT GROUP_CONCAT(o.remark) as order_id_group_concat FROM t_order o where o.order_id > 1 - 1" db-types="MySQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting,db_tbl_sql_federation">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT GROUP_CONCAT(distinct o.remark SEPARATOR ' ') as order_id_group_concat FROM t_order o where o.order_id > 1 - 1" db-types="MySQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+    <test-case sql="SELECT GROUP_CONCAT(distinct o.remark SEPARATOR ' ') as order_id_group_concat FROM t_order o where o.order_id > 1 - 1" db-types="MySQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 </e2e-test-cases>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove openGauss db-types for group_concat e2e test case

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
