### PR TITLE
Add  `SQLStatementParserCacheHook` to Provide Extension Point for Application SQL Parse  Cache Warm-up , Referred to as Preheat

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,6 +39,7 @@
 1. SQL Parser: Support MySQL update with statement parse - [#34126](https://github.com/apache/shardingsphere/pull/34126)
 1. SQL Binder: Remove TablesContext#findTableNames method and implement select order by, group by bind logic - [#34123](https://github.com/apache/shardingsphere/pull/34123)
 1. SQL Binder: Support select with statement sql bind and add bind test case - [#34141](https://github.com/apache/shardingsphere/pull/34141)
+1. SQL Parser: Add  SQLStatementParserCacheHook to Provide Extension Point for Application SQL Parse  Cache Warm-up , Referred to as Preheat  - [#34155](https://github.com/apache/shardingsphere/issues/34155)
 
 ### Bug Fixes
 

--- a/infra/parser/src/main/java/org/apache/shardingsphere/infra/parser/cache/hook/SPISQLStatementParserCacheHook.java
+++ b/infra/parser/src/main/java/org/apache/shardingsphere/infra/parser/cache/hook/SPISQLStatementParserCacheHook.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.parser.cache.hook;
+
+import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
+
+import java.util.Collection;
+
+public class SPISQLStatementParserCacheHook implements SQLStatementParserCacheHook {
+    
+    private final Collection<SQLStatementParserCacheHook> sqlStatementParserCacheHooks = ShardingSphereServiceLoader.getServiceInstances(SQLStatementParserCacheHook.class);
+    
+    @Override
+    public void start(final String sql) {
+        for (SQLStatementParserCacheHook each : sqlStatementParserCacheHooks) {
+            each.start(sql);
+        }
+    }
+    
+    @Override
+    public void finishSuccess(final String sql, final SQLStatement sqlStatement) {
+        for (SQLStatementParserCacheHook each : sqlStatementParserCacheHooks) {
+            each.finishSuccess(sql, sqlStatement);
+        }
+    }
+    
+    @Override
+    public void finishFailure(final String sql, final Exception cause) {
+        for (SQLStatementParserCacheHook each : sqlStatementParserCacheHooks) {
+            each.finishFailure(sql, cause);
+        }
+    }
+}

--- a/infra/parser/src/main/java/org/apache/shardingsphere/infra/parser/cache/hook/SQLStatementParserCacheHook.java
+++ b/infra/parser/src/main/java/org/apache/shardingsphere/infra/parser/cache/hook/SQLStatementParserCacheHook.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.parser.cache.hook;
+
+import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
+
+/**
+ * SQL Statement Parser Cache hook.
+ */
+public interface SQLStatementParserCacheHook {
+    
+    /**
+     * Handle when parse started.
+     *
+     * @param sql SQL to be parsed
+     */
+    void start(String sql);
+    
+    /**
+     * Handle when parse finished success.
+     *
+     * @param sql          SQL to be parsed
+     * @param sqlStatement sql statement
+     */
+    void finishSuccess(String sql, SQLStatement sqlStatement);
+    
+    /**
+     * Handle when parse finished failure.
+     *
+     * @param sql   SQL to be parsed
+     * @param cause failure cause
+     */
+    void finishFailure(String sql, Exception cause);
+}

--- a/infra/parser/src/test/java/org/apache/shardingsphere/infra/parser/cache/hook/SPISQLStatementParserCacheHookTest.java
+++ b/infra/parser/src/test/java/org/apache/shardingsphere/infra/parser/cache/hook/SPISQLStatementParserCacheHookTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.parser.cache.hook;
+
+import org.apache.shardingsphere.sql.parser.statement.mysql.dml.MySQLSelectStatement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SPISQLStatementParserCacheHookTest {
+    
+    public static final String SQL = "SELECT 1";
+    
+    private SPISQLStatementParserCacheHook spisqlStatementParserCacheHook;
+    
+    @BeforeEach
+    void setUp() {
+        SQLStatementParserCacheHookFixture.clearActions();
+        spisqlStatementParserCacheHook = new SPISQLStatementParserCacheHook();
+    }
+    
+    @Test
+    void assertStart() {
+        spisqlStatementParserCacheHook.start(SQL);
+        assertTrue(SQLStatementParserCacheHookFixture.containsAction("start"));
+    }
+    
+    @Test
+    void assertFinishSuccess() {
+        spisqlStatementParserCacheHook.finishSuccess(SQL, new MySQLSelectStatement());
+        assertTrue(SQLStatementParserCacheHookFixture.containsAction("finishSuccess"));
+    }
+    
+    @Test
+    void assertFinishFailure() {
+        spisqlStatementParserCacheHook.finishFailure(SQL, new Exception());
+        assertTrue(SQLStatementParserCacheHookFixture.containsAction("finishFailure"));
+    }
+}

--- a/infra/parser/src/test/java/org/apache/shardingsphere/infra/parser/cache/hook/SQLStatementParserCacheHookFixture.java
+++ b/infra/parser/src/test/java/org/apache/shardingsphere/infra/parser/cache/hook/SQLStatementParserCacheHookFixture.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.parser.cache.hook;
+
+import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+public final class SQLStatementParserCacheHookFixture implements SQLStatementParserCacheHook {
+    
+    private static final Collection<String> ACTIONS = new LinkedList<>();
+    
+    @Override
+    public void start(final String sql) {
+        ACTIONS.add("start");
+    }
+    
+    @Override
+    public void finishSuccess(final String sql, final SQLStatement statement) {
+        ACTIONS.add("finishSuccess");
+    }
+    
+    @Override
+    public void finishFailure(final String sql, final Exception cause) {
+        ACTIONS.add("finishFailure");
+    }
+    
+    /**
+     * Contains action or not.
+     *
+     * @param action action
+     * @return contains action or not
+     */
+    public static boolean containsAction(final String action) {
+        return ACTIONS.contains(action);
+    }
+    
+    /**
+     * Clear actions.
+     */
+    public static void clearActions() {
+        ACTIONS.clear();
+    }
+}

--- a/infra/parser/src/test/resources/META-INF/services/org.apache.shardingsphere.infra.parser.cache.hook.SQLStatementParserCacheHook
+++ b/infra/parser/src/test/resources/META-INF/services/org.apache.shardingsphere.infra.parser.cache.hook.SQLStatementParserCacheHook
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.infra.parser.cache.hook.SQLStatementParserCacheHookFixture


### PR DESCRIPTION
Add  `SQLStatementParserCacheHook` to Provide Extension Point for Application SQL Parse  Cache Warm-up , Referred to as Preheat

Fixes #34155.

Changes proposed in this pull request:
  - Add  `SQLStatementParserCacheHook` to Provide Extension Point for Application SQL Parse  Cache Warm-up , Referred to as Preheat

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
