### PR TITLE
Bump Zookeeper Client to 3.9.3

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,7 +13,7 @@
 
 ### Bug Fixes
 
-1. Alleviate connection leaks caused by Seata Client throwing exceptions - [#34463](https://github.com/apache/shardingsphere/pull/34463)
+1. JDBC: Alleviate connection leaks caused by Seata Client throwing exceptions - [#34463](https://github.com/apache/shardingsphere/pull/34463)
 
 ### Change Logs
 

--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -304,8 +304,8 @@ The text of each license is the standard Apache 2.0 license.
     transmittable-thread-local 2.14.2: https://github.com/alibaba/transmittable-thread-local, Apache 2.0
     uzaygezen-core 0.2: https://code.google.com/p/uzaygezen, Apache 2.0
     woodstox-core 6.5.1: https://github.com/FasterXML/woodstox, Apache 2.0
-    zookeeper 3.9.2: https://github.com/apache/zookeeper, Apache 2.0
-    zookeeper-jute 3.9.2: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper 3.9.3: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper-jute 3.9.3: https://github.com/apache/zookeeper, Apache 2.0
     java-util 2.4.0: https://github.com/jdereg/java-util, Apache 2.0
 
 ========================================================================

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
@@ -750,6 +750,11 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"add","parameterTypes":["long"] }, {"name":"sum","parameterTypes":[] }]
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.command.CommandExecutorTask"},
+  "name":"java.util.concurrent.atomic.Striped64$Cell",
+  "fields":[{"name":"value"}]
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"},
   "name":"java.util.function.DoubleFunction",
   "queryAllPublicMethods":true

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/resource-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/resource-config.json
@@ -329,7 +329,7 @@
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.deliver.DeliverEventSubscriber\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
-    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.manager.ContextManagerBuilder\\E"
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.manager.builder.ContextManagerBuilder\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.mode.manager.listener.ContextManagerLifecycleListener\\E"

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <bouncycastle.version>1.78.1</bouncycastle.version>
         
         <curator.version>5.7.0</curator.version>
-        <zookeeper.version>3.9.2</zookeeper.version>
+        <zookeeper.version>3.9.3</zookeeper.version>
         <audience-annotations.version>0.12.0</audience-annotations.version>
         <jetcd.version>0.7.7</jetcd.version>
         <vertx.version>4.5.1</vertx.version>

--- a/test/native/pom.xml
+++ b/test/native/pom.xml
@@ -123,6 +123,11 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-pool2</artifactId>
                 </exclusion>
+                <!-- See https://github.com/apache/incubator-seata/issues/7045 -->
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-webmvc</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -232,6 +237,13 @@
             <artifactId>jetcd-test</artifactId>
             <version>${jetcd.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- See https://github.com/testcontainers/testcontainers-java/issues/8338 -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
Fixes #34414.

Changes proposed in this pull request:
  - Bump Zookeeper Client to 3.9.3.
  - Actively mark the impact of https://github.com/apache/incubator-seata/issues/7045 and https://github.com/testcontainers/testcontainers-java/issues/8338 in POM to resolve dependency conflict warnings.
  - Parts not relevant to this PR have been split into #34463 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
