### PR TITLE
Bump the OpenGauss JDBC Driver included in the Proxy to `6.0.0-og`

### DIFF
--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
@@ -1,9 +1,5 @@
 [
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
-  "name":"JdkLogger"
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.executor.kernel.ExecutorEngine"},
   "name":"JdkLogger"
 },
@@ -20,7 +16,7 @@
   "name":"[Lcom.github.dockerjava.api.model.VolumesFrom;"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager$$Lambda/0x00007f74ffb9d648"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager$$Lambda/0x00007fa063b9d408"},
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
@@ -1629,7 +1625,7 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.ComputeNodeOnlineHandler"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.compute.type.ComputeNodeOnlineHandler"},
   "name":"org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeData",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -1757,7 +1753,7 @@
   "methods":[{"name":"getRows","parameterTypes":[] }, {"name":"getUniqueKey","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService$$Lambda/0x00007f74ffa45720"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService$$Lambda/0x00007fa063a46cd0"},
   "name":"org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
 },
 {
@@ -2068,31 +2064,31 @@
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"},
-  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.ComputeNodeLabelChangedHandler"
+  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.compute.type.ComputeNodeLabelChangedHandler"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"},
-  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.ComputeNodeOnlineHandler"
+  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.compute.type.ComputeNodeOnlineHandler"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"},
-  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.ComputeNodeStateChangedHandler"
+  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.compute.type.ComputeNodeStateChangedHandler"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"},
-  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.ComputeNodeWorkerIdChangedHandler"
+  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.compute.type.ComputeNodeWorkerIdChangedHandler"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"},
-  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.KillProcessHandler"
+  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.process.KillProcessHandler"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"},
-  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.QualifiedDataSourceChangedHandler"
+  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.process.ShowProcessListHandler"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"},
-  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.ShowProcessListHandler"
+  "name":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.storage.QualifiedDataSourceChangedHandler"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"},
@@ -2302,7 +2298,7 @@
   "fields":[{"name":"instanceProcess"}]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.ComputeNodeOnlineHandler"},
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.compute.type.ComputeNodeOnlineHandler"},
   "name":"org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.OnlineNodePath",
   "fields":[{"name":"instanceId"}, {"name":"instanceType"}]
 },

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reflect-config.json
@@ -333,6 +333,11 @@
   "allDeclaredFields": true
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"},
+  "name":"org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
+  "allPublicMethods": true
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.yaml.data.pojo.YamlShardingSphereRowData"},
   "name":"org.apache.shardingsphere.infra.yaml.data.pojo.YamlShardingSphereRowData",
   "allPublicMethods": true

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <mysql-connector-java.version>8.3.0</mysql-connector-java.version>
         <mssql.version>6.1.7.jre8-preview</mssql.version>
         <h2.version>2.2.224</h2.version>
-        <opengauss.version>3.1.0-og</opengauss.version>
+        <opengauss.version>6.0.0-og</opengauss.version>
         <mariadb-java-client.version>2.4.2</mariadb-java-client.version>
         <clickhouse-jdbc.version>0.6.3</clickhouse-jdbc.version>
         <hive-server2-jdbc-driver-thin.version>1.7.0</hive-server2-jdbc-driver-thin.version>

--- a/test/native/src/test/resources/test-native/yaml/jdbc/databases/hive/acid.yaml
+++ b/test/native/src/test/resources/test-native/yaml/jdbc/databases/hive/acid.yaml
@@ -56,8 +56,8 @@ rules:
     snowflake:
       type: SNOWFLAKE
       props:
-        # TODO This is to avoid `SQL Algorithm 'Object.SNOWFLAKE' execute failed, reason is: Clock is moving backwards, last time is 1741619224673 milliseconds, current time is 1741619222930 milliseconds..`, this requires investigating what is happening inside HiveServer2
-        max-tolerate-time-difference-milliseconds: 1744
+        # TODO This is to avoid `SQL Algorithm 'Object.SNOWFLAKE' execute failed, reason is: Clock is moving backwards, last time is 1741696248036 milliseconds, current time is 1741696246171 milliseconds..`, this requires investigating what is happening inside HiveServer2
+        max-tolerate-time-difference-milliseconds: 1866
   auditors:
     sharding_key_required_auditor:
       type: DML_SHARDING_CONDITIONS

--- a/test/native/src/test/resources/test-native/yaml/jdbc/databases/hive/iceberg.yaml
+++ b/test/native/src/test/resources/test-native/yaml/jdbc/databases/hive/iceberg.yaml
@@ -56,8 +56,8 @@ rules:
     snowflake:
       type: SNOWFLAKE
       props:
