### PR TITLE
Unique actual data nodes issue in sharding rule checker

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/checker/ShardingRuleChecker.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/checker/ShardingRuleChecker.java
@@ -191,8 +191,8 @@ public class ShardingRuleChecker {
             if (isAlteration && toBeAddedDataNodes.containsKey(key)) {
                 return;
             }
-            checkUniqueActualDataNodes(uniqueActualDataNodes, key, value.getActualDataNodes().iterator().next());
+            value.getActualDataNodes().forEach(each -> checkUniqueActualDataNodes(uniqueActualDataNodes, key, each));
         });
-        toBeAddedDataNodes.forEach((key, value) -> checkUniqueActualDataNodes(uniqueActualDataNodes, key, value.iterator().next()));
+        toBeAddedDataNodes.forEach((key, value) -> value.forEach(each -> checkUniqueActualDataNodes(uniqueActualDataNodes, key, each)));
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/checker/ShardingRuleChecker.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/checker/ShardingRuleChecker.java
@@ -64,7 +64,7 @@ public class ShardingRuleChecker {
     
     private void checkUniqueActualDataNodesInTableRules() {
         Collection<DataNode> uniqueActualDataNodes = new HashSet<>(shardingRule.getShardingTables().size(), 1F);
-        shardingRule.getShardingTables().forEach((key, value) -> checkUniqueActualDataNodes(uniqueActualDataNodes, key, value.getActualDataNodes().iterator().next()));
+        shardingRule.getShardingTables().forEach((key, value) -> value.getActualDataNodes().forEach(each -> checkUniqueActualDataNodes(uniqueActualDataNodes, key, each)));
     }
     
     private void checkUniqueActualDataNodes(final Collection<DataNode> uniqueActualDataNodes, final String logicTable, final DataNode sampleActualDataNode) {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
-

In ShardingRuleChecker, while performing the check for Unique Actual Data Nodes, the initial check was performed for the first actualDataNode in the ShardingTable. Now, it has been changed to perform the check for every actualDataNode

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
