### PR TITLE
Fix wrong jdbc database metadata pass through logic

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -34,6 +34,7 @@
 1. Mode: Fixes the exception to missing renamed schema name when alter schema - [#34465](https://github.com/apache/shardingsphere/pull/34465)
 1. SQL Parser: Fix set OnDuplicateKeyColumnsSegment on PostgreSQLInsertStatement - [#34425](https://github.com/apache/shardingsphere/pull/34425)
 1. SQL Parser: Fix mysql sql parser error when sql contains implicit concat expression - [#34660](https://github.com/apache/shardingsphere/pull/34660)
+1. JDBC: Fix wrong jdbc database metadata pass through logic - [#34959](https://github.com/apache/shardingsphere/pull/34959)
 
 ### Change Logs
 

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AdaptedDatabaseMetaData.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AdaptedDatabaseMetaData.java
@@ -138,7 +138,7 @@ public abstract class AdaptedDatabaseMetaData extends WrapperAdapter implements 
     
     @Override
     public final boolean supportsMixedCaseIdentifiers() throws SQLException {
-        return databaseMetaData.storesMixedCaseIdentifiers();
+        return databaseMetaData.supportsMixedCaseIdentifiers();
     }
     
     @Override
@@ -243,7 +243,7 @@ public abstract class AdaptedDatabaseMetaData extends WrapperAdapter implements 
     
     @Override
     public final boolean supportsConvert(final int fromType, final int toType) throws SQLException {
-        return databaseMetaData.supportsConvert();
+        return databaseMetaData.supportsConvert(fromType, toType);
     }
     
     @Override
@@ -702,67 +702,67 @@ public abstract class AdaptedDatabaseMetaData extends WrapperAdapter implements 
     }
     
     @Override
-    public final boolean ownInsertsAreVisible(final int type) {
-        return true;
+    public final boolean ownInsertsAreVisible(final int type) throws SQLException {
+        return databaseMetaData.ownInsertsAreVisible(type);
     }
     
     @Override
-    public final boolean ownUpdatesAreVisible(final int type) {
-        return true;
+    public final boolean ownUpdatesAreVisible(final int type) throws SQLException {
+        return databaseMetaData.ownUpdatesAreVisible(type);
     }
     
     @Override
-    public final boolean ownDeletesAreVisible(final int type) {
-        return true;
+    public final boolean ownDeletesAreVisible(final int type) throws SQLException {
+        return databaseMetaData.ownDeletesAreVisible(type);
     }
     
     @Override
-    public final boolean othersInsertsAreVisible(final int type) {
-        return true;
+    public final boolean othersInsertsAreVisible(final int type) throws SQLException {
+        return databaseMetaData.othersInsertsAreVisible(type);
     }
     
     @Override
-    public final boolean othersUpdatesAreVisible(final int type) {
-        return true;
+    public final boolean othersUpdatesAreVisible(final int type) throws SQLException {
+        return databaseMetaData.othersUpdatesAreVisible(type);
     }
     
     @Override
-    public final boolean othersDeletesAreVisible(final int type) {
-        return true;
+    public final boolean othersDeletesAreVisible(final int type) throws SQLException {
+        return databaseMetaData.othersDeletesAreVisible(type);
     }
     
     @Override
-    public final boolean insertsAreDetected(final int type) {
-        return true;
+    public final boolean insertsAreDetected(final int type) throws SQLException {
+        return databaseMetaData.insertsAreDetected(type);
     }
     
     @Override
-    public final boolean updatesAreDetected(final int type) {
-        return true;
+    public final boolean updatesAreDetected(final int type) throws SQLException {
+        return databaseMetaData.updatesAreDetected(type);
     }
     
     @Override
-    public final boolean deletesAreDetected(final int type) {
-        return true;
+    public final boolean deletesAreDetected(final int type) throws SQLException {
+        return databaseMetaData.deletesAreDetected(type);
     }
     
     @Override
-    public final boolean supportsResultSetType(final int type) {
-        return true;
+    public final boolean supportsResultSetType(final int type) throws SQLException {
+        return databaseMetaData.supportsResultSetType(type);
     }
     
     @Override
-    public final boolean supportsResultSetConcurrency(final int type, final int concurrency) {
-        return true;
+    public final boolean supportsResultSetConcurrency(final int type, final int concurrency) throws SQLException {
+        return databaseMetaData.supportsResultSetConcurrency(type, concurrency);
     }
     
     @Override
-    public final boolean supportsResultSetHoldability(final int holdability) {
-        return true;
+    public final boolean supportsResultSetHoldability(final int holdability) throws SQLException {
+        return databaseMetaData.supportsResultSetHoldability(holdability);
     }
     
     @Override
-    public final boolean supportsTransactionIsolationLevel(final int level) {
-        return true;
+    public final boolean supportsTransactionIsolationLevel(final int level) throws SQLException {
+        return databaseMetaData.supportsTransactionIsolationLevel(level);
     }
 }

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/datasource/metadata/ShardingSphereDatabaseMetaDataTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/datasource/metadata/ShardingSphereDatabaseMetaDataTest.java
@@ -49,7 +49,6 @@ import java.util.Collections;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -776,68 +775,70 @@ class ShardingSphereDatabaseMetaDataTest {
     }
     
     @Test
-    void assertOwnInsertsAreVisible() {
-        assertTrue(shardingSphereDatabaseMetaData.ownInsertsAreVisible(ResultSet.TYPE_FORWARD_ONLY));
+    void assertOwnInsertsAreVisible() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.ownInsertsAreVisible(ResultSet.TYPE_FORWARD_ONLY), is(databaseMetaData.ownInsertsAreVisible(ResultSet.TYPE_FORWARD_ONLY)));
     }
     
     @Test
-    void assertOwnUpdatesAreVisible() {
-        assertTrue(shardingSphereDatabaseMetaData.ownUpdatesAreVisible(ResultSet.TYPE_FORWARD_ONLY));
+    void assertOwnUpdatesAreVisible() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.ownUpdatesAreVisible(ResultSet.TYPE_FORWARD_ONLY), is(databaseMetaData.ownUpdatesAreVisible(ResultSet.TYPE_FORWARD_ONLY)));
     }
     
     @Test
-    void assertOwnDeletesAreVisible() {
-        assertTrue(shardingSphereDatabaseMetaData.ownDeletesAreVisible(ResultSet.TYPE_FORWARD_ONLY));
+    void assertOwnDeletesAreVisible() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.ownDeletesAreVisible(ResultSet.TYPE_FORWARD_ONLY), is(databaseMetaData.ownDeletesAreVisible(ResultSet.TYPE_FORWARD_ONLY)));
     }
     
     @Test
-    void assertOthersInsertsAreVisible() {
-        assertTrue(shardingSphereDatabaseMetaData.othersInsertsAreVisible(ResultSet.TYPE_FORWARD_ONLY));
+    void assertOthersInsertsAreVisible() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.othersInsertsAreVisible(ResultSet.TYPE_FORWARD_ONLY), is(databaseMetaData.othersInsertsAreVisible(ResultSet.TYPE_FORWARD_ONLY)));
     }
     
     @Test
-    void assertOthersUpdatesAreVisible() {
-        assertTrue(shardingSphereDatabaseMetaData.othersUpdatesAreVisible(ResultSet.TYPE_FORWARD_ONLY));
+    void assertOthersUpdatesAreVisible() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.othersUpdatesAreVisible(ResultSet.TYPE_FORWARD_ONLY), is(databaseMetaData.othersUpdatesAreVisible(ResultSet.TYPE_FORWARD_ONLY)));
     }
     
     @Test
-    void assertOthersDeletesAreVisible() {
-        assertTrue(shardingSphereDatabaseMetaData.othersDeletesAreVisible(ResultSet.TYPE_FORWARD_ONLY));
+    void assertOthersDeletesAreVisible() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.othersDeletesAreVisible(ResultSet.TYPE_FORWARD_ONLY), is(databaseMetaData.othersDeletesAreVisible(ResultSet.TYPE_FORWARD_ONLY)));
     }
     
     @Test
-    void assertInsertsAreDetected() {
-        assertTrue(shardingSphereDatabaseMetaData.insertsAreDetected(ResultSet.TYPE_FORWARD_ONLY));
+    void assertInsertsAreDetected() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.insertsAreDetected(ResultSet.TYPE_FORWARD_ONLY), is(databaseMetaData.insertsAreDetected(ResultSet.TYPE_FORWARD_ONLY)));
     }
     
     @Test
-    void assertUpdatesAreDetected() {
-        assertTrue(shardingSphereDatabaseMetaData.updatesAreDetected(ResultSet.TYPE_FORWARD_ONLY));
+    void assertUpdatesAreDetected() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.updatesAreDetected(ResultSet.TYPE_FORWARD_ONLY), is(databaseMetaData.updatesAreDetected(ResultSet.TYPE_FORWARD_ONLY)));
     }
     
     @Test
-    void assertDeletesAreDetected() {
-        assertTrue(shardingSphereDatabaseMetaData.deletesAreDetected(ResultSet.TYPE_FORWARD_ONLY));
+    void assertDeletesAreDetected() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.deletesAreDetected(ResultSet.TYPE_FORWARD_ONLY), is(databaseMetaData.deletesAreDetected(ResultSet.TYPE_FORWARD_ONLY)));
     }
     
     @Test
-    void assertSupportsResultSetType() {
-        assertTrue(shardingSphereDatabaseMetaData.supportsResultSetType(ResultSet.TYPE_FORWARD_ONLY));
+    void assertSupportsResultSetType() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.supportsResultSetType(ResultSet.TYPE_FORWARD_ONLY), is(databaseMetaData.supportsResultSetType(ResultSet.TYPE_FORWARD_ONLY)));
     }
     
     @Test
-    void assertSupportsResultSetConcurrency() {
-        assertTrue(shardingSphereDatabaseMetaData.supportsResultSetConcurrency(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY));
+    void assertSupportsResultSetConcurrency() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.supportsResultSetConcurrency(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY),
+                is(databaseMetaData.supportsResultSetConcurrency(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)));
     }
     
     @Test
-    void assertSupportsResultSetHoldability() {
-        assertTrue(shardingSphereDatabaseMetaData.supportsResultSetHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT));
+    void assertSupportsResultSetHoldability() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.supportsResultSetHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT),
+                is(databaseMetaData.supportsResultSetHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT)));
     }
     
     @Test
-    void assertSupportsTransactionIsolationLevel() {
-        assertTrue(shardingSphereDatabaseMetaData.supportsTransactionIsolationLevel(Connection.TRANSACTION_NONE));
+    void assertSupportsTransactionIsolationLevel() throws SQLException {
+        assertThat(shardingSphereDatabaseMetaData.supportsTransactionIsolationLevel(Connection.TRANSACTION_NONE), is(databaseMetaData.supportsTransactionIsolationLevel(Connection.TRANSACTION_NONE)));
     }
     
     @Test


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix wrong jdbc database metadata pass through logic

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
