### PR TITLE
Migrate from `jsr305` to `jspecify` and `error_prone_annotations`

### DIFF
--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -252,7 +252,7 @@ The text of each license is the standard Apache 2.0 license.
     grpc-stub 1.65.1: https://github.com/grpc/grpc-java, Apache 2.0
     grpc-util 1.65.1: https://github.com/grpc/grpc-java, Apache 2.0
     gson 2.10.1: https://github.com/google/gson, Apache 2.0
-    guava 32.1.2-jre: https://github.com/google/guava, Apache 2.0
+    guava 33.4.6-jre: https://github.com/google/guava, Apache 2.0
     HikariCP 4.0.3: https://github.com/brettwooldridge/HikariCP, Apache 2.0
     httpclient5 5.1.3: https://hc.apache.org/httpcomponents-client-5.1.x, Apache 2.0
     httpcore5 5.2.3: https://hc.apache.org/httpcomponents-core-5.1.x, Apache 2.0

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/ComputeNodeInstance.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/ComputeNodeInstance.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.infra.instance.metadata.InstanceMetaData;
 import org.apache.shardingsphere.infra.state.instance.InstanceState;
 import org.apache.shardingsphere.infra.state.instance.InstanceStateContext;
 
-import javax.annotation.concurrent.ThreadSafe;
+import com.google.errorprone.annotations.ThreadSafe;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArrayList;
 

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/ComputeNodeInstanceContext.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/ComputeNodeInstanceContext.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.infra.instance.workerid.WorkerIdGenerator;
 import org.apache.shardingsphere.infra.state.instance.InstanceState;
 import org.apache.shardingsphere.infra.util.eventbus.EventBusContext;
 
-import javax.annotation.concurrent.ThreadSafe;
+import com.google.errorprone.annotations.ThreadSafe;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Properties;

--- a/infra/parser/src/main/java/org/apache/shardingsphere/infra/parser/cache/SQLStatementCacheLoader.java
+++ b/infra/parser/src/main/java/org/apache/shardingsphere/infra/parser/cache/SQLStatementCacheLoader.java
@@ -23,7 +23,7 @@ import org.apache.shardingsphere.infra.parser.sql.SQLStatementParserExecutor;
 import org.apache.shardingsphere.sql.parser.api.CacheOption;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * SQL statement cache loader.
@@ -45,7 +45,7 @@ public final class SQLStatementCacheLoader implements CacheLoader<String, SQLSta
         sqlStatementParserExecutor.updateCacheOption(parseTreeCacheOption);
     }
     
