### PR TITLE
Update PostgreSQL version for ShardingSphere-Proxy to support BigDecimal with infinity

### DIFF
--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -333,7 +333,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     commons-compiler 3.1.11: https://github.com/janino-compiler/janino, BSD-3-Clause
     janino 3.1.11: https://github.com/janino-compiler/janino, BSD-3-Clause
     opengauss-jdbc 3.1.0-og: https://gitee.com/opengauss/openGauss-connector-jdbc, BSD-2-Clause
-    postgresql 42.7.2: https://github.com/pgjdbc/pgjdbc, BSD-2-Clause
+    postgresql 42.7.5: https://github.com/pgjdbc/pgjdbc, BSD-2-Clause
     protobuf-java 3.21.12: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
     protobuf-java-util 3.21.12: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
     stax2-api 4.2.1: https://github.com/FasterXML/stax2-api, BSD-2-Clause

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/testcontainers/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/testcontainers/_index.cn.md
@@ -27,7 +27,7 @@ ShardingSphere 默认情况下不提供对 `org.testcontainers.jdbc.ContainerDat
     <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.7.2</version>
+        <version>42.7.5</version>
     </dependency>
     <dependency>
         <groupId>org.testcontainers</groupId>

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/testcontainers/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/testcontainers/_index.en.md
@@ -27,7 +27,7 @@ the possible Maven dependencies are as follows,
     <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.7.2</version>
+        <version>42.7.5</version>
     </dependency>
     <dependency>
         <groupId>org.testcontainers</groupId>

--- a/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/seata-at/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/seata-at/_index.cn.md
@@ -332,7 +332,7 @@ CREATE SHARDING TABLE RULE t_order (
 <dependency>
     <groupId>org.postgresql</groupId>
     <artifactId>postgresql</artifactId>
-    <version>42.7.4</version>
+    <version>42.7.5</version>
 </dependency>
 ```
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/seata-at/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/seata-at/_index.en.md
@@ -337,7 +337,7 @@ The required JDBC Driver corresponds to the `proxy-frontend-database-protocol-ty
 <dependency>
     <groupId>org.postgresql</groupId>
     <artifactId>postgresql</artifactId>
-    <version>42.7.4</version>
+    <version>42.7.5</version>
 </dependency>
 ```
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -42,7 +42,7 @@
         <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
         <hikari-cp.version>3.4.2</hikari-cp.version>
         <mysql-connector-java.version>8.3.0</mysql-connector-java.version>
-        <postgresql.version>42.7.2</postgresql.version>
+        <postgresql.version>42.7.5</postgresql.version>
         <h2.version>2.2.224</h2.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.2.13</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <lombok.version>1.18.36</lombok.version>
         <immutables.version>2.9.3</immutables.version>
         
-        <postgresql.version>42.7.2</postgresql.version>
+        <postgresql.version>42.7.5</postgresql.version>
         <mysql-connector-java.version>8.3.0</mysql-connector-java.version>
         <mssql.version>6.1.7.jre8-preview</mssql.version>
         <h2.version>2.2.224</h2.version>


### PR DESCRIPTION
Fixes #23499 Fixes #23597

Changes proposed in this pull request:
  -
  
Update the PostgreSQL version in the pom.xml file to ensure that ShardingSphere-Proxy supports the conversion of numeric infinity to BigDecimal.

For Example previously PostgreSQL query like - 
`Select 'infinity'::numeric` were not supported.

But now it works fine.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
