### PR TITLE
Support connecting to Firebird via jdbcUrl containing the absolute path to fdb

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -55,6 +55,7 @@
 1. Agent: Simplify the use of Agent's Docker Image - [#33356](https://github.com/apache/shardingsphere/pull/33356)
 1. Mode: Support modifying Hikari-CP configurations via props in standalone mode [#34185](https://github.com/apache/shardingsphere/pull/34185)
 1. Encrypt: Support insert statement rewrite use quote [#34259](https://github.com/apache/shardingsphere/pull/34259)
+1. Infra: Support connecting to Firebird via jdbcUrl containing the absolute path to fdb - [#34335](https://github.com/apache/shardingsphere/pull/34335)
 
 ### Bug Fixes
 

--- a/infra/database/type/firebird/pom.xml
+++ b/infra/database/type/firebird/pom.xml
@@ -34,6 +34,13 @@
         </dependency>
         
         <dependency>
+            <groupId>org.firebirdsql.jdbc</groupId>
+            <artifactId>jaybird</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        
+        <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-test-util</artifactId>
             <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@
         <hive-server2-jdbc-driver-thin.version>1.6.0</hive-server2-jdbc-driver-thin.version>
         <hadoop.version>3.3.6</hadoop.version>
         <presto.version>0.288.1</presto.version>
+        <jaybird.version>5.0.6.java8</jaybird.version>
         
         <hikari-cp.version>4.0.3</hikari-cp.version>
         
@@ -487,6 +488,12 @@
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-jdbc</artifactId>
                 <version>${presto.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.firebirdsql.jdbc</groupId>
+                <artifactId>jaybird</artifactId>
+                <version>${jaybird.version}</version>
                 <scope>test</scope>
             </dependency>
             


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Support connecting to Firebird via jdbcUrl containing the absolute path to fdb. The current PR was split from #34307 to facilitate review.
  - This is due to #33773 which does not support resolving jdbcUrls like `jdbc:firebird://localhost:32783//var/lib/firebird/data/demo_ds_2.fdb`.
  - The current PR is affected by multiple external issues.
    - Done discussion around LICENSE for `org.firebirdsql.jdbc:jaybird:5.0.6.java8` not being distributed under the ASF license at https://github.com/apache/gravitino/issues/4352#issuecomment-2453295083 .
    - Due to the change of the minimum supported JDK version to JDK17 as reported by https://firebirdsql.org/en/news/jaybird-6-0-0-released , it is not possible to use `org.firebirdsql.jdbc:jaybird:6.0.0` in unit tests of shardingsphere. We still need JDK8 to run unit tests.
    - According to some verification in https://github.com/FirebirdSQL/jaybird/blob/v6.0.0/src/test/org/firebirdsql/jdbc/FBDriverTest.java , it seems that the exception should not be thrown although a jdbcUrl like `jdbc:firebirdsql:xxxxxxxx` does not make sense.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
