### PR TITLE
Use EncryptDerivedColumnSuffix to enhance encrypt table subquery rewrite logic

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,7 @@
 1. SQL Parser: Support MySQL SELECT MAX(ALL expr) statement parse - [#34639](https://github.com/apache/shardingsphere/pull/34639)
 1. SQL Parser: Support MySQL INSERT with GEOMCOLLECTION function parse - [#34654](https://github.com/apache/shardingsphere/pull/34654)
 1. SQL Parser: Support MySQL DELETE with statement parse - [#34817](https://github.com/apache/shardingsphere/pull/34817) 
+1. Encrypt: Use EncryptDerivedColumnSuffix to enhance encrypt table subquery rewrite logic - [#34829](https://github.com/apache/shardingsphere/pull/34829)
 
 ### Bug Fixes
 

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/checker/sql/projection/EncryptSelectProjectionSupportedChecker.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/checker/sql/projection/EncryptSelectProjectionSupportedChecker.java
@@ -94,7 +94,8 @@ public final class EncryptSelectProjectionSupportedChecker implements SupportedS
     
     private ColumnSegmentBoundInfo getColumnSegmentBoundInfo(final Projection projection) {
         return projection instanceof ColumnProjection
-                ? new ColumnSegmentBoundInfo(null, ((ColumnProjection) projection).getOriginalTable(), ((ColumnProjection) projection).getOriginalColumn())
+                ? new ColumnSegmentBoundInfo(null, ((ColumnProjection) projection).getOriginalTable(), ((ColumnProjection) projection).getOriginalColumn(),
+                        ((ColumnProjection) projection).getColumnBoundInfo().getTableSourceType())
                 : new ColumnSegmentBoundInfo(new IdentifierValue(projection.getColumnLabel()));
     }
     

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/enums/EncryptDerivedColumnSuffix.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/enums/EncryptDerivedColumnSuffix.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.enums;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.database.core.metadata.database.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
+
+/**
+ * Encrypt derived column suffix.
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum EncryptDerivedColumnSuffix {
+    
+    DERIVED_PLAIN("_DERIVED_PLAIN"),
+    DERIVED_CIPHER("_DERIVED_CIPHER"),
+    DERIVED_ASSISTED_QUERY("_DERIVED_ASSISTED_QUERY"),
+    DERIVED_LIKE_QUERY("_DERIVED_LIKE_QUERY"),
+    DERIVED_ORDER_QUERY("_DERIVED_ORDER_QUERY");
+    
+    private final String suffix;
+    
+    /**
+     * Get derived column name.
+     *
+     * @param columnName column name
+     * @param databaseType database type
+     * @return derived column name
+     */
+    public String getDerivedColumnName(final String columnName, final DatabaseType databaseType) {
+        DialectDatabaseMetaData dialectDatabaseMetaData = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData();
+        return String.format("%s%s", columnName, dialectDatabaseMetaData.formatTableNamePattern(suffix));
+    }
+}

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGenerator.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.encrypt.rewrite.token.generator.predicate;
 import com.google.common.base.Preconditions;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.apache.shardingsphere.encrypt.enums.EncryptDerivedColumnSuffix;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.column.EncryptColumn;
 import org.apache.shardingsphere.encrypt.rule.column.item.LikeQueryColumnItem;
@@ -31,11 +32,11 @@ import org.apache.shardingsphere.infra.binder.context.segment.select.projection.
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.binder.context.type.WhereAvailable;
-import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.CollectionSQLTokenGenerator;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.generic.SubstitutableColumnNameToken;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.extractor.ColumnExtractor;
 import org.apache.shardingsphere.sql.parser.statement.core.extractor.ExpressionExtractor;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
@@ -110,12 +111,12 @@ public final class EncryptPredicateColumnTokenGenerator implements CollectionSQL
         if (isIncludeLike(expression)) {
             Optional<LikeQueryColumnItem> likeQueryColumnItem = encryptColumn.getLikeQuery();
             Preconditions.checkState(likeQueryColumnItem.isPresent());
-            Collection<Projection> columnProjections = createColumnProjections(likeQueryColumnItem.get().getName(), columnSegment.getIdentifier().getQuoteCharacter(), databaseType);
-            return Collections.singleton(new SubstitutableColumnNameToken(startIndex, stopIndex, columnProjections, databaseType));
+            return Collections.singleton(new SubstitutableColumnNameToken(startIndex, stopIndex, createColumnProjections(
+                    likeQueryColumnItem.get().getName(), columnSegment, EncryptDerivedColumnSuffix.DERIVED_LIKE_QUERY, databaseType), databaseType));
         }
         Collection<Projection> columnProjections = encryptColumn.getAssistedQuery()
-                .map(optional -> createColumnProjections(optional.getName(), columnSegment.getIdentifier().getQuoteCharacter(), databaseType))
-                .orElseGet(() -> createColumnProjections(encryptColumn.getCipher().getName(), columnSegment.getIdentifier().getQuoteCharacter(), databaseType));
+                .map(optional -> createColumnProjections(optional.getName(), columnSegment, EncryptDerivedColumnSuffix.DERIVED_ASSISTED_QUERY, databaseType))
+                .orElseGet(() -> createColumnProjections(encryptColumn.getCipher().getName(), columnSegment, EncryptDerivedColumnSuffix.DERIVED_CIPHER, databaseType));
         return Collections.singleton(new SubstitutableColumnNameToken(startIndex, stopIndex, columnProjections, databaseType));
     }
     
@@ -123,8 +124,12 @@ public final class EncryptPredicateColumnTokenGenerator implements CollectionSQL
         return expression instanceof BinaryOperationExpression && "LIKE".equalsIgnoreCase(((BinaryOperationExpression) expression).getOperator());
     }
     
-    private Collection<Projection> createColumnProjections(final String columnName, final QuoteCharacter quoteCharacter, final DatabaseType databaseType) {
-        ColumnProjection columnProjection = new ColumnProjection(null, new IdentifierValue(columnName, quoteCharacter), null, databaseType);
+    private Collection<Projection> createColumnProjections(final String actualColumnName, final ColumnSegment columnSegment, final EncryptDerivedColumnSuffix derivedColumnSuffix,
+                                                           final DatabaseType databaseType) {
+        String columnName = TableSourceType.TEMPORARY_TABLE == columnSegment.getColumnBoundInfo().getTableSourceType()
+                ? derivedColumnSuffix.getDerivedColumnName(columnSegment.getIdentifier().getValue(), databaseType)
+                : actualColumnName;
+        ColumnProjection columnProjection = new ColumnProjection(null, new IdentifierValue(columnName, columnSegment.getIdentifier().getQuoteCharacter()), null, databaseType);
         return Collections.singleton(columnProjection);
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/checker/cryptographic/InsertSelectColumnsEncryptorCheckerTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/checker/cryptographic/InsertSelectColumnsEncryptorCheckerTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.encrypt.config.rule.EncryptTableRuleConfigurati
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.infra.algorithm.core.config.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ColumnProjection;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.ColumnSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.TableSegmentBoundInfo;
@@ -59,14 +60,16 @@ class InsertSelectColumnsEncryptorCheckerTest {
     }
     
     private ColumnProjection getSelectProjection(final String pwd, final IdentifierValue databaseValue, final IdentifierValue schemaValue) {
+        TableSegmentBoundInfo tableSegmentBoundInfo = new TableSegmentBoundInfo(databaseValue, schemaValue);
         return new ColumnProjection(new IdentifierValue("table2"), new IdentifierValue(pwd), null, null, null, null,
-                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(databaseValue, schemaValue), new IdentifierValue("table2"), new IdentifierValue(pwd)));
+                new ColumnSegmentBoundInfo(tableSegmentBoundInfo, new IdentifierValue("table2"), new IdentifierValue(pwd), TableSourceType.TEMPORARY_TABLE));
     }
     
     private ColumnSegment getInsertColumnSegment(final IdentifierValue databaseValue, final IdentifierValue schemaValue, final String tableName, final String columnName) {
         ColumnSegment result = mock(ColumnSegment.class);
+        TableSegmentBoundInfo tableSegmentBoundInfo = new TableSegmentBoundInfo(databaseValue, schemaValue);
         when(result.getColumnBoundInfo())
-                .thenReturn(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(databaseValue, schemaValue), new IdentifierValue(tableName), new IdentifierValue(columnName)));
+                .thenReturn(new ColumnSegmentBoundInfo(tableSegmentBoundInfo, new IdentifierValue(tableName), new IdentifierValue(columnName), TableSourceType.TEMPORARY_TABLE));
         return result;
     }
     

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/checker/sql/orderby/EncryptOrderByItemSupportedCheckerTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/checker/sql/orderby/EncryptOrderByItemSupportedCheckerTest.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.enums.Nul
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.OrderDirection;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.item.ColumnOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.AliasSegment;
@@ -118,8 +119,8 @@ class EncryptOrderByItemSupportedCheckerTest {
         simpleTableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("a")));
         ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("foo_col"));
         columnSegment.setOwner(new OwnerSegment(0, 0, new IdentifierValue("a")));
-        columnSegment.setColumnBoundInfo(
-                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue(tableName), new IdentifierValue("foo_col")));
+        TableSegmentBoundInfo tableSegmentBoundInfo = new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db"));
+        columnSegment.setColumnBoundInfo(new ColumnSegmentBoundInfo(tableSegmentBoundInfo, new IdentifierValue(tableName), new IdentifierValue("foo_col"), TableSourceType.TEMPORARY_TABLE));
         SelectStatementContext result = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(result.getDatabaseType()).thenReturn(databaseType);
         ColumnOrderByItemSegment columnOrderByItemSegment = new ColumnOrderByItemSegment(columnSegment, OrderDirection.ASC, NullsOrderType.FIRST);

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/checker/sql/predicate/EncryptPredicateColumnSupportedCheckerTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/checker/sql/predicate/EncryptPredicateColumnSupportedCheckerTest.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.encrypt.rewrite.token.generator.fixture.Encrypt
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
@@ -68,10 +69,11 @@ class EncryptPredicateColumnSupportedCheckerTest {
     private SQLStatementContext mockSelectStatementContextWithDifferentEncryptorsInJoinCondition() {
         ColumnSegment leftColumn = new ColumnSegment(0, 0, new IdentifierValue("user_name"));
         leftColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")), new IdentifierValue("t_user"),
-                new IdentifierValue("user_name")));
+                new IdentifierValue("user_name"), TableSourceType.PHYSICAL_TABLE));
         ColumnSegment rightColumn = new ColumnSegment(0, 0, new IdentifierValue("user_id"));
         rightColumn.setColumnBoundInfo(
-                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")), new IdentifierValue("t_user"), new IdentifierValue("user_id")));
+                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")), new IdentifierValue("t_user"), new IdentifierValue("user_id"),
+                        TableSourceType.PHYSICAL_TABLE));
         SelectStatementContext result = mock(SelectStatementContext.class);
         when(result.getJoinConditions()).thenReturn(Collections.singleton(new BinaryOperationExpression(0, 0, leftColumn, rightColumn, "=", "")));
         return result;
@@ -86,7 +88,7 @@ class EncryptPredicateColumnSupportedCheckerTest {
     private SQLStatementContext mockSelectStatementContextWithLike() {
         ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("user_name"));
         columnSegment.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")), new IdentifierValue("t_user"),
-                new IdentifierValue("user_name")));
+                new IdentifierValue("user_name"), TableSourceType.PHYSICAL_TABLE));
         SelectStatementContext result = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(result.getColumnSegments()).thenReturn(Collections.singleton(columnSegment));
         when(result.getWhereSegments()).thenReturn(Collections.singleton(new WhereSegment(0, 0, new BinaryOperationExpression(0, 0, columnSegment, columnSegment, "LIKE", ""))));
