### PR TITLE
Fix errors caused by missing oid column in pg_description, pg_attribute, pg_type, pg_attrdef table of OpenGauss

### DIFF
--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/empty_storage_units/opengauss/select_opengauss_pg_catalog_pg_attrdef.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/empty_storage_units/opengauss/select_opengauss_pg_catalog_pg_attrdef.xml
@@ -17,6 +17,7 @@
 
 <dataset>
     <metadata>
+        <column name="oid"/>
         <column name="adrelid"/>
         <column name="adnum"/>
         <column name="adbin"/>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/empty_storage_units/opengauss/select_opengauss_pg_catalog_pg_attribute.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/empty_storage_units/opengauss/select_opengauss_pg_catalog_pg_attribute.xml
@@ -17,6 +17,7 @@
 
 <dataset>
     <metadata>
+        <column name="oid"/>
         <column name="attrelid"/>
         <column name="attname"/>
         <column name="atttypid"/>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/empty_storage_units/opengauss/select_opengauss_pg_catalog_pg_description.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/empty_storage_units/opengauss/select_opengauss_pg_catalog_pg_description.xml
@@ -17,6 +17,7 @@
 
 <dataset>
     <metadata>
+        <column name="oid"/>
         <column name="objoid"/>
         <column name="classoid"/>
         <column name="objsubid"/>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/empty_storage_units/opengauss/select_opengauss_pg_catalog_pg_type.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/empty_storage_units/opengauss/select_opengauss_pg_catalog_pg_type.xml
@@ -17,6 +17,7 @@
 
 <dataset>
     <metadata>
+        <column name="oid"/>
         <column name="typname"/>
         <column name="typnamespace"/>
         <column name="typowner"/>


### PR DESCRIPTION
Ref #34073

Changes proposed in this pull request:
  - Fix errors caused by missing oid column in pg_description, pg_attribute, pg_type, pg_attrdef table of OpenGauss

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
