### PR TITLE
Modify sql federation e2e test to add order in subquery

### DIFF
--- a/test/e2e/sql/src/test/resources/cases/dql/cases/db_tbl_sql_federation/e2e-dql-select-for-db-tbl-sql-federation.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/cases/db_tbl_sql_federation/e2e-dql-select-for-db-tbl-sql-federation.xml
@@ -132,8 +132,8 @@
     </test-case>
 
     <test-case sql="SELECT ATAN(res1.order_id), ATAN(res1.order_id, res2.item_id), ATAN2(res1.order_id), ATAN2(res1.order_id, res2.item_id)
-                    FROM (SELECT order_id FROM t_order limit 10) res1
-                    INNER JOIN (SELECT item_id, order_id FROM t_order_item limit 10) res2 ON res1.order_id = res2.order_id" db-types="MySQL" scenario-types="db_tbl_sql_federation">
+                    FROM (SELECT order_id FROM t_order ORDER BY order_id limit 10) res1
+                    INNER JOIN (SELECT item_id, order_id FROM t_order_item ORDER BY item_id limit 10) res2 ON res1.order_id = res2.order_id" db-types="MySQL" scenario-types="db_tbl_sql_federation">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Modify sql federation e2e test to add order in subquery

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
