### PR TITLE
Remove comment in ColumnSegmentBinder and SubqueryTableBindUtils

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/expression/type/ColumnSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/expression/type/ColumnSegmentBinder.java
@@ -180,7 +180,6 @@ public final class ColumnSegmentBinder {
                         () -> new AmbiguousColumnException(segment.getExpression(), SEGMENT_TYPE_MESSAGES.getOrDefault(parentSegmentType, UNKNOWN_SEGMENT_TYPE_MESSAGE)));
             }
             inputColumnSegment = getColumnSegment(projectionSegment.get());
-            // NOTE: MIXED_TABLE 用于表示 JOIN 之后的字段，其中可能会包含部分物理表字段，以及派生的临时表字段，同层级查询的 ORDER BY, GROUP BY, HAVING 会引用 JOIN 之后的字段
             tableSourceType = TableSourceType.MIXED_TABLE == each.getTableSourceType() ? getTableSourceTypeFromInputColumn(inputColumnSegment) : each.getTableSourceType();
             if (each instanceof SimpleTableSegmentBinderContext && ((SimpleTableSegmentBinderContext) each).isFromWithSegment()) {
                 break;

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/util/SubqueryTableBindUtils.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/util/SubqueryTableBindUtils.java
@@ -81,7 +81,6 @@ public final class SubqueryTableBindUtils {
         }
         ColumnSegmentBoundInfo inputColumnBoundInfo = originalColumn.getColumn().getColumnBoundInfo();
         TableSegmentBoundInfo tableBoundInfo = new TableSegmentBoundInfo(inputColumnBoundInfo.getOriginalDatabase(), inputColumnBoundInfo.getOriginalSchema());
-        // NOTE: MIXED_TABLE 用于表示 JOIN 之后的字段，其中可能会包含部分物理表字段，以及派生的临时表字段，同层级查询的 ORDER BY, GROUP BY, HAVING 会引用 JOIN 之后的字段
         TableSourceType columnTableSourceType = TableSourceType.MIXED_TABLE == tableSourceType ? getTableSourceTypeFromInputColumn(inputColumnBoundInfo) : tableSourceType;
         newColumnSegment.setColumnBoundInfo(new ColumnSegmentBoundInfo(tableBoundInfo, inputColumnBoundInfo.getOriginalTable(), inputColumnBoundInfo.getOriginalColumn(), columnTableSourceType));
         ColumnProjectionSegment result = new ColumnProjectionSegment(newColumnSegment);


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove comment in ColumnSegmentBinder and SubqueryTableBindUtils

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
