### PR TITLE
Fix the Flaky Test related to ClickHouse in NativeTest under GraalVM Native Image

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.cn.md
@@ -322,6 +322,8 @@ Args=--initialize-at-run-time=\
     io.grpc.netty.shaded.io.netty.util.AttributeKey
 ```
 
+ShardingSphere 的单元测试仅使用 Maven 模块 `io.github.linghengqian:hive-server2-jdbc-driver-thin` 来在 GraalVM Native Image 下验证可用性。
+
 8. 由于 https://github.com/oracle/graal/issues/7979 的影响，
 对应 `com.oracle.database.jdbc:ojdbc8` Maven 模块的 Oracle JDBC Driver 无法在 GraalVM Native Image 下使用。
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.en.md
@@ -336,6 +336,8 @@ Args=--initialize-at-run-time=\
     io.grpc.netty.shaded.io.netty.util.AttributeKey
 ```
 
+ShardingSphere's unit test only uses the Maven module `io.github.linghengqian:hive-server2-jdbc-driver-thin` to verify the availability under GraalVM Native Image.
+
 8. Due to https://github.com/oracle/graal/issues/7979 , 
 the Oracle JDBC Driver corresponding to the `com.oracle.database.jdbc:ojdbc8` Maven module cannot be used under GraalVM Native Image.
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/unsupported/p6spy/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/unsupported/p6spy/_index.cn.md
@@ -143,7 +143,7 @@ public class ExampleUtils {
              Statement statement = connection.createStatement()) {
             statement.execute("INSERT INTO t_order (user_id, order_type, address_id, status) VALUES (1, 1, 1, 'INSERT_TEST')");
             statement.executeQuery("SELECT * FROM t_order");
-            statement.execute("alter table t_order delete where order_id=1");
+            statement.execute("DELETE FROM t_order WHERE order_id=1");
         }
     }
 }

--- a/docs/document/content/user-manual/shardingsphere-jdbc/unsupported/p6spy/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/unsupported/p6spy/_index.en.md
@@ -145,7 +145,7 @@ public class ExampleUtils {
              Statement statement = connection.createStatement()) {
             statement.execute("INSERT INTO t_order (user_id, order_type, address_id, status) VALUES (1, 1, 1, 'INSERT_TEST')");
             statement.executeQuery("SELECT * FROM t_order");
-            statement.execute("alter table t_order delete where order_id=1");
+            statement.execute("DELETE FROM t_order WHERE order_id=1");
         }
     }
 }

--- a/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/seata-at/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/seata-at/_index.cn.md
@@ -40,7 +40,7 @@ sdk install java 23-open
 sdk use java 23-open
 sdk install maven 3.9.9
 sdk use maven 3.9.9
-mvn clean dependency:get -Dartifact=org.apache.seata:seata-all:2.2.0
+mvn dependency:get -Dartifact=org.apache.seata:seata-all:2.2.0
 mvn -f ~/.m2/repository/org/apache/seata/seata-all/2.2.0/seata-all-2.2.0.pom dependency:tree | grep -v ':provided' | grep -v ':runtime'
 ```
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/seata-at/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/seata-at/_index.en.md
@@ -41,7 +41,7 @@ sdk install java 23-open
 sdk use java 23-open
 sdk install maven 3.9.9
 sdk use maven 3.9.9
-mvn clean dependency:get -Dartifact=org.apache.seata:seata-all:2.2.0
+mvn dependency:get -Dartifact=org.apache.seata:seata-all:2.2.0
 mvn -f ~/.m2/repository/org/apache/seata/seata-all/2.2.0/seata-all-2.2.0.pom dependency:tree | grep -v ':provided' | grep -v ':runtime'
 ```
 

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
@@ -4,10 +4,6 @@
   "name":"JdkLogger"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.executor.kernel.ExecutorEngine"},
-  "name":"JdkLogger"
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.standalone.jdbc.sql.JDBCRepositorySQLLoader"},
   "name":"[Lcom.fasterxml.jackson.databind.deser.BeanDeserializerModifier;"
 },
@@ -28,7 +24,7 @@
   "name":"[Lcom.github.dockerjava.api.model.VolumesFrom;"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager$$Lambda/0x00007fe4e3e13858"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager$$Lambda/0x00007f8e2be1b4b0"},
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
@@ -72,15 +68,15 @@
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.service.version.MetaDataVersionPersistService"},
-  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.manager.SchemaMetaDataManager"},
+  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.service.version.MetaDataVersionPersistService"},
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
@@ -357,6 +353,11 @@
   "allDeclaredFields":true
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
+  "name":"java.lang.Object",
+  "allDeclaredFields":true
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
   "name":"java.lang.Object",
   "allDeclaredFields":true
@@ -373,11 +374,6 @@
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.service.metadata.table.TableRowDataPersistService"},
-  "name":"java.lang.Object",
-  "allDeclaredFields":true
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
   "name":"java.lang.Object",
   "allDeclaredFields":true
 },
@@ -958,12 +954,12 @@
   "name":"org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
   "allDeclaredFields":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
   "name":"org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
   "allDeclaredFields":true
 },
