### PR TITLE
Refactor argument placeholder to support SPI

### DIFF
--- a/infra/argument/core/pom.xml
+++ b/infra/argument/core/pom.xml
@@ -20,34 +20,24 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
-        <artifactId>shardingsphere</artifactId>
+        <artifactId>shardingsphere-infra-argument</artifactId>
         <version>5.5.2-SNAPSHOT</version>
     </parent>
-    <artifactId>shardingsphere-infra</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>shardingsphere-infra-argument-core</artifactId>
     <name>${project.artifactId}</name>
     
-    <modules>
-        <module>spi</module>
-        <module>exception</module>
-        <module>database</module>
-        <module>data-source-pool</module>
-        <module>common</module>
-        <module>context</module>
-        <module>argument</module>
-        <module>url</module>
-        <module>algorithm</module>
-        <module>distsql-handler</module>
-        <module>parser</module>
-        <module>binder</module>
-        <module>checker</module>
-        <module>route</module>
-        <module>rewrite</module>
-        <module>merge</module>
-        <module>executor</module>
-        <module>session</module>
-        <module>expr</module>
-        <module>util</module>
-        <module>reachability-metadata</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-test-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/infra/argument/core/src/main/java/org/apache/shardingsphere/infra/argument/core/ShardingSpherePlaceholderLoader.java
+++ b/infra/argument/core/src/main/java/org/apache/shardingsphere/infra/argument/core/ShardingSpherePlaceholderLoader.java
@@ -15,12 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.url.core.arg;
+package org.apache.shardingsphere.infra.argument.core;
+
+import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPI;
 
 /**
- * URL argument placeholder type.
+ * ShardingSphere placeholder loader.
  */