@@ -103,7 +105,7 @@ class EncryptPredicateColumnSupportedCheckerTest {
     private SQLStatementContext mockSelectStatementContextWithEqual() {
         ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("user_name"));
         columnSegment.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")), new IdentifierValue("t_user"),
-                new IdentifierValue("user_name")));
+                new IdentifierValue("user_name"), TableSourceType.PHYSICAL_TABLE));
         SelectStatementContext result = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(result.getColumnSegments()).thenReturn(Collections.singleton(columnSegment));
         when(result.getWhereSegments()).thenReturn(Collections.singleton(new WhereSegment(0, 0, new BinaryOperationExpression(0, 0, columnSegment, columnSegment, "=", ""))));

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/checker/sql/projection/EncryptSelectProjectionSupportedCheckerTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/checker/sql/projection/EncryptSelectProjectionSupportedCheckerTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.infra.binder.context.statement.dml.SelectStatem
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.combine.CombineSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ShorthandProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.ColumnSegmentBoundInfo;
@@ -70,7 +71,7 @@ class EncryptSelectProjectionSupportedCheckerTest {
     void assertCheckWhenShorthandExpandContainsSubqueryTable() {
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.containsTableSubquery()).thenReturn(true);
-        when(sqlStatementContext.getSqlStatement().getProjections().getProjections()).thenReturn(Collections.singleton(new ShorthandProjectionSegment(0, 0)));
+        when(sqlStatementContext.getSqlStatement().getProjections().getProjections()).thenReturn(Collections.singletonList(new ShorthandProjectionSegment(0, 0)));
         assertThrows(UnsupportedSQLOperationException.class, () -> new EncryptSelectProjectionSupportedChecker().check(mock(EncryptRule.class, RETURNS_DEEP_STUBS), null, null, sqlStatementContext));
     }
     
@@ -93,15 +94,19 @@ class EncryptSelectProjectionSupportedCheckerTest {
         when(combineSegment.getRight().getStartIndex()).thenReturn(1);
         when(result.getSqlStatement().getCombine()).thenReturn(Optional.of(combineSegment));
         ColumnProjection leftColumn1 = new ColumnProjection(new IdentifierValue("f"), new IdentifierValue("foo_col_1"), null, databaseType, null, null,
-                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue(""), new IdentifierValue("")), new IdentifierValue("foo_tbl"), new IdentifierValue("foo_col_1")));
+                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue(""), new IdentifierValue("")), new IdentifierValue("foo_tbl"), new IdentifierValue("foo_col_1"),
+                        TableSourceType.PHYSICAL_TABLE));
         ColumnProjection leftColumn2 = new ColumnProjection(new IdentifierValue("f"), new IdentifierValue("foo_col_2"), null, databaseType, null, null,
-                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue(""), new IdentifierValue("")), new IdentifierValue("foo_tbl"), new IdentifierValue("foo_col_2")));
+                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue(""), new IdentifierValue("")), new IdentifierValue("foo_tbl"), new IdentifierValue("foo_col_2"),
+                        TableSourceType.PHYSICAL_TABLE));
         SelectStatementContext leftSelectStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(leftSelectStatementContext.getProjectionsContext().getExpandProjections()).thenReturn(Arrays.asList(leftColumn1, leftColumn2));
         ColumnProjection rightColumn1 = new ColumnProjection(new IdentifierValue("b"), new IdentifierValue("bar_col_1"), null, databaseType, null, null,
-                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue(""), new IdentifierValue("")), new IdentifierValue("bar_tbl"), new IdentifierValue("bar_col_1")));
+                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue(""), new IdentifierValue("")), new IdentifierValue("bar_tbl"), new IdentifierValue("bar_col_1"),
+                        TableSourceType.PHYSICAL_TABLE));
         ColumnProjection rightColumn2 = new ColumnProjection(new IdentifierValue("b"), new IdentifierValue("bar_col_2"), null, databaseType, null, null,
-                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue(""), new IdentifierValue("")), new IdentifierValue("bar_tbl"), new IdentifierValue("bar_col_2")));
+                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue(""), new IdentifierValue("")), new IdentifierValue("bar_tbl"), new IdentifierValue("bar_col_2"),
+                        TableSourceType.PHYSICAL_TABLE));
         SelectStatementContext rightSelectStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(rightSelectStatementContext.getProjectionsContext().getExpandProjections()).thenReturn(Arrays.asList(rightColumn1, rightColumn2));
         Map<Integer, SelectStatementContext> subqueryContexts = new LinkedHashMap<>(2, 1F);

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResultTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResultTest.java
@@ -32,6 +32,7 @@ import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.ColumnSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.TableSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
@@ -112,7 +113,8 @@ class EncryptMergedResultTest {
     void assertGetValueWithEncryptColumn() throws SQLException {
         ColumnProjection columnProjection =
                 new ColumnProjection(new IdentifierValue("foo_tbl"), new IdentifierValue("foo_col"), new IdentifierValue("foo_alias"), databaseType, null, null, new ColumnSegmentBoundInfo(
-                        new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")), new IdentifierValue("foo_tbl"), new IdentifierValue("foo_col")));
+                        new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")), new IdentifierValue("foo_tbl"), new IdentifierValue("foo_col"),
+                        TableSourceType.PHYSICAL_TABLE));
         when(selectStatementContext.findColumnProjection(1)).thenReturn(Optional.of(columnProjection));
         when(selectStatementContext.getTablesContext().getSchemaName()).thenReturn(Optional.of("foo_schema"));
         EncryptAlgorithm encryptAlgorithm = mock(EncryptAlgorithm.class);
@@ -128,7 +130,8 @@ class EncryptMergedResultTest {
     void assertGetValueFailed() throws SQLException {
         ColumnProjection columnProjection =
                 new ColumnProjection(new IdentifierValue("foo_tbl"), new IdentifierValue("foo_col"), new IdentifierValue("foo_alias"), databaseType, null, null, new ColumnSegmentBoundInfo(
-                        new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")), new IdentifierValue("foo_tbl"), new IdentifierValue("foo_col")));
+                        new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")), new IdentifierValue("foo_tbl"), new IdentifierValue("foo_col"),
+                        TableSourceType.PHYSICAL_TABLE));
         when(selectStatementContext.findColumnProjection(1)).thenReturn(Optional.of(columnProjection));
         when(selectStatementContext.getTablesContext().getSchemaName()).thenReturn(Optional.of("foo_schema"));
         EncryptAlgorithm encryptAlgorithm = mock(EncryptAlgorithm.class);

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/fixture/EncryptGeneratorFixtureBuilder.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/fixture/EncryptGeneratorFixtureBuilder.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.generic.InsertValue;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.ColumnAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.InsertValuesSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.SetAssignmentSegment;
@@ -130,10 +131,10 @@ public final class EncryptGeneratorFixtureBuilder {
         result.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_user"))));
         ColumnSegment userIdColumn = new ColumnSegment(0, 0, new IdentifierValue("user_id"));
         userIdColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("t_user"),
-                new IdentifierValue("user_id")));
+                new IdentifierValue("user_id"), TableSourceType.PHYSICAL_TABLE));
         ColumnSegment userNameColumn = new ColumnSegment(0, 0, new IdentifierValue("user_name"));
         userNameColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")),
-                new IdentifierValue("t_user"), new IdentifierValue("user_name")));
+                new IdentifierValue("t_user"), new IdentifierValue("user_name"), TableSourceType.PHYSICAL_TABLE));
         List<ColumnSegment> insertColumns = Arrays.asList(userIdColumn, userNameColumn);
         if (containsInsertColumns) {
             result.setInsertColumns(new InsertColumnsSegment(0, 0, insertColumns));
@@ -147,7 +148,7 @@ public final class EncryptGeneratorFixtureBuilder {
         projections.getProjections().add(new ColumnProjectionSegment(userIdColumn));
         ColumnSegment statusColumn = new ColumnSegment(0, 0, new IdentifierValue("status"));
         statusColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("t_user"),
-                new IdentifierValue("status")));
+                new IdentifierValue("status"), TableSourceType.PHYSICAL_TABLE));
         projections.getProjections().add(new ColumnProjectionSegment(statusColumn));
         selectStatement.setProjections(projections);
         result.setInsertSelect(new SubquerySegment(0, 0, selectStatement, ""));
@@ -169,12 +170,11 @@ public final class EncryptGeneratorFixtureBuilder {
     
     private static WhereSegment createWhereSegment() {
         ColumnSegment nameColumnSegment = new ColumnSegment(10, 13, new IdentifierValue("name"));
-        nameColumnSegment.setColumnBoundInfo(
-                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("t_user"), new IdentifierValue("name")));
+        TableSegmentBoundInfo tableSegmentBoundInfo = new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db"));
+        nameColumnSegment.setColumnBoundInfo(new ColumnSegmentBoundInfo(tableSegmentBoundInfo, new IdentifierValue("t_user"), new IdentifierValue("name"), TableSourceType.TEMPORARY_TABLE));
         BinaryOperationExpression nameExpression = new BinaryOperationExpression(10, 24, nameColumnSegment, new LiteralExpressionSegment(18, 22, "LiLei"), "=", "name = 'LiLei'");
         ColumnSegment pwdColumnSegment = new ColumnSegment(30, 32, new IdentifierValue("pwd"));
-        pwdColumnSegment.setColumnBoundInfo(
-                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("t_user"), new IdentifierValue("pwd")));
+        pwdColumnSegment.setColumnBoundInfo(new ColumnSegmentBoundInfo(tableSegmentBoundInfo, new IdentifierValue("t_user"), new IdentifierValue("pwd"), TableSourceType.TEMPORARY_TABLE));
         BinaryOperationExpression pwdExpression = new BinaryOperationExpression(30, 44, pwdColumnSegment, new LiteralExpressionSegment(40, 45, "123456"), "=", "pwd = '123456'");
         return new WhereSegment(0, 0, new BinaryOperationExpression(0, 0, nameExpression, pwdExpression, "AND", "name = 'LiLei' AND pwd = '123456'"));
     }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGeneratorTest.java
@@ -47,6 +47,6 @@ class EncryptPredicateColumnTokenGeneratorTest {
     void assertGenerateSQLTokenFromGenerateNewSQLToken() {
         Collection<SQLToken> substitutableColumnNameTokens = generator.generateSQLTokens(EncryptGeneratorFixtureBuilder.createUpdateStatementContext());
         assertThat(substitutableColumnNameTokens.size(), is(1));
-        assertThat(((SubstitutableColumnNameToken) substitutableColumnNameTokens.iterator().next()).toString(null), is("pwd_assist"));
+        assertThat(((SubstitutableColumnNameToken) substitutableColumnNameTokens.iterator().next()).toString(null), is("pwd_DERIVED_ASSISTED_QUERY"));
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptProjectionTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptProjectionTokenGeneratorTest.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ColumnProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionsSegment;
@@ -86,10 +87,10 @@ class EncryptProjectionTokenGeneratorTest {
         doctorTable.setAlias(new AliasSegment(0, 0, new IdentifierValue("a")));
         ColumnSegment column = new ColumnSegment(0, 0, new IdentifierValue("mobile"));
         column.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("doctor"),
-                new IdentifierValue("mobile")));
+                new IdentifierValue("mobile"), TableSourceType.PHYSICAL_TABLE));
         column.setOwner(new OwnerSegment(0, 0, new IdentifierValue("a")));
         ProjectionsSegment projections = mock(ProjectionsSegment.class);
-        when(projections.getProjections()).thenReturn(Collections.singleton(new ColumnProjectionSegment(column)));
+        when(projections.getProjections()).thenReturn(Collections.singletonList(new ColumnProjectionSegment(column)));
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getSubqueryType()).thenReturn(null);
         when(sqlStatementContext.getDatabaseType()).thenReturn(databaseType);
@@ -108,10 +109,10 @@ class EncryptProjectionTokenGeneratorTest {
         doctorTable.setAlias(new AliasSegment(0, 0, new IdentifierValue("a")));
         ColumnSegment column = new ColumnSegment(0, 0, new IdentifierValue("mobile"));
         column.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("doctor"),
-                new IdentifierValue("mobile")));
+                new IdentifierValue("mobile"), TableSourceType.PHYSICAL_TABLE));
         column.setOwner(new OwnerSegment(0, 0, new IdentifierValue("a")));
         ProjectionsSegment projections = mock(ProjectionsSegment.class);
-        when(projections.getProjections()).thenReturn(Collections.singleton(new ColumnProjectionSegment(column)));
+        when(projections.getProjections()).thenReturn(Collections.singletonList(new ColumnProjectionSegment(column)));
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getSubqueryType()).thenReturn(null);
         when(sqlStatementContext.getDatabaseType()).thenReturn(databaseType);
@@ -129,7 +130,7 @@ class EncryptProjectionTokenGeneratorTest {
         ColumnSegment column = new ColumnSegment(0, 0, new IdentifierValue("mobile"));
         column.setOwner(new OwnerSegment(0, 0, new IdentifierValue("doctor")));
         ProjectionsSegment projections = mock(ProjectionsSegment.class);
-        when(projections.getProjections()).thenReturn(Collections.singleton(new ColumnProjectionSegment(column)));
+        when(projections.getProjections()).thenReturn(Collections.singletonList(new ColumnProjectionSegment(column)));
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getSubqueryType()).thenReturn(null);
         when(sqlStatementContext.getDatabaseType()).thenReturn(databaseType);

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/select/EncryptGroupByItemTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/select/EncryptGroupByItemTokenGeneratorTest.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.enums.Nul
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.OrderDirection;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.item.ColumnOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.AliasSegment;
@@ -79,8 +80,9 @@ class EncryptGroupByItemTokenGeneratorTest {
         SimpleTableSegment simpleTableSegment = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_encrypt")));
         simpleTableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("a")));
         ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("certificate_number"));
