### PR TITLE
Use CaseInsensitiveSet to replace TreeSet<>(String.CASE_INSENSITIVE_ORDER)

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/condition/EncryptConditionEngine.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/condition/EncryptConditionEngine.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.condition;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.encrypt.exception.syntax.UnsupportedEncryptSQLException;
 import org.apache.shardingsphere.encrypt.rewrite.condition.impl.EncryptBinaryCondition;
@@ -44,8 +45,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * Encrypt condition engine.
@@ -54,26 +53,26 @@ import java.util.TreeSet;
 @RequiredArgsConstructor
 public final class EncryptConditionEngine {
     
-    private static final Set<String> LOGICAL_OPERATOR = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    private static final Collection<String> LOGICAL_OPERATORS = new CaseInsensitiveSet<>();
     
-    private static final Set<String> SUPPORTED_COMPARE_OPERATOR = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    private static final Collection<String> SUPPORTED_COMPARE_OPERATORS = new CaseInsensitiveSet<>();
     
     private final EncryptRule rule;
     
     static {
-        LOGICAL_OPERATOR.add("AND");
-        LOGICAL_OPERATOR.add("&&");
-        LOGICAL_OPERATOR.add("OR");
-        LOGICAL_OPERATOR.add("||");
-        SUPPORTED_COMPARE_OPERATOR.add("=");
-        SUPPORTED_COMPARE_OPERATOR.add("<>");
-        SUPPORTED_COMPARE_OPERATOR.add("!=");
-        SUPPORTED_COMPARE_OPERATOR.add(">");
-        SUPPORTED_COMPARE_OPERATOR.add("<");
-        SUPPORTED_COMPARE_OPERATOR.add(">=");
-        SUPPORTED_COMPARE_OPERATOR.add("<=");
-        SUPPORTED_COMPARE_OPERATOR.add("IS");
-        SUPPORTED_COMPARE_OPERATOR.add("LIKE");
+        LOGICAL_OPERATORS.add("AND");
+        LOGICAL_OPERATORS.add("&&");
+        LOGICAL_OPERATORS.add("OR");
+        LOGICAL_OPERATORS.add("||");
+        SUPPORTED_COMPARE_OPERATORS.add("=");
+        SUPPORTED_COMPARE_OPERATORS.add("<>");
+        SUPPORTED_COMPARE_OPERATORS.add("!=");
+        SUPPORTED_COMPARE_OPERATORS.add(">");
+        SUPPORTED_COMPARE_OPERATORS.add("<");
+        SUPPORTED_COMPARE_OPERATORS.add(">=");
+        SUPPORTED_COMPARE_OPERATORS.add("<=");
+        SUPPORTED_COMPARE_OPERATORS.add("IS");
+        SUPPORTED_COMPARE_OPERATORS.add("LIKE");
     }
     
     /**
@@ -148,10 +147,10 @@ public final class EncryptConditionEngine {
     
     private Optional<EncryptCondition> createBinaryEncryptCondition(final BinaryOperationExpression expression, final String tableName) {
         String operator = expression.getOperator();
-        if (LOGICAL_OPERATOR.contains(operator)) {
+        if (LOGICAL_OPERATORS.contains(operator)) {
             return Optional.empty();
         }
-        ShardingSpherePreconditions.checkContains(SUPPORTED_COMPARE_OPERATOR, operator, () -> new UnsupportedEncryptSQLException(operator));
+        ShardingSpherePreconditions.checkContains(SUPPORTED_COMPARE_OPERATORS, operator, () -> new UnsupportedEncryptSQLException(operator));
         return createCompareEncryptCondition(tableName, expression);
     }
     

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/complex/ShardingComplexRouteEngine.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/complex/ShardingComplexRouteEngine.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sharding.route.engine.type.complex;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
@@ -32,7 +33,6 @@ import org.apache.shardingsphere.sharding.rule.ShardingTable;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Optional;
-import java.util.TreeSet;
 
 /**
  * Sharding complex route engine.
@@ -52,7 +52,7 @@ public final class ShardingComplexRouteEngine implements ShardingRouteEngine {
     
     @Override
     public RouteContext route(final ShardingRule shardingRule) {
-        Collection<String> bindingTableNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        Collection<String> bindingTableNames = new CaseInsensitiveSet<>();
         Collection<RouteContext> routeContexts = new LinkedList<>();
         for (String each : logicTables) {
             Optional<ShardingTable> shardingTable = shardingRule.findShardingTable(each);

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/complex/ComplexShardingStrategy.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/complex/ComplexShardingStrategy.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sharding.route.strategy.type.complex;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Range;
 import lombok.Getter;
@@ -34,7 +35,6 @@ import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeSet;
 
 /**
  * Complex sharding strategy.
@@ -49,7 +49,7 @@ public final class ComplexShardingStrategy implements ShardingStrategy {
     public ComplexShardingStrategy(final String shardingColumns, final ComplexKeysShardingAlgorithm<?> shardingAlgorithm) {
         ShardingSpherePreconditions.checkNotNull(shardingColumns, () -> new MissingRequiredShardingConfigurationException("Complex sharding columns"));
         ShardingSpherePreconditions.checkNotNull(shardingAlgorithm, () -> new MissingRequiredShardingConfigurationException("Complex sharding algorithm"));
-        this.shardingColumns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        this.shardingColumns = new CaseInsensitiveSet<>();
         this.shardingColumns.addAll(Splitter.on(",").trimResults().splitToList(shardingColumns));
         this.shardingAlgorithm = shardingAlgorithm;
     }
@@ -70,8 +70,6 @@ public final class ComplexShardingStrategy implements ShardingStrategy {
             logicTableName = each.getTableName();
         }
         Collection<String> shardingResult = shardingAlgorithm.doSharding(availableTargetNames, new ComplexKeysShardingValue(logicTableName, columnShardingValues, columnRangeValues));
-        Collection<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-        result.addAll(shardingResult);
-        return result;
+        return new CaseInsensitiveSet<>(shardingResult);
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/hint/HintShardingStrategy.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/hint/HintShardingStrategy.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sharding.route.strategy.type.hint;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.Getter;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.datanode.DataNodeInfo;
@@ -29,7 +30,6 @@ import org.apache.shardingsphere.sharding.route.engine.condition.value.ShardingC
 import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
 
 import java.util.Collection;
-import java.util.TreeSet;
 
 /**
  * Hint sharding strategy.
@@ -43,7 +43,7 @@ public final class HintShardingStrategy implements ShardingStrategy {
     
     public HintShardingStrategy(final HintShardingAlgorithm<?> shardingAlgorithm) {
         ShardingSpherePreconditions.checkNotNull(shardingAlgorithm, () -> new MissingRequiredShardingConfigurationException("Hint sharding algorithm"));
-        shardingColumns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        shardingColumns = new CaseInsensitiveSet<>();
         this.shardingAlgorithm = shardingAlgorithm;
     }
     
@@ -54,8 +54,6 @@ public final class HintShardingStrategy implements ShardingStrategy {
         ListShardingConditionValue<?> shardingValue = (ListShardingConditionValue) shardingConditionValues.iterator().next();
         Collection<String> shardingResult = shardingAlgorithm.doSharding(availableTargetNames,
                 new HintShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), shardingValue.getValues()));
-        Collection<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-        result.addAll(shardingResult);
-        return result;
+        return new CaseInsensitiveSet<>(shardingResult);
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategy.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategy.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sharding.route.strategy.type.standard;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.Getter;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.datanode.DataNodeInfo;
@@ -33,7 +34,6 @@ import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
-import java.util.TreeSet;
 
 /**
  * Standard sharding strategy.
@@ -48,7 +48,7 @@ public final class StandardShardingStrategy implements ShardingStrategy {
     public StandardShardingStrategy(final String shardingColumn, final StandardShardingAlgorithm<?> shardingAlgorithm) {
         ShardingSpherePreconditions.checkNotNull(shardingColumn, () -> new MissingRequiredShardingConfigurationException("Standard sharding column"));
         ShardingSpherePreconditions.checkNotNull(shardingAlgorithm, () -> new MissingRequiredShardingConfigurationException("Standard sharding algorithm"));
-        Collection<String> shardingColumns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        Collection<String> shardingColumns = new CaseInsensitiveSet<>();
         shardingColumns.add(shardingColumn);
         this.shardingColumns = Collections.unmodifiableCollection(shardingColumns);
         this.shardingAlgorithm = shardingAlgorithm;
@@ -62,9 +62,7 @@ public final class StandardShardingStrategy implements ShardingStrategy {
         Collection<String> shardingResult = shardingConditionValue instanceof ListShardingConditionValue
                 ? doSharding(availableTargetNames, (ListShardingConditionValue) shardingConditionValue, dataNodeInfo)
                 : doSharding(availableTargetNames, (RangeShardingConditionValue) shardingConditionValue, dataNodeInfo);
-        Collection<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-        result.addAll(shardingResult);
-        return result;
+        return new CaseInsensitiveSet<>(shardingResult);
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingRule.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingRule.java
@@ -76,7 +76,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -331,8 +330,7 @@ public final class ShardingRule implements DatabaseRule {
         if (!bindingTableRule.isPresent()) {
             return false;
         }
-        Collection<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-        result.addAll(bindingTableRule.get().getAllLogicTables());
+        Collection<String> result = new CaseInsensitiveSet<>(bindingTableRule.get().getAllLogicTables());
         return !result.isEmpty() && result.containsAll(logicTableNames);
     }
     

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingTable.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingTable.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sharding.rule;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -47,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -159,7 +159,7 @@ public final class ShardingTable {
     }
     
     private Set<String> getActualTables() {
-        return actualDataNodes.stream().map(DataNode::getTableName).collect(Collectors.toCollection(() -> new TreeSet<>(String.CASE_INSENSITIVE_ORDER)));
+        return actualDataNodes.stream().map(DataNode::getTableName).collect(Collectors.toCollection(CaseInsensitiveSet::new));
     }
     
     private void addActualTable(final String datasourceName, final String tableName) {

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/util/SingleTableLoadUtils.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/util/SingleTableLoadUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.single.util;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import com.google.common.base.Splitter;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -31,7 +32,6 @@ import org.apache.shardingsphere.single.constant.SingleTableConstants;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Optional;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -49,7 +49,7 @@ public final class SingleTableLoadUtils {
      * @return excluded tables
      */
     public static Collection<String> getExcludedTables(final Collection<ShardingSphereRule> builtRules) {
-        Collection<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        Collection<String> result = new CaseInsensitiveSet<>();
         for (ShardingSphereRule each : builtRules) {
             Optional<TableMapperRuleAttribute> ruleAttribute = each.getAttributes().findAttribute(TableMapperRuleAttribute.class);
             if (ruleAttribute.isPresent()) {
@@ -67,7 +67,7 @@ public final class SingleTableLoadUtils {
      * @return feature required single tables
      */
     public static Collection<String> getFeatureRequiredSingleTables(final Collection<ShardingSphereRule> builtRules) {
-        Collection<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        Collection<String> result = new CaseInsensitiveSet<>();
         for (ShardingSphereRule each : builtRules) {
             Optional<TableMapperRuleAttribute> ruleAttribute = each.getAttributes().findAttribute(TableMapperRuleAttribute.class);
             if (!ruleAttribute.isPresent()) {

--- a/proxy/backend/type/opengauss/src/main/java/org/apache/shardingsphere/proxy/backend/opengauss/handler/admin/OpenGaussAdminExecutorCreator.java
+++ b/proxy/backend/type/opengauss/src/main/java/org/apache/shardingsphere/proxy/backend/opengauss/handler/admin/OpenGaussAdminExecutorCreator.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.proxy.backend.opengauss.handler.admin;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.type.TableAvailable;
 import org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager;
@@ -34,17 +35,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * Database admin executor creator for openGauss.
  */
 public final class OpenGaussAdminExecutorCreator implements DatabaseAdminExecutorCreator {
     
-    private static final Set<String> SYSTEM_CATALOG_QUERY_EXPRESSIONS = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    private static final Collection<String> SYSTEM_CATALOG_QUERY_EXPRESSIONS = new CaseInsensitiveSet<>();
     
-    private static final Set<String> SYSTEM_CATALOG_TABLES = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    private static final Collection<String> SYSTEM_CATALOG_TABLES = new CaseInsensitiveSet<>();
     
     static {
         SYSTEM_CATALOG_QUERY_EXPRESSIONS.add("VERSION()");


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Use CaseInsensitiveSet to replace TreeSet<>(String.CASE_INSENSITIVE_ORDER)

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