@@ -1345,13 +1341,13 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setProps","parameterTypes":["java.util.Properties"] }, {"name":"setType","parameterTypes":["java.lang.String"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
   "allDeclaredFields":true,
   "methods":[{"name":"getProps","parameterTypes":[] }, {"name":"getType","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
   "name":"org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
   "allDeclaredFields":true,
   "methods":[{"name":"getProps","parameterTypes":[] }, {"name":"getType","parameterTypes":[] }]
@@ -1694,6 +1690,11 @@
   "name":"org.apache.shardingsphere.infra.instance.metadata.proxy.ProxyInstanceMetaDataBuilder"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.ComputeNodeOnlineHandler"},
+  "name":"org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeData",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.persist.service.unified.ComputeNodePersistService"},
   "name":"org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeData",
   "allDeclaredFields":true,
@@ -1821,7 +1822,7 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setCaseSensitive","parameterTypes":["boolean"] }, {"name":"setDataType","parameterTypes":["int"] }, {"name":"setGenerated","parameterTypes":["boolean"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setPrimaryKey","parameterTypes":["boolean"] }, {"name":"setUnsigned","parameterTypes":["boolean"] }, {"name":"setVisible","parameterTypes":["boolean"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn",
   "methods":[{"name":"setNullable","parameterTypes":["boolean"] }]
 },
@@ -1851,7 +1852,7 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setName","parameterTypes":["java.lang.String"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
   "methods":[{"name":"setColumns","parameterTypes":["java.util.Collection"] }, {"name":"setUnique","parameterTypes":["boolean"] }]
 },
@@ -1881,7 +1882,7 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setColumns","parameterTypes":["java.util.Map"] }, {"name":"setIndexes","parameterTypes":["java.util.Map"] }, {"name":"setName","parameterTypes":["java.lang.String"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
   "methods":[{"name":"setType","parameterTypes":["org.apache.shardingsphere.infra.database.core.metadata.database.enums.TableType"] }]
 },
@@ -2452,12 +2453,12 @@
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.eventbus.EventBusContext"},
-  "name":"org.apache.shardingsphere.readwritesplitting.cluster.ReadwriteSplittingQualifiedDataSourceDeletedSubscriber",
+  "name":"org.apache.shardingsphere.readwritesplitting.deliver.ReadwriteSplittingQualifiedDataSourceChangedSubscriber",
   "queryAllDeclaredMethods":true
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"},
-  "name":"org.apache.shardingsphere.readwritesplitting.cluster.ReadwriteSplittingQualifiedDataSourceDeletedSubscriber"
+  "name":"org.apache.shardingsphere.readwritesplitting.deliver.ReadwriteSplittingQualifiedDataSourceChangedSubscriber"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"},
@@ -2994,12 +2995,12 @@
   "name":"org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
   "allDeclaredFields":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
   "allDeclaredFields":true
 },