-        columnSegment.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("t_encrypt"),
-                new IdentifierValue("certificate_number")));
+        TableSegmentBoundInfo tableSegmentBoundInfo = new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db"));
+        columnSegment
+                .setColumnBoundInfo(new ColumnSegmentBoundInfo(tableSegmentBoundInfo, new IdentifierValue("t_encrypt"), new IdentifierValue("certificate_number"), TableSourceType.TEMPORARY_TABLE));
         columnSegment.setOwner(new OwnerSegment(0, 0, new IdentifierValue("a")));
         SelectStatementContext result = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(result.getDatabaseType()).thenReturn(databaseType);

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
@@ -48,6 +48,7 @@ import org.apache.shardingsphere.sharding.api.config.strategy.sharding.StandardS
 import org.apache.shardingsphere.sharding.exception.metadata.DuplicateShardingActualDataNodeException;
 import org.apache.shardingsphere.sharding.exception.metadata.InvalidBindingTablesException;
 import org.apache.shardingsphere.sharding.exception.metadata.ShardingTableRuleNotFoundException;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
@@ -684,17 +685,17 @@ class ShardingRuleTest {
     void assertIsAllBindingTableWithJoinQueryWithDatabaseTableJoinCondition() {
         ColumnSegment leftDatabaseJoin = createColumnSegment("user_id", "logic_Table");
         leftDatabaseJoin.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("logic_Table"),
-                new IdentifierValue("user_id")));
+                new IdentifierValue("user_id"), TableSourceType.TEMPORARY_TABLE));
         ColumnSegment rightDatabaseJoin = createColumnSegment("user_id", "sub_Logic_Table");
         rightDatabaseJoin.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("sub_Logic_Table"),
-                new IdentifierValue("user_id")));
+                new IdentifierValue("user_id"), TableSourceType.TEMPORARY_TABLE));
         BinaryOperationExpression databaseJoin = createBinaryOperationExpression(leftDatabaseJoin, rightDatabaseJoin, EQUAL);
         ColumnSegment leftTableJoin = createColumnSegment("order_id", "logic_Table");
         leftTableJoin.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("logic_Table"),
-                new IdentifierValue("order_id")));
+                new IdentifierValue("order_id"), TableSourceType.TEMPORARY_TABLE));
         ColumnSegment rightTableJoin = createColumnSegment("order_id", "sub_Logic_Table");
         rightTableJoin.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("sub_Logic_Table"),
-                new IdentifierValue("order_id")));
+                new IdentifierValue("order_id"), TableSourceType.TEMPORARY_TABLE));
         BinaryOperationExpression tableJoin = createBinaryOperationExpression(leftTableJoin, rightTableJoin, EQUAL);
         JoinTableSegment joinTable = mock(JoinTableSegment.class);
         BinaryOperationExpression condition = createBinaryOperationExpression(databaseJoin, tableJoin, AND);

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/extractor/SQLStatementContextExtractor.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/extractor/SQLStatementContextExtractor.java
@@ -94,7 +94,6 @@ public final class SQLStatementContextExtractor {
             insertSelectContext.getSelectStatementContext().getSubqueryContexts().values().forEach(each -> result.addAll(getAllSubqueryContexts(each)));
             return result;
         }
-        // SPEX ADDED: BEGIN
         if (sqlStatementContext instanceof CreateViewStatementContext) {
             CreateViewStatementContext createViewStatementContext = (CreateViewStatementContext) sqlStatementContext;
             result.add(createViewStatementContext.getSelectStatementContext());
@@ -109,7 +108,6 @@ public final class SQLStatementContextExtractor {
             alterViewStatementContext.getSelectStatementContext().get().getSubqueryContexts().values().forEach(each -> result.addAll(getAllSubqueryContexts(each)));
             return result;
         }
-        // SPEX ADDED: END
         return result;
     }
     

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/context/type/FunctionTableSegmentBinderContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/context/type/FunctionTableSegmentBinderContext.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context.type;
 
 import org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context.TableSegmentBinderContext;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
 
 import java.util.Collection;
@@ -37,5 +38,10 @@ public final class FunctionTableSegmentBinderContext implements TableSegmentBind
     @Override
     public Collection<ProjectionSegment> getProjectionSegments() {
         return Collections.emptyList();
+    }
+    
+    @Override
+    public TableSourceType getTableSourceType() {
+        return TableSourceType.TEMPORARY_TABLE;
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/context/type/SimpleTableSegmentBinderContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/context/type/SimpleTableSegmentBinderContext.java
@@ -18,10 +18,12 @@
 package org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context.type;
 
 import com.cedarsoftware.util.CaseInsensitiveMap;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context.TableSegmentBinderContext;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ShorthandProjectionSegment;
 
@@ -37,13 +39,17 @@ import java.util.Optional;
 @Setter
 public final class SimpleTableSegmentBinderContext implements TableSegmentBinderContext {
     
+    @Getter(AccessLevel.NONE)
     private final Map<String, ProjectionSegment> columnLabelProjectionSegments;
+    
+    private final TableSourceType tableSourceType;
     
     private boolean fromWithSegment;
     
-    public SimpleTableSegmentBinderContext(final Collection<ProjectionSegment> projectionSegments) {
+    public SimpleTableSegmentBinderContext(final Collection<ProjectionSegment> projectionSegments, final TableSourceType tableSourceType) {
         columnLabelProjectionSegments = new CaseInsensitiveMap<>(projectionSegments.size(), 1F);
         projectionSegments.forEach(each -> putColumnLabelProjectionSegments(each, columnLabelProjectionSegments));
+        this.tableSourceType = tableSourceType;
     }
     
     private void putColumnLabelProjectionSegments(final ProjectionSegment projectionSegment, final Map<String, ProjectionSegment> columnLabelProjectionSegments) {

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/type/SimpleTableSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/type/SimpleTableSegmentBinder.java
@@ -40,6 +40,7 @@ import org.apache.shardingsphere.infra.exception.kernel.metadata.TableNotFoundEx
 import org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.column.ColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.table.RenameTableDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
@@ -206,22 +207,26 @@ public final class SimpleTableSegmentBinder {
             return createSimpleTableSegmentBinderContextWithMetaData(segment, schema, databaseName, schemaName, binderContext, tableName);
         }
         if (binderContext.getSqlStatement() instanceof CreateTableStatement) {
-            return new SimpleTableSegmentBinderContext(createProjectionSegments((CreateTableStatement) binderContext.getSqlStatement(), databaseName, schemaName, tableName));
+            Collection<ProjectionSegment> projectionSegments = createProjectionSegments((CreateTableStatement) binderContext.getSqlStatement(), databaseName, schemaName, tableName);
+            return new SimpleTableSegmentBinderContext(projectionSegments, TableSourceType.PHYSICAL_TABLE);
         }
         CaseInsensitiveString caseInsensitiveTableName = new CaseInsensitiveString(tableName.getValue());
         if (binderContext.getExternalTableBinderContexts().containsKey(caseInsensitiveTableName)) {
             TableSegmentBinderContext tableSegmentBinderContext = binderContext.getExternalTableBinderContexts().get(caseInsensitiveTableName).iterator().next();
-            return new SimpleTableSegmentBinderContext(
-                    SubqueryTableBindUtils.createSubqueryProjections(tableSegmentBinderContext.getProjectionSegments(), tableName, binderContext.getSqlStatement().getDatabaseType()));
+            Collection<ProjectionSegment> subqueryProjections =
+                    SubqueryTableBindUtils.createSubqueryProjections(tableSegmentBinderContext.getProjectionSegments(), tableName, binderContext.getSqlStatement().getDatabaseType(),
+                            TableSourceType.TEMPORARY_TABLE);
+            return new SimpleTableSegmentBinderContext(subqueryProjections, TableSourceType.TEMPORARY_TABLE);
         }
-        return new SimpleTableSegmentBinderContext(Collections.emptyList());
+        return new SimpleTableSegmentBinderContext(Collections.emptyList(), TableSourceType.TEMPORARY_TABLE);
     }
     
     private static Collection<ProjectionSegment> createProjectionSegments(final CreateTableStatement sqlStatement, final IdentifierValue databaseName,
                                                                           final IdentifierValue schemaName, final IdentifierValue tableName) {
         Collection<ProjectionSegment> result = new LinkedList<>();
         for (ColumnDefinitionSegment each : sqlStatement.getColumnDefinitions()) {
-            each.getColumnName().setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(databaseName, schemaName), tableName, each.getColumnName().getIdentifier()));
+            each.getColumnName().setColumnBoundInfo(
+                    new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(databaseName, schemaName), tableName, each.getColumnName().getIdentifier(), TableSourceType.TEMPORARY_TABLE));
             result.add(new ColumnProjectionSegment(each.getColumnName()));
         }
         return result;
@@ -237,14 +242,15 @@ public final class SimpleTableSegmentBinder {
             columnProjectionSegment.setVisible(each.isVisible());
             projectionSegments.add(columnProjectionSegment);
         }
-        return new SimpleTableSegmentBinderContext(projectionSegments);
+        return new SimpleTableSegmentBinderContext(projectionSegments, TableSourceType.PHYSICAL_TABLE);
     }
     
     private static ColumnSegment createColumnSegment(final SimpleTableSegment segment, final IdentifierValue databaseName, final IdentifierValue schemaName,
                                                      final ShardingSphereColumn column, final QuoteCharacter quoteCharacter, final IdentifierValue tableName) {
         ColumnSegment result = new ColumnSegment(0, 0, new IdentifierValue(column.getName(), quoteCharacter));
         result.setOwner(new OwnerSegment(0, 0, segment.getAlias().orElse(tableName)));
-        result.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(databaseName, schemaName), tableName, new IdentifierValue(column.getName(), quoteCharacter)));
+        result.setColumnBoundInfo(
+                new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(databaseName, schemaName), tableName, new IdentifierValue(column.getName(), quoteCharacter), TableSourceType.PHYSICAL_TABLE));
         return result;
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/type/SubqueryTableSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/type/SubqueryTableSegmentBinder.java
@@ -26,11 +26,15 @@ import org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context.ty
 import org.apache.shardingsphere.infra.binder.engine.segment.util.SubqueryTableBindUtils;
 import org.apache.shardingsphere.infra.binder.engine.statement.SQLStatementBinderContext;
 import org.apache.shardingsphere.infra.binder.engine.statement.dml.SelectStatementBinder;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubquerySegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.AliasSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SubqueryTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
