### PR TITLE
Minor refactor in TableRuleSegment's constructor parameter.

### DIFF
--- a/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/segment/table/TableRuleSegment.java
+++ b/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/segment/table/TableRuleSegment.java
@@ -36,8 +36,8 @@ public final class TableRuleSegment extends AbstractTableRuleSegment {
     
     private ShardingStrategySegment databaseStrategySegment;
     
-    public TableRuleSegment(final String logicTable, final Collection<String> dataSourcesNote,
+    public TableRuleSegment(final String logicTable, final Collection<String> dataSourcesNodes,
                             final KeyGenerateStrategySegment keyGenerateStrategySegment, final AuditStrategySegment auditStrategySegment) {
-        super(logicTable, dataSourcesNote, keyGenerateStrategySegment, auditStrategySegment);
+        super(logicTable, dataSourcesNodes, keyGenerateStrategySegment, auditStrategySegment);
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

Made changes in the name of the parameter from `dataSourcesNote` to `dataSourcesNodes`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
