### PR TITLE
Remove wrong owner set for CommonTableExpressionSegmentBinder

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/with/CommonTableExpressionSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/with/CommonTableExpressionSegmentBinder.java
@@ -21,11 +21,6 @@ import com.cedarsoftware.util.CaseInsensitiveMap;
 import com.cedarsoftware.util.CaseInsensitiveMap.CaseInsensitiveString;
 import com.google.common.base.Strings;
 import com.google.common.collect.LinkedHashMultimap;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.binder.engine.segment.SegmentType;
@@ -43,11 +38,16 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.Colu
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ExpressionProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ShorthandProjectionSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.OwnerSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.ColumnSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.TableSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SubqueryTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Common table expression segment binder.
@@ -98,11 +98,7 @@ public final class CommonTableExpressionSegmentBinder {
         } else {
             Collection<ProjectionSegment> projectionSegments = new LinkedList<>();
             bindWithColumns(commonTableExpressionSegment.getColumns(), commonTableExpressionSegment);
-            commonTableExpressionSegment.getColumns().forEach(each -> {
-                ColumnProjectionSegment columnProjectionSegment = new ColumnProjectionSegment(each);
-                columnProjectionSegment.getColumn().setOwner(new OwnerSegment(0, 0, commonTableExpressionSegment.getAliasSegment().getIdentifier()));
-                projectionSegments.add(columnProjectionSegment);
-            });
+            commonTableExpressionSegment.getColumns().forEach(each -> projectionSegments.add(new ColumnProjectionSegment(each)));
             return new SimpleTableSegmentBinderContext(projectionSegments);
         }
     }

--- a/test/it/binder/src/test/resources/cases/dml/select.xml
+++ b/test/it/binder/src/test/resources/cases/dml/select.xml
@@ -328,7 +328,6 @@
                     </select>
                 </subquery-expression>
                 <column name="status" start-index="10" stop-index="15" >
-                    <owner name="cte1" start-index="0" stop-index="0" />
                     <column-bound>
                         <original-database name="foo_db_1" />
                         <original-schema name="foo_db_1" />
@@ -337,7 +336,6 @@
                     </column-bound>
                 </column>
                 <column name="user_id" start-index="18" stop-index="24" >
-                    <owner name="cte1" start-index="0" stop-index="0" />
                     <column-bound>
                         <original-database name="foo_db_1" />
                         <original-schema name="foo_db_1" />
@@ -378,7 +376,6 @@
                     </select>
                 </subquery-expression>
                 <column name="user_id" start-index="76" stop-index="82" >
-                    <owner name="cte2" start-index="0" stop-index="0" />
                     <column-bound>
                         <original-database name="foo_db_1" />
                         <original-schema name="foo_db_1" />
@@ -387,7 +384,6 @@
                     </column-bound>
                 </column>
                 <column name="item_id" start-index="85" stop-index="91" >
-                    <owner name="cte2" start-index="0" stop-index="0" />
                     <column-bound>
                         <original-database name="foo_db_1" />
                         <original-schema name="foo_db_1" />
@@ -558,7 +554,6 @@
                     </select>
                 </subquery-expression>
                 <column name="col1" start-index="18" stop-index="21">
-                    <owner name="t_order_tmp" start-index="0" stop-index="0" />
                     <column-bound>
                         <original-database name="foo_db_1" />
                         <original-schema name="foo_db_1" />
@@ -567,7 +562,6 @@
                     </column-bound>
                 </column>
                 <column name="col2" start-index="24" stop-index="27">
-                    <owner name="t_order_tmp" start-index="0" stop-index="0" />
                     <column-bound>
                         <original-database name="foo_db_1" />
                         <original-schema name="foo_db_1" />
@@ -576,7 +570,6 @@
                     </column-bound>
                 </column>
                 <column name="col3" start-index="30" stop-index="33">
-                    <owner name="t_order_tmp" start-index="0" stop-index="0" />
                     <column-bound>
                         <original-database name="foo_db_1" />
                         <original-schema name="foo_db_1" />
@@ -585,7 +578,6 @@
                     </column-bound>
                 </column>
                 <column name="col4" start-index="36" stop-index="39">
-                    <owner name="t_order_tmp" start-index="0" stop-index="0" />
                     <column-bound>
                         <original-database name="foo_db_1" />
                         <original-schema name="foo_db_1" />
@@ -594,7 +586,6 @@
                     </column-bound>
                 </column>
                 <column name="col5" start-index="42" stop-index="45">
-                    <owner name="t_order_tmp" start-index="0" stop-index="0" />
                     <column-bound>
                         <original-database name="foo_db_1" />
                         <original-schema name="foo_db_1" />
@@ -603,7 +594,6 @@
                     </column-bound>
                 </column>
                 <column name="col6" start-index="48" stop-index="51">
-                    <owner name="t_order_tmp" start-index="0" stop-index="0" />
                     <column-bound>
                         <original-database name="foo_db_1" />
                         <original-schema name="foo_db_1" />


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove wrong owner set for CommonTableExpressionSegmentBinder

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
