### PR TITLE
Use DistSQLDatabaseRuleQueryExecutorAssert in ShowShardingTableReferenceRuleExecutorTest

### DIFF
--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/handler/query/ShowShardingTableReferenceRuleExecutorTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/handler/query/ShowShardingTableReferenceRuleExecutorTest.java
@@ -18,58 +18,27 @@
 package org.apache.shardingsphere.sharding.distsql.handler.query;
 
 import org.apache.shardingsphere.distsql.statement.DistSQLStatement;
-import org.apache.shardingsphere.infra.config.rule.scope.DatabaseRuleConfiguration;
 import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
-import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableReferenceRuleConfiguration;
-import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
-import org.apache.shardingsphere.sharding.distsql.statement.ShowShardingTableReferenceRulesStatement;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
-import org.apache.shardingsphere.test.it.distsql.handler.engine.query.DistSQLDatabaseRuleQueryExecutorTest;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.apache.shardingsphere.test.it.distsql.handler.engine.query.DistSQLDatabaseRuleQueryExecutorAssert;
+import org.apache.shardingsphere.test.it.distsql.handler.engine.query.DistSQLRuleQueryExecutorSettings;
+import org.apache.shardingsphere.test.it.distsql.handler.engine.query.DistSQLRuleQueryExecutorTestCaseArgumentsProvider;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
 
