### PR TITLE
Improve pipeline job progress incremental latestActiveTimeMillis persistence

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/IncrementalTaskAckCallback.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/IncrementalTaskAckCallback.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.data.pipeline.core.task;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.data.pipeline.core.channel.PipelineChannelAckCallback;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.type.placeholder.IngestPlaceholderPosition;
+import org.apache.shardingsphere.data.pipeline.core.ingest.record.DataRecord;
 import org.apache.shardingsphere.data.pipeline.core.ingest.record.Record;
 import org.apache.shardingsphere.data.pipeline.core.task.progress.IncrementalTaskProgress;
 
@@ -40,6 +41,8 @@ public final class IncrementalTaskAckCallback implements PipelineChannelAckCallb
             progress.setPosition(lastHandledRecord.getPosition());
             progress.getIncrementalTaskDelay().setLastEventTimestamps(lastHandledRecord.getCommitTime());
         }
-        progress.getIncrementalTaskDelay().setLatestActiveTimeMillis(System.currentTimeMillis());
+        if (!records.isEmpty() && records.stream().anyMatch(DataRecord.class::isInstance)) {
+            progress.getIncrementalTaskDelay().setLatestActiveTimeMillis(System.currentTimeMillis());
+        }
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Improve pipeline job progress incremental latestActiveTimeMillis persistence

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
