### PR TITLE
Fix g4 syntax for DistSQL show table metadata

### DIFF
--- a/parser/distsql/engine/src/main/antlr4/imports/RALStatement.g4
+++ b/parser/distsql/engine/src/main/antlr4/imports/RALStatement.g4
@@ -56,7 +56,7 @@ refreshTableMetadata
     ;
 
 showTableMetadata
-    : SHOW TABLE METADATA tableName (COMMA_ tableName*)? (FROM databaseName)?
+    : SHOW TABLE METADATA tableName (COMMA_ tableName)* (FROM databaseName)?
     ;
 
 showComputeNodeInfo


### PR DESCRIPTION
The `*` is in the wrong position