### PR TITLE
Support SQL parsing of Oracle comparison operators containing spaces

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -694,7 +694,7 @@ booleanPrimary
     ;
 
 comparisonOperator
-    : EQ_ | GTE_ | GT_ | LTE_ | LT_ | NEQ_
+    : EQ_ | GTE_ | GT_ | LTE_ | LT_ | NEQ_ | (GT_ | LT_) EQ_
     ;
 
 predicate

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -10068,4 +10068,42 @@
             </expr>
         </where>
     </select>
+    
+    <select sql-case-id="select_with_comparison_with_space">
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <from start-delimiter="" end-delimiter="" start-index="14" stop-index="17">
+            <simple-table name="test" start-delimiter="" end-delimiter="" start-index="14" stop-index="17"/>
+        </from>
+        <where start-index="19" stop-index="48">
+            <expr start-index="25" stop-index="48">
+                <binary-operation-expression start-index="25" stop-index="48">
+                    <left start-index="25" stop-index="32">
+                        <binary-operation-expression start-index="25" stop-index="32">
+                            <left start-index="25" stop-index="26">
+                                <column name="id" start-delimiter="" end-delimiter="" start-index="25" stop-index="26"/>
+                            </left>
+                            <operator>&gt;=</operator>
+                            <right start-index="32" stop-index="32">
+                                <literal-expression value="1" start-index="32" stop-index="32"/>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>or</operator>
+                    <right start-index="37" stop-index="48">
+                        <binary-operation-expression start-index="37" stop-index="48">
+                            <left start-index="37" stop-index="40">
+                                <column name="name" start-delimiter="" end-delimiter="" start-index="37" stop-index="40"/>
+                            </left>
+                            <operator>&lt;=</operator>
+                            <right start-index="48" stop-index="48">
+                                <literal-expression value="2" start-index="48" stop-index="48"/>
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -315,5 +315,5 @@
     <sql-case id="select_with_multi_literals" value="SELECT 'x' 'x' 'x'" db-types="MySQL"/>
     <sql-case id="select_with_mixed_single_double_quoted_literals" value="SELECT 'x' &quot;x&quot; 'x' FROM t_order WHERE status LIKE &quot;%&quot; '123' &quot;%&quot;" db-types="MySQL"/>
     <sql-case id="select_is_not_nan" value="SELECT COUNT(*) FROM employees WHERE commission_pct IS NOT NAN" db-types="Oracle"/>
-    <sql-case id="select_with_comparison_with_space" value="select * from test where id > = 1 or name <   = 2" db-types="Oracle"/>
+    <sql-case id="select_with_comparison_with_space" value="select * from test where id &gt; = 1 or name &lt;   = 2" db-types="Oracle"/>
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -315,4 +315,5 @@
     <sql-case id="select_with_multi_literals" value="SELECT 'x' 'x' 'x'" db-types="MySQL"/>
     <sql-case id="select_with_mixed_single_double_quoted_literals" value="SELECT 'x' &quot;x&quot; 'x' FROM t_order WHERE status LIKE &quot;%&quot; '123' &quot;%&quot;" db-types="MySQL"/>
     <sql-case id="select_is_not_nan" value="SELECT COUNT(*) FROM employees WHERE commission_pct IS NOT NAN" db-types="Oracle"/>
+    <sql-case id="select_with_comparison_with_space" value="select * from test where id > = 1 or name <   = 2" db-types="Oracle"/>
 </sql-cases>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