-    @ParametersAreNonnullByDefault
+    @NullMarked
     @Override
     public SQLStatement load(final String sql) {
         return sqlStatementParserExecutor.parse(sql);

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtils.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/DataConsistencyCheckUtils.java
@@ -23,7 +23,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/SingleTableInventoryCalculateParameter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/SingleTableInventoryCalculateParameter.java
@@ -26,7 +26,7 @@ import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineColum
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineDataConsistencyCalculateSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineDataConsistencyCalculateSQLBuilder.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/task/CDCIncrementalTask.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/task/CDCIncrementalTask.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.data.pipeline.core.task.PipelineTask;
 import org.apache.shardingsphere.data.pipeline.core.task.TaskExecuteCallback;
 import org.apache.shardingsphere.data.pipeline.core.task.progress.IncrementalTaskProgress;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.concurrent.CompletableFuture;

--- a/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/task/CDCInventoryTask.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/task/CDCInventoryTask.java
@@ -29,7 +29,7 @@ import org.apache.shardingsphere.data.pipeline.core.task.PipelineTask;
 import org.apache.shardingsphere.data.pipeline.core.task.TaskExecuteCallback;
 import org.apache.shardingsphere.data.pipeline.core.task.progress.InventoryTaskProgress;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;

--- a/kernel/sql-federation/compiler/pom.xml
+++ b/kernel/sql-federation/compiler/pom.xml
@@ -121,6 +121,12 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${jsr305.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     
     <profiles>

--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/planner/cache/ExecutionPlanCacheLoader.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/planner/cache/ExecutionPlanCacheLoader.java
@@ -20,14 +20,14 @@ package org.apache.shardingsphere.sqlfederation.compiler.planner.cache;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import org.apache.shardingsphere.sqlfederation.compiler.SQLFederationExecutionPlan;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Execution plan cache loader.
  */
 public final class ExecutionPlanCacheLoader implements CacheLoader<ExecutionPlanCacheKey, SQLFederationExecutionPlan> {
     
-    @ParametersAreNonnullByDefault
+    @NullMarked
     @Override
     public SQLFederationExecutionPlan load(final ExecutionPlanCacheKey cacheKey) {
         return cacheKey.getSqlStatementCompiler().compile(cacheKey.getSqlStatement(), cacheKey.getDatabaseType());

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/MetaDataContexts.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/MetaDataContexts.java
@@ -22,7 +22,7 @@ import org.apache.shardingsphere.infra.metadata.statistics.ShardingSphereStatist
 import org.apache.shardingsphere.infra.metadata.statistics.builder.ShardingSphereStatisticsFactory;
 import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade;
 
-import javax.annotation.concurrent.ThreadSafe;
+import com.google.errorprone.annotations.ThreadSafe;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**

--- a/parser/sql/engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/cache/ParseTreeCacheLoader.java
+++ b/parser/sql/engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/cache/ParseTreeCacheLoader.java
@@ -22,7 +22,7 @@ import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.sql.parser.core.ParseASTNode;
 import org.apache.shardingsphere.sql.parser.core.database.parser.SQLParserExecutor;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Parse context cache loader.
@@ -35,7 +35,7 @@ public final class ParseTreeCacheLoader implements CacheLoader<String, ParseASTN
         sqlParserExecutor = new SQLParserExecutor(databaseType);
     }
     
-    @ParametersAreNonnullByDefault
+    @NullMarked
     @Override
     public ParseASTNode load(final String sql) {
         return sqlParserExecutor.parse(sql);

--- a/parser/sql/engine/src/test/java/org/apache/shardingsphere/sql/parser/api/SQLParserExecutorTest.java
+++ b/parser/sql/engine/src/test/java/org/apache/shardingsphere/sql/parser/api/SQLParserExecutorTest.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.sql.parser.core.database.parser.SQLParserExecut
 import org.junit.jupiter.api.Test;
 import org.mockito.internal.configuration.plugins.Plugins;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+import org.jspecify.annotations.NullMarked;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -46,7 +46,7 @@ class SQLParserExecutorTest {
         LoadingCache<String, ParseASTNode> parseTreeCache = Caffeine.newBuilder().softValues().initialCapacity(128)
                 .maximumSize(1024L).build(new CacheLoader<String, ParseASTNode>() {
                     
-                    @ParametersAreNonnullByDefault
+                    @NullMarked
                     @Override
                     public ParseASTNode load(final String sql) {
                         return sqlParserExecutor.parse(sql);

--- a/parser/sql/engine/src/test/java/org/apache/shardingsphere/sql/parser/core/SQLParserEngineTest.java
+++ b/parser/sql/engine/src/test/java/org/apache/shardingsphere/sql/parser/core/SQLParserEngineTest.java
@@ -23,7 +23,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import org.apache.shardingsphere.sql.parser.core.database.parser.SQLParserExecutor;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+import org.jspecify.annotations.NullMarked;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -39,7 +39,7 @@ class SQLParserEngineTest {
         LoadingCache<String, ParseASTNode> parseTreeCache = Caffeine.newBuilder().softValues()
                 .initialCapacity(128).maximumSize(1024L).build(new CacheLoader<String, ParseASTNode>() {
                     
-                    @ParametersAreNonnullByDefault
+                    @NullMarked
                     @Override
                     public ParseASTNode load(final String sql) {
                         return sqlParserExecutor.parse(sql);

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <sonar.exclusions>**/autogen/**/*</sonar.exclusions>
         
         <!-- 3rd party library versions -->
-        <guava.version>32.1.2-jre</guava.version>
+        <guava.version>33.4.6-jre</guava.version>
         <checker-qual.version>3.39.0</checker-qual.version>
         <error_prone_annotations.version>2.22.0</error_prone_annotations.version>
         <j2objc-annotations.version>1.3</j2objc-annotations.version>
@@ -121,7 +121,8 @@
         <commons-logging.version>1.2</commons-logging.version>
         
         <lombok.version>1.18.38</lombok.version>
-        <immutables.version>2.9.3</immutables.version>
+        <immutables.version>2.10.1</immutables.version>
+        <jsr305.version>3.0.2</jsr305.version>
         
         <postgresql.version>42.7.5</postgresql.version>
         <mysql-connector-java.version>8.3.0</mysql-connector-java.version>


### PR DESCRIPTION
For #26041 .

Changes proposed in this pull request:
  - Migrate from `jsr305` to `jspecify` and `error_prone_annotations`. For more background, see https://github.com/google/guava/issues/2960 , Guava no longer uses `com.google.code.findbugs:jsr305`.
  - The current PR is unfortunately affected by https://github.com/immutables/immutables/issues/1403 and https://github.com/immutables/immutables/issues/1500 .
```shell
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.13.0:compile (default-compile) on project shardingsphere-sql-federation-optimizer: Compilation failure: Compilation failure:
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushFilterIntoScanRule.java:[8,24] 找不到符号
[ERROR]   符号:   类 Nullable
[ERROR]   位置: 程序包 javax.annotation
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushProjectIntoScanRule.java:[8,24] 找不到符号
[ERROR]   符号:   类 Nullable
[ERROR]   位置: 程序包 javax.annotation
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushFilterIntoScanRule.java:[34,20] 找不到符号
[ERROR]   符号:   类 Nullable
[ERROR]   位置: 类 org.apache.shardingsphere.sqlfederation.optimizer.planner.rule.transformation.ImmutablePushFilterIntoScanRule.Config
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushFilterIntoScanRule.java:[52,10] 找不到符号
[ERROR]   符号:   类 Nullable
[ERROR]   位置: 类 org.apache.shardingsphere.sqlfederation.optimizer.planner.rule.transformation.ImmutablePushFilterIntoScanRule.Config
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushFilterIntoScanRule.java:[135,13] 找不到符号
[ERROR]   符号:   类 Nullable
[ERROR]   位置: 类 org.apache.shardingsphere.sqlfederation.optimizer.planner.rule.transformation.ImmutablePushFilterIntoScanRule.Config
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushFilterIntoScanRule.java:[168,74] 找不到符号
[ERROR]   符号:   类 Nullable
[ERROR]   位置: 类 org.apache.shardingsphere.sqlfederation.optimizer.planner.rule.transformation.ImmutablePushFilterIntoScanRule.Config
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushFilterIntoScanRule.java:[357,41] 找不到符号
[ERROR]   符号:   类 Nullable
[ERROR]   位置: 类 org.apache.shardingsphere.sqlfederation.optimizer.planner.rule.transformation.ImmutablePushFilterIntoScanRule.Config.Builder
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushProjectIntoScanRule.java:[34,20] 找不到符号
[ERROR]   符号:   类 Nullable
[ERROR]   位置: 类 org.apache.shardingsphere.sqlfederation.optimizer.planner.rule.transformation.ImmutablePushProjectIntoScanRule.Config
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushProjectIntoScanRule.java:[52,10] 找不到符号
[ERROR]   符号:   类 Nullable
[ERROR]   位置: 类 org.apache.shardingsphere.sqlfederation.optimizer.planner.rule.transformation.ImmutablePushProjectIntoScanRule.Config
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushProjectIntoScanRule.java:[135,13] 找不到符号
[ERROR]   符号:   类 Nullable
[ERROR]   位置: 类 org.apache.shardingsphere.sqlfederation.optimizer.planner.rule.transformation.ImmutablePushProjectIntoScanRule.Config
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushProjectIntoScanRule.java:[168,75] 找不到符号
[ERROR]   符号:   类 Nullable
[ERROR]   位置: 类 org.apache.shardingsphere.sqlfederation.optimizer.planner.rule.transformation.ImmutablePushProjectIntoScanRule.Config
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushProjectIntoScanRule.java:[357,41] 找不到符号
[ERROR]   符号:   类 Nullable
[ERROR]   位置: 类 org.apache.shardingsphere.sqlfederation.optimizer.planner.rule.transformation.ImmutablePushProjectIntoScanRule.Config.Builder
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushFilterIntoScanRule.java:[269,60] 无法使用 type-use 批注 @org.jspecify.annotations.Nullable 来批注确定作用域结构  
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushFilterIntoScanRule.java:[270,57] 无法使用 type-use 批注 @org.jspecify.annotations.Nullable 来批注确定作用域结构  
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushProjectIntoScanRule.java:[269,60] 无法使用 type-use 批注 @org.jspecify.annotations.Nullable 来批注确定作用域结构 
[ERROR] /D:/TwinklingLiftWorks/git/public/shardingsphere/kernel/sql-federation/optimizer/target/generated-sources/annotations/org/apache/shardingsphere/sqlfederation/optimizer/planner/rule/transformation/ImmutablePushProjectIntoScanRule.java:[270,57] 无法使用 type-use 批注 @org.jspecify.annotations.Nullable 来批注确定作用域结构 
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