-class ShowShardingTableReferenceRuleExecutorTest extends DistSQLDatabaseRuleQueryExecutorTest {
+@DistSQLRuleQueryExecutorSettings("cases/show-sharding-table-reference-rule.xml")
+class ShowShardingTableReferenceRuleExecutorTest {
     
-    ShowShardingTableReferenceRuleExecutorTest() {
-        super(mock(ShardingRule.class));
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @ArgumentsSource(TestCaseArgumentsProvider.class)
-    void assertExecuteQuery(final String name, final DatabaseRuleConfiguration ruleConfig, final DistSQLStatement sqlStatement,
-                            final Collection<LocalDataQueryResultRow> expected) throws SQLException {
-        assertQueryResultRows(ruleConfig, sqlStatement, expected);
-    }
-    
-    private static class TestCaseArgumentsProvider implements ArgumentsProvider {
-        
-        @Override
-        public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext) {
-            return Stream.of(Arguments.arguments("normal", createRuleConfiguration(), new ShowShardingTableReferenceRulesStatement(null, null),
-                    Collections.singleton(new LocalDataQueryResultRow("foo", "t_order,t_order_item"))),
-                    Arguments.arguments("withSpecifiedRuleName", createRuleConfiguration(), new ShowShardingTableReferenceRulesStatement("foo", null),
-                            Collections.singleton(new LocalDataQueryResultRow("foo", "t_order,t_order_item"))));
-        }
-        
-        private ShardingRuleConfiguration createRuleConfiguration() {
-            ShardingRuleConfiguration result = new ShardingRuleConfiguration();
-            result.getTables().add(new ShardingTableRuleConfiguration("t_order", null));
-            result.getTables().add(new ShardingTableRuleConfiguration("t_order_item", null));
-            result.getTables().add(new ShardingTableRuleConfiguration("t_1", null));
-            result.getTables().add(new ShardingTableRuleConfiguration("t_2", null));
-            result.getBindingTableGroups().add(new ShardingTableReferenceRuleConfiguration("foo", "t_order,t_order_item"));
-            return result;
-        }
+    @ParameterizedTest(name = "DistSQL -> {0}")
+    @ArgumentsSource(DistSQLRuleQueryExecutorTestCaseArgumentsProvider.class)
+    void assertExecuteQuery(@SuppressWarnings("unused") final String distSQL, final DistSQLStatement sqlStatement,
+                            final ShardingRuleConfiguration currentRuleConfig, final Collection<LocalDataQueryResultRow> expected) throws SQLException {
+        new DistSQLDatabaseRuleQueryExecutorAssert(mock(ShardingRule.class)).assertQueryResultRows(currentRuleConfig, sqlStatement, expected);
     }
 }

--- a/features/sharding/distsql/handler/src/test/resources/cases/show-sharding-table-reference-rule-current-config.yaml
+++ b/features/sharding/distsql/handler/src/test/resources/cases/show-sharding-table-reference-rule-current-config.yaml
@@ -1,0 +1,100 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+rules:
+  - !SHARDING
+    tables:
+      t_user:
+        actualDataNodes: ds_${0..1}.t_user_${0..15}
+        databaseStrategy:
+          complex:
+            shardingColumns: region_id, user_id
+            shardingAlgorithmName: core_complex_fixture
+        tableStrategy:
+          complex:
+            shardingColumns: region_id, user_id
+            shardingAlgorithmName: core_complex_fixture
+      t_stock:
+        actualDataNodes: ds_${0..1}.t_stock{0..8}
+        databaseStrategy:
+          hint:
+            shardingAlgorithmName: core_hint_fixture
+        tableStrategy:
+          hint:
+            shardingAlgorithmName: core_hint_fixture
+      t_order:
+        actualDataNodes: ds_${0..1}.t_order_${0..1}
+        tableStrategy:
+          standard:
+            shardingColumn: order_id
+            shardingAlgorithmName: table_inline
+        keyGenerateStrategy:
+          column: order_id
+          keyGeneratorName: snowflake
+      t_order_item:
+        actualDataNodes: ds_${0..1}.t_order_item_${0..1}
+        tableStrategy:
+          standard:
+            shardingColumn: order_id
+            shardingAlgorithmName: core_standard_fixture
+    bindingTables:
+      - foo:t_order, t_order_item
+    defaultDatabaseStrategy:
+      standard:
+        shardingColumn: order_id
+        shardingAlgorithmName: database_inline
+    defaultTableStrategy:
+      none:
+    defaultShardingColumn: order_id
+    defaultKeyGenerateStrategy:
+      column: id
+      keyGeneratorName: snowflake
+    defaultAuditStrategy:
+      auditorNames:
+        - sharding_key_required_auditor
+      allowHintDisable: true
+
+    shardingAlgorithms:
+      core_standard_fixture:
+        type: CORE.STANDARD.FIXTURE
+      core_complex_fixture:
+        type: CORE.COMPLEX.FIXTURE
+      core_hint_fixture:
+        type: CORE.HINT.FIXTURE
+      database_inline:
+        type: INLINE
+        props:
+          algorithm-expression: ds_${order_id % 2}
+      table_inline:
+        type: INLINE
+        props:
+          algorithm-expression: t_order_${order_id % 2}
+
+    keyGenerators:
+      snowflake:
+        type: SNOWFLAKE
+
+    auditors:
+      sharding_key_required_auditor:
+        type: DML_SHARDING_CONDITIONS
+
+    shardingCache:
+      allowedMaxSqlLength: 512
+      routeCache:
+        softValues: true
+        initialCapacity: 65536
+        maximumSize: 262144

--- a/features/sharding/distsql/handler/src/test/resources/cases/show-sharding-table-reference-rule.xml
+++ b/features/sharding/distsql/handler/src/test/resources/cases/show-sharding-table-reference-rule.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<distsql-rule-query-executor-test-cases>
+    <test-case dist-sql="SHOW SHARDING TABLE REFERENCE RULES" current-rule-config-yaml-file="cases/show-sharding-table-reference-rule-current-config.yaml">
+        <expected-query-result-rows>
+            <expected-query-result-row>
+                foo|t_order, t_order_item
+            </expected-query-result-row>
+        </expected-query-result-rows>
+    </test-case>
+</distsql-rule-query-executor-test-cases>


### PR DESCRIPTION
For #33142 .

Changes proposed in this pull request:
  - Use DistSQLDatabaseRuleQueryExecutorAssert in ShowShardingTableReferenceRuleExecutorTest

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