-public enum URLArgumentPlaceholderType {
+@SingletonSPI
+public interface ShardingSpherePlaceholderLoader extends TypedSPI {
     
-    NONE, ENVIRONMENT, SYSTEM_PROPS
+    /**
+     * Render configuration argument.
+     *
+     * @param argName configuration content
+     * @return argument value
+     */
+    String getArgumentValue(String argName);
 }

--- a/infra/argument/pom.xml
+++ b/infra/argument/pom.xml
@@ -20,34 +20,14 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
-        <artifactId>shardingsphere</artifactId>
+        <artifactId>shardingsphere-infra</artifactId>
         <version>5.5.2-SNAPSHOT</version>
     </parent>
-    <artifactId>shardingsphere-infra</artifactId>
+    <artifactId>shardingsphere-infra-argument</artifactId>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
-    
     <modules>
-        <module>spi</module>
-        <module>exception</module>
-        <module>database</module>
-        <module>data-source-pool</module>
-        <module>common</module>
-        <module>context</module>
-        <module>argument</module>
-        <module>url</module>
-        <module>algorithm</module>
-        <module>distsql-handler</module>
-        <module>parser</module>
-        <module>binder</module>
-        <module>checker</module>
-        <module>route</module>
-        <module>rewrite</module>
-        <module>merge</module>
-        <module>executor</module>
-        <module>session</module>
-        <module>expr</module>
-        <module>util</module>
-        <module>reachability-metadata</module>
+        <module>core</module>
+        <module>type</module>
     </modules>
 </project>

--- a/infra/argument/type/environment-property/pom.xml
+++ b/infra/argument/type/environment-property/pom.xml
@@ -20,34 +20,17 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
-        <artifactId>shardingsphere</artifactId>
+        <artifactId>shardingsphere-infra-argument-type</artifactId>
         <version>5.5.2-SNAPSHOT</version>
     </parent>
-    <artifactId>shardingsphere-infra</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>shardingsphere-infra-argument-environment-property</artifactId>
     <name>${project.artifactId}</name>
     
-    <modules>
-        <module>spi</module>
-        <module>exception</module>
-        <module>database</module>
-        <module>data-source-pool</module>
-        <module>common</module>
-        <module>context</module>
-        <module>argument</module>
-        <module>url</module>
-        <module>algorithm</module>
-        <module>distsql-handler</module>
-        <module>parser</module>
-        <module>binder</module>
-        <module>checker</module>
-        <module>route</module>
-        <module>rewrite</module>
-        <module>merge</module>
-        <module>executor</module>
-        <module>session</module>
-        <module>expr</module>
-        <module>util</module>
-        <module>reachability-metadata</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-argument-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/infra/argument/type/environment-property/src/main/java/org/apache/shardingsphere/infra/argument/environment/property/EnvironmentPropertyPlaceholderLoader.java
+++ b/infra/argument/type/environment-property/src/main/java/org/apache/shardingsphere/infra/argument/environment/property/EnvironmentPropertyPlaceholderLoader.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
 public final class EnvironmentPropertyPlaceholderLoader implements ShardingSpherePlaceholderLoader {
     
     @Override
-    public String getArgumentValue(String argName) {
+    public String getArgumentValue(final String argName) {
         return System.getenv(argName);
     }
     

--- a/infra/argument/type/environment-property/src/main/java/org/apache/shardingsphere/infra/argument/environment/property/EnvironmentPropertyPlaceholderLoader.java
+++ b/infra/argument/type/environment-property/src/main/java/org/apache/shardingsphere/infra/argument/environment/property/EnvironmentPropertyPlaceholderLoader.java
@@ -15,28 +15,24 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.url.core.arg;
+package org.apache.shardingsphere.infra.argument.environment.property;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
-import java.util.Properties;
+import org.apache.shardingsphere.infra.argument.core.ShardingSpherePlaceholderLoader;
+import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
 
 /**
- * URL argument placeholder type factory.
+ * Environment property placeholder loader.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class URLArgumentPlaceholderTypeFactory {
+@SingletonSPI
+public final class EnvironmentPropertyPlaceholderLoader implements ShardingSpherePlaceholderLoader {
     
-    private static final String KEY = "placeholder-type";
+    @Override
+    public String getArgumentValue(String argName) {
+        return System.getenv(argName);
+    }
     
-    /**
-     * Get the value of placeholder type.
-     *
-     * @param queryProps query properties
-     * @return placeholder type
-     */
-    public static String valueOf(final Properties queryProps) {
-        return queryProps.getProperty(KEY, "none").toLowerCase();
+    @Override
+    public String getType() {
+        return "environment";
     }
 }

--- a/infra/argument/type/environment-property/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.argument.core.ShardingSpherePlaceholderLoader
+++ b/infra/argument/type/environment-property/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.argument.core.ShardingSpherePlaceholderLoader
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.infra.argument.environment.property.EnvironmentPropertyPlaceholderLoader

--- a/infra/argument/type/environment-property/src/test/java/org/apache/shardingsphere/infra/argument/environment/property/EnvironmentPropertyPlaceholderLoaderLoaderTest.java
+++ b/infra/argument/type/environment-property/src/test/java/org/apache/shardingsphere/infra/argument/environment/property/EnvironmentPropertyPlaceholderLoaderLoaderTest.java
@@ -15,28 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.url.core.arg;
+package org.apache.shardingsphere.infra.argument.environment.property;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
 
-import java.util.Properties;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * URL argument placeholder type factory.
- */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class URLArgumentPlaceholderTypeFactory {
+class EnvironmentPropertyPlaceholderLoaderLoaderTest {
     
-    private static final String KEY = "placeholder-type";
+    @Test
+    void assertGetArgumentValue() {
+        assertEquals(System.getenv("PATH"), new EnvironmentPropertyPlaceholderLoader().getArgumentValue("PATH"));
+    }
     
-    /**
-     * Get the value of placeholder type.
-     *
-     * @param queryProps query properties
-     * @return placeholder type
-     */
-    public static String valueOf(final Properties queryProps) {
-        return queryProps.getProperty(KEY, "none").toLowerCase();
+    @Test
+    void assertGetType() {
+        assertEquals("environment", new EnvironmentPropertyPlaceholderLoader().getType());
     }
 }

--- a/infra/argument/type/pom.xml
+++ b/infra/argument/type/pom.xml
@@ -20,34 +20,15 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
-        <artifactId>shardingsphere</artifactId>
+        <artifactId>shardingsphere-infra-argument</artifactId>
         <version>5.5.2-SNAPSHOT</version>
     </parent>
-    <artifactId>shardingsphere-infra</artifactId>
+    <artifactId>shardingsphere-infra-argument-type</artifactId>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     
     <modules>
-        <module>spi</module>
-        <module>exception</module>
-        <module>database</module>
-        <module>data-source-pool</module>
-        <module>common</module>
-        <module>context</module>
-        <module>argument</module>
-        <module>url</module>
-        <module>algorithm</module>
-        <module>distsql-handler</module>
-        <module>parser</module>
-        <module>binder</module>
-        <module>checker</module>
-        <module>route</module>
-        <module>rewrite</module>
-        <module>merge</module>
-        <module>executor</module>
-        <module>session</module>
-        <module>expr</module>
-        <module>util</module>
-        <module>reachability-metadata</module>
+        <module>environment-property</module>
+        <module>system-property</module>
     </modules>
 </project>

--- a/infra/argument/type/system-property/pom.xml
+++ b/infra/argument/type/system-property/pom.xml
@@ -20,34 +20,17 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
-        <artifactId>shardingsphere</artifactId>
+        <artifactId>shardingsphere-infra-argument-type</artifactId>
         <version>5.5.2-SNAPSHOT</version>
     </parent>
-    <artifactId>shardingsphere-infra</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>shardingsphere-infra-argument-system-property</artifactId>
     <name>${project.artifactId}</name>
     
-    <modules>
-        <module>spi</module>
-        <module>exception</module>
-        <module>database</module>
-        <module>data-source-pool</module>
-        <module>common</module>
-        <module>context</module>
-        <module>argument</module>
-        <module>url</module>
-        <module>algorithm</module>
-        <module>distsql-handler</module>
-        <module>parser</module>
-        <module>binder</module>
-        <module>checker</module>
-        <module>route</module>
-        <module>rewrite</module>
-        <module>merge</module>
-        <module>executor</module>
-        <module>session</module>
-        <module>expr</module>
-        <module>util</module>
-        <module>reachability-metadata</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-argument-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/infra/argument/type/system-property/src/main/java/org/apache/shardingsphere/infra/argument/system/property/SystemPropertyPlaceholderLoader.java
+++ b/infra/argument/type/system-property/src/main/java/org/apache/shardingsphere/infra/argument/system/property/SystemPropertyPlaceholderLoader.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
 public final class SystemPropertyPlaceholderLoader implements ShardingSpherePlaceholderLoader {
     
     @Override
-    public String getArgumentValue(String argName) {
+    public String getArgumentValue(final String argName) {
         return System.getProperty(argName);
     }
     

--- a/infra/argument/type/system-property/src/main/java/org/apache/shardingsphere/infra/argument/system/property/SystemPropertyPlaceholderLoader.java
+++ b/infra/argument/type/system-property/src/main/java/org/apache/shardingsphere/infra/argument/system/property/SystemPropertyPlaceholderLoader.java
@@ -15,28 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.url.core.arg;
+package org.apache.shardingsphere.infra.argument.system.property;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
-import java.util.Properties;
+import org.apache.shardingsphere.infra.argument.core.ShardingSpherePlaceholderLoader;
+import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
 
 /**
- * URL argument placeholder type factory.
+ * System property placeholder loader.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class URLArgumentPlaceholderTypeFactory {
+@SingletonSPI
+public final class SystemPropertyPlaceholderLoader implements ShardingSpherePlaceholderLoader {
     
-    private static final String KEY = "placeholder-type";
-    
-    /**
-     * Get the value of placeholder type.
-     *
-     * @param queryProps query properties
-     * @return placeholder type
-     */
-    public static String valueOf(final Properties queryProps) {
-        return queryProps.getProperty(KEY, "none").toLowerCase();
+    @Override
+    public String getArgumentValue(String argName) {
+        return System.getProperty(argName);
     }
+    
+    @Override
+    public String getType() {
+        return "system_props";
+    }
+    
 }

--- a/infra/argument/type/system-property/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.argument.core.ShardingSpherePlaceholderLoader
+++ b/infra/argument/type/system-property/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.argument.core.ShardingSpherePlaceholderLoader
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.infra.argument.system.property.SystemPropertyPlaceholderLoader

--- a/infra/argument/type/system-property/src/test/java/org/apache/shardingsphere/infra/argument/system/property/SystemPropertyPlaceholderLoaderTest.java
+++ b/infra/argument/type/system-property/src/test/java/org/apache/shardingsphere/infra/argument/system/property/SystemPropertyPlaceholderLoaderTest.java
@@ -15,28 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.url.core.arg;
+package org.apache.shardingsphere.infra.argument.system.property;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
 
-import java.util.Properties;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * URL argument placeholder type factory.
- */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class URLArgumentPlaceholderTypeFactory {
+class SystemPropertyPlaceholderLoaderTest {
     
-    private static final String KEY = "placeholder-type";
+    @Test
+    void assertGetArgumentValue() {
+        System.setProperty("test", "value");
+        assertEquals("value", new SystemPropertyPlaceholderLoader().getArgumentValue("test"));
+        System.clearProperty("test");
+    }
     
-    /**
-     * Get the value of placeholder type.
-     *
-     * @param queryProps query properties
-     * @return placeholder type
-     */
-    public static String valueOf(final Properties queryProps) {
-        return queryProps.getProperty(KEY, "none").toLowerCase();
+    @Test
+    void assertGetType() {
+        assertEquals("system_props", new SystemPropertyPlaceholderLoader().getType());
     }
 }

--- a/infra/url/core/pom.xml
+++ b/infra/url/core/pom.xml
@@ -32,7 +32,21 @@
             <artifactId>shardingsphere-infra-url-spi</artifactId>
             <version>${project.version}</version>
         </dependency>
-        
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-argument-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-argument-environment-property</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-argument-system-property</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-test-util</artifactId>

--- a/infra/url/core/src/main/java/org/apache/shardingsphere/infra/url/core/ShardingSphereURLLoadEngine.java
+++ b/infra/url/core/src/main/java/org/apache/shardingsphere/infra/url/core/ShardingSphereURLLoadEngine.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.infra.url.core;
 
 import org.apache.shardingsphere.infra.url.core.arg.URLArgumentLineRender;
-import org.apache.shardingsphere.infra.url.core.arg.URLArgumentPlaceholderTypeFactory;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.infra.url.spi.ShardingSphereURLLoader;
 
@@ -46,6 +45,6 @@ public final class ShardingSphereURLLoadEngine {
      */
     public byte[] loadContent() {
         Collection<String> lines = Arrays.asList(urlLoader.load(url.getConfigurationSubject(), url.getQueryProps()).split(System.lineSeparator()));
-        return URLArgumentLineRender.render(lines, URLArgumentPlaceholderTypeFactory.valueOf(url.getQueryProps()));
+        return URLArgumentLineRender.render(lines, url.getQueryProps());
     }
 }

--- a/infra/url/core/src/main/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLine.java
+++ b/infra/url/core/src/main/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLine.java
@@ -20,6 +20,8 @@ package org.apache.shardingsphere.infra.url.core.arg;
 import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.argument.core.ShardingSpherePlaceholderLoader;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -55,7 +57,7 @@ public final class URLArgumentLine {
      * @param type placeholder type
      * @return replaced argument
      */
-    public String replaceArgument(final URLArgumentPlaceholderType type) {
+    public String replaceArgument(final String type) {
         placeholderMatcher.reset();
         StringBuffer result = new StringBuffer();
         while (placeholderMatcher.find()) {
@@ -78,13 +80,11 @@ public final class URLArgumentLine {
         return buffer.toString();
     }
     
-    private String getArgumentValue(final String argName, final URLArgumentPlaceholderType type) {
-        if (URLArgumentPlaceholderType.ENVIRONMENT == type) {
-            return System.getenv(argName);
+    private String getArgumentValue(final String argName, final String type) {
+        if (Strings.isNullOrEmpty(type) || "none".equalsIgnoreCase(type)) {
+            return null;
         }
-        if (URLArgumentPlaceholderType.SYSTEM_PROPS == type) {
-            return System.getProperty(argName);
-        }
-        return null;
+        ShardingSpherePlaceholderLoader shardingSpherePlaceholderLoader = TypedSPILoader.getService(ShardingSpherePlaceholderLoader.class, type);
+        return shardingSpherePlaceholderLoader.getArgumentValue(argName);
     }
 }

--- a/infra/url/core/src/main/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLine.java
+++ b/infra/url/core/src/main/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLine.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.infra.argument.core.ShardingSpherePlaceholderLo
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 
 import java.util.Optional;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -37,18 +38,21 @@ public final class URLArgumentLine {
     
     private final Matcher placeholderMatcher;
     
+    private final Properties props;
+    
     /**
      * Parse URL argument line.
      *
      * @param line line
+     * @param props properties
      * @return parsed URL argument line
      */
-    public static Optional<URLArgumentLine> parse(final String line) {
+    public static Optional<URLArgumentLine> parse(final String line, final Properties props) {
         Matcher matcher = PLACEHOLDER_PATTERN.matcher(line);
         if (!matcher.find()) {
             return Optional.empty();
         }
-        return Optional.of(new URLArgumentLine(matcher));
+        return Optional.of(new URLArgumentLine(matcher, props));
     }
     
     /**
@@ -84,7 +88,7 @@ public final class URLArgumentLine {
         if (Strings.isNullOrEmpty(type) || "none".equalsIgnoreCase(type)) {
             return null;
         }
-        ShardingSpherePlaceholderLoader shardingSpherePlaceholderLoader = TypedSPILoader.getService(ShardingSpherePlaceholderLoader.class, type);
+        ShardingSpherePlaceholderLoader shardingSpherePlaceholderLoader = TypedSPILoader.getService(ShardingSpherePlaceholderLoader.class, type, props);
         return shardingSpherePlaceholderLoader.getArgumentValue(argName);
     }
 }

--- a/infra/url/core/src/main/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLineRender.java
+++ b/infra/url/core/src/main/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLineRender.java
@@ -37,10 +37,10 @@ public final class URLArgumentLineRender {
      * @param placeholderType configuration content placeholder type
      * @return rendered content
      */
-    public static byte[] render(final Collection<String> lines, final URLArgumentPlaceholderType placeholderType) {
+    public static byte[] render(final Collection<String> lines, final String placeholderType) {
         StringBuilder result = new StringBuilder();
         for (String each : lines) {
-            Optional<URLArgumentLine> argLine = URLArgumentPlaceholderType.NONE == placeholderType ? Optional.empty() : URLArgumentLine.parse(each);
+            Optional<URLArgumentLine> argLine = "none".equalsIgnoreCase(placeholderType) ? Optional.empty() : URLArgumentLine.parse(each);
             result.append(argLine.map(optional -> optional.replaceArgument(placeholderType)).orElse(each)).append(System.lineSeparator());
         }
         return result.toString().getBytes(StandardCharsets.UTF_8);

--- a/infra/url/core/src/main/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLineRender.java
+++ b/infra/url/core/src/main/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLineRender.java
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Properties;
 
 /**
  * URL argument line render.
@@ -34,13 +35,14 @@ public final class URLArgumentLineRender {
      * Render argument.
      *
      * @param lines lines to be rendered
-     * @param placeholderType configuration content placeholder type
+     * @param props properties
      * @return rendered content
      */
-    public static byte[] render(final Collection<String> lines, final String placeholderType) {
+    public static byte[] render(final Collection<String> lines, final Properties props) {
+        String placeholderType = URLArgumentPlaceholderTypeFactory.valueOf(props);
         StringBuilder result = new StringBuilder();
         for (String each : lines) {
-            Optional<URLArgumentLine> argLine = "none".equalsIgnoreCase(placeholderType) ? Optional.empty() : URLArgumentLine.parse(each);
+            Optional<URLArgumentLine> argLine = "none".equalsIgnoreCase(placeholderType) ? Optional.empty() : URLArgumentLine.parse(each, props);
             result.append(argLine.map(optional -> optional.replaceArgument(placeholderType)).orElse(each)).append(System.lineSeparator());
         }
         return result.toString().getBytes(StandardCharsets.UTF_8);

--- a/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLineRenderTest.java
+++ b/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLineRenderTest.java
@@ -52,19 +52,19 @@ class URLArgumentLineRenderTest {
     
     @Test
     void assertReadWithNonePlaceholder() throws IOException, URISyntaxException {
-        byte[] actual = readContent("config/to-be-replaced-fixture.yaml", URLArgumentPlaceholderType.NONE);
-        byte[] expected = readContent("config/to-be-replaced-fixture.yaml", URLArgumentPlaceholderType.NONE);
+        byte[] actual = readContent("config/to-be-replaced-fixture.yaml", "none");
+        byte[] expected = readContent("config/to-be-replaced-fixture.yaml", "none");
         assertThat(new String(actual), is(new String(expected)));
     }
     
     @Test
     void assertReadWithSystemPropertiesPlaceholder() throws IOException, URISyntaxException {
-        byte[] actual = readContent("config/to-be-replaced-fixture.yaml", URLArgumentPlaceholderType.SYSTEM_PROPS);
-        byte[] expected = readContent("config/replaced-fixture.yaml", URLArgumentPlaceholderType.SYSTEM_PROPS);
+        byte[] actual = readContent("config/to-be-replaced-fixture.yaml", "system_props");
+        byte[] expected = readContent("config/replaced-fixture.yaml", "system_props");
         assertThat(new String(actual), is(new String(expected)));
     }
     
-    private byte[] readContent(final String name, final URLArgumentPlaceholderType placeholderType) throws IOException, URISyntaxException {
+    private byte[] readContent(final String name, final String placeholderType) throws IOException, URISyntaxException {
         File file = new File(Objects.requireNonNull(Thread.currentThread().getContextClassLoader().getResource(name)).toURI().getPath());
         return URLArgumentLineRender.render(Files.readAllLines(file.toPath(), StandardCharsets.UTF_8).stream().filter(each -> !each.startsWith("#")).collect(Collectors.toList()), placeholderType);
     }

--- a/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLineRenderTest.java
+++ b/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLineRenderTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.infra.url.core.arg;
 
+import org.apache.shardingsphere.test.util.PropertiesBuilder;
+import org.apache.shardingsphere.test.util.PropertiesBuilder.Property;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -27,6 +29,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -52,20 +55,20 @@ class URLArgumentLineRenderTest {
     
     @Test
     void assertReadWithNonePlaceholder() throws IOException, URISyntaxException {
-        byte[] actual = readContent("config/to-be-replaced-fixture.yaml", "none");
-        byte[] expected = readContent("config/to-be-replaced-fixture.yaml", "none");
+        byte[] actual = readContent("config/to-be-replaced-fixture.yaml", PropertiesBuilder.build(new Property("placeholder-type", "none")));
+        byte[] expected = readContent("config/to-be-replaced-fixture.yaml", PropertiesBuilder.build(new Property("placeholder-type", "none")));
         assertThat(new String(actual), is(new String(expected)));
     }
     
     @Test
     void assertReadWithSystemPropertiesPlaceholder() throws IOException, URISyntaxException {
-        byte[] actual = readContent("config/to-be-replaced-fixture.yaml", "system_props");
-        byte[] expected = readContent("config/replaced-fixture.yaml", "system_props");
+        byte[] actual = readContent("config/to-be-replaced-fixture.yaml", PropertiesBuilder.build(new Property("placeholder-type", "system_props")));
+        byte[] expected = readContent("config/replaced-fixture.yaml", PropertiesBuilder.build(new Property("placeholder-type", "system_props")));
         assertThat(new String(actual), is(new String(expected)));
     }
     
-    private byte[] readContent(final String name, final String placeholderType) throws IOException, URISyntaxException {
+    private byte[] readContent(final String name, final Properties prop) throws IOException, URISyntaxException {
         File file = new File(Objects.requireNonNull(Thread.currentThread().getContextClassLoader().getResource(name)).toURI().getPath());
-        return URLArgumentLineRender.render(Files.readAllLines(file.toPath(), StandardCharsets.UTF_8).stream().filter(each -> !each.startsWith("#")).collect(Collectors.toList()), placeholderType);
+        return URLArgumentLineRender.render(Files.readAllLines(file.toPath(), StandardCharsets.UTF_8).stream().filter(each -> !each.startsWith("#")).collect(Collectors.toList()), prop);
     }
 }

--- a/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLineTest.java
+++ b/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLineTest.java
@@ -47,9 +47,9 @@ class URLArgumentLineTest {
         assertTrue(argLine.isPresent());
         assertTrue(argLineMultiple1.isPresent());
         assertTrue(argLineMultiple2.isPresent());
-        assertThat(argLine.get().replaceArgument(URLArgumentPlaceholderType.NONE), is("key=default_value"));
-        assertThat(argLineMultiple1.get().replaceArgument(URLArgumentPlaceholderType.NONE), is("key1=default_value1:key2=default_value2:tail"));
-        assertThat(argLineMultiple2.get().replaceArgument(URLArgumentPlaceholderType.NONE), is("key1=:key2=:tail"));
+        assertThat(argLine.get().replaceArgument("none"), is("key=default_value"));
+        assertThat(argLineMultiple1.get().replaceArgument("none"), is("key1=default_value1:key2=default_value2:tail"));
+        assertThat(argLineMultiple2.get().replaceArgument("none"), is("key1=:key2=:tail"));
     }
     
     @Test
@@ -60,9 +60,9 @@ class URLArgumentLineTest {
         assertTrue(argLine.isPresent());
         assertTrue(argLineMultiple1.isPresent());
         assertTrue(argLineMultiple2.isPresent());
-        assertThat(argLine.get().replaceArgument(URLArgumentPlaceholderType.ENVIRONMENT), is("key=default_value"));
-        assertThat(argLineMultiple1.get().replaceArgument(URLArgumentPlaceholderType.ENVIRONMENT), is("key1=default_value1:key2=default_value2:tail"));
-        assertThat(argLineMultiple2.get().replaceArgument(URLArgumentPlaceholderType.ENVIRONMENT), is("key1=:key2=:tail"));
+        assertThat(argLine.get().replaceArgument("environment"), is("key=default_value"));
+        assertThat(argLineMultiple1.get().replaceArgument("environment"), is("key1=default_value1:key2=default_value2:tail"));
+        assertThat(argLineMultiple2.get().replaceArgument("environment"), is("key1=:key2=:tail"));
     }
     
     @Test
@@ -76,8 +76,8 @@ class URLArgumentLineTest {
         assertTrue(argLine.isPresent());
         assertTrue(argLineMultiple1.isPresent());
         assertTrue(argLineMultiple2.isPresent());
-        assertThat(argLine.get().replaceArgument(URLArgumentPlaceholderType.SYSTEM_PROPS), is("key=props_value"));
-        assertThat(argLineMultiple1.get().replaceArgument(URLArgumentPlaceholderType.SYSTEM_PROPS), is("key1=props_value1:key2=props_value2:tail"));
-        assertThat(argLineMultiple2.get().replaceArgument(URLArgumentPlaceholderType.SYSTEM_PROPS), is("key1=props_value1:key2=props_value2:tail"));
+        assertThat(argLine.get().replaceArgument("system_props"), is("key=props_value"));
+        assertThat(argLineMultiple1.get().replaceArgument("system_props"), is("key1=props_value1:key2=props_value2:tail"));
+        assertThat(argLineMultiple2.get().replaceArgument("system_props"), is("key1=props_value1:key2=props_value2:tail"));
     }
 }

--- a/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLineTest.java
+++ b/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentLineTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.url.core.arg;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,14 +37,14 @@ class URLArgumentLineTest {
     
     @Test
     void assertParseWithInvalidPattern() {
-        assertFalse(URLArgumentLine.parse("invalid").isPresent());
+        assertFalse(URLArgumentLine.parse("invalid", new Properties()).isPresent());
     }
     
     @Test
     void assertReplaceArgumentWithNone() {
-        Optional<URLArgumentLine> argLine = URLArgumentLine.parse(line);
-        Optional<URLArgumentLine> argLineMultiple1 = URLArgumentLine.parse(lineMultiple1);
-        Optional<URLArgumentLine> argLineMultiple2 = URLArgumentLine.parse(lineMultiple2);
+        Optional<URLArgumentLine> argLine = URLArgumentLine.parse(line, new Properties());
+        Optional<URLArgumentLine> argLineMultiple1 = URLArgumentLine.parse(lineMultiple1, new Properties());
+        Optional<URLArgumentLine> argLineMultiple2 = URLArgumentLine.parse(lineMultiple2, new Properties());
         assertTrue(argLine.isPresent());
         assertTrue(argLineMultiple1.isPresent());
         assertTrue(argLineMultiple2.isPresent());
@@ -54,9 +55,9 @@ class URLArgumentLineTest {
     
     @Test
     void assertReplaceArgumentWithEnvironment() {
-        Optional<URLArgumentLine> argLine = URLArgumentLine.parse(line);
-        Optional<URLArgumentLine> argLineMultiple1 = URLArgumentLine.parse(lineMultiple1);
-        Optional<URLArgumentLine> argLineMultiple2 = URLArgumentLine.parse(lineMultiple2);
+        Optional<URLArgumentLine> argLine = URLArgumentLine.parse(line, new Properties());
+        Optional<URLArgumentLine> argLineMultiple1 = URLArgumentLine.parse(lineMultiple1, new Properties());
+        Optional<URLArgumentLine> argLineMultiple2 = URLArgumentLine.parse(lineMultiple2, new Properties());
         assertTrue(argLine.isPresent());
         assertTrue(argLineMultiple1.isPresent());
         assertTrue(argLineMultiple2.isPresent());
@@ -70,9 +71,9 @@ class URLArgumentLineTest {
         System.setProperty("value", "props_value");
         System.setProperty("value1", "props_value1");
         System.setProperty("value2", "props_value2");
-        Optional<URLArgumentLine> argLine = URLArgumentLine.parse(line);
-        Optional<URLArgumentLine> argLineMultiple1 = URLArgumentLine.parse(lineMultiple1);
-        Optional<URLArgumentLine> argLineMultiple2 = URLArgumentLine.parse(lineMultiple2);
+        Optional<URLArgumentLine> argLine = URLArgumentLine.parse(line, new Properties());
+        Optional<URLArgumentLine> argLineMultiple1 = URLArgumentLine.parse(lineMultiple1, new Properties());
+        Optional<URLArgumentLine> argLineMultiple2 = URLArgumentLine.parse(lineMultiple2, new Properties());
         assertTrue(argLine.isPresent());
         assertTrue(argLineMultiple1.isPresent());
         assertTrue(argLineMultiple2.isPresent());

--- a/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentPlaceholderTypeFactoryTest.java
+++ b/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentPlaceholderTypeFactoryTest.java
@@ -25,7 +25,6 @@ import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
 class URLArgumentPlaceholderTypeFactoryTest {
     
     @Test

--- a/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentPlaceholderTypeFactoryTest.java
+++ b/infra/url/core/src/test/java/org/apache/shardingsphere/infra/url/core/arg/URLArgumentPlaceholderTypeFactoryTest.java
@@ -23,23 +23,18 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 class URLArgumentPlaceholderTypeFactoryTest {
     
     @Test
     void assertValueOfWithValidQueryProperties() {
-        assertThat(URLArgumentPlaceholderTypeFactory.valueOf(PropertiesBuilder.build(new Property("placeholder-type", "environment"))), is(URLArgumentPlaceholderType.ENVIRONMENT));
-    }
-    
-    @Test
-    void assertValueOfWithInvalidQueryProperties() {
-        assertThat(URLArgumentPlaceholderTypeFactory.valueOf(PropertiesBuilder.build(new Property("placeholder-type", "invalid"))), is(URLArgumentPlaceholderType.NONE));
+        assertEquals("environment", URLArgumentPlaceholderTypeFactory.valueOf(PropertiesBuilder.build(new Property("placeholder-type", "environment"))));
     }
     
     @Test
     void assertValueOfWithEmptyQueryProperties() {
-        assertThat(URLArgumentPlaceholderTypeFactory.valueOf(new Properties()), is(URLArgumentPlaceholderType.NONE));
+        assertEquals("none", URLArgumentPlaceholderTypeFactory.valueOf(new Properties()));
     }
 }


### PR DESCRIPTION
In some cloud compliance scenarios, using environment properties or system properties to manage secrets is not allowed. Instead, we need to use approved property sources to handle these sensitive values.

To meet this requirement, I refactored the argument placeholder so it can support reading from other property sources through a plugin module. This ensures compliance with the rules.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