-        # TODO This is to avoid `SQL Algorithm 'Object.SNOWFLAKE' execute failed, reason is: Clock is moving backwards, last time is 1741619224673 milliseconds, current time is 1741619222930 milliseconds..`, this requires investigating what is happening inside HiveServer2
-        max-tolerate-time-difference-milliseconds: 1744
+        # TODO This is to avoid `SQL Algorithm 'Object.SNOWFLAKE' execute failed, reason is: Clock is moving backwards, last time is 1741696248036 milliseconds, current time is 1741696246171 milliseconds..`, this requires investigating what is happening inside HiveServer2
+        max-tolerate-time-difference-milliseconds: 1866
   auditors:
     sharding_key_required_auditor:
       type: DML_SHARDING_CONDITIONS

--- a/test/native/src/test/resources/test-native/yaml/jdbc/databases/hive/standalone-hms.yaml
+++ b/test/native/src/test/resources/test-native/yaml/jdbc/databases/hive/standalone-hms.yaml
@@ -56,8 +56,8 @@ rules:
     snowflake:
       type: SNOWFLAKE
       props:
-        # TODO This is to avoid `SQL Algorithm 'Object.SNOWFLAKE' execute failed, reason is: Clock is moving backwards, last time is 1741619224673 milliseconds, current time is 1741619222930 milliseconds..`, this requires investigating what is happening inside HiveServer2
-        max-tolerate-time-difference-milliseconds: 1744
+        # TODO This is to avoid `SQL Algorithm 'Object.SNOWFLAKE' execute failed, reason is: Clock is moving backwards, last time is 1741696248036 milliseconds, current time is 1741696246171 milliseconds..`, this requires investigating what is happening inside HiveServer2
+        max-tolerate-time-difference-milliseconds: 1866
   auditors:
     sharding_key_required_auditor:
       type: DML_SHARDING_CONDITIONS

--- a/test/native/src/test/resources/test-native/yaml/jdbc/databases/hive/zsd.yaml
+++ b/test/native/src/test/resources/test-native/yaml/jdbc/databases/hive/zsd.yaml
@@ -56,8 +56,8 @@ rules:
     snowflake:
       type: SNOWFLAKE
       props:
-        # TODO This is to avoid `SQL Algorithm 'Object.SNOWFLAKE' execute failed, reason is: Clock is moving backwards, last time is 1741619224673 milliseconds, current time is 1741619222930 milliseconds..`, this requires investigating what is happening inside HiveServer2
-        max-tolerate-time-difference-milliseconds: 1744
+        # TODO This is to avoid `SQL Algorithm 'Object.SNOWFLAKE' execute failed, reason is: Clock is moving backwards, last time is 1741696248036 milliseconds, current time is 1741696246171 milliseconds..`, this requires investigating what is happening inside HiveServer2
+        max-tolerate-time-difference-milliseconds: 1866
   auditors:
     sharding_key_required_auditor:
       type: DML_SHARDING_CONDITIONS


### PR DESCRIPTION
For #34925.

Changes proposed in this pull request:
  - Bump the OpenGauss JDBC Driver included in the Proxy to `6.0.0-og`. Due to the lack of available Docker Image of OpenGauss 6.0.0, this PR is only tested on Docker Image `enmotech/opengauss-lite:5.1.0` with `org.opengauss:opengauss-jdbc:6.0.0-og`. See https://github.com/enmotech/enmotech-docker-opengauss/issues/52 .
  - The current PR further adjusts `max-tolerate-time-difference-milliseconds` of HiveServer2 unit tests to mitigate the unknown issue found in #34951.
```shell
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 53.07 s <<< FAILURE! -- in org.apache.shardingsphere.test.natived.jdbc.databases.hive.AcidTableTest
[ERROR] org.apache.shardingsphere.test.natived.jdbc.databases.hive.AcidTableTest.assertShardingInLocalTransactions -- Time elapsed: 53.06 s <<< ERROR!
java.sql.SQLException: Algorithm 'Object.SNOWFLAKE' execute failed, reason is: Clock is moving backwards, last time is 1741618344711 milliseconds, current time is 1741618343387 milliseconds..
        at org.apache.shardingsphere.infra.exception.core.external.sql.ShardingSphereSQLException.toSQLException(ShardingSphereSQLException.java:81)
        at org.apache.shardingsphere.infra.exception.dialect.SQLExceptionTransformEngine.toSQLException(SQLExceptionTransformEngine.java:54)
        at org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement.executeUpdate(ShardingSpherePreparedStatement.java:229)
        at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61)
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java)
        at org.apache.shardingsphere.test.natived.commons.repository.OrderItemRepository.insert(OrderItemRepository.java:248)
        at org.apache.shardingsphere.test.natived.commons.TestShardingService.insertData(TestShardingService.java:153)
        at org.apache.shardingsphere.test.natived.commons.TestShardingService.processSuccessInHive(TestShardingService.java:122)
        at org.apache.shardingsphere.test.natived.jdbc.databases.hive.AcidTableTest.assertShardingInLocalTransactions(AcidTableTest.java:95)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
