### PR TITLE
Fix transaction deadlock assertion in different mysql versions

### DIFF
--- a/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/cases/deadlock/TransactionDeadlockTestCase.java
+++ b/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/cases/deadlock/TransactionDeadlockTestCase.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**

--- a/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/cases/deadlock/TransactionDeadlockTestCase.java
+++ b/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/cases/deadlock/TransactionDeadlockTestCase.java
@@ -79,7 +79,7 @@ public final class TransactionDeadlockTestCase extends BaseTransactionTestCase {
                 // CHECKSTYLE:OFF
             } catch (final Exception ex) {
                 // CHECKSTYLE:ON
-                assertThat(ex.getMessage(), is("com.mysql.cj.jdbc.exceptions.MySQLTransactionRollbackException: Lock wait timeout exceeded; try restarting transaction"));
+                assertThat(ex.getMessage(), containsString("Lock wait timeout exceeded; try restarting transaction"));
             }
         }
         log.info("The deadlock test case execution time is: {}", System.currentTimeMillis() - startTime);


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