@@ -3030,13 +3031,13 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setActualDataNodes","parameterTypes":["java.lang.String"] }, {"name":"setKeyGenerateStrategy","parameterTypes":["org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
   "allDeclaredFields":true,
   "methods":[{"name":"getActualDataNodes","parameterTypes":[] }, {"name":"getAuditStrategy","parameterTypes":[] }, {"name":"getDatabaseStrategy","parameterTypes":[] }, {"name":"getKeyGenerateStrategy","parameterTypes":[] }, {"name":"getLogicTable","parameterTypes":[] }, {"name":"getTableStrategy","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
   "allDeclaredFields":true,
   "methods":[{"name":"getActualDataNodes","parameterTypes":[] }, {"name":"getAuditStrategy","parameterTypes":[] }, {"name":"getDatabaseStrategy","parameterTypes":[] }, {"name":"getKeyGenerateStrategy","parameterTypes":[] }, {"name":"getLogicTable","parameterTypes":[] }, {"name":"getTableStrategy","parameterTypes":[] }]
@@ -3100,13 +3101,13 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setStandard","parameterTypes":["org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
   "allDeclaredFields":true,
   "methods":[{"name":"getComplex","parameterTypes":[] }, {"name":"getHint","parameterTypes":[] }, {"name":"getNone","parameterTypes":[] }, {"name":"getStandard","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
   "name":"org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
   "allDeclaredFields":true,
   "methods":[{"name":"getComplex","parameterTypes":[] }, {"name":"getHint","parameterTypes":[] }, {"name":"getNone","parameterTypes":[] }, {"name":"getStandard","parameterTypes":[] }]
@@ -3222,12 +3223,12 @@
   "name":"org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
   "name":"org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration",
   "allDeclaredFields":true
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService"},
   "name":"org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration",
   "allDeclaredFields":true
 },

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/resource-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/resource-config.json
@@ -91,7 +91,7 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager"},
     "pattern":"\\QMETA-INF/services/com.clickhouse.client.ClickHouseClient\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager$$Lambda/0x00007fe4e3cc4218"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager$$Lambda/0x00007f8e2bcc2910"},
     "pattern":"\\QMETA-INF/services/com.clickhouse.client.ClickHouseClient\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
@@ -349,9 +349,6 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.repository.standalone.StandalonePersistRepository\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.decorator.RuleConfigurationPersistDecorateEngine"},
-    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.spi.RuleConfigurationPersistDecorator\\E"
-  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.spi.RuleItemConfigurationChangedProcessor\\E"
   }, {
@@ -484,910 +481,910 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
     "pattern":"\\Qschema/common/shardingsphere/sharding_table_statistics.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/administrable_role_authorizations.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/applicable_roles.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/character_sets.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/check_constraints.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/collation_character_set_applicability.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/collations.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/column_privileges.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/column_statistics.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/columns.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/columns_extensions.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/enabled_roles.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/engines.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/events.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/files.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/global_status.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/global_variables.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_buffer_page.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_buffer_page_lru.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_buffer_pool_stats.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_cached_indexes.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_cmp.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_cmp_per_index.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_cmp_per_index_reset.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_cmp_reset.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_cmpmem.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_cmpmem_reset.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_columns.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_datafiles.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_fields.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_foreign.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_foreign_cols.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_ft_being_deleted.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_ft_config.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_ft_default_stopword.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_ft_deleted.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_ft_index_cache.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_ft_index_table.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_indexes.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_lock_waits.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_locks.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_metrics.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_session_temp_tablespaces.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_sys_columns.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_sys_datafiles.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_sys_fields.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_sys_foreign.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_sys_foreign_cols.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_sys_indexes.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_sys_tables.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_sys_tablespaces.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_sys_tablestats.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_sys_virtual.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_tables.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_tablespaces.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_tablespaces_brief.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_tablestats.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_temp_table_info.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_trx.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/innodb_virtual.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/key_column_usage.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/keywords.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/optimizer_trace.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/parameters.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/partitions.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/plugins.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/processlist.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/profiling.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/referential_constraints.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/resource_groups.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/role_column_grants.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/role_routine_grants.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/role_table_grants.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/routines.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/schema_privileges.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/schemata.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/schemata_extensions.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/session_status.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/session_variables.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/st_geometry_columns.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/st_spatial_reference_systems.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/st_units_of_measure.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/statistics.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/table_constraints.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/table_constraints_extensions.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/table_privileges.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/tables.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/tables_extensions.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/tablespaces.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/tablespaces_extensions.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/triggers.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/user_attributes.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/user_privileges.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/view_routine_usage.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/view_table_usage.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/information_schema/views.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/columns_priv.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/component.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/db.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/default_roles.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/engine_cost.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/event.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/func.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/general_log.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/global_grants.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/gtid_executed.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/help_category.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/help_keyword.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/help_relation.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/help_topic.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/innodb_index_stats.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/innodb_table_stats.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/ndb_binlog_index.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/password_history.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/plugin.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/proc.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/procs_priv.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/proxies_priv.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/replication_asynchronous_connection_failover.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/replication_asynchronous_connection_failover_managed.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/replication_group_configuration_version.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/replication_group_member_actions.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/role_edges.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/server_cost.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/servers.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/slave_master_info.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/slave_relay_log_info.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/slave_worker_info.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/slow_log.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/tables_priv.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/time_zone.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/time_zone_leap_second.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/time_zone_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/time_zone_transition.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/time_zone_transition_type.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/mysql/user.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/accounts.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/binary_log_transaction_compression_stats.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/cond_instances.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/data_lock_waits.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/data_locks.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/error_log.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_errors_summary_by_account_by_error.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_errors_summary_by_host_by_error.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_errors_summary_by_thread_by_error.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_errors_summary_by_user_by_error.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_errors_summary_global_by_error.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_stages_current.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_stages_history.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_stages_history_long.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_stages_summary_by_account_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_stages_summary_by_host_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_stages_summary_by_thread_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_stages_summary_by_user_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_stages_summary_global_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_statements_current.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_statements_histogram_by_digest.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_statements_histogram_global.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_statements_history.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_statements_history_long.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_statements_summary_by_account_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_statements_summary_by_digest.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_statements_summary_by_host_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_statements_summary_by_program.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_statements_summary_by_thread_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_statements_summary_by_user_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_statements_summary_global_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_transactions_current.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_transactions_history.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_transactions_history_long.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_transactions_summary_by_account_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_transactions_summary_by_host_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_transactions_summary_by_thread_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_transactions_summary_by_user_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_transactions_summary_global_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_waits_current.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_waits_history.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_waits_history_long.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_waits_summary_by_account_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_waits_summary_by_host_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_waits_summary_by_instance.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_waits_summary_by_thread_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_waits_summary_by_user_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/events_waits_summary_global_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/file_instances.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/file_summary_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/file_summary_by_instance.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/global_status.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/global_variables.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/host_cache.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/hosts.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/innodb_redo_log_files.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/keyring_component_status.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/keyring_keys.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/log_status.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/memory_summary_by_account_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/memory_summary_by_host_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/memory_summary_by_thread_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/memory_summary_by_user_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/memory_summary_global_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/metadata_locks.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/mutex_instances.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/objects_summary_global_by_type.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/performance_timers.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/persisted_variables.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/prepared_statements_instances.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/processlist.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/replication_applier_configuration.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/replication_applier_filters.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/replication_applier_global_filters.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/replication_applier_status.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/replication_applier_status_by_coordinator.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/replication_applier_status_by_worker.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/replication_asynchronous_connection_failover.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/replication_asynchronous_connection_failover_managed.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/replication_connection_configuration.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/replication_connection_status.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/replication_group_member_stats.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/replication_group_members.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/rwlock_instances.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/session_account_connect_attrs.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/session_connect_attrs.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/session_status.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/session_variables.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/setup_actors.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/setup_consumers.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/setup_instruments.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/setup_meters.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/setup_metrics.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/setup_objects.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/setup_threads.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/setup_timers.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/socket_instances.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/socket_summary_by_event_name.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/socket_summary_by_instance.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/status_by_account.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/status_by_host.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/status_by_thread.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/status_by_user.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/table_handles.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/table_io_waits_summary_by_index_usage.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/table_io_waits_summary_by_table.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/table_lock_waits_summary_by_table.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/threads.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/tls_channel_status.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/user_defined_functions.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/user_variables_by_thread.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/users.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/variables_by_thread.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/performance_schema/variables_info.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/host_summary.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/host_summary_by_file_io.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/host_summary_by_file_io_type.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/host_summary_by_stages.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/host_summary_by_statement_latency.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/host_summary_by_statement_type.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/innodb_buffer_stats_by_schema.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/innodb_buffer_stats_by_table.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/innodb_lock_waits.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/io_by_thread_by_latency.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/io_global_by_file_by_bytes.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/io_global_by_file_by_latency.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/io_global_by_wait_by_bytes.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/io_global_by_wait_by_latency.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/latest_file_io.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/memory_by_host_by_current_bytes.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/memory_by_thread_by_current_bytes.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/memory_by_user_by_current_bytes.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/memory_global_by_current_bytes.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/memory_global_total.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/metrics.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/processlist.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/ps_check_lost_instrumentation.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/schema_auto_increment_columns.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/schema_index_statistics.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/schema_object_overview.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/schema_redundant_indexes.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/schema_table_lock_waits.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/schema_table_statistics.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/schema_table_statistics_with_buffer.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/schema_tables_with_full_table_scans.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/schema_unused_indexes.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/session.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/session_ssl_status.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/statement_analysis.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/statements_with_errors_or_warnings.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/statements_with_full_table_scans.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/statements_with_runtimes_in_95th_percentile.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/statements_with_sorting.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/statements_with_temp_tables.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/sys_config.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/user_summary.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/user_summary_by_file_io.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/user_summary_by_file_io_type.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/user_summary_by_stages.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/user_summary_by_statement_latency.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/user_summary_by_statement_type.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/version.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/wait_classes_global_by_avg_latency.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/wait_classes_global_by_latency.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/waits_by_host_by_latency.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/waits_by_user_by_latency.yaml\\E"
   }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.metadata.factory.ExternalMetaDataFactory"},
+    "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.factory.ExternalMetaDataFactory"},
     "pattern":"\\Qschema/mysql/sys/waits_global_by_latency.yaml\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reflect-config.json
@@ -358,6 +358,11 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "condition":{"typeReachable":"javax.security.auth.login.Configuration"},
+  "name":"sun.security.provider.ConfigFile",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "condition":{"typeReachable":"sun.security.provider.SecureRandom"},
   "name":"sun.security.provider.SecureRandom",
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"<init>","parameterTypes":["java.security.SecureRandomParameters"] }]

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.jboss.narayana.jta/jta/5.12.7.Final/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.jboss.narayana.jta/jta/5.12.7.Final/reflect-config.json
@@ -61,6 +61,11 @@
   "methods":[{"name":"<init>","parameterTypes":["com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean"] }]
 },
 {
+  "condition":{"typeReachable":"com.arjuna.ats.internal.arjuna.recovery.TransactionStatusManagerItem"},
+  "name":"com.arjuna.ats.internal.arjuna.objectstore.ShadowNoFileLockStore",
+  "queryAllPublicConstructors":true
+},
+{
   "condition":{"typeReachable":"com.arjuna.ats.arjuna.common.CoreEnvironmentBean"},
   "name":"com.arjuna.ats.internal.arjuna.utils.SocketProcessId",
   "queryAllPublicConstructors":true,
@@ -120,5 +125,46 @@
 {
   "condition":{"typeReachable":"com.arjuna.common.logging.commonLogger"},
   "name":"com.arjuna.common.logging.commonI18NLogger_$logger_zh_CN"
+},
+{
+  "condition":{"typeReachable":"com.arjuna.common.util.propertyservice.PropertiesFactory"},
+  "name":"com.arjuna.common.util.propertyservice.PropertiesFactory",
+  "fields":[{"name":"delegatePropertiesFactory"}]
+},
+{
+  "condition":{"typeReachable":"com.arjuna.common.internal.util.propertyservice.BeanPopulator"},
+  "name":"com.arjuna.common.internal.util.propertyservice.BeanPopulator",
+  "fields":[{"name":"beanInstances"}]
+},
+{
+  "condition":{"typeReachable":"com.arjuna.ats.internal.arjuna.recovery.AtomicActionRecoveryModule"},
+  "name":"com.arjuna.ats.internal.arjuna.recovery.AtomicActionRecoveryModule",
+  "fields":[{"name":"_recoveryStore"}]
+},
+{
+  "condition":{"typeReachable":"com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule"},
+  "name":"com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule",
+  "fields":[{"name":"registeredXARecoveryModule"}]
+},
+{
+  "condition":{"typeReachable":"com.arjuna.ats.arjuna.objectstore.StoreManager"},
+  "name":"com.arjuna.ats.arjuna.objectstore.StoreManager",
+  "allDeclaredFields":true
+},
+{
+  "condition":{"typeReachable":"com.arjuna.common.logging.commonI18NLogger"},
+  "name":"com.arjuna.common.logging.commonI18NLogger_$logger_en"
+},
+{
+  "condition":{"typeReachable":"com.arjuna.ats.arjuna.logging.arjunaI18NLogger"},
+  "name":"com.arjuna.ats.arjuna.logging.arjunaI18NLogger_$logger_en"
+},
+{
+  "condition":{"typeReachable":"com.arjuna.ats.jbossatx.logging.jbossatxI18NLogger"},
+  "name":"com.arjuna.ats.jbossatx.logging.jbossatxI18NLogger_$logger_en"
+},
+{
+  "condition":{"typeReachable":"com.arjuna.ats.jta.logging.jtaI18NLogger"},
+  "name":"com.arjuna.ats.jta.logging.jtaI18NLogger_$logger_en"
 }
 ]

