### PR TITLE
Simplify EncryptDerivedColumnSuffix to avoid identifier too long

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/enums/EncryptDerivedColumnSuffix.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/enums/EncryptDerivedColumnSuffix.java
@@ -29,11 +29,9 @@ import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum EncryptDerivedColumnSuffix {
     
-    DERIVED_PLAIN("_DERIVED_PLAIN"),
-    DERIVED_CIPHER("_DERIVED_CIPHER"),
-    DERIVED_ASSISTED_QUERY("_DERIVED_ASSISTED_QUERY"),
-    DERIVED_LIKE_QUERY("_DERIVED_LIKE_QUERY"),
-    DERIVED_ORDER_QUERY("_DERIVED_ORDER_QUERY");
+    CIPHER("_CIPHER"),
+    ASSISTED_QUERY("_ASSISTED"),
+    LIKE_QUERY("_LIKE");
     
     private final String suffix;
     

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGenerator.java
@@ -112,11 +112,11 @@ public final class EncryptPredicateColumnTokenGenerator implements CollectionSQL
             Optional<LikeQueryColumnItem> likeQueryColumnItem = encryptColumn.getLikeQuery();
             Preconditions.checkState(likeQueryColumnItem.isPresent());
             return Collections.singleton(new SubstitutableColumnNameToken(startIndex, stopIndex, createColumnProjections(
-                    likeQueryColumnItem.get().getName(), columnSegment, EncryptDerivedColumnSuffix.DERIVED_LIKE_QUERY, databaseType), databaseType));
+                    likeQueryColumnItem.get().getName(), columnSegment, EncryptDerivedColumnSuffix.LIKE_QUERY, databaseType), databaseType));
         }
         Collection<Projection> columnProjections = encryptColumn.getAssistedQuery()
