### PR TITLE
Fix mysql sql parser error when sql contains implicit concat expression

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@
 1. Mode: Fixes issue of drop schema can not work on standalone mode - [#34470](https://github.com/apache/shardingsphere/pull/34470)
 1. Mode: Fixes the exception to missing renamed schema name when alter schema - [#34465](https://github.com/apache/shardingsphere/pull/34465)
 1. SQL Parser: Fix set OnDuplicateKeyColumnsSegment on PostgreSQLInsertStatement - [#34425](https://github.com/apache/shardingsphere/pull/34425)
+1. SQL Parser: Fix mysql sql parser error when sql contains implicit concat expression - [#34660](https://github.com/apache/shardingsphere/pull/34660)
 
 ### Change Logs
 

--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -956,6 +956,7 @@ simpleExpr
     | matchExpression
     | caseExpression
     | intervalExpression
+    | implicitConcat
     ;
 
 path
@@ -1256,6 +1257,10 @@ caseElse
 
 intervalExpression
     : INTERVAL intervalValue
+    ;
+
+implicitConcat
+    : string_ (string_)*
     ;
 
 intervalValue

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -10018,4 +10018,32 @@
             </expression-projection>
         </projections>
     </select>
+
+    <select sql-case-id="select_with_mixed_single_double_quoted_literals">
+        <projections start-index="7" stop-index="17">
+            <expression-projection text="xxx" start-index="7" stop-index="17">
+                <literal-expression start-index="7" stop-index="17" value="xxx" />
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table name="t_order" start-index="24" stop-index="30" />
+        </from>
+        <where start-index="32" stop-index="62">
+            <expr>
+                <binary-operation-expression text="status LIKE &quot;%&quot; '123' &quot;%&quot;" start-index="38" stop-index="62">
+                    <left>
+                        <column name="status" start-index="38" stop-index="43" />
+                    </left>
+                    <right>
+                        <list-expression start-index="50" stop-index="62">
+                            <items>
+                                <literal-expression start-index="50" stop-index="62" value="%123%" />
+                            </items>
+                        </list-expression>
+                    </right>
+                    <operator>LIKE</operator>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -313,4 +313,5 @@
     <sql-case id="select_with_zone_keyword" value="SELECT order_id, zone FROM t_order" db-types="MySQL" />
     <sql-case id="select_with_reserved_word_range_and_table_owner" value="SELECT * FROM t_order o WHERE o.range = 1" db-types="MySQL"/>
     <sql-case id="select_with_multi_literals" value="SELECT 'x' 'x' 'x'" db-types="MySQL"/>
+    <sql-case id="select_with_mixed_single_double_quoted_literals" value="SELECT 'x' &quot;x&quot; 'x' FROM t_order WHERE status LIKE &quot;%&quot; '123' &quot;%&quot;" db-types="MySQL"/>
 </sql-cases>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix mysql sql parser error when sql contains implicit concat expression

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
