### PR TITLE
Add oid column for pg_description, pg_attribute, pg_type, pg_attrdef table of OpenGauss

### DIFF
--- a/db-protocol/opengauss/src/main/java/org/apache/shardingsphere/db/protocol/opengauss/constant/OpenGaussProtocolDefaultVersionProvider.java
+++ b/db-protocol/opengauss/src/main/java/org/apache/shardingsphere/db/protocol/opengauss/constant/OpenGaussProtocolDefaultVersionProvider.java
@@ -26,7 +26,7 @@ public final class OpenGaussProtocolDefaultVersionProvider implements DatabasePr
     
     @Override
     public String provide() {
-        return "12.3";
+        return "9.2.4";
     }
     
     @Override

--- a/infra/database/type/opengauss/src/main/resources/schema/opengauss/pg_catalog/pg_attrdef.yaml
+++ b/infra/database/type/opengauss/src/main/resources/schema/opengauss/pg_catalog/pg_attrdef.yaml
@@ -17,6 +17,14 @@
 
 name: pg_attrdef
 columns:
+  oid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: oid
+    primaryKey: false
+    unsigned: false
+    visible: true
   adrelid:
     caseSensitive: true
     dataType: -5

--- a/infra/database/type/opengauss/src/main/resources/schema/opengauss/pg_catalog/pg_attribute.yaml
+++ b/infra/database/type/opengauss/src/main/resources/schema/opengauss/pg_catalog/pg_attribute.yaml
@@ -17,6 +17,14 @@
 
 name: pg_attribute
 columns:
+  oid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: oid
+    primaryKey: false
+    unsigned: false
+    visible: true
   attrelid:
     caseSensitive: true
     dataType: -5

--- a/infra/database/type/opengauss/src/main/resources/schema/opengauss/pg_catalog/pg_description.yaml
+++ b/infra/database/type/opengauss/src/main/resources/schema/opengauss/pg_catalog/pg_description.yaml
@@ -17,6 +17,14 @@
 
 name: pg_description
 columns:
+  oid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: oid
+    primaryKey: false
+    unsigned: false
+    visible: true
   objoid:
     caseSensitive: true
     dataType: -5

--- a/infra/database/type/opengauss/src/main/resources/schema/opengauss/pg_catalog/pg_type.yaml
+++ b/infra/database/type/opengauss/src/main/resources/schema/opengauss/pg_catalog/pg_type.yaml
@@ -17,6 +17,14 @@
 
 name: pg_type
 columns:
+  oid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: oid
+    primaryKey: false
+    unsigned: false
+    visible: true
   typname:
     caseSensitive: true
     dataType: 12


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Add oid column for pg_description, pg_attribute, pg_type, pg_attrdef table of OpenGauss
  - Change default version from 12.3 to 9.2.4 of openGauss

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