+
+import java.util.Collection;
 
 /**
  * Subquery table segment binder.
@@ -62,9 +66,10 @@ public final class SubqueryTableSegmentBinder {
         IdentifierValue subqueryTableName = segment.getAliasSegment().map(AliasSegment::getIdentifier).orElseGet(() -> new IdentifierValue(""));
         SubqueryTableSegment result = new SubqueryTableSegment(segment.getStartIndex(), segment.getStopIndex(), boundSubquerySegment);
         segment.getAliasSegment().ifPresent(result::setAlias);
-        SimpleTableSegmentBinderContext tableBinderContext =
-                new SimpleTableSegmentBinderContext(
-                        SubqueryTableBindUtils.createSubqueryProjections(boundSubSelect.getProjections().getProjections(), subqueryTableName, binderContext.getSqlStatement().getDatabaseType()));
+        Collection<ProjectionSegment> subqueryProjections =
+                SubqueryTableBindUtils.createSubqueryProjections(boundSubSelect.getProjections().getProjections(), subqueryTableName, binderContext.getSqlStatement().getDatabaseType(),
+                        TableSourceType.TEMPORARY_TABLE);
+        SimpleTableSegmentBinderContext tableBinderContext = new SimpleTableSegmentBinderContext(subqueryProjections, TableSourceType.TEMPORARY_TABLE);
         tableBinderContext.setFromWithSegment(fromWithSegment);
         tableBinderContexts.put(new CaseInsensitiveString(subqueryTableName.getValue()), tableBinderContext);
         return result;

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/projection/ProjectionsSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/projection/ProjectionsSegmentBinder.java
@@ -29,9 +29,10 @@ import org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context.ty
 import org.apache.shardingsphere.infra.binder.engine.segment.dml.projection.type.ColumnProjectionSegmentBinder;
 import org.apache.shardingsphere.infra.binder.engine.segment.dml.projection.type.ShorthandProjectionSegmentBinder;
 import org.apache.shardingsphere.infra.binder.engine.segment.dml.projection.type.SubqueryProjectionSegmentBinder;
-import org.apache.shardingsphere.infra.binder.engine.statement.SQLStatementBinderContext;
 import org.apache.shardingsphere.infra.binder.engine.segment.util.SubqueryTableBindUtils;
+import org.apache.shardingsphere.infra.binder.engine.statement.SQLStatementBinderContext;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.ColumnNotFoundException;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationDistinctProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationProjectionSegment;
@@ -147,8 +148,9 @@ public final class ProjectionsSegmentBinder {
     private static Multimap<CaseInsensitiveString, TableSegmentBinderContext> createCurrentTableBinderContexts(final SQLStatementBinderContext binderContext,
                                                                                                                final Collection<ProjectionSegment> projections) {
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> result = LinkedHashMultimap.create();
-        Collection<ProjectionSegment> subqueryProjections = SubqueryTableBindUtils.createSubqueryProjections(projections, new IdentifierValue(""), binderContext.getSqlStatement().getDatabaseType());
-        result.put(new CaseInsensitiveString(""), new SimpleTableSegmentBinderContext(subqueryProjections));
+        Collection<ProjectionSegment> subqueryProjections =
+                SubqueryTableBindUtils.createSubqueryProjections(projections, new IdentifierValue(""), binderContext.getSqlStatement().getDatabaseType(), TableSourceType.TEMPORARY_TABLE);
+        result.put(new CaseInsensitiveString(""), new SimpleTableSegmentBinderContext(subqueryProjections, TableSourceType.TEMPORARY_TABLE));
         return result;
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/SelectStatementBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/SelectStatementBinder.java
@@ -33,9 +33,10 @@ import org.apache.shardingsphere.infra.binder.engine.segment.dml.predicate.Havin
 import org.apache.shardingsphere.infra.binder.engine.segment.dml.predicate.WhereSegmentBinder;
 import org.apache.shardingsphere.infra.binder.engine.segment.dml.projection.ProjectionsSegmentBinder;
 import org.apache.shardingsphere.infra.binder.engine.segment.dml.with.WithSegmentBinder;
+import org.apache.shardingsphere.infra.binder.engine.segment.util.SubqueryTableBindUtils;
 import org.apache.shardingsphere.infra.binder.engine.statement.SQLStatementBinder;
 import org.apache.shardingsphere.infra.binder.engine.statement.SQLStatementBinderContext;
-import org.apache.shardingsphere.infra.binder.engine.segment.util.SubqueryTableBindUtils;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement;
@@ -80,8 +81,8 @@ public final class SelectStatementBinder implements SQLStatementBinder<SelectSta
     private Multimap<CaseInsensitiveString, TableSegmentBinderContext> createCurrentTableBinderContexts(final SQLStatementBinderContext binderContext, final SelectStatement selectStatement) {
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> result = LinkedHashMultimap.create();
         Collection<ProjectionSegment> subqueryProjections = SubqueryTableBindUtils.createSubqueryProjections(
-                selectStatement.getProjections().getProjections(), new IdentifierValue(""), binderContext.getSqlStatement().getDatabaseType());
-        result.put(new CaseInsensitiveString(""), new SimpleTableSegmentBinderContext(subqueryProjections));
+                selectStatement.getProjections().getProjections(), new IdentifierValue(""), binderContext.getSqlStatement().getDatabaseType(), TableSourceType.MIXED_TABLE);
+        result.put(new CaseInsensitiveString(""), new SimpleTableSegmentBinderContext(subqueryProjections, TableSourceType.MIXED_TABLE));
         return result;
     }
     

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/impl/ColumnProjectionTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/impl/ColumnProjectionTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.binder.context.segment.select.projection
 
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.ColumnSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.TableSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
@@ -54,7 +55,7 @@ class ColumnProjectionTest {
     @Test
     void assertGetOriginalTable() {
         ColumnProjection projection = new ColumnProjection(new IdentifierValue("owner"), new IdentifierValue("name"), new IdentifierValue("alias"), databaseType,
-                null, null, new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(null, null), new IdentifierValue("tbl"), new IdentifierValue("")));
+                null, null, new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(null, null), new IdentifierValue("tbl"), new IdentifierValue(""), TableSourceType.PHYSICAL_TABLE));
         assertThat(projection.getOriginalTable(), is(new IdentifierValue("tbl")));
     }
     

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/assign/AssignmentSegmentBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/assign/AssignmentSegmentBinderTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Multimap;
 import org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context.TableSegmentBinderContext;
 import org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context.type.SimpleTableSegmentBinderContext;
 import org.apache.shardingsphere.infra.binder.engine.statement.SQLStatementBinderContext;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.ColumnAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.SetAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
@@ -49,12 +50,13 @@ class AssignmentSegmentBinderTest {
         Collection<ColumnAssignmentSegment> assignments = new LinkedList<>();
         ColumnSegment boundOrderIdColumn = new ColumnSegment(0, 0, new IdentifierValue("order_id"));
         boundOrderIdColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_db")),
-                new IdentifierValue("t_order"), new IdentifierValue("order_id")));
+                new IdentifierValue("t_order"), new IdentifierValue("order_id"), TableSourceType.PHYSICAL_TABLE));
         ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("order_id"));
         assignments.add(new ColumnAssignmentSegment(0, 0, Collections.singletonList(columnSegment), new LiteralExpressionSegment(0, 0, 1)));
         SetAssignmentSegment setAssignmentSegment = new SetAssignmentSegment(0, 0, assignments);
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts = LinkedHashMultimap.create();
-        tableBinderContexts.put(new CaseInsensitiveString("t_order"), new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderIdColumn))));
+        tableBinderContexts.put(new CaseInsensitiveString("t_order"),
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderIdColumn)), TableSourceType.PHYSICAL_TABLE));
         SetAssignmentSegment actual = AssignmentSegmentBinder.bind(setAssignmentSegment, mock(SQLStatementBinderContext.class), tableBinderContexts, LinkedHashMultimap.create());
         assertThat(actual, not(setAssignmentSegment));
         assertThat(actual.getAssignments().iterator().next(), not(setAssignmentSegment.getAssignments().iterator().next()));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/expression/type/ColumnSegmentBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/expression/type/ColumnSegmentBinderTest.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.infra.exception.kernel.syntax.AmbiguousColumnEx
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ColumnProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.OwnerSegment;
@@ -58,12 +59,14 @@ class ColumnSegmentBinderTest {
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts = LinkedHashMultimap.create();
         ColumnSegment boundOrderIdColumn = new ColumnSegment(0, 0, new IdentifierValue("order_id"));
         boundOrderIdColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")),
-                new IdentifierValue("t_order"), new IdentifierValue("order_id")));
-        tableBinderContexts.put(new CaseInsensitiveString("t_order"), new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderIdColumn))));
+                new IdentifierValue("t_order"), new IdentifierValue("order_id"), TableSourceType.PHYSICAL_TABLE));
+        tableBinderContexts.put(new CaseInsensitiveString("t_order"),
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderIdColumn)), TableSourceType.PHYSICAL_TABLE));
         ColumnSegment boundItemIdColumn = new ColumnSegment(0, 0, new IdentifierValue("item_id"));
         boundItemIdColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")),
-                new IdentifierValue("t_order_item"), new IdentifierValue("item_id")));
-        tableBinderContexts.put(new CaseInsensitiveString("t_order_item"), new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundItemIdColumn))));
+                new IdentifierValue("t_order_item"), new IdentifierValue("item_id"), TableSourceType.PHYSICAL_TABLE));
+        tableBinderContexts.put(new CaseInsensitiveString("t_order_item"),
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundItemIdColumn)), TableSourceType.PHYSICAL_TABLE));
         ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("order_id"));
         SelectStatement selectStatement = mock(SelectStatement.class);
         when(selectStatement.getDatabaseType()).thenReturn(databaseType);
@@ -82,12 +85,14 @@ class ColumnSegmentBinderTest {
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> outerTableBinderContexts = LinkedHashMultimap.create();
         ColumnSegment boundOrderStatusColumn = new ColumnSegment(0, 0, new IdentifierValue("status"));
         boundOrderStatusColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")),
-                new IdentifierValue("t_order"), new IdentifierValue("status")));
-        outerTableBinderContexts.put(new CaseInsensitiveString("t_order"), new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderStatusColumn))));
+                new IdentifierValue("t_order"), new IdentifierValue("status"), TableSourceType.PHYSICAL_TABLE));
+        outerTableBinderContexts.put(new CaseInsensitiveString("t_order"),
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderStatusColumn)), TableSourceType.PHYSICAL_TABLE));
         ColumnSegment boundOrderItemStatusColumn = new ColumnSegment(0, 0, new IdentifierValue("status"));
         boundOrderItemStatusColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")),
-                new IdentifierValue("t_order_item"), new IdentifierValue("status")));
-        outerTableBinderContexts.put(new CaseInsensitiveString("t_order_item"), new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderItemStatusColumn))));
+                new IdentifierValue("t_order_item"), new IdentifierValue("status"), TableSourceType.PHYSICAL_TABLE));
+        outerTableBinderContexts.put(new CaseInsensitiveString("t_order_item"),
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderItemStatusColumn)), TableSourceType.PHYSICAL_TABLE));
         SelectStatement selectStatement = mock(SelectStatement.class);
         when(selectStatement.getDatabaseType()).thenReturn(databaseType);
         SQLStatementBinderContext binderContext = new SQLStatementBinderContext(mock(ShardingSphereMetaData.class), "foo_db", new HintValueContext(), selectStatement);
@@ -106,12 +111,14 @@ class ColumnSegmentBinderTest {
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts = LinkedHashMultimap.create();
         ColumnSegment boundOrderColumn = new ColumnSegment(0, 0, new IdentifierValue("status"));
         boundOrderColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")),
-                new IdentifierValue("t_order"), new IdentifierValue("status")));
-        tableBinderContexts.put(new CaseInsensitiveString("temp"), new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderColumn))));
+                new IdentifierValue("t_order"), new IdentifierValue("status"), TableSourceType.PHYSICAL_TABLE));
+        tableBinderContexts.put(new CaseInsensitiveString("temp"),
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderColumn)), TableSourceType.PHYSICAL_TABLE));
         ColumnSegment boundOrderItemColumn = new ColumnSegment(0, 0, new IdentifierValue("status"));
         boundOrderItemColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")),
-                new IdentifierValue("t_order_item"), new IdentifierValue("status")));
-        tableBinderContexts.put(new CaseInsensitiveString("temp"), new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderItemColumn))));
+                new IdentifierValue("t_order_item"), new IdentifierValue("status"), TableSourceType.PHYSICAL_TABLE));
+        tableBinderContexts.put(new CaseInsensitiveString("temp"),
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderItemColumn)), TableSourceType.PHYSICAL_TABLE));
         SelectStatement selectStatement = mock(SelectStatement.class);
         when(selectStatement.getDatabaseType()).thenReturn(databaseType);
         SQLStatementBinderContext binderContext = new SQLStatementBinderContext(mock(ShardingSphereMetaData.class), "foo_db", new HintValueContext(), selectStatement);
@@ -125,12 +132,14 @@ class ColumnSegmentBinderTest {
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts = LinkedHashMultimap.create();
         ColumnSegment boundOrderColumn = new ColumnSegment(0, 0, new IdentifierValue("order_id"));
         boundOrderColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")),
-                new IdentifierValue("t_order"), new IdentifierValue("order_id")));
-        tableBinderContexts.put(new CaseInsensitiveString("temp"), new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderColumn))));
+                new IdentifierValue("t_order"), new IdentifierValue("order_id"), TableSourceType.PHYSICAL_TABLE));
+        tableBinderContexts.put(new CaseInsensitiveString("temp"),
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderColumn)), TableSourceType.PHYSICAL_TABLE));
         ColumnSegment boundOrderItemColumn = new ColumnSegment(0, 0, new IdentifierValue("status"));
         boundOrderItemColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")),
-                new IdentifierValue("t_order_item"), new IdentifierValue("status")));
-        tableBinderContexts.put(new CaseInsensitiveString("temp"), new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderItemColumn))));
+                new IdentifierValue("t_order_item"), new IdentifierValue("status"), TableSourceType.PHYSICAL_TABLE));
+        tableBinderContexts.put(new CaseInsensitiveString("temp"),
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderItemColumn)), TableSourceType.PHYSICAL_TABLE));
         SelectStatement selectStatement = mock(SelectStatement.class);
         when(selectStatement.getDatabaseType()).thenReturn(databaseType);
         SQLStatementBinderContext binderContext = new SQLStatementBinderContext(mock(ShardingSphereMetaData.class), "foo_db", new HintValueContext(), selectStatement);
@@ -150,12 +159,14 @@ class ColumnSegmentBinderTest {
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts = LinkedHashMultimap.create();
         ColumnSegment boundOrderIdColumn = new ColumnSegment(0, 0, new IdentifierValue("order_id"));
         boundOrderIdColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")),
-                new IdentifierValue("t_order"), new IdentifierValue("order_id")));
-        tableBinderContexts.put(new CaseInsensitiveString("t_order"), new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderIdColumn))));
+                new IdentifierValue("t_order"), new IdentifierValue("order_id"), TableSourceType.PHYSICAL_TABLE));
+        tableBinderContexts.put(new CaseInsensitiveString("t_order"),
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundOrderIdColumn)), TableSourceType.PHYSICAL_TABLE));
         ColumnSegment boundItemIdColumn = new ColumnSegment(0, 0, new IdentifierValue("item_id"));
         boundItemIdColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(new IdentifierValue("foo_db"), new IdentifierValue("foo_schema")),
-                new IdentifierValue("t_order_item"), new IdentifierValue("item_id")));
-        tableBinderContexts.put(new CaseInsensitiveString("t_order_item"), new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundItemIdColumn))));
+                new IdentifierValue("t_order_item"), new IdentifierValue("item_id"), TableSourceType.PHYSICAL_TABLE));
+        tableBinderContexts.put(new CaseInsensitiveString("t_order_item"),
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundItemIdColumn)), TableSourceType.PHYSICAL_TABLE));
         ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("order_id"));
         columnSegment.setOwner(new OwnerSegment(0, 0, new IdentifierValue("t_order")));
         SelectStatement selectStatement = mock(SelectStatement.class);

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/expression/type/SubquerySegmentBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/expression/type/SubquerySegmentBinderTest.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubquerySegment;
@@ -72,9 +73,9 @@ class SubquerySegmentBinderTest {
         SQLStatementBinderContext sqlStatementBinderContext = new SQLStatementBinderContext(createMetaData(), "foo_db", new HintValueContext(), mock(SQLStatement.class));
         ColumnSegment boundNameColumn = new ColumnSegment(7, 13, new IdentifierValue("user_id"));
         boundNameColumn.setColumnBoundInfo(new ColumnSegmentBoundInfo(new TableSegmentBoundInfo(
-                new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("t_order_item"), new IdentifierValue("user_id")));
+                new IdentifierValue("foo_db"), new IdentifierValue("foo_db")), new IdentifierValue("t_order_item"), new IdentifierValue("user_id"), TableSourceType.TEMPORARY_TABLE));
         sqlStatementBinderContext.getExternalTableBinderContexts().put(new CaseInsensitiveString("t_order_item"),
-                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundNameColumn))));
+                new SimpleTableSegmentBinderContext(Collections.singleton(new ColumnProjectionSegment(boundNameColumn)), TableSourceType.TEMPORARY_TABLE));
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> outerTableBinderContexts = LinkedHashMultimap.create();
         SubquerySegment actual = SubquerySegmentBinder.bind(subquerySegment, sqlStatementBinderContext, outerTableBinderContexts);
         assertNotNull(actual.getSelect());

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/projection/type/ShorthandProjectionSegmentBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/projection/type/ShorthandProjectionSegmentBinderTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context.TableSegmentBinderContext;
 import org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context.type.SimpleTableSegmentBinderContext;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubquerySegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ColumnProjectionSegment;
@@ -55,7 +56,8 @@ class ShorthandProjectionSegmentBinderTest {
         invisibleColumn.setVisible(false);
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts = LinkedHashMultimap.create();
         tableBinderContexts.put(new CaseInsensitiveString("o"),
-                new SimpleTableSegmentBinderContext(Arrays.asList(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("order_id"))), invisibleColumn)));
+                new SimpleTableSegmentBinderContext(Arrays.asList(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("order_id"))), invisibleColumn),
+                        TableSourceType.PHYSICAL_TABLE));
         ShorthandProjectionSegment actual = ShorthandProjectionSegmentBinder.bind(shorthandProjectionSegment, mock(TableSegment.class), tableBinderContexts);
         assertThat(actual.getActualProjectionSegments().size(), is(1));
         ProjectionSegment visibleColumn = actual.getActualProjectionSegments().iterator().next();
@@ -69,7 +71,8 @@ class ShorthandProjectionSegmentBinderTest {
         invisibleColumn.setVisible(false);
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts = LinkedHashMultimap.create();
         tableBinderContexts.put(new CaseInsensitiveString("o"),
-                new SimpleTableSegmentBinderContext(Arrays.asList(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("order_id"))), invisibleColumn)));
+                new SimpleTableSegmentBinderContext(Arrays.asList(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("order_id"))), invisibleColumn),
+                        TableSourceType.PHYSICAL_TABLE));
         SimpleTableSegment boundTableSegment = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")));
         boundTableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("o")));
         ShorthandProjectionSegment actual = ShorthandProjectionSegmentBinder.bind(new ShorthandProjectionSegment(0, 0), boundTableSegment, tableBinderContexts);
@@ -85,7 +88,8 @@ class ShorthandProjectionSegmentBinderTest {
         invisibleColumn.setVisible(false);
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts = LinkedHashMultimap.create();
         tableBinderContexts.put(new CaseInsensitiveString("o"),
-                new SimpleTableSegmentBinderContext(Arrays.asList(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("order_id"))), invisibleColumn)));
+                new SimpleTableSegmentBinderContext(Arrays.asList(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("order_id"))), invisibleColumn),
+                        TableSourceType.PHYSICAL_TABLE));
         SubqueryTableSegment boundTableSegment = new SubqueryTableSegment(0, 0, new SubquerySegment(0, 0, mock(MySQLSelectStatement.class), ""));
         boundTableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("o")));
         ShorthandProjectionSegment actual = ShorthandProjectionSegmentBinder.bind(new ShorthandProjectionSegment(0, 0), boundTableSegment, tableBinderContexts);

--- a/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
+++ b/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
@@ -94,6 +94,11 @@ public final class OpenGaussDatabaseMetaData implements DialectDatabaseMetaData 
     }
     
     @Override
+    public String formatTableNamePattern(final String tableNamePattern) {
+        return tableNamePattern.toLowerCase();
+    }
+    
+    @Override
     public String getDatabaseType() {
         return "openGauss";
     }

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/enums/TableSourceType.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/enums/TableSourceType.java
@@ -15,29 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item;
-
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.SQLSegment;
-
-import java.util.LinkedList;
-import java.util.List;
+package org.apache.shardingsphere.sql.parser.statement.core.enums;
 
 /**
- * projections segment.
+ * Table source type.
  */
