### PR TITLE
Fix error that AdvisorConfigurationLoader cannot read the configuration file in the window environment

### DIFF
--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/config/AdvisorConfigurationLoader.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/config/AdvisorConfigurationLoader.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.agent.core.advisor.config.yaml.loader.YamlAdvis
 import org.apache.shardingsphere.agent.core.advisor.config.yaml.swapper.YamlAdvisorsConfigurationSwapper;
 import org.apache.shardingsphere.agent.core.plugin.classloader.AgentPluginClassLoader;
 
-import java.io.File;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashMap;
@@ -56,7 +55,7 @@ public final class AdvisorConfigurationLoader {
     }
     
     private static InputStream getResourceStream(final ClassLoader pluginClassLoader, final String pluginType) {
-        return pluginClassLoader.getResourceAsStream(String.join(File.separator, "META-INF", "conf", getFileName(pluginType)));
+        return pluginClassLoader.getResourceAsStream(String.join("/", "META-INF", "conf", getFileName(pluginType)));
     }
     
     private static String getFileName(final String pluginType) {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix error that AdvisorConfigurationLoader cannot read the configuration file in the window environment

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