-                .map(optional -> createColumnProjections(optional.getName(), columnSegment, EncryptDerivedColumnSuffix.DERIVED_ASSISTED_QUERY, databaseType))
-                .orElseGet(() -> createColumnProjections(encryptColumn.getCipher().getName(), columnSegment, EncryptDerivedColumnSuffix.DERIVED_CIPHER, databaseType));
+                .map(optional -> createColumnProjections(optional.getName(), columnSegment, EncryptDerivedColumnSuffix.ASSISTED_QUERY, databaseType))
+                .orElseGet(() -> createColumnProjections(encryptColumn.getCipher().getName(), columnSegment, EncryptDerivedColumnSuffix.CIPHER, databaseType));
         return Collections.singleton(new SubstitutableColumnNameToken(startIndex, stopIndex, columnProjections, databaseType));
     }
     

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptProjectionTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptProjectionTokenGenerator.java
@@ -179,7 +179,7 @@ public final class EncryptProjectionTokenGenerator {
     private String getEncryptColumnName(final ColumnProjection columnProjection, final EncryptColumn encryptColumn) {
         IdentifierValue columnName = columnProjection.getName();
         return TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()
-                ? EncryptDerivedColumnSuffix.DERIVED_CIPHER.getDerivedColumnName(columnName.getValue(), databaseType)
+                ? EncryptDerivedColumnSuffix.CIPHER.getDerivedColumnName(columnName.getValue(), databaseType)
                 : encryptColumn.getCipher().getName();
     }
     
@@ -190,15 +190,15 @@ public final class EncryptProjectionTokenGenerator {
     private Collection<Projection> generateCipherProjectionsInTableSegmentSubquery(final EncryptColumn encryptColumn, final ColumnProjection columnProjection) {
         Collection<Projection> result = new LinkedList<>();
         IdentifierValue cipherColumnName = TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()
-                ? new IdentifierValue(EncryptDerivedColumnSuffix.DERIVED_CIPHER.getDerivedColumnName(columnProjection.getName().getValue(), databaseType),
+                ? new IdentifierValue(EncryptDerivedColumnSuffix.CIPHER.getDerivedColumnName(columnProjection.getName().getValue(), databaseType),
                         columnProjection.getName().getQuoteCharacter())
                 : new IdentifierValue(encryptColumn.getCipher().getName(), columnProjection.getName().getQuoteCharacter());
         IdentifierValue columnAlias = columnProjection.getAlias().orElse(columnProjection.getName());
         IdentifierValue cipherColumnAlias = TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()
                 ? columnProjection.getAlias()
-                        .map(optional -> new IdentifierValue(EncryptDerivedColumnSuffix.DERIVED_CIPHER.getDerivedColumnName(optional.getValue(), databaseType), optional.getQuoteCharacter()))
+                        .map(optional -> new IdentifierValue(EncryptDerivedColumnSuffix.CIPHER.getDerivedColumnName(optional.getValue(), databaseType), optional.getQuoteCharacter()))
                         .orElse(null)
-                : new IdentifierValue(EncryptDerivedColumnSuffix.DERIVED_CIPHER.getDerivedColumnName(columnAlias.getValue(), databaseType), columnAlias.getQuoteCharacter());
+                : new IdentifierValue(EncryptDerivedColumnSuffix.CIPHER.getDerivedColumnName(columnAlias.getValue(), databaseType), columnAlias.getQuoteCharacter());
         result.add(new ColumnProjection(columnProjection.getOwner().orElse(null), cipherColumnName, cipherColumnAlias, databaseType));
         encryptColumn.getAssistedQuery().ifPresent(optional -> addAssistedQueryColumn(columnProjection, optional, columnAlias, result));
         encryptColumn.getLikeQuery().ifPresent(optional -> addLikeQueryColumn(columnProjection, optional, columnAlias, result));
@@ -208,28 +208,28 @@ public final class EncryptProjectionTokenGenerator {
     private void addAssistedQueryColumn(final ColumnProjection columnProjection, final AssistedQueryColumnItem assistedQueryColumnItem, final IdentifierValue columnAlias,
                                         final Collection<Projection> result) {
         IdentifierValue assistedQueryName = TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()
-                ? new IdentifierValue(EncryptDerivedColumnSuffix.DERIVED_ASSISTED_QUERY.getDerivedColumnName(columnProjection.getName().getValue(), databaseType),
+                ? new IdentifierValue(EncryptDerivedColumnSuffix.ASSISTED_QUERY.getDerivedColumnName(columnProjection.getName().getValue(), databaseType),
                         columnProjection.getName().getQuoteCharacter())
                 : new IdentifierValue(assistedQueryColumnItem.getName(), columnProjection.getName().getQuoteCharacter());
         IdentifierValue assistedQueryAlias = TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()
                 ? columnProjection.getAlias()
-                        .map(optional -> new IdentifierValue(EncryptDerivedColumnSuffix.DERIVED_ASSISTED_QUERY.getDerivedColumnName(optional.getValue(), databaseType), optional.getQuoteCharacter()))
+                        .map(optional -> new IdentifierValue(EncryptDerivedColumnSuffix.ASSISTED_QUERY.getDerivedColumnName(optional.getValue(), databaseType), optional.getQuoteCharacter()))
                         .orElse(null)
-                : new IdentifierValue(EncryptDerivedColumnSuffix.DERIVED_ASSISTED_QUERY.getDerivedColumnName(columnAlias.getValue(), databaseType));
+                : new IdentifierValue(EncryptDerivedColumnSuffix.ASSISTED_QUERY.getDerivedColumnName(columnAlias.getValue(), databaseType));
         result.add(new ColumnProjection(columnProjection.getOwner().orElse(null), assistedQueryName, assistedQueryAlias, databaseType, columnProjection.getLeftParentheses().orElse(null),
                 columnProjection.getRightParentheses().orElse(null)));
     }
     
     private void addLikeQueryColumn(final ColumnProjection columnProjection, final LikeQueryColumnItem likeQueryColumnItem, final IdentifierValue columnAlias, final Collection<Projection> result) {
         IdentifierValue likeQueryName = TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()
-                ? new IdentifierValue(EncryptDerivedColumnSuffix.DERIVED_LIKE_QUERY.getDerivedColumnName(columnProjection.getName().getValue(), databaseType),
+                ? new IdentifierValue(EncryptDerivedColumnSuffix.LIKE_QUERY.getDerivedColumnName(columnProjection.getName().getValue(), databaseType),
                         columnProjection.getName().getQuoteCharacter())
                 : new IdentifierValue(likeQueryColumnItem.getName(), columnProjection.getName().getQuoteCharacter());
         IdentifierValue likeQueryAlias = TableSourceType.TEMPORARY_TABLE == columnProjection.getColumnBoundInfo().getTableSourceType()
                 ? columnProjection.getAlias()
-                        .map(optional -> new IdentifierValue(EncryptDerivedColumnSuffix.DERIVED_LIKE_QUERY.getDerivedColumnName(optional.getValue(), databaseType), optional.getQuoteCharacter()))
+                        .map(optional -> new IdentifierValue(EncryptDerivedColumnSuffix.LIKE_QUERY.getDerivedColumnName(optional.getValue(), databaseType), optional.getQuoteCharacter()))
                         .orElse(null)
-                : new IdentifierValue(EncryptDerivedColumnSuffix.DERIVED_LIKE_QUERY.getDerivedColumnName(columnAlias.getValue(), databaseType), columnAlias.getQuoteCharacter());
+                : new IdentifierValue(EncryptDerivedColumnSuffix.LIKE_QUERY.getDerivedColumnName(columnAlias.getValue(), databaseType), columnAlias.getQuoteCharacter());
         result.add(new ColumnProjection(columnProjection.getOwner().orElse(null), likeQueryName, likeQueryAlias, databaseType, columnProjection.getLeftParentheses().orElse(null),
                 columnProjection.getRightParentheses().orElse(null)));
     }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGeneratorTest.java
@@ -47,6 +47,6 @@ class EncryptPredicateColumnTokenGeneratorTest {
     void assertGenerateSQLTokenFromGenerateNewSQLToken() {
         Collection<SQLToken> substitutableColumnNameTokens = generator.generateSQLTokens(EncryptGeneratorFixtureBuilder.createUpdateStatementContext());
         assertThat(substitutableColumnNameTokens.size(), is(1));
-        assertThat(((SubstitutableColumnNameToken) substitutableColumnNameTokens.iterator().next()).toString(null), is("pwd_DERIVED_ASSISTED_QUERY"));
+        assertThat(((SubstitutableColumnNameToken) substitutableColumnNameTokens.iterator().next()).toString(null), is("pwd_ASSISTED"));
     }
 }

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-subquery.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-subquery.xml
@@ -24,32 +24,32 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT certificate_number FROM t_account) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_DERIVED_CIPHER AS certificate_number FROM (SELECT cipher_certificate_number AS certificate_number_DERIVED_CIPHER, assisted_query_certificate_number AS certificate_number_DERIVED_ASSISTED_QUERY, like_query_certificate_number AS certificate_number_DERIVED_LIKE_QUERY FROM t_account) o, t_account u WHERE o.certificate_number_DERIVED_ASSISTED_QUERY=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_CIPHER AS certificate_number FROM (SELECT cipher_certificate_number AS certificate_number_CIPHER, assisted_query_certificate_number AS certificate_number_ASSISTED, like_query_certificate_number AS certificate_number_LIKE FROM t_account) o, t_account u WHERE o.certificate_number_ASSISTED=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_refed" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT certificate_number FROM t_account_bak) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_DERIVED_CIPHER AS certificate_number FROM (SELECT cipher_certificate_number AS certificate_number_DERIVED_CIPHER, assisted_query_certificate_number AS certificate_number_DERIVED_ASSISTED_QUERY, like_query_certificate_number AS certificate_number_DERIVED_LIKE_QUERY FROM t_account_bak) o, t_account u WHERE o.certificate_number_DERIVED_ASSISTED_QUERY=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_CIPHER AS certificate_number FROM (SELECT cipher_certificate_number AS certificate_number_CIPHER, assisted_query_certificate_number AS certificate_number_ASSISTED, like_query_certificate_number AS certificate_number_LIKE FROM t_account_bak) o, t_account u WHERE o.certificate_number_ASSISTED=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_alias" db-types="MySQL">
         <input sql="SELECT o.certificate_number FROM (SELECT a.certificate_number FROM t_account a) o" />
-        <output sql="SELECT o.certificate_number_DERIVED_CIPHER AS certificate_number FROM (SELECT a.cipher_certificate_number AS certificate_number_DERIVED_CIPHER, a.assisted_query_certificate_number AS certificate_number_DERIVED_ASSISTED_QUERY, a.like_query_certificate_number AS certificate_number_DERIVED_LIKE_QUERY FROM t_account a) o" />
+        <output sql="SELECT o.certificate_number_CIPHER AS certificate_number FROM (SELECT a.cipher_certificate_number AS certificate_number_CIPHER, a.assisted_query_certificate_number AS certificate_number_ASSISTED, a.like_query_certificate_number AS certificate_number_LIKE FROM t_account a) o" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.* FROM t_account a) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_DERIVED_CIPHER AS certificate_number FROM (SELECT a.`account_id`, a.`cipher_certificate_number` AS `certificate_number_DERIVED_CIPHER`, a.`assisted_query_certificate_number` AS certificate_number_DERIVED_ASSISTED_QUERY, a.`like_query_certificate_number` AS `certificate_number_DERIVED_LIKE_QUERY`, a.`cipher_password` AS `password_DERIVED_CIPHER`, a.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, a.`like_query_password` AS `password_DERIVED_LIKE_QUERY`, a.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account a) o, t_account u WHERE o.certificate_number_DERIVED_ASSISTED_QUERY=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_CIPHER AS certificate_number FROM (SELECT a.`account_id`, a.`cipher_certificate_number` AS `certificate_number_CIPHER`, a.`assisted_query_certificate_number` AS certificate_number_ASSISTED, a.`like_query_certificate_number` AS `certificate_number_LIKE`, a.`cipher_password` AS `password_CIPHER`, a.`assisted_query_password` AS password_ASSISTED, a.`like_query_password` AS `password_LIKE`, a.`cipher_amount` AS `amount_CIPHER` FROM t_account a) o, t_account u WHERE o.certificate_number_ASSISTED=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias_quote" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.* FROM t_account `a`) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_DERIVED_CIPHER AS certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_certificate_number` AS `certificate_number_DERIVED_CIPHER`, `a`.`assisted_query_certificate_number` AS certificate_number_DERIVED_ASSISTED_QUERY, `a`.`like_query_certificate_number` AS `certificate_number_DERIVED_LIKE_QUERY`, `a`.`cipher_password` AS `password_DERIVED_CIPHER`, `a`.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, `a`.`like_query_password` AS `password_DERIVED_LIKE_QUERY`, `a`.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account `a`) o, t_account u WHERE o.certificate_number_DERIVED_ASSISTED_QUERY=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_CIPHER AS certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_certificate_number` AS `certificate_number_CIPHER`, `a`.`assisted_query_certificate_number` AS certificate_number_ASSISTED, `a`.`like_query_certificate_number` AS `certificate_number_LIKE`, `a`.`cipher_password` AS `password_CIPHER`, `a`.`assisted_query_password` AS password_ASSISTED, `a`.`like_query_password` AS `password_LIKE`, `a`.`cipher_amount` AS `amount_CIPHER` FROM t_account `a`) o, t_account u WHERE o.certificate_number_ASSISTED=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT * FROM t_account) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_DERIVED_CIPHER AS certificate_number FROM (SELECT t_account.`account_id`, t_account.`cipher_certificate_number` AS `certificate_number_DERIVED_CIPHER`, t_account.`assisted_query_certificate_number` AS certificate_number_DERIVED_ASSISTED_QUERY, t_account.`like_query_certificate_number` AS `certificate_number_DERIVED_LIKE_QUERY`, t_account.`cipher_password` AS `password_DERIVED_CIPHER`, t_account.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, t_account.`like_query_password` AS `password_DERIVED_LIKE_QUERY`, t_account.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account) o, t_account u WHERE o.certificate_number_DERIVED_ASSISTED_QUERY=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number_CIPHER AS certificate_number FROM (SELECT t_account.`account_id`, t_account.`cipher_certificate_number` AS `certificate_number_CIPHER`, t_account.`assisted_query_certificate_number` AS certificate_number_ASSISTED, t_account.`like_query_certificate_number` AS `certificate_number_LIKE`, t_account.`cipher_password` AS `password_CIPHER`, t_account.`assisted_query_password` AS password_ASSISTED, t_account.`like_query_password` AS `password_LIKE`, t_account.`cipher_amount` AS `amount_CIPHER` FROM t_account) o, t_account u WHERE o.certificate_number_ASSISTED=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_predicate_right_equal_condition" db-types="MySQL">
@@ -64,7 +64,7 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_with_alias" db-types="MySQL">
         <input sql="SELECT count(*) as cnt FROM (SELECT ab.certificate_number FROM t_account ab) X" />
-        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_certificate_number AS certificate_number_DERIVED_CIPHER, ab.assisted_query_certificate_number AS certificate_number_DERIVED_ASSISTED_QUERY, ab.like_query_certificate_number AS certificate_number_DERIVED_LIKE_QUERY FROM t_account ab) X" />
+        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_certificate_number AS certificate_number_CIPHER, ab.assisted_query_certificate_number AS certificate_number_ASSISTED, ab.like_query_certificate_number AS certificate_number_LIKE FROM t_account ab) X" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_predicate_left_and_right_equal_condition" db-types="MySQL">
@@ -89,7 +89,7 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_tablesegment_from_alias" db-types="MySQL">
         <input sql="SELECT b.certificate_number, b.amount FROM (SELECT a.certificate_number as certificate_number, a.amount FROM t_account a WHERE a.amount = 1373) b" />
-        <output sql="SELECT b.certificate_number_DERIVED_CIPHER AS certificate_number, b.amount_DERIVED_CIPHER AS amount FROM (SELECT a.cipher_certificate_number AS certificate_number_DERIVED_CIPHER, a.assisted_query_certificate_number AS certificate_number_DERIVED_ASSISTED_QUERY, a.like_query_certificate_number AS certificate_number_DERIVED_LIKE_QUERY, a.cipher_amount AS amount_DERIVED_CIPHER FROM t_account a WHERE a.cipher_amount = 'encrypt_1373') b" />
+        <output sql="SELECT b.certificate_number_CIPHER AS certificate_number, b.amount_CIPHER AS amount FROM (SELECT a.cipher_certificate_number AS certificate_number_CIPHER, a.assisted_query_certificate_number AS certificate_number_ASSISTED, a.like_query_certificate_number AS certificate_number_LIKE, a.cipher_amount AS amount_CIPHER FROM t_account a WHERE a.cipher_amount = 'encrypt_1373') b" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_with_exists_sub_query" db-types="MySQL">
@@ -99,6 +99,6 @@
 
     <rewrite-assertion id="select_sub_query_with_group_by" db-types="MySQL">
         <input sql="SELECT COUNT(1) AS cnt FROM (SELECT a.amount FROM t_account a GROUP BY a.amount DESC ) AS tmp" />
-        <output sql="SELECT COUNT(1) AS cnt FROM (SELECT a.cipher_amount AS amount_DERIVED_CIPHER FROM t_account a GROUP BY a.cipher_amount DESC ) AS tmp" />
+        <output sql="SELECT COUNT(1) AS cnt FROM (SELECT a.cipher_amount AS amount_CIPHER FROM t_account a GROUP BY a.cipher_amount DESC ) AS tmp" />
     </rewrite-assertion>
 </rewrite-assertions>

--- a/test/it/rewriter/src/test/resources/scenario/mix/case/query-with-cipher/dml/select/select-subquery.xml
+++ b/test/it/rewriter/src/test/resources/scenario/mix/case/query-with-cipher/dml/select/select-subquery.xml
@@ -19,25 +19,25 @@
 <rewrite-assertions yaml-rule="scenario/mix/config/query-with-cipher.yaml">
     <rewrite-assertion id="select_not_nested_subquery_in_table_alias" db-types="MySQL">
         <input sql="SELECT count(*) as cnt FROM (SELECT ab.password FROM t_account ab) X" />
-        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_password AS password_DERIVED_CIPHER, ab.assisted_query_password AS password_DERIVED_ASSISTED_QUERY FROM t_account_0 ab) X" />
-        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_password AS password_DERIVED_CIPHER, ab.assisted_query_password AS password_DERIVED_ASSISTED_QUERY FROM t_account_1 ab) X" />
+        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_password AS password_CIPHER, ab.assisted_query_password AS password_ASSISTED FROM t_account_0 ab) X" />
+        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_password AS password_CIPHER, ab.assisted_query_password AS password_ASSISTED FROM t_account_1 ab) X" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias" db-types="MySQL">
         <input sql="SELECT u.amount, u.password FROM (SELECT a.* FROM t_account a) o, t_account u WHERE u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT a.`account_id`, a.`cipher_password` AS `password_DERIVED_CIPHER`, a.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, a.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account_0 a) o, t_account_0 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT a.`account_id`, a.`cipher_password` AS `password_DERIVED_CIPHER`, a.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, a.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account_1 a) o, t_account_1 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT a.`account_id`, a.`cipher_password` AS `password_CIPHER`, a.`assisted_query_password` AS password_ASSISTED, a.`cipher_amount` AS `amount_CIPHER` FROM t_account_0 a) o, t_account_0 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT a.`account_id`, a.`cipher_password` AS `password_CIPHER`, a.`assisted_query_password` AS password_ASSISTED, a.`cipher_amount` AS `amount_CIPHER` FROM t_account_1 a) o, t_account_1 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias_quote" db-types="MySQL">
         <input sql="SELECT u.amount, u.password FROM (SELECT `a`.* FROM t_account `a`) o, t_account u WHERE u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT `a`.`account_id`, `a`.`cipher_password` AS `password_DERIVED_CIPHER`, `a`.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, `a`.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account_0 `a`) o, t_account_0 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT `a`.`account_id`, `a`.`cipher_password` AS `password_DERIVED_CIPHER`, `a`.`assisted_query_password` AS password_DERIVED_ASSISTED_QUERY, `a`.`cipher_amount` AS `amount_DERIVED_CIPHER` FROM t_account_1 `a`) o, t_account_1 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT `a`.`account_id`, `a`.`cipher_password` AS `password_CIPHER`, `a`.`assisted_query_password` AS password_ASSISTED, `a`.`cipher_amount` AS `amount_CIPHER` FROM t_account_0 `a`) o, t_account_0 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password FROM (SELECT `a`.`account_id`, `a`.`cipher_password` AS `password_CIPHER`, `a`.`assisted_query_password` AS password_ASSISTED, `a`.`cipher_amount` AS `amount_CIPHER` FROM t_account_1 `a`) o, t_account_1 u WHERE u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_alias" db-types="MySQL">
         <input sql="SELECT o.password FROM (SELECT a.password FROM t_account a) o" />
-        <output sql="SELECT o.password_DERIVED_CIPHER AS password FROM (SELECT a.cipher_password AS password_DERIVED_CIPHER, a.assisted_query_password AS password_DERIVED_ASSISTED_QUERY FROM t_account_0 a) o" />
-        <output sql="SELECT o.password_DERIVED_CIPHER AS password FROM (SELECT a.cipher_password AS password_DERIVED_CIPHER, a.assisted_query_password AS password_DERIVED_ASSISTED_QUERY FROM t_account_1 a) o" />
+        <output sql="SELECT o.password_CIPHER AS password FROM (SELECT a.cipher_password AS password_CIPHER, a.assisted_query_password AS password_ASSISTED FROM t_account_0 a) o" />
+        <output sql="SELECT o.password_CIPHER AS password FROM (SELECT a.cipher_password AS password_CIPHER, a.assisted_query_password AS password_ASSISTED FROM t_account_1 a) o" />
     </rewrite-assertion>
 </rewrite-assertions>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Simplify EncryptDerivedColumnSuffix to avoid identifier too long

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
