### PR TITLE
Support parsing MySQL stored procedure syntax part2

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
@@ -293,7 +293,7 @@ dropFunction
 
 createProcedure
     : CREATE ownerStatement?
-      PROCEDURE functionName LP_ procedureParameter? (COMMA_ procedureParameter)* RP_
+      PROCEDURE ifNotExists? functionName LP_ procedureParameter? (COMMA_ procedureParameter)* RP_
       routineOption*
       routineBody
     ;
@@ -681,7 +681,8 @@ validStatement
     : (createTable | alterTable | dropTable | dropDatabase | truncateTable
     | insert | replace | update | delete | select | call
     | createView | prepare | executeStmt | commit | deallocate
-    | setVariable | beginStatement | declareStatement | flowControlStatement | cursorStatement | conditionHandlingStatement) SEMI_?
+    | setVariable | beginStatement | declareStatement | flowControlStatement | cursorStatement | conditionHandlingStatement
+    | showCreateTable | startTransaction | rollback | commit) SEMI_?
     ;
 
 beginStatement

--- a/test/it/parser/src/main/resources/case/ddl/create-procedure.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-procedure.xml
@@ -64,4 +64,40 @@
             <sql-statement start-index="152" stop-index="169" statement-class-simple-name="FirebirdOpenCursorStatement" />
         </sql-statements>
     </create-procedure>
+    <create-procedure sql-case-id="create_procedure_if_not_exists">
+        <sql-statements>
+            <sql-statement start-index="0" stop-index="51" statement-class-simple-name="MySQLCreateProcedureStatement" />
+        </sql-statements>
+    </create-procedure>
+    <create-procedure sql-case-id="create_procedure_with_transaction">
+        <procedure-name name="proc1" />
+        <sql-statements>
+            <sql-statement start-index="30" stop-index="50" statement-class-simple-name="MySQLStartTransactionStatement" />
+            <sql-statement start-index="52" stop-index="83" statement-class-simple-name="MySQLCreateTableStatement" />
+            <sql-statement start-index="85" stop-index="93" statement-class-simple-name="MySQLRollbackStatement" />
+            <sql-statement start-index="95" stop-index="115" statement-class-simple-name="MySQLStartTransactionStatement" />
+            <sql-statement start-index="117" stop-index="148" statement-class-simple-name="MySQLCreateTableStatement" />
+            <sql-statement start-index="150" stop-index="158" statement-class-simple-name="MySQLCommitStatement" />
+        </sql-statements>
+    </create-procedure>
+    <create-procedure sql-case-id="create_procedure_with_charset_parameters_and_insert">
+        <procedure-name name="bug18293" />
+        <sql-statements>
+            <sql-statement start-index="125" stop-index="172" statement-class-simple-name="MySQLInsertStatement" />
+        </sql-statements>
+    </create-procedure>
+    <create-procedure sql-case-id="create_procedure_with_create_table_and_show_create_table_schema">
+        <procedure-name name="p2" />
+        <sql-statements>
+            <sql-statement start-index="47" stop-index="90" statement-class-simple-name="MySQLCreateTableStatement" />
+            <sql-statement start-index="92" stop-index="116" statement-class-simple-name="MySQLShowCreateTableStatement" />
+        </sql-statements>
+    </create-procedure>
+    <create-procedure sql-case-id="create_procedure_with_show_create_table_in_default_schema">
+        <procedure-name name="p1" />
+        <sql-statements>
+            <sql-statement start-index="33" stop-index="76" statement-class-simple-name="MySQLCreateTableStatement" />
+            <sql-statement start-index="78" stop-index="102" statement-class-simple-name="MySQLShowCreateTableStatement" />
+        </sql-statements>
+    </create-procedure>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-procedure.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-procedure.xml
@@ -49,4 +49,9 @@
     <sql-case id="create_plsql_block" value="DECLARE warehouse NUMBER := 1;   ground    NUMBER := 1;   insured   NUMBER := 1;   result    NUMBER; BEGIN   SELECT BIN_TO_NUM(warehouse, ground, insured) INTO result FROM DUAL;   UPDATE orders SET order_status = result WHERE order_id = 2441; END;" db-types="Oracle" />
     <sql-case id="create_procedure_with_insert_into_values" value="create procedure T522_PROC (i int =10) as begin insert into T522 (ROW_INT) values (:i); end" db-types="Firebird"/>
     <sql-case id="create_procedure_with_declare_and_cursor_for_in_select_and_open" value="CREATE PROCEDURE F865_PROC (offset_value INT, page_size INT) as DECLARE catalog_page CURSOR FOR (SELECT * FROM company ORDER BY namecompany OFFSET :offset_value ROWS FETCH NEXT :page_size ROWS ONLY); BEGIN OPEN catalog_page; END" db-types="Firebird"/>
+    <sql-case id="create_procedure_if_not_exists" value="CREATE PROCEDURE IF NOT EXISTS sp1() BEGIN END;" db-types="MySQL" />
+    <sql-case id="create_procedure_with_transaction" value="CREATE PROCEDURE proc1() BEGIN START TRANSACTION; CREATE TABLE t1 (f1 INT); ROLLBACK; START TRANSACTION; CREATE TABLE t1 (f1 INT); COMMIT; END;" db-types="MySQL" />
+    <sql-case id="create_procedure_with_charset_parameters_and_insert" value="CREATE PROCEDURE bug18293 (IN ins1 CHAR(50), IN ins2 CHAR(50) CHARACTER SET cp932, IN ind DECIMAL(10,2)) BEGIN INSERT INTO t4 VALUES (ins1, ins2, ind); END;" db-types="MySQL" />
+    <sql-case id="create_procedure_with_create_table_and_show_create_table_schema" value="CREATE PROCEDURE mysqltest2.p2() BEGIN CREATE TABLE t2(col1 VARCHAR(10)); SHOW CREATE TABLE t2; END;" db-types="MySQL" />
+    <sql-case id="create_procedure_with_show_create_table_in_default_schema" value="CREATE PROCEDURE p1() BEGIN CREATE TABLE t1(col1 VARCHAR(10)); SHOW CREATE TABLE t1; END;" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
Fixes #35086 .

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
