### PR TITLE
Fix duplicate result when show rules used storage unit with readwrite-splitting rule

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,7 @@
 1. SQL Parser: Fix mysql sql parser error when sql contains implicit concat expression - [#34660](https://github.com/apache/shardingsphere/pull/34660)
 1. JDBC: Fix wrong jdbc database metadata pass through logic - [#34959](https://github.com/apache/shardingsphere/pull/34959)
 1. JDBC: Fix getting database name from sql statement context - [#34960](https://github.com/apache/shardingsphere/pull/34960)
+1. DistSQL: Fix duplicate result when show rules used storage unit with readwrite-splitting rule - [#35129](https://github.com/apache/shardingsphere/pull/35129)
 
 ### Change Logs
 

--- a/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/InUsedReadwriteSplittingStorageUnitRetriever.java
+++ b/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/InUsedReadwriteSplittingStorageUnitRetriever.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.readwritesplitting.rule.ReadwriteSplittingRule;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
+import java.util.HashSet;
 
 /**
  * In used readwrite-splitting storage unit retriever.
@@ -37,7 +37,7 @@ public final class InUsedReadwriteSplittingStorageUnitRetriever implements InUse
         if (!sqlStatement.getStorageUnitName().isPresent()) {
             return Collections.emptyList();
         }
-        Collection<String> result = new LinkedList<>();
+        Collection<String> result = new HashSet<>(1, 1F);
         for (ReadwriteSplittingDataSourceGroupRuleConfiguration each : rule.getConfiguration().getDataSourceGroups()) {
             if (each.getWriteDataSourceName().equalsIgnoreCase(sqlStatement.getStorageUnitName().get())) {
                 result.add(each.getName());

--- a/features/readwrite-splitting/distsql/handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/InUsedReadwriteSplittingStorageUnitRetrieverTest.java
+++ b/features/readwrite-splitting/distsql/handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/InUsedReadwriteSplittingStorageUnitRetrieverTest.java
@@ -47,13 +47,13 @@ class InUsedReadwriteSplittingStorageUnitRetrieverTest {
     @Test
     void assertGetInUsedResourcesWithWriteDataSource() {
         ShowRulesUsedStorageUnitStatement sqlStatement = new ShowRulesUsedStorageUnitStatement("foo_unit_write", null);
-        assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.singletonList("foo_ds")));
+        assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.singleton("foo_ds")));
     }
     
     @Test
     void assertGetInUsedResourcesWithReadDataSource() {
         ShowRulesUsedStorageUnitStatement sqlStatement = new ShowRulesUsedStorageUnitStatement("foo_unit_read", null);
-        assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.singletonList("foo_ds")));
+        assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.singleton("foo_ds")));
     }
     
     private ReadwriteSplittingRule mockRule() {


### PR DESCRIPTION
Fixes #35128.

### Before
![image](https://github.com/user-attachments/assets/ed0c0d97-8f60-46d3-9d04-c922c5b9c9a1)

### After
<img width="1027" alt="image" src="https://github.com/user-attachments/assets/4028eb6d-2289-4cd4-a33b-2627cee6ec24" />
