### PR TITLE
refactor(infra): optimize schema names loading logic

### DIFF
--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/data/loader/type/SchemaMetaDataLoader.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/data/loader/type/SchemaMetaDataLoader.java
@@ -23,6 +23,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.database.core.metadata.data.loader.MetaDataLoaderConnection;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.system.SystemDatabase;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
@@ -89,8 +90,8 @@ public final class SchemaMetaDataLoader {
      * @throws SQLException SQL exception
      */
     public static Collection<String> loadSchemaNames(final Connection connection, final DatabaseType databaseType) throws SQLException {
-        DialectDatabaseMetaData dialectDatabaseMetaData = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData();
-        if (!dialectDatabaseMetaData.getSchemaOption().getDefaultSchema().isPresent()) {
+        DialectSchemaOption schemaOption = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getSchemaOption();
+        if (!schemaOption.getDefaultSchema().isPresent()) {
             return Collections.singletonList(connection.getSchema());
         }
         Collection<String> result = new LinkedList<>();


### PR DESCRIPTION
- Extract DialectSchemaOption to a separate variable for better readability
- Simplify the condition to check for default schema presence