### PR TITLE
Support parsing MySQL stored procedure syntax - part 3

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -860,8 +860,8 @@ charsetWithOptBinary
     : ascii
     | unicode
     | BYTE
-    | charset charsetName BINARY?
-    | BINARY (charset charsetName)?
+    | charset charsetName collateClause? BINARY?
+    | BINARY (charset charsetName collateClause?)?
     ;
 
 ascii

--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
@@ -682,7 +682,8 @@ validStatement
     | insert | replace | update | delete | select | call
     | createView | prepare | executeStmt | commit | deallocate
     | setVariable | beginStatement | declareStatement | flowControlStatement | cursorStatement | conditionHandlingStatement
-    | setStatement | showStatement) SEMI_?
+    | setStatement | showStatement
+    | show | alterEvent | dropEvent) SEMI_?
     ;
 
 showStatement

--- a/test/it/parser/src/main/resources/case/ddl/create-procedure.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-procedure.xml
@@ -91,4 +91,39 @@
         </sql-statements>
     </create-procedure>
     <create-procedure sql-case-id="create_procedure_if_not_exists" />
+    <create-procedure sql-case-id="create_procedure_with_show_create_table_default">
+        <procedure-name name="p1" />
+        <sql-statements>
+            <sql-statement start-index="28" stop-index="60" statement-class-simple-name="MySQLCreateTableStatement" />
+            <sql-statement start-index="63" stop-index="82" statement-class-simple-name="MySQLShowCreateTableStatement" />
+        </sql-statements>
+    </create-procedure>
+    <create-procedure sql-case-id="create_procedure_with_create_table_and_show_create_table">
+        <procedure-name name="p2" />
+        <sql-statements>
+            <sql-statement start-index="39" stop-index="71" statement-class-simple-name="MySQLCreateTableStatement" />
+            <sql-statement start-index="74" stop-index="93" statement-class-simple-name="MySQLShowCreateTableStatement" />
+        </sql-statements>
+    </create-procedure>
+    <create-procedure sql-case-id="create_procedure_with_custom_collation_and_insert">
+        <procedure-name name="p" />
+        <sql-statements>
+            <sql-statement start-index="28" stop-index="87" statement-class-simple-name="DeclareStatement" />
+            <sql-statement start-index="90" stop-index="125" statement-class-simple-name="MySQLSetStatement" />
+            <sql-statement start-index="128" stop-index="181" statement-class-simple-name="MySQLCreateTableStatement" />
+            <sql-statement start-index="184" stop-index="208" statement-class-simple-name="MySQLInsertStatement" />
+        </sql-statements>
+    </create-procedure>
+    <create-procedure sql-case-id="create_procedure_with_alter_event">
+        <procedure-name name="p1" />
+        <sql-statements>
+            <sql-statement start-index="28" stop-index="54" statement-class-simple-name="MySQLAlterEventStatement" />
+        </sql-statements>
+    </create-procedure>
+    <create-procedure sql-case-id="create_procedure_with_drop_event">
+        <procedure-name name="p1" />
+        <sql-statements>
+            <sql-statement start-index="28" stop-index="40" statement-class-simple-name="MySQLDropEventStatement" />
+        </sql-statements>
+    </create-procedure>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-procedure.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-procedure.xml
@@ -54,4 +54,9 @@
     <sql-case id="create_procedure_with_transaction_read_only_and_isolation" value="CREATE PROCEDURE p1() SET SESSION TRANSACTION READ ONLY, ISOLATION LEVEL SERIALIZABLE" db-types="MySQL" />
     <sql-case id="create_procedure_with_transaction_read_only" value="CREATE PROCEDURE p1() SET SESSION TRANSACTION READ ONLY" db-types="MySQL" />
     <sql-case id="create_procedure_if_not_exists" value="CREATE PROCEDURE IF NOT EXISTS sp1() BEGIN END" db-types="MySQL" />
+    <sql-case id="create_procedure_with_show_create_table_default" value="CREATE PROCEDURE p1() BEGIN CREATE TABLE t1(col1 VARCHAR(10)); SHOW CREATE TABLE t1; END;" db-types="MySQL"/>
+    <sql-case id="create_procedure_with_create_table_and_show_create_table" value="CREATE PROCEDURE mysqltest2.p2() BEGIN CREATE TABLE t2(col1 VARCHAR(10)); SHOW CREATE TABLE t2; END;" db-types="MySQL"/>
+    <sql-case id="create_procedure_with_custom_collation_and_insert" value="create procedure p () begin declare a varchar(1) charset utf8mb4 collate utf8mb4_test_ci; set @a = 'a' collate utf8mb4_test_ci; create table tp (t varchar(1) collate utf8mb4_test_ci); insert into t values (@a); end;" db-types="MySQL"/>
+    <sql-case id="create_procedure_with_alter_event" value="create procedure p1() begin alter event e1 rename to e2; end;" db-types="MySQL"/>
+    <sql-case id="create_procedure_with_drop_event" value="create procedure p1() begin drop event e1; end;" db-types="MySQL"/>
 </sql-cases>


### PR DESCRIPTION
Fixes #35087 .

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
