### PR TITLE
Optimize properties data export in ClusterExportMetaDataGenerator

### DIFF
--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/util/ClusterExportMetaDataGenerator.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/util/ClusterExportMetaDataGenerator.java
@@ -77,17 +77,7 @@ public final class ClusterExportMetaDataGenerator {
     }
     
     private String generatePropsData(final Properties props) {
-        if (props.isEmpty()) {
-            return "";
-        }
-        StringBuilder result = new StringBuilder();
-        result.append("props:").append(System.lineSeparator());
-        for (Entry<Object, Object> entry : props.entrySet()) {
-            if (null != entry.getValue() && !"".equals(entry.getValue().toString())) {
-                result.append("  ").append(entry.getKey()).append(": ").append(entry.getValue()).append(System.lineSeparator());
-            }
-        }
-        return result.toString();
+        return props.isEmpty() ? "" : YamlEngine.marshal(Collections.singletonMap("props", props));
     }
     
     @SuppressWarnings({"rawtypes", "unchecked"})


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Optimize properties data export in ClusterExportMetaDataGenerator

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