-@RequiredArgsConstructor
-@Getter
-public final class ProjectionsSegment implements SQLSegment {
+public enum TableSourceType {
     
-    private final int startIndex;
-    
-    private final int stopIndex;
-    
-    private final List<ProjectionSegment> projections = new LinkedList<>();
-    
-    @Setter
-    private boolean distinctRow;
+    TEMPORARY_TABLE, PHYSICAL_TABLE, MIXED_TABLE
 }

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/generic/bound/ColumnSegmentBoundInfo.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/generic/bound/ColumnSegmentBoundInfo.java
@@ -18,29 +18,32 @@
 package org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound;
 
 import lombok.Getter;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
 /**
  * Column segment bound info.
  */
+@Getter
 public final class ColumnSegmentBoundInfo {
     
     private final TableSegmentBoundInfo tableBoundInfo;
     
-    @Getter
     private final IdentifierValue originalTable;
     
-    @Getter
     private final IdentifierValue originalColumn;
     
+    private final TableSourceType tableSourceType;
+    
     public ColumnSegmentBoundInfo(final IdentifierValue originalColumn) {
-        this(null, null, originalColumn);
+        this(null, null, originalColumn, TableSourceType.TEMPORARY_TABLE);
     }
     
-    public ColumnSegmentBoundInfo(final TableSegmentBoundInfo tableBoundInfo, final IdentifierValue originalTable, final IdentifierValue originalColumn) {
+    public ColumnSegmentBoundInfo(final TableSegmentBoundInfo tableBoundInfo, final IdentifierValue originalTable, final IdentifierValue originalColumn, final TableSourceType tableSourceType) {
         this.tableBoundInfo = null == tableBoundInfo ? new TableSegmentBoundInfo(null, null) : tableBoundInfo;
         this.originalTable = null == originalTable ? new IdentifierValue("") : originalTable;
         this.originalColumn = null == originalColumn ? new IdentifierValue("") : originalColumn;
+        this.tableSourceType = tableSourceType;
     }
     
     /**

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/generic/bound/ColumnSegmentInputInfo.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/generic/bound/ColumnSegmentInputInfo.java
@@ -15,38 +15,37 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context;
+package org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 
-import java.util.Collection;
 import java.util.Optional;
 
 /**
- * Table segment binder context.
+ * Column segment input info.
  */
-public interface TableSegmentBinderContext {
+@RequiredArgsConstructor
+@Getter
+public final class ColumnSegmentInputInfo {
+    
+    private final ColumnSegment inputColumnSegment;
+    
+    private final TableSourceType tableSourceType;
+    
+    public ColumnSegmentInputInfo(final ColumnSegment inputColumnSegment) {
+        this.inputColumnSegment = inputColumnSegment;
+        tableSourceType = TableSourceType.TEMPORARY_TABLE;
+    }
     
     /**
-     * Find projection segment by column label.
+     * Get input column segment.
      *
-     * @param columnLabel column label
-     * @return projection segment
+     * @return input column segment
      */
-    Optional<ProjectionSegment> findProjectionSegmentByColumnLabel(String columnLabel);
-    
-    /**
-     * Get projection segments.
-     *
-     * @return projection segments
-     */
-    Collection<ProjectionSegment> getProjectionSegments();
-    
-    /**
-     * Get table source type.
-     *
-     * @return table source type
-     */
-    TableSourceType getTableSourceType();
+    public Optional<ColumnSegment> getInputColumnSegment() {
+        return Optional.ofNullable(inputColumnSegment);
+    }
 }

--- a/proxy/backend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowConnectionIdExecutorTest.java
+++ b/proxy/backend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowConnectionIdExecutorTest.java
@@ -28,8 +28,8 @@ import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.Iden
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.LinkedList;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -71,7 +71,7 @@ class ShowConnectionIdExecutorTest {
     }
     
     private SelectStatement mockSelectStatement() {
-        Collection<ProjectionSegment> projections = new LinkedList<>();
+        List<ProjectionSegment> projections = new LinkedList<>();
         ProjectionsSegment segment = mock(ProjectionsSegment.class);
         when(segment.getProjections()).thenReturn(projections);
         SelectStatement result = mock(SelectStatement.class);
@@ -80,7 +80,7 @@ class ShowConnectionIdExecutorTest {
     }
     
     private SelectStatement mockSelectStatementWithAlias() {
-        Collection<ProjectionSegment> projections = new LinkedList<>();
+        List<ProjectionSegment> projections = new LinkedList<>();
         ExpressionProjectionSegment projectionSegment = new ExpressionProjectionSegment(0, 0, "connection_id()");
         projectionSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("test_alias")));
         projections.add(projectionSegment);

--- a/test/it/binder/src/test/resources/cases/ddl/alter-view.xml
+++ b/test/it/binder/src/test/resources/cases/ddl/alter-view.xml
@@ -32,6 +32,7 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order" />
                         <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="PHYSICAL_TABLE"/>
                     </column-bound>
                 </column-projection>
             </projections>

--- a/test/it/binder/src/test/resources/cases/ddl/create-index.xml
+++ b/test/it/binder/src/test/resources/cases/ddl/create-index.xml
@@ -34,6 +34,7 @@
                 <original-schema name="public" />
                 <original-table name="t_order" />
                 <original-column name="user_id" start-delimiter="&quot;" end-delimiter="&quot;" />
+                <table-source-type name="PHYSICAL_TABLE"/>
             </column-bound>
         </column>
     </create-index>

--- a/test/it/binder/src/test/resources/cases/ddl/create-table.xml
+++ b/test/it/binder/src/test/resources/cases/ddl/create-table.xml
@@ -31,6 +31,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order_tmp" />
                     <original-column name="order_id" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -41,6 +42,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order_tmp" />
                     <original-column name="user_id" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -51,6 +53,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order_tmp" />
                     <original-column name="status" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -61,6 +64,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order_tmp" />
                     <original-column name="merchant_id" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -71,6 +75,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order_tmp" />
                     <original-column name="remark" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -81,6 +86,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order_tmp" />
                     <original-column name="creation_date" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -100,6 +106,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -110,6 +117,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -120,6 +128,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="status" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -130,6 +139,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="merchant_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -140,6 +150,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="remark" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -150,6 +161,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="creation_date" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -170,6 +182,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -180,6 +193,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -190,6 +204,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="status" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -200,6 +215,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="merchant_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -210,6 +226,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="remark" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>
@@ -220,6 +237,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="creation_date" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </column-definition>

--- a/test/it/binder/src/test/resources/cases/ddl/create-view.xml
+++ b/test/it/binder/src/test/resources/cases/ddl/create-view.xml
@@ -32,6 +32,7 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order" />
                         <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="PHYSICAL_TABLE"/>
                     </column-bound>
                 </column-projection>
             </projections>

--- a/test/it/binder/src/test/resources/cases/ddl/cursor.xml
+++ b/test/it/binder/src/test/resources/cases/ddl/cursor.xml
@@ -30,6 +30,7 @@
                                 <original-schema name="public" />
                                 <original-table name="t_order" />
                                 <original-column name="order_id" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                <table-source-type name="PHYSICAL_TABLE"/>
                             </column-bound>
                         </column-projection>
                         <column-projection name="user_id" start-index="0" stop-index="0" start-delimiter="&quot;" end-delimiter="&quot;">
@@ -39,6 +40,7 @@
                                 <original-schema name="public" />
                                 <original-table name="t_order" />
                                 <original-column name="user_id" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                <table-source-type name="PHYSICAL_TABLE"/>
                             </column-bound>
                         </column-projection>
                         <column-projection name="status" start-index="0" stop-index="0" start-delimiter="&quot;" end-delimiter="&quot;">
@@ -48,6 +50,7 @@
                                 <original-schema name="public" />
                                 <original-table name="t_order" />
                                 <original-column name="status" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                <table-source-type name="PHYSICAL_TABLE"/>
                             </column-bound>
                         </column-projection>
                         <column-projection name="merchant_id" start-index="0" stop-index="0" start-delimiter="&quot;" end-delimiter="&quot;">
@@ -57,6 +60,7 @@
                                 <original-schema name="public" />
                                 <original-table name="t_order" />
                                 <original-column name="merchant_id" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                <table-source-type name="PHYSICAL_TABLE"/>
                             </column-bound>
                         </column-projection>
                         <column-projection name="remark" start-index="0" stop-index="0" start-delimiter="&quot;" end-delimiter="&quot;">
@@ -66,6 +70,7 @@
                                 <original-schema name="public" />
                                 <original-table name="t_order" />
                                 <original-column name="remark" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                <table-source-type name="PHYSICAL_TABLE"/>
                             </column-bound>
                         </column-projection>
                         <column-projection name="creation_date" start-index="0" stop-index="0" start-delimiter="&quot;" end-delimiter="&quot;">
@@ -75,6 +80,7 @@
                                 <original-schema name="public" />
                                 <original-table name="t_order" />
                                 <original-column name="creation_date" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                <table-source-type name="PHYSICAL_TABLE"/>
                             </column-bound>
                         </column-projection>
                     </actual-projections>

--- a/test/it/binder/src/test/resources/cases/dml/copy.xml
+++ b/test/it/binder/src/test/resources/cases/dml/copy.xml
@@ -41,6 +41,7 @@
                                     <original-schema name="public" />
                                     <original-table name="t_order" />
                                     <original-column name="order_id" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                    <table-source-type name="PHYSICAL_TABLE"/>
                                 </column-bound>
                             </column-projection>
                             <column-projection name="user_id" start-index="0" stop-index="0" start-delimiter="&quot;" end-delimiter="&quot;">
@@ -50,6 +51,7 @@
                                     <original-schema name="public" />
                                     <original-table name="t_order" />
                                     <original-column name="user_id" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                    <table-source-type name="PHYSICAL_TABLE"/>
                                 </column-bound>
                             </column-projection>
                             <column-projection name="status" start-index="0" stop-index="0" start-delimiter="&quot;" end-delimiter="&quot;">
@@ -59,6 +61,7 @@
                                     <original-schema name="public" />
                                     <original-table name="t_order" />
                                     <original-column name="status" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                    <table-source-type name="PHYSICAL_TABLE"/>
                                 </column-bound>
                             </column-projection>
                             <column-projection name="merchant_id" start-index="0" stop-index="0" start-delimiter="&quot;" end-delimiter="&quot;">
@@ -68,6 +71,7 @@
                                     <original-schema name="public" />
                                     <original-table name="t_order" />
                                     <original-column name="merchant_id" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                    <table-source-type name="PHYSICAL_TABLE"/>
                                 </column-bound>
                             </column-projection>
                             <column-projection name="remark" start-index="0" stop-index="0" start-delimiter="&quot;" end-delimiter="&quot;">
@@ -77,6 +81,7 @@
                                     <original-schema name="public" />
                                     <original-table name="t_order" />
                                     <original-column name="remark" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                    <table-source-type name="PHYSICAL_TABLE"/>
                                 </column-bound>
                             </column-projection>
                             <column-projection name="creation_date" start-index="0" stop-index="0" start-delimiter="&quot;" end-delimiter="&quot;">
@@ -86,6 +91,7 @@
                                     <original-schema name="public" />
                                     <original-table name="t_order" />
                                     <original-column name="creation_date" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                    <table-source-type name="PHYSICAL_TABLE"/>
                                 </column-bound>
                             </column-projection>
                         </actual-projections>

--- a/test/it/binder/src/test/resources/cases/dml/delete.xml
+++ b/test/it/binder/src/test/resources/cases/dml/delete.xml
@@ -34,6 +34,7 @@
                                 <original-schema name="foo_db_1" />
                                 <original-table name="t_order" />
                                 <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                                <table-source-type name="PHYSICAL_TABLE"/>
                             </column-bound>
                         </column>
                     </left>
@@ -51,6 +52,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column-item>
         </order-by>

--- a/test/it/binder/src/test/resources/cases/dml/insert.xml
+++ b/test/it/binder/src/test/resources/cases/dml/insert.xml
@@ -31,6 +31,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
             <column name="user_id" start-index="31" stop-index="37">
@@ -39,6 +40,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
             <column name="status" start-index="40" stop-index="45">
@@ -47,6 +49,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="status" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
             <column name="merchant_id" start-index="48" stop-index="58">
@@ -55,6 +58,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="merchant_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
             <column name="remark" start-index="61" stop-index="66">
@@ -63,6 +67,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="remark" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
             <column name="creation_date" start-index="69" stop-index="81">
@@ -71,6 +76,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="creation_date" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </columns>
@@ -114,6 +120,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
             <column name="user_id" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`" >
@@ -123,6 +130,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
             <column name="status" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`" >
@@ -132,6 +140,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="status" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
             <column name="merchant_id" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`" >
@@ -141,6 +150,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="merchant_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
             <column name="remark" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`" >
@@ -150,6 +160,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="remark" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
             <column name="creation_date" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`" >
@@ -159,6 +170,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="creation_date" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column>
         </derived-columns>

--- a/test/it/binder/src/test/resources/cases/dml/select-aggregate.xml
+++ b/test/it/binder/src/test/resources/cases/dml/select-aggregate.xml
@@ -28,6 +28,7 @@
                             <original-schema name="foo_db_2" />
                             <original-table name="t_product" />
                             <original-column name="price" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="PHYSICAL_TABLE"/>
                         </column-bound>
                     </column>
                 </paramters>
@@ -41,6 +42,7 @@
                             <original-schema name="foo_db_2" />
                             <original-table name="t_product" />
                             <original-column name="price" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="PHYSICAL_TABLE"/>
                         </column-bound>
                     </column>
                 </paramters>
@@ -54,6 +56,7 @@
                             <original-schema name="foo_db_2" />
                             <original-table name="t_product" />
                             <original-column name="price" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="PHYSICAL_TABLE"/>
                         </column-bound>
                     </column>
                 </paramters>
@@ -67,6 +70,7 @@
                             <original-schema name="foo_db_2" />
                             <original-table name="t_product" />
                             <original-column name="price" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="PHYSICAL_TABLE"/>
                         </column-bound>
                     </column>
                 </paramters>
@@ -107,6 +111,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column>
                                 </left>
@@ -119,6 +124,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order_item" />
                                             <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column>
                                 </right>
@@ -145,6 +151,7 @@
                                     <original-schema name="foo_db_1" />
                                     <original-table name="t_order_item" />
                                     <original-column name="product_id" start-delimiter="`" end-delimiter="`" />
+                                    <table-source-type name="PHYSICAL_TABLE"/>
                                 </column-bound>
                             </column>
                         </left>
@@ -157,6 +164,7 @@
                                     <original-schema name="foo_db_2" />
                                     <original-table name="t_product" />
                                     <original-column name="product_id" start-delimiter="`" end-delimiter="`" />
+                                    <table-source-type name="PHYSICAL_TABLE"/>
                                 </column-bound>
                             </column>
                         </right>
@@ -172,6 +180,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column-item>
         </group-by>
@@ -188,6 +197,7 @@
                                         <original-schema name="foo_db_2" />
                                         <original-table name="t_product" />
                                         <original-column name="price" start-delimiter="`" end-delimiter="`" />
+                                        <table-source-type name="PHYSICAL_TABLE"/>
                                     </column-bound>
                                 </column>
                             </paramters>

--- a/test/it/binder/src/test/resources/cases/dml/select.xml
+++ b/test/it/binder/src/test/resources/cases/dml/select.xml
@@ -28,6 +28,7 @@
                             <original-schema name="foo_db_1" />
                             <original-table name="t_order" />
                             <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="PHYSICAL_TABLE"/>
                         </column-bound>
                     </column-projection>
                     <column-projection name="user_id" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -37,6 +38,7 @@
                             <original-schema name="foo_db_1" />
                             <original-table name="t_order" />
                             <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="PHYSICAL_TABLE"/>
                         </column-bound>
                     </column-projection>
                     <column-projection name="status" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -46,6 +48,7 @@
                             <original-schema name="foo_db_1" />
                             <original-table name="t_order" />
                             <original-column name="status" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="PHYSICAL_TABLE"/>
                         </column-bound>
                     </column-projection>
                     <column-projection name="merchant_id" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -55,6 +58,7 @@
                             <original-schema name="foo_db_1" />
                             <original-table name="t_order" />
                             <original-column name="merchant_id" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="PHYSICAL_TABLE"/>
                         </column-bound>
                     </column-projection>
                     <column-projection name="remark" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -64,6 +68,7 @@
                             <original-schema name="foo_db_1" />
                             <original-table name="t_order" />
                             <original-column name="remark" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="PHYSICAL_TABLE"/>
                         </column-bound>
                     </column-projection>
                     <column-projection name="creation_date" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -73,6 +78,7 @@
                             <original-schema name="foo_db_1" />
                             <original-table name="t_order" />
                             <original-column name="creation_date" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="PHYSICAL_TABLE"/>
                         </column-bound>
                     </column-projection>
                 </actual-projections>
@@ -96,6 +102,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column-projection>
             <aggregation-projection type="COUNT" expression="COUNT(1)" start-index="17" stop-index="24" alias="count">
@@ -119,6 +126,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column-item>
         </group-by>
@@ -142,6 +150,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column-item>
         </order-by>
@@ -162,6 +171,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column-projection>
                                     <column-projection name="user_id" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -171,6 +181,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column-projection>
                                     <column-projection name="status" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -180,6 +191,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="status" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column-projection>
                                     <column-projection name="merchant_id" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -189,6 +201,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="merchant_id" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column-projection>
                                     <column-projection name="remark" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -198,6 +211,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="remark" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column-projection>
                                     <column-projection name="creation_date" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -207,6 +221,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="creation_date" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column-projection>
                                 </actual-projections>
@@ -234,6 +249,7 @@
                             <original-schema name="foo_db_1" />
                             <original-table name="t_order" />
                             <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="TEMPORARY_TABLE"/>
                         </column-bound>
                     </column-projection>
                     <column-projection name="user_id" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -243,6 +259,7 @@
                             <original-schema name="foo_db_1" />
                             <original-table name="t_order" />
                             <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="TEMPORARY_TABLE"/>
                         </column-bound>
                     </column-projection>
                     <column-projection name="status" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -252,6 +269,7 @@
                             <original-schema name="foo_db_1" />
                             <original-table name="t_order" />
                             <original-column name="status" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="TEMPORARY_TABLE"/>
                         </column-bound>
                     </column-projection>
                     <column-projection name="merchant_id" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -261,6 +279,7 @@
                             <original-schema name="foo_db_1" />
                             <original-table name="t_order" />
                             <original-column name="merchant_id" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="TEMPORARY_TABLE"/>
                         </column-bound>
                     </column-projection>
                     <column-projection name="remark" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -270,6 +289,7 @@
                             <original-schema name="foo_db_1" />
                             <original-table name="t_order" />
                             <original-column name="remark" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="TEMPORARY_TABLE"/>
                         </column-bound>
                     </column-projection>
                     <column-projection name="creation_date" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -279,6 +299,7 @@
                             <original-schema name="foo_db_1" />
                             <original-table name="t_order" />
                             <original-column name="creation_date" start-delimiter="`" end-delimiter="`" />
+                            <table-source-type name="TEMPORARY_TABLE"/>
                         </column-bound>
                     </column-projection>
                 </actual-projections>
@@ -314,6 +335,7 @@
                                     <original-schema name="foo_db_1" />
                                     <original-table name="t_order" />
                                     <original-column name="status" start-delimiter="`" end-delimiter="`" />
+                                    <table-source-type name="PHYSICAL_TABLE"/>
                                 </column-bound>
                             </column-projection>
                             <column-projection name="user_id" start-index="46" stop-index="52" >
@@ -322,6 +344,7 @@
                                     <original-schema name="foo_db_1" />
                                     <original-table name="t_order" />
                                     <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                                    <table-source-type name="PHYSICAL_TABLE"/>
                                 </column-bound>
                             </column-projection>
                         </projections>
@@ -333,6 +356,7 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order" />
                         <original-column name="status" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="TEMPORARY_TABLE"/>
                     </column-bound>
                 </column>
                 <column name="user_id" start-index="18" stop-index="24" >
@@ -341,6 +365,7 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order" />
                         <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="TEMPORARY_TABLE"/>
                     </column-bound>
                 </column>
             </common-table-expression>
@@ -362,6 +387,7 @@
                                     <original-schema name="foo_db_1" />
                                     <original-table name="t_order_item" />
                                     <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                                    <table-source-type name="PHYSICAL_TABLE"/>
                                 </column-bound>
                             </column-projection>
                             <column-projection name="item_id" start-index="114" stop-index="120" >
@@ -370,6 +396,7 @@
                                     <original-schema name="foo_db_1" />
                                     <original-table name="t_order_item" />
                                     <original-column name="item_id" start-delimiter="`" end-delimiter="`" />
+                                    <table-source-type name="PHYSICAL_TABLE"/>
                                 </column-bound>
                             </column-projection>
                         </projections>
@@ -381,6 +408,7 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order_item" />
                         <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="TEMPORARY_TABLE"/>
                     </column-bound>
                 </column>
                 <column name="item_id" start-index="85" stop-index="91" >
@@ -389,10 +417,40 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order_item" />
                         <original-column name="item_id" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="TEMPORARY_TABLE"/>
                     </column-bound>
                 </column>
             </common-table-expression>
         </with>
+        <projections start-index="150" stop-index="173">
+            <column-projection name="status" start-index="150" stop-index="155">
+                <column-bound>
+                    <original-database name="foo_db_1" />
+                    <original-schema name="foo_db_1" />
+                    <original-table name="t_order" />
+                    <original-column name="status" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="TEMPORARY_TABLE"/>
+                </column-bound>
+            </column-projection>
+            <column-projection name="user_id" start-index="158" stop-index="164">
+                <column-bound>
+                    <original-database name="foo_db_1" />
+                    <original-schema name="foo_db_1" />
+                    <original-table name="t_order_item" />
+                    <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="TEMPORARY_TABLE"/>
+                </column-bound>
+            </column-projection>
+            <column-projection name="item_id" start-index="167" stop-index="173">
+                <column-bound>
+                    <original-database name="foo_db_1" />
+                    <original-schema name="foo_db_1" />
+                    <original-table name="t_order_item" />
+                    <original-column name="item_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="TEMPORARY_TABLE"/>
+                </column-bound>
+            </column-projection>
+        </projections>
         <from start-index="180" stop-index="230">
             <join-table join-type="INNER">
                 <left>
@@ -420,6 +478,7 @@
                                     <original-schema name="foo_db_1" />
                                     <original-table name="t_order" />
                                     <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                                    <table-source-type name="TEMPORARY_TABLE"/>
                                 </column-bound>
                                 <owner name="cte1" start-index="204" stop-index="207" >
                                     <table-bound>
@@ -437,6 +496,7 @@
                                     <original-schema name="foo_db_1" />
                                     <original-table name="t_order_item" />
                                     <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                                    <table-source-type name="TEMPORARY_TABLE"/>
                                 </column-bound>
                                 <owner name="cte2" start-index="219" stop-index="222" >
                                     <table-bound>
@@ -450,32 +510,6 @@
                 </on-condition>
             </join-table>
         </from>
-        <projections start-index="150" stop-index="173">
-            <column-projection name="status" start-index="150" stop-index="155">
-                <column-bound>
-                    <original-database name="foo_db_1" />
-                    <original-schema name="foo_db_1" />
-                    <original-table name="t_order" />
-                    <original-column name="status" start-delimiter="`" end-delimiter="`" />
-                </column-bound>
-            </column-projection>
-            <column-projection name="user_id" start-index="158" stop-index="164">
-                <column-bound>
-                    <original-database name="foo_db_1" />
-                    <original-schema name="foo_db_1" />
-                    <original-table name="t_order_item" />
-                    <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
-                </column-bound>
-            </column-projection>
-            <column-projection name="item_id" start-index="167" stop-index="173">
-                <column-bound>
-                    <original-database name="foo_db_1" />
-                    <original-schema name="foo_db_1" />
-                    <original-table name="t_order_item" />
-                    <original-column name="item_id" start-delimiter="`" end-delimiter="`" />
-                </column-bound>
-            </column-projection>
-        </projections>
     </select>
 
     <select sql-case-id="select_with_with_clause_with_column_definition">
@@ -493,6 +527,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column-projection>
                                     <column-projection name="user_id" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -502,6 +537,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column-projection>
                                     <column-projection name="status" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -511,6 +547,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="status" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column-projection>
                                     <column-projection name="merchant_id" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -520,6 +557,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="merchant_id" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column-projection>
                                     <column-projection name="remark" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -529,6 +567,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="remark" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column-projection>
                                     <column-projection name="creation_date" start-index="0" stop-index="0" start-delimiter="`" end-delimiter="`">
@@ -538,6 +577,7 @@
                                             <original-schema name="foo_db_1" />
                                             <original-table name="t_order" />
                                             <original-column name="creation_date" start-delimiter="`" end-delimiter="`" />
+                                            <table-source-type name="PHYSICAL_TABLE"/>
                                         </column-bound>
                                     </column-projection>
                                 </actual-projections>
@@ -559,6 +599,7 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order" />
                         <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="TEMPORARY_TABLE"/>
                     </column-bound>
                 </column>
                 <column name="col2" start-index="24" stop-index="27">
@@ -567,6 +608,7 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order" />
                         <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="TEMPORARY_TABLE"/>
                     </column-bound>
                 </column>
                 <column name="col3" start-index="30" stop-index="33">
@@ -575,6 +617,7 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order" />
                         <original-column name="status" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="TEMPORARY_TABLE"/>
                     </column-bound>
                 </column>
                 <column name="col4" start-index="36" stop-index="39">
@@ -583,6 +626,7 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order" />
                         <original-column name="merchant_id" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="TEMPORARY_TABLE"/>
                     </column-bound>
                 </column>
                 <column name="col5" start-index="42" stop-index="45">
@@ -591,6 +635,7 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order" />
                         <original-column name="remark" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="TEMPORARY_TABLE"/>
                     </column-bound>
                 </column>
                 <column name="col6" start-index="48" stop-index="51">
@@ -599,6 +644,7 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order" />
                         <original-column name="creation_date" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="TEMPORARY_TABLE"/>
                     </column-bound>
                 </column>
             </common-table-expression>
@@ -610,6 +656,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="TEMPORARY_TABLE"/>
                 </column-bound>
             </column-projection>
         </projections>
@@ -631,6 +678,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column-projection>
             <subquery-projection start-index="28" stop-index="43" alias="tempOrderId" text="(SELECT orderId)">
@@ -643,6 +691,7 @@
                                     <original-schema name="foo_db_1" />
                                     <original-table name="t_order" />
                                     <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                                    <table-source-type name="TEMPORARY_TABLE"/>
                                 </column-bound>
                             </column-projection>
                         </projections>

--- a/test/it/binder/src/test/resources/cases/dml/update.xml
+++ b/test/it/binder/src/test/resources/cases/dml/update.xml
@@ -34,6 +34,7 @@
                         <original-schema name="foo_db_1" />
                         <original-table name="t_order" />
                         <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                        <table-source-type name="PHYSICAL_TABLE"/>
                     </column-bound>
                 </column>
                 <assignment-value>
@@ -51,6 +52,7 @@
                                 <original-schema name="foo_db_1" />
                                 <original-table name="t_order" />
                                 <original-column name="order_id" start-delimiter="`" end-delimiter="`" />
+                                <table-source-type name="PHYSICAL_TABLE"/>
                             </column-bound>
                         </column>
                     </left>
@@ -68,6 +70,7 @@
                     <original-schema name="foo_db_1" />
                     <original-table name="t_order" />
                     <original-column name="user_id" start-delimiter="`" end-delimiter="`" />
+                    <table-source-type name="PHYSICAL_TABLE"/>
                 </column-bound>
             </column-item>
         </order-by>

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/bound/ColumnBoundAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/bound/ColumnBoundAssert.java
@@ -19,10 +19,17 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.bo
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.ColumnSegmentBoundInfo;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.identifier.IdentifierValueAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.bound.ExpectedColumnBoundInfo;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.bound.ExpectedTableSourceType;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Column bound assert.
@@ -45,5 +52,17 @@ public final class ColumnBoundAssert {
         IdentifierValueAssert.assertIs(assertContext, actual.getOriginalSchema(), expected.getOriginalSchema(), "Bound Schema");
         IdentifierValueAssert.assertIs(assertContext, actual.getOriginalTable(), expected.getOriginalTable(), "Bound Table");
         IdentifierValueAssert.assertIs(assertContext, actual.getOriginalColumn(), expected.getOriginalColumn(), "Bound Column");
+        assertTableSourceType(assertContext, actual, expected);
+    }
+    
+    private static void assertTableSourceType(final SQLCaseAssertContext assertContext, final ColumnSegmentBoundInfo actual, final ExpectedColumnBoundInfo expected) {
+        ExpectedTableSourceType expectedTableSourceType = expected.getTableSourceType();
+        TableSourceType actualTableSourceType = actual.getTableSourceType();
+        if (null == expectedTableSourceType) {
+            assertNull(actualTableSourceType, assertContext.getText("Actual table source type should not exist."));
+        } else {
+            assertNotNull(actualTableSourceType, assertContext.getText("Actual table source type should exist."));
+            assertThat(assertContext.getText(String.format("%s name assertion error: ", "Table Source Type")), actualTableSourceType.name(), is(expectedTableSourceType.getName()));
+        }
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/bound/ExpectedColumnBoundInfo.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/bound/ExpectedColumnBoundInfo.java
@@ -45,4 +45,7 @@ public final class ExpectedColumnBoundInfo extends AbstractExpectedSQLSegment {
     
     @XmlElement(name = "original-column")
     private ExpectedOriginalColumn originalColumn;
+    
+    @XmlElement(name = "table-source-type")
+    private ExpectedTableSourceType tableSourceType;
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/bound/ExpectedTableSourceType.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/bound/ExpectedTableSourceType.java
@@ -15,29 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item;
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.bound;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.SQLSegment;
-
-import java.util.LinkedList;
-import java.util.List;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.AbstractExpectedIdentifierSQLSegment;
 
 /**
- * projections segment.
+ * Expected table source type.
  */
-@RequiredArgsConstructor
-@Getter
-public final class ProjectionsSegment implements SQLSegment {
-    
-    private final int startIndex;
-    
-    private final int stopIndex;
-    
-    private final List<ProjectionSegment> projections = new LinkedList<>();
-    
-    @Setter
-    private boolean distinctRow;
+public final class ExpectedTableSourceType extends AbstractExpectedIdentifierSQLSegment {
 }

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-subquery.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-subquery.xml
@@ -24,32 +24,32 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT certificate_number FROM t_account) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.cipher_certificate_number AS certificate_number FROM (SELECT cipher_certificate_number AS certificate_number, cipher_certificate_number, assisted_query_certificate_number, like_query_certificate_number FROM t_account) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_DERIVED_CIPHER AS certificate_number FROM (SELECT cipher_certificate_number AS certificate_number_DERIVED_CIPHER, assisted_query_certificate_number AS certificate_number_DERIVED_ASSISTED_QUERY, like_query_certificate_number AS certificate_number_DERIVED_LIKE_QUERY FROM t_account) o, t_account u WHERE o.certificate_number_DERIVED_ASSISTED_QUERY=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_refed" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT certificate_number FROM t_account_bak) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.cipher_certificate_number AS certificate_number FROM (SELECT cipher_certificate_number AS certificate_number, cipher_certificate_number, assisted_query_certificate_number, like_query_certificate_number FROM t_account_bak) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_DERIVED_CIPHER AS certificate_number FROM (SELECT cipher_certificate_number AS certificate_number_DERIVED_CIPHER, assisted_query_certificate_number AS certificate_number_DERIVED_ASSISTED_QUERY, like_query_certificate_number AS certificate_number_DERIVED_LIKE_QUERY FROM t_account_bak) o, t_account u WHERE o.certificate_number_DERIVED_ASSISTED_QUERY=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_alias" db-types="MySQL">
         <input sql="SELECT o.certificate_number FROM (SELECT a.certificate_number FROM t_account a) o" />
-        <output sql="SELECT o.cipher_certificate_number AS certificate_number FROM (SELECT a.cipher_certificate_number AS certificate_number, a.cipher_certificate_number, a.assisted_query_certificate_number, a.like_query_certificate_number FROM t_account a) o" />
+        <output sql="SELECT o.certificate_number_DERIVED_CIPHER AS certificate_number FROM (SELECT a.cipher_certificate_number AS certificate_number_DERIVED_CIPHER, a.assisted_query_certificate_number AS certificate_number_DERIVED_ASSISTED_QUERY, a.like_query_certificate_number AS certificate_number_DERIVED_LIKE_QUERY FROM t_account a) o" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.* FROM t_account a) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.cipher_certificate_number AS certificate_number FROM (SELECT a.`account_id`, a.`cipher_certificate_number` AS `certificate_number`, a.`cipher_certificate_number`, a.`assisted_query_certificate_number`, a.`like_query_certificate_number`, a.`cipher_password` AS `password`, a.`cipher_password`, a.`assisted_query_password`, a.`like_query_password`, a.`cipher_amount` AS `amount`, a.`cipher_amount` FROM t_account a) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_DERIVED_CIPHER AS certificate_number FROM (SELECT a.`account_id`, a.`cipher_certificate_number` AS `certificate_number_DERIVED_CIPHER`, a.`assisted_query_certificate_number` AS certificate_number_DERIVED_ASSISTED_QUERY, a.`like_query_certificate_number` AS `certificate_number_DERIVED_LIKE_QUERY`, a.`cipher_password` AS `password_DERIVED_CIPHER`, a.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, a.`like_query_password` AS `password_DERIVED_LIKE_QUERY`, a.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account a) o, t_account u WHERE o.certificate_number_DERIVED_ASSISTED_QUERY=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias_quote" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.* FROM t_account `a`) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.cipher_certificate_number AS certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_certificate_number` AS `certificate_number`, `a`.`cipher_certificate_number`, `a`.`assisted_query_certificate_number`, `a`.`like_query_certificate_number`, `a`.`cipher_password` AS `password`, `a`.`cipher_password`, `a`.`assisted_query_password`, `a`.`like_query_password`, `a`.`cipher_amount` AS `amount`, `a`.`cipher_amount` FROM t_account `a`) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_DERIVED_CIPHER AS certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_certificate_number` AS `certificate_number_DERIVED_CIPHER`, `a`.`assisted_query_certificate_number` AS certificate_number_DERIVED_ASSISTED_QUERY, `a`.`like_query_certificate_number` AS `certificate_number_DERIVED_LIKE_QUERY`, `a`.`cipher_password` AS `password_DERIVED_CIPHER`, `a`.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, `a`.`like_query_password` AS `password_DERIVED_LIKE_QUERY`, `a`.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account `a`) o, t_account u WHERE o.certificate_number_DERIVED_ASSISTED_QUERY=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT * FROM t_account) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.cipher_certificate_number AS certificate_number FROM (SELECT t_account.`account_id`, t_account.`cipher_certificate_number` AS `certificate_number`, t_account.`cipher_certificate_number`, t_account.`assisted_query_certificate_number`, t_account.`like_query_certificate_number`, t_account.`cipher_password` AS `password`, t_account.`cipher_password`, t_account.`assisted_query_password`, t_account.`like_query_password`, t_account.`cipher_amount` AS `amount`, t_account.`cipher_amount` FROM t_account) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_DERIVED_CIPHER AS certificate_number FROM (SELECT t_account.`account_id`, t_account.`cipher_certificate_number` AS `certificate_number_DERIVED_CIPHER`, t_account.`assisted_query_certificate_number` AS certificate_number_DERIVED_ASSISTED_QUERY, t_account.`like_query_certificate_number` AS `certificate_number_DERIVED_LIKE_QUERY`, t_account.`cipher_password` AS `password_DERIVED_CIPHER`, t_account.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, t_account.`like_query_password` AS `password_DERIVED_LIKE_QUERY`, t_account.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account) o, t_account u WHERE o.certificate_number_DERIVED_ASSISTED_QUERY=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_predicate_right_equal_condition" db-types="MySQL">
@@ -64,7 +64,7 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_with_alias" db-types="MySQL">
         <input sql="SELECT count(*) as cnt FROM (SELECT ab.certificate_number FROM t_account ab) X" />
-        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_certificate_number AS certificate_number, ab.cipher_certificate_number, ab.assisted_query_certificate_number, ab.like_query_certificate_number FROM t_account ab) X" />
+        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_certificate_number AS certificate_number_DERIVED_CIPHER, ab.assisted_query_certificate_number AS certificate_number_DERIVED_ASSISTED_QUERY, ab.like_query_certificate_number AS certificate_number_DERIVED_LIKE_QUERY FROM t_account ab) X" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_predicate_left_and_right_equal_condition" db-types="MySQL">
@@ -89,7 +89,7 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_tablesegment_from_alias" db-types="MySQL">
         <input sql="SELECT b.certificate_number, b.amount FROM (SELECT a.certificate_number as certificate_number, a.amount FROM t_account a WHERE a.amount = 1373) b" />
-        <output sql="SELECT b.cipher_certificate_number AS certificate_number, b.cipher_amount AS amount FROM (SELECT a.cipher_certificate_number AS certificate_number, a.cipher_certificate_number, a.assisted_query_certificate_number, a.like_query_certificate_number, a.cipher_amount AS amount, a.cipher_amount FROM t_account a WHERE a.cipher_amount = 'encrypt_1373') b" />
+        <output sql="SELECT b.certificate_number_DERIVED_CIPHER AS certificate_number, b.amount_DERIVED_CIPHER AS amount FROM (SELECT a.cipher_certificate_number AS certificate_number_DERIVED_CIPHER, a.assisted_query_certificate_number AS certificate_number_DERIVED_ASSISTED_QUERY, a.like_query_certificate_number AS certificate_number_DERIVED_LIKE_QUERY, a.cipher_amount AS amount_DERIVED_CIPHER FROM t_account a WHERE a.cipher_amount = 'encrypt_1373') b" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_with_exists_sub_query" db-types="MySQL">
@@ -99,6 +99,6 @@
 
     <rewrite-assertion id="select_sub_query_with_group_by" db-types="MySQL">
         <input sql="SELECT COUNT(1) AS cnt FROM (SELECT a.amount FROM t_account a GROUP BY a.amount DESC ) AS tmp" />
-        <output sql="SELECT COUNT(1) AS cnt FROM (SELECT a.cipher_amount AS amount, a.cipher_amount FROM t_account a GROUP BY a.cipher_amount DESC ) AS tmp" />
+        <output sql="SELECT COUNT(1) AS cnt FROM (SELECT a.cipher_amount AS amount_DERIVED_CIPHER FROM t_account a GROUP BY a.cipher_amount DESC ) AS tmp" />
     </rewrite-assertion>
 </rewrite-assertions>

--- a/test/it/rewriter/src/test/resources/scenario/mix/case/query-with-cipher/dml/select/select-subquery.xml
+++ b/test/it/rewriter/src/test/resources/scenario/mix/case/query-with-cipher/dml/select/select-subquery.xml
@@ -19,25 +19,25 @@
 <rewrite-assertions yaml-rule="scenario/mix/config/query-with-cipher.yaml">
     <rewrite-assertion id="select_not_nested_subquery_in_table_alias" db-types="MySQL">
         <input sql="SELECT count(*) as cnt FROM (SELECT ab.password FROM t_account ab) X" />
-        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_password AS password, ab.cipher_password, ab.assisted_query_password FROM t_account_0 ab) X" />
-        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_password AS password, ab.cipher_password, ab.assisted_query_password FROM t_account_1 ab) X" />
+        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_password AS password_DERIVED_CIPHER, ab.assisted_query_password AS password_DERIVED_ASSISTED_QUERY FROM t_account_0 ab) X" />
+        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_password AS password_DERIVED_CIPHER, ab.assisted_query_password AS password_DERIVED_ASSISTED_QUERY FROM t_account_1 ab) X" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias" db-types="MySQL">
         <input sql="SELECT u.amount, u.password FROM (SELECT a.* FROM t_account a) o, t_account u WHERE u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_password`, a.`assisted_query_password`, a.`cipher_amount` AS `amount`, a.`cipher_amount` FROM t_account_0 a) o, t_account_0 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_password`, a.`assisted_query_password`, a.`cipher_amount` AS `amount`, a.`cipher_amount` FROM t_account_1 a) o, t_account_1 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT a.`account_id`, a.`cipher_password` AS `password_DERIVED_CIPHER`, a.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, a.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account_0 a) o, t_account_0 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT a.`account_id`, a.`cipher_password` AS `password_DERIVED_CIPHER`, a.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, a.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account_1 a) o, t_account_1 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias_quote" db-types="MySQL">
         <input sql="SELECT u.amount, u.password FROM (SELECT `a`.* FROM t_account `a`) o, t_account u WHERE u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_password`, `a`.`assisted_query_password`, `a`.`cipher_amount` AS `amount`, `a`.`cipher_amount` FROM t_account_0 `a`) o, t_account_0 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_password`, `a`.`assisted_query_password`, `a`.`cipher_amount` AS `amount`, `a`.`cipher_amount` FROM t_account_1 `a`) o, t_account_1 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT `a`.`account_id`, `a`.`cipher_password` AS `password_DERIVED_CIPHER`, `a`.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, `a`.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account_0 `a`) o, t_account_0 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT `a`.`account_id`, `a`.`cipher_password` AS `password_DERIVED_CIPHER`, `a`.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, `a`.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account_1 `a`) o, t_account_1 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_alias" db-types="MySQL">
         <input sql="SELECT o.password FROM (SELECT a.password FROM t_account a) o" />
-        <output sql="SELECT o.cipher_password AS password FROM (SELECT a.cipher_password AS password, a.cipher_password, a.assisted_query_password FROM t_account_0 a) o" />
-        <output sql="SELECT o.cipher_password AS password FROM (SELECT a.cipher_password AS password, a.cipher_password, a.assisted_query_password FROM t_account_1 a) o" />
+        <output sql="SELECT o.password_DERIVED_CIPHER AS password FROM (SELECT a.cipher_password AS password_DERIVED_CIPHER, a.assisted_query_password AS password_DERIVED_ASSISTED_QUERY FROM t_account_0 a) o" />
+        <output sql="SELECT o.password_DERIVED_CIPHER AS password FROM (SELECT a.cipher_password AS password_DERIVED_CIPHER, a.assisted_query_password AS password_DERIVED_ASSISTED_QUERY FROM t_account_1 a) o" />
     </rewrite-assertion>
 </rewrite-assertions>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Use EncryptDerivedColumnSuffix to enhance encrypt table subquery rewrite logic

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