--- a/test/native/native-image-filter/extra-filter.json
+++ b/test/native/native-image-filter/extra-filter.json
@@ -17,6 +17,7 @@
     {"excludeClasses": "org.**"},
     {"includeClasses": "org.apache.shardingsphere.**"},
     {"excludeClasses": "sun.**"},
+    {"includeClasses": "sun.security.provider.ConfigFile"},
     {"includeClasses": "sun.security.provider.SecureRandom"},
 
     {"excludeClasses": "org.apache.shardingsphere.test.natived.**"}

--- a/test/native/pom.xml
+++ b/test/native/pom.xml
@@ -194,6 +194,7 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${hadoop.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/TestShardingService.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/TestShardingService.java
@@ -196,8 +196,8 @@ public final class TestShardingService {
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
     public void cleanEnvironment() throws SQLException {
-        orderRepository.dropTable();
-        orderItemRepository.dropTable();
-        addressRepository.dropTable();
+        orderRepository.dropTableInMySQL();
+        orderItemRepository.dropTableInMySQL();
+        addressRepository.dropTableInMySQL();
     }
 }

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/proxy/ProxyTestingServer.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/proxy/ProxyTestingServer.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.test.natived.commons.proxy;
 import lombok.Getter;
 import org.apache.curator.test.InstanceSpec;
 import org.apache.shardingsphere.proxy.Bootstrap;
+import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -29,6 +30,8 @@ import java.util.concurrent.CompletableFuture;
  * This class is designed to start ShardingSphere Proxy directly in the current process,
  * whether it is HotSpot VM or GraalVM Native Image,
  * so this class intentionally uses fewer than a few dozen JVM parameters.
+ * It is necessary to avoid creating multiple ShardingSphere Proxy instances in parallel in Junit5 unit tests.
+ * Currently, Junit5 unit tests are all executed serially.
  */
 @Getter
 public final class ProxyTestingServer {
@@ -53,9 +56,10 @@ public final class ProxyTestingServer {
     }
     
     /**
-     * Force close ShardingSphere Proxy.
+     * Force close ShardingSphere Proxy. See {@link org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy#close}.
      */
     public void close() {
-        completableFuture.cancel(true);
+        ProxyContext.getInstance().getContextManager().close();
+        completableFuture.cancel(false);
     }
 }

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/repository/AddressRepository.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/repository/AddressRepository.java
@@ -71,11 +71,11 @@ public final class AddressRepository {
     }
     
     /**
-     * drop table t_address.
+     * drop table t_address in MySQL.
      *
      * @throws SQLException SQL exception
      */
-    public void dropTable() throws SQLException {
+    public void dropTableInMySQL() throws SQLException {
         String sql = "DROP TABLE IF EXISTS t_address";
         try (
                 Connection connection = dataSource.getConnection();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/repository/OrderItemRepository.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/repository/OrderItemRepository.java
@@ -103,11 +103,11 @@ public final class OrderItemRepository {
     }
     
     /**
-     * drop table.
+     * drop table in MySQL.
      *
      * @throws SQLException SQL exception
      */
-    public void dropTable() throws SQLException {
+    public void dropTableInMySQL() throws SQLException {
         String sql = "DROP TABLE IF EXISTS t_order_item";
         try (
                 Connection connection = dataSource.getConnection();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/repository/OrderRepository.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/repository/OrderRepository.java
@@ -78,7 +78,7 @@ public final class OrderRepository {
     }
     
     /**
-     * create table in MS SQL Server. `order_item_id` is not set to `IDENTITY(1,1)` to simplify the unit test.
+     * create table in MS SQL Server. `order_id` is not set to `IDENTITY(1,1)` to simplify the unit test.
      * This also ignored the default schema of the `dbo`.
      *
      * @throws SQLException SQL exception
@@ -100,12 +100,12 @@ public final class OrderRepository {
     }
     
     /**
-     * drop table.
+     * drop table in MySQL.
      * TODO There is a bug in this function in shadow's unit test and requires additional fixes.
      *
      * @throws SQLException SQL exception
      */
-    public void dropTable() throws SQLException {
+    public void dropTableInMySQL() throws SQLException {
         String sql = "DROP TABLE IF EXISTS t_order";
         try (
                 Connection connection = dataSource.getConnection();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/OpenGaussTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/OpenGaussTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.test.natived.jdbc.databases;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.test.natived.commons.TestShardingService;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
@@ -49,11 +50,17 @@ class OpenGaussTest {
     
     private static final String PASSWORD = "Enmo@123";
     
+    /**
+     * Unable to use Docker Image `enmotech/opengauss` under WSL.
+     * Background comes from <a href="https://github.com/enmotech/enmotech-docker-opengauss/issues/52">enmotech/enmotech-docker-opengauss#52</a>.
+     */
     @SuppressWarnings("resource")
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("enmotech/opengauss-lite:5.1.0")
+    private static final GenericContainer<?> CONTAINER = new GenericContainer<>("enmotech/opengauss-lite:5.1.0")
             .withEnv("GS_PASSWORD", PASSWORD)
             .withExposedPorts(5432);
+    
+    private static DataSource logicDataSource;
     
     private String jdbcUrlPrefix;
     
@@ -67,7 +74,10 @@ class OpenGaussTest {
     }
     
     @AfterAll
-    static void afterAll() {
+    static void afterAll() throws SQLException {
+        try (Connection connection = logicDataSource.getConnection()) {
+            connection.unwrap(ShardingSphereConnection.class).getContextManager().close();
+        }
         System.clearProperty(SYSTEM_PROP_KEY_PREFIX + "ds0.jdbc-url");
         System.clearProperty(SYSTEM_PROP_KEY_PREFIX + "ds1.jdbc-url");
         System.clearProperty(SYSTEM_PROP_KEY_PREFIX + "ds2.jdbc-url");
@@ -76,8 +86,8 @@ class OpenGaussTest {
     @Test
     void assertShardingInLocalTransactions() throws SQLException {
         jdbcUrlPrefix = "jdbc:opengauss://localhost:" + CONTAINER.getMappedPort(5432) + "/";
-        DataSource dataSource = createDataSource();
-        testShardingService = new TestShardingService(dataSource);
+        logicDataSource = createDataSource();
+        testShardingService = new TestShardingService(logicDataSource);
         initEnvironment();
         testShardingService.processSuccess();
         testShardingService.cleanEnvironment();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/SQLServerTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/SQLServerTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.test.natived.jdbc.databases;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.test.natived.commons.TestShardingService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -26,15 +27,21 @@ import org.junit.jupiter.api.condition.EnabledInNativeImage;
 import org.testcontainers.jdbc.ContainerDatabaseDriver;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 import java.sql.SQLException;
 
 @EnabledInNativeImage
 class SQLServerTest {
     
+    private static DataSource logicDataSource;
+    
     private TestShardingService testShardingService;
     
     @AfterAll
-    static void afterAll() {
+    static void afterAll() throws SQLException {
+        try (Connection connection = logicDataSource.getConnection()) {
+            connection.unwrap(ShardingSphereConnection.class).getContextManager().close();
+        }
         ContainerDatabaseDriver.killContainers();
     }
     
@@ -43,8 +50,8 @@ class SQLServerTest {
         HikariConfig config = new HikariConfig();
         config.setDriverClassName("org.apache.shardingsphere.driver.ShardingSphereDriver");
         config.setJdbcUrl("jdbc:shardingsphere:classpath:test-native/yaml/jdbc/databases/sqlserver.yaml");
-        DataSource dataSource = new HikariDataSource(config);
-        testShardingService = new TestShardingService(dataSource);
+        logicDataSource = new HikariDataSource(config);
+        testShardingService = new TestShardingService(logicDataSource);
         initEnvironment();
         testShardingService.processSuccess();
         testShardingService.cleanEnvironment();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/hive/AcidTableTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/hive/AcidTableTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.test.natived.jdbc.databases.hive;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.test.natived.commons.TestShardingService;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
@@ -58,6 +59,8 @@ class AcidTableTest {
     // Due to https://issues.apache.org/jira/browse/HIVE-28317 , the `initFile` parameter of HiveServer2 JDBC Driver must be an absolute path.
     private static final String ABSOLUTE_PATH = Paths.get("src/test/resources/test-native/sql/test-native-databases-hive-acid.sql").toAbsolutePath().toString();
     
+    private static DataSource logicDataSource;
+    
     private String jdbcUrlPrefix;
     
     @BeforeAll
@@ -68,7 +71,10 @@ class AcidTableTest {
     }
     
     @AfterAll
-    static void afterAll() {
+    static void afterAll() throws SQLException {
+        try (Connection connection = logicDataSource.getConnection()) {
+            connection.unwrap(ShardingSphereConnection.class).getContextManager().close();
+        }
         System.clearProperty(SYSTEM_PROP_KEY_PREFIX + "ds0.jdbc-url");
         System.clearProperty(SYSTEM_PROP_KEY_PREFIX + "ds1.jdbc-url");
         System.clearProperty(SYSTEM_PROP_KEY_PREFIX + "ds2.jdbc-url");
@@ -77,8 +83,8 @@ class AcidTableTest {
     @Test
     void assertShardingInLocalTransactions() throws SQLException {
         jdbcUrlPrefix = "jdbc:hive2://localhost:" + CONTAINER.getMappedPort(10000) + "/";
-        DataSource dataSource = createDataSource();
-        TestShardingService testShardingService = new TestShardingService(dataSource);
+        logicDataSource = createDataSource();
+        TestShardingService testShardingService = new TestShardingService(logicDataSource);
         testShardingService.processSuccessInHive();
     }
     

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/features/EncryptTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/features/EncryptTest.java
@@ -19,15 +19,18 @@ package org.apache.shardingsphere.test.natived.jdbc.features;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.test.natived.commons.entity.Address;
 import org.apache.shardingsphere.test.natived.commons.entity.Order;
 import org.apache.shardingsphere.test.natived.commons.entity.OrderItem;
 import org.apache.shardingsphere.test.natived.commons.repository.AddressRepository;
 import org.apache.shardingsphere.test.natived.commons.repository.OrderItemRepository;
 import org.apache.shardingsphere.test.natived.commons.repository.OrderRepository;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,21 +43,30 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 class EncryptTest {
     
+    private static DataSource logicDataSource;
+    
     private OrderRepository orderRepository;
     
     private OrderItemRepository orderItemRepository;
     
     private AddressRepository addressRepository;
     
+    @AfterAll
+    static void afterAll() throws SQLException {
+        try (Connection connection = logicDataSource.getConnection()) {
+            connection.unwrap(ShardingSphereConnection.class).getContextManager().close();
+        }
+    }
+    
     @Test
     void assertEncryptInLocalTransactions() throws SQLException {
         HikariConfig config = new HikariConfig();
         config.setDriverClassName("org.apache.shardingsphere.driver.ShardingSphereDriver");
         config.setJdbcUrl("jdbc:shardingsphere:classpath:test-native/yaml/jdbc/features/encrypt.yaml");
-        DataSource dataSource = new HikariDataSource(config);
-        orderRepository = new OrderRepository(dataSource);
-        orderItemRepository = new OrderItemRepository(dataSource);
-        addressRepository = new AddressRepository(dataSource);
+        logicDataSource = new HikariDataSource(config);
+        orderRepository = new OrderRepository(logicDataSource);
+        orderItemRepository = new OrderItemRepository(logicDataSource);
+        addressRepository = new AddressRepository(logicDataSource);
         initEnvironment();
         processSuccess();
         cleanEnvironment();
@@ -115,8 +127,8 @@ class EncryptTest {
     }
     
     private void cleanEnvironment() throws SQLException {
-        orderRepository.dropTable();
-        orderItemRepository.dropTable();
-        addressRepository.dropTable();
+        orderRepository.dropTableInMySQL();
+        orderItemRepository.dropTableInMySQL();
+        addressRepository.dropTableInMySQL();
     }
 }

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/features/ReadWriteSplittingTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/features/ReadWriteSplittingTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.test.natived.jdbc.features;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.test.natived.commons.entity.Address;
 import org.apache.shardingsphere.test.natived.commons.entity.Order;
 import org.apache.shardingsphere.test.natived.commons.entity.OrderItem;
@@ -26,9 +27,11 @@ import org.apache.shardingsphere.test.natived.commons.repository.AddressReposito
 import org.apache.shardingsphere.test.natived.commons.repository.OrderItemRepository;
 import org.apache.shardingsphere.test.natived.commons.repository.OrderRepository;
 import org.h2.jdbc.JdbcSQLSyntaxErrorException;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,21 +40,30 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ReadWriteSplittingTest {
     
+    private static DataSource logicDataSource;
+    
     private OrderRepository orderRepository;
     
     private OrderItemRepository orderItemRepository;
     
     private AddressRepository addressRepository;
     
+    @AfterAll
+    static void afterAll() throws SQLException {
+        try (Connection connection = logicDataSource.getConnection()) {
+            connection.unwrap(ShardingSphereConnection.class).getContextManager().close();
+        }
+    }
+    
     @Test
     void assertReadWriteSplittingInLocalTransactions() throws SQLException {
         HikariConfig config = new HikariConfig();
         config.setDriverClassName("org.apache.shardingsphere.driver.ShardingSphereDriver");
         config.setJdbcUrl("jdbc:shardingsphere:classpath:test-native/yaml/jdbc/features/readwrite-splitting.yaml");
-        DataSource dataSource = new HikariDataSource(config);
-        orderRepository = new OrderRepository(dataSource);
-        orderItemRepository = new OrderItemRepository(dataSource);
-        addressRepository = new AddressRepository(dataSource);
+        logicDataSource = new HikariDataSource(config);
+        orderRepository = new OrderRepository(logicDataSource);
+        orderItemRepository = new OrderItemRepository(logicDataSource);
+        addressRepository = new AddressRepository(logicDataSource);
         initEnvironment();
         processSuccess();
         cleanEnvironment();
@@ -113,8 +125,8 @@ class ReadWriteSplittingTest {
     }
     
     private void cleanEnvironment() throws SQLException {
-        orderRepository.dropTable();
-        orderItemRepository.dropTable();
-        addressRepository.dropTable();
+        orderRepository.dropTableInMySQL();
+        orderItemRepository.dropTableInMySQL();
+        addressRepository.dropTableInMySQL();
     }
 }

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/features/ShadowTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/features/ShadowTest.java
@@ -19,15 +19,18 @@ package org.apache.shardingsphere.test.natived.jdbc.features;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.test.natived.commons.entity.Address;
 import org.apache.shardingsphere.test.natived.commons.entity.Order;
 import org.apache.shardingsphere.test.natived.commons.entity.OrderItem;
 import org.apache.shardingsphere.test.natived.commons.repository.AddressRepository;
 import org.apache.shardingsphere.test.natived.commons.repository.OrderItemRepository;
 import org.apache.shardingsphere.test.natived.commons.repository.OrderRepository;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,21 +44,30 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 class ShadowTest {
     
+    private static DataSource logicDataSource;
+    
     private OrderRepository orderRepository;
     
     private OrderItemRepository orderItemRepository;
     
     private AddressRepository addressRepository;
     
+    @AfterAll
+    static void afterAll() throws SQLException {
+        try (Connection connection = logicDataSource.getConnection()) {
+            connection.unwrap(ShardingSphereConnection.class).getContextManager().close();
+        }
+    }
+    
     @Test
     void assertShadowInLocalTransactions() throws SQLException {
         HikariConfig config = new HikariConfig();
         config.setDriverClassName("org.apache.shardingsphere.driver.ShardingSphereDriver");
         config.setJdbcUrl("jdbc:shardingsphere:classpath:test-native/yaml/jdbc/features/shadow.yaml");
-        DataSource dataSource = new HikariDataSource(config);
-        orderRepository = new OrderRepository(dataSource);
-        orderItemRepository = new OrderItemRepository(dataSource);
-        addressRepository = new AddressRepository(dataSource);
+        logicDataSource = new HikariDataSource(config);
+        orderRepository = new OrderRepository(logicDataSource);
+        orderItemRepository = new OrderItemRepository(logicDataSource);
+        addressRepository = new AddressRepository(logicDataSource);
         initEnvironment();
         processSuccess();
         cleanEnvironment();
@@ -144,8 +156,8 @@ class ShadowTest {
     
     private void cleanEnvironment() throws SQLException {
         orderRepository.dropTableShadow();
-        orderRepository.dropTable();
-        orderItemRepository.dropTable();
-        addressRepository.dropTable();
+        orderRepository.dropTableInMySQL();
+        orderItemRepository.dropTableInMySQL();
+        addressRepository.dropTableInMySQL();
     }
 }

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/features/ShardingTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/features/ShardingTest.java
@@ -19,23 +19,35 @@ package org.apache.shardingsphere.test.natived.jdbc.features;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.test.natived.commons.TestShardingService;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 import java.sql.SQLException;
 
 class ShardingTest {
     
+    private static DataSource logicDataSource;
+    
     private TestShardingService testShardingService;
+    
+    @AfterAll
+    static void afterAll() throws SQLException {
+        try (Connection connection = logicDataSource.getConnection()) {
+            connection.unwrap(ShardingSphereConnection.class).getContextManager().close();
+        }
+    }
     
     @Test
     void assertShardingInLocalTransactions() throws SQLException {
         HikariConfig config = new HikariConfig();
         config.setDriverClassName("org.apache.shardingsphere.driver.ShardingSphereDriver");
         config.setJdbcUrl("jdbc:shardingsphere:classpath:test-native/yaml/jdbc/features/sharding.yaml");
-        DataSource dataSource = new HikariDataSource(config);
-        testShardingService = new TestShardingService(dataSource);
+        logicDataSource = new HikariDataSource(config);
+        testShardingService = new TestShardingService(logicDataSource);
         initEnvironment();
         testShardingService.processSuccess();
         testShardingService.cleanEnvironment();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/transactions/base/SeataTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/transactions/base/SeataTest.java
@@ -46,7 +46,7 @@ class SeataTest {
     
     @SuppressWarnings("resource")
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/seata-server:2.2.0")
+    private static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/seata-server:2.2.0")
             .withExposedPorts(7091, 8091)
             .waitingFor(Wait.forHttp("/health")
                     .forPort(7091)
@@ -64,12 +64,6 @@ class SeataTest {
         assertThat(System.getProperty(SERVICE_DEFAULT_GROUP_LIST_KEY), is(nullValue()));
     }
     
-    /**
-     * TODO Need to investigate why {@link org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager#close()} is not called.
-     *  The manual call {@link org.apache.shardingsphere.mode.manager.ContextManager#close()} is not intuitive.
-     *
-     * @throws SQLException SQL exception
-     */
     @AfterAll
     static void afterAll() throws SQLException {
         try (Connection connection = logicDataSource.getConnection()) {

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/transactions/xa/AtomikosTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/transactions/xa/AtomikosTest.java
@@ -19,23 +19,35 @@ package org.apache.shardingsphere.test.natived.jdbc.transactions.xa;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.test.natived.commons.TestShardingService;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 import java.sql.SQLException;
 
 class AtomikosTest {
     
+    private static DataSource logicDataSource;
+    
     private TestShardingService testShardingService;
+    
+    @AfterAll
+    static void afterAll() throws SQLException {
+        try (Connection connection = logicDataSource.getConnection()) {
+            connection.unwrap(ShardingSphereConnection.class).getContextManager().close();
+        }
+    }
     
     @Test
     void assertShardingInAtomikosTransactions() throws SQLException {
         HikariConfig config = new HikariConfig();
         config.setDriverClassName("org.apache.shardingsphere.driver.ShardingSphereDriver");
         config.setJdbcUrl("jdbc:shardingsphere:classpath:test-native/yaml/jdbc/transactions/xa/atomikos.yaml");
-        DataSource dataSource = new HikariDataSource(config);
-        testShardingService = new TestShardingService(dataSource);
+        logicDataSource = new HikariDataSource(config);
+        testShardingService = new TestShardingService(logicDataSource);
         initEnvironment();
         testShardingService.processSuccess();
         testShardingService.cleanEnvironment();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/transactions/xa/NarayanaTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/transactions/xa/NarayanaTest.java
@@ -21,15 +21,27 @@ import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.test.natived.commons.TestShardingService;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 import java.sql.SQLException;
 
 class NarayanaTest {
     
+    private static DataSource logicDataSource;
+    
     private TestShardingService testShardingService;
+    
+    @AfterAll
+    static void afterAll() throws SQLException {
+        try (Connection connection = logicDataSource.getConnection()) {
+            connection.unwrap(ShardingSphereConnection.class).getContextManager().close();
+        }
+    }
     
     @Test
     void assertShardingInNarayanaTransactions() throws SQLException, CoreEnvironmentBeanException {
@@ -37,8 +49,8 @@ class NarayanaTest {
         HikariConfig config = new HikariConfig();
         config.setDriverClassName("org.apache.shardingsphere.driver.ShardingSphereDriver");
         config.setJdbcUrl("jdbc:shardingsphere:classpath:test-native/yaml/jdbc/transactions/xa/narayana.yaml");
-        DataSource dataSource = new HikariDataSource(config);
-        testShardingService = new TestShardingService(dataSource);
+        logicDataSource = new HikariDataSource(config);
+        testShardingService = new TestShardingService(logicDataSource);
         initEnvironment();
         testShardingService.processSuccess();
         testShardingService.cleanEnvironment();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/databases/MySQLTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/databases/MySQLTest.java
@@ -46,7 +46,7 @@ import java.util.Properties;
 class MySQLTest {
     
     @Container
-    public static final GenericContainer<?> MYSQL_CONTAINER = new GenericContainer<>("mysql:9.1.0-oraclelinux9")
+    private static final GenericContainer<?> MYSQL_CONTAINER = new GenericContainer<>("mysql:9.1.0-oraclelinux9")
             .withEnv("MYSQL_ROOT_PASSWORD", "yourStrongPassword123!")
             .withExposedPorts(3306);
     

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/databases/PostgresTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/databases/PostgresTest.java
@@ -45,7 +45,7 @@ import java.util.Properties;
 class PostgresTest {
     
     @Container
-    public static final PostgreSQLContainer<?> POSTGRES_CONTAINER = new PostgreSQLContainer<>("postgres:17.2-bookworm");
+    private static final PostgreSQLContainer<?> POSTGRES_CONTAINER = new PostgreSQLContainer<>("postgres:17.2-bookworm");
     
     private static ProxyTestingServer proxyTestingServer;
     

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/transactions/base/SeataTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/transactions/base/SeataTest.java
@@ -20,12 +20,8 @@ package org.apache.shardingsphere.test.natived.proxy.transactions.base;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.http.HttpStatus;
-import org.apache.seata.config.ConfigurationFactory;
-import org.apache.seata.core.rpc.netty.RmNettyRemotingClient;
-import org.apache.seata.core.rpc.netty.TmNettyRemotingClient;
 import org.apache.shardingsphere.test.natived.commons.TestShardingService;
 import org.apache.shardingsphere.test.natived.commons.proxy.ProxyTestingServer;
-import org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionHolder;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -57,12 +53,12 @@ import static org.hamcrest.Matchers.nullValue;
 class SeataTest {
     
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/seata-server:2.2.0")
+    private static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/seata-server:2.2.0")
             .withExposedPorts(7091, 8091)
             .waitingFor(Wait.forHttp("/health").forPort(7091).forStatusCode(HttpStatus.SC_OK).forResponsePredicate("ok"::equals));
     
     @Container
-    public static final PostgreSQLContainer<?> POSTGRES_CONTAINER = new PostgreSQLContainer<>("postgres:17.2-bookworm")
+    private static final PostgreSQLContainer<?> POSTGRES_CONTAINER = new PostgreSQLContainer<>("postgres:17.2-bookworm")
             .withCopyFileToContainer(
                     MountableFile.forHostPath(Paths.get("src/test/resources/test-native/sh/postgres.sh").toAbsolutePath()),
                     "/docker-entrypoint-initdb.d/postgres.sh");
@@ -90,16 +86,8 @@ class SeataTest {
         });
     }
     
-    /**
-     * TODO Facing the same issue with {@code org.apache.shardingsphere.test.natived.jdbc.transactions.base.SeataTest},
-     *  {@link org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager#close()} was never called.
-     */
     @AfterAll
     static void afterAll() {
-        SeataTransactionHolder.clear();
-        RmNettyRemotingClient.getInstance().destroy();
-        TmNettyRemotingClient.getInstance().destroy();
-        ConfigurationFactory.reload();
         proxyTestingServer.close();
         System.clearProperty(SERVICE_DEFAULT_GROUP_LIST_KEY);
     }


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Fix the Flaky Test related to ClickHouse in NativeTest under GraalVM Native Image. The current PR was split from #34307 to facilitate review.
  - `org.apache.shardingsphere.test.natived.jdbc.databases.ClickHouseTest` previously started ClickHouse Server and ClickHouse Keeper at the same time, but never performed a health check on ClickHouse Keeper. This caused this unit test to fail frequently. This PR performs a health check on ClickHouse Keeper through Apache Curator to fix the unstable state of CI.
  - Fix several documentation errors.
  - Fix several historical issues with nativeTest, including the problem that the global ContextManager instance was not closed properly during the unit test lifecycle.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
