### PR TITLE
Remove PipelineJdbcUtils and use DialectDataTypeOption instead

### DIFF
--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/datatype/DefaultDataTypeOption.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/datatype/DefaultDataTypeOption.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype;
 
+import java.sql.Types;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -34,5 +35,45 @@ public final class DefaultDataTypeOption implements DialectDataTypeOption {
     @Override
     public Optional<Class<?>> findExtraSQLTypeClass(final int dataType, final boolean unsigned) {
         return Optional.empty();
+    }
+    
+    @Override
+    public boolean isIntegerDataType(final int sqlType) {
+        switch (sqlType) {
+            case Types.INTEGER:
+            case Types.BIGINT:
+            case Types.SMALLINT:
+            case Types.TINYINT:
+                return true;
+            default:
+                return false;
+        }
+    }
+    
+    @Override
+    public boolean isStringDataType(final int sqlType) {
+        switch (sqlType) {
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+            case Types.NCHAR:
+            case Types.NVARCHAR:
+            case Types.LONGNVARCHAR:
+                return true;
+            default:
+                return false;
+        }
+    }
+    
+    @Override
+    public boolean isBinaryDataType(final int sqlType) {
+        switch (sqlType) {
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+                return true;
+            default:
+                return false;
+        }
     }
 }

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/datatype/DialectDataTypeOption.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/datatype/DialectDataTypeOption.java
@@ -40,4 +40,29 @@ public interface DialectDataTypeOption {
      * @return extra SQL type class
      */
     Optional<Class<?>> findExtraSQLTypeClass(int dataType, boolean unsigned);
+    
+    /**
+     * Whether data type is integer type.
+     *
+     * @param sqlType value of java.sql.Types
+     * @return is integer type or not
+     */
+    boolean isIntegerDataType(int sqlType);
+    
+    /**
+     * Whether data type is string column.
+     *
+     * @param sqlType value of java.sql.Types
+     * @return is string type or not
+     */
+    boolean isStringDataType(int sqlType);
+    
+    /**
+     * Whether data type is binary type.
+     * <p>it doesn't include BLOB etc.</p>
+     *
+     * @param sqlType value of java.sql.Types
+     * @return is binary type or not
+     */
+    boolean isBinaryDataType(int sqlType);
 }

--- a/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/datatype/DefaultDataTypeOptionTest.java
+++ b/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/datatype/DefaultDataTypeOptionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Types;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultDataTypeOptionTest {
+    
+    private final DialectDataTypeOption dataTypeOption = new DefaultDataTypeOption();
+    
+    @Test
+    void assertIsIntegerDataType() {
+        assertTrue(dataTypeOption.isIntegerDataType(Types.INTEGER));
+        assertTrue(dataTypeOption.isIntegerDataType(Types.BIGINT));
+        assertTrue(dataTypeOption.isIntegerDataType(Types.SMALLINT));
+        assertTrue(dataTypeOption.isIntegerDataType(Types.TINYINT));
+        assertFalse(dataTypeOption.isIntegerDataType(Types.VARCHAR));
+    }
+    
+    @Test
+    void assertIsStringDataType() {
+        assertTrue(dataTypeOption.isStringDataType(Types.CHAR));
+        assertTrue(dataTypeOption.isStringDataType(Types.VARCHAR));
+        assertTrue(dataTypeOption.isStringDataType(Types.LONGVARCHAR));
+        assertTrue(dataTypeOption.isStringDataType(Types.NCHAR));
+        assertTrue(dataTypeOption.isStringDataType(Types.NVARCHAR));
+        assertTrue(dataTypeOption.isStringDataType(Types.LONGNVARCHAR));
+        assertFalse(dataTypeOption.isStringDataType(Types.INTEGER));
+    }
+    
+    @Test
+    void assertIsBinaryDataType() {
+        assertTrue(dataTypeOption.isBinaryDataType(Types.BINARY));
+        assertTrue(dataTypeOption.isBinaryDataType(Types.VARBINARY));
+        assertTrue(dataTypeOption.isBinaryDataType(Types.LONGVARBINARY));
+        assertFalse(dataTypeOption.isBinaryDataType(Types.VARCHAR));
+    }
+}

--- a/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/option/MySQLDataTypeOption.java
+++ b/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/option/MySQLDataTypeOption.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.database.mysql.metadata.database.option;
 
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DefaultDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 
 import java.math.BigInteger;
@@ -29,6 +30,8 @@ import java.util.Optional;
  * Data type option for MySQL.
  */
 public final class MySQLDataTypeOption implements DialectDataTypeOption {
+    
+    private final DialectDataTypeOption dataTypeOption = new DefaultDataTypeOption();
     
     @Override
     public Map<String, Integer> getExtraDataTypes() {
@@ -58,5 +61,20 @@ public final class MySQLDataTypeOption implements DialectDataTypeOption {
             return unsigned ? Optional.of(BigInteger.class) : Optional.of(Long.class);
         }
         return Optional.empty();
+    }
+    
+    @Override
+    public boolean isIntegerDataType(final int sqlType) {
+        return dataTypeOption.isIntegerDataType(sqlType);
+    }
+    
+    @Override
+    public boolean isStringDataType(final int sqlType) {
+        return dataTypeOption.isStringDataType(sqlType);
+    }
+    
+    @Override
+    public boolean isBinaryDataType(final int sqlType) {
+        return dataTypeOption.isBinaryDataType(sqlType);
     }
 }

--- a/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/option/OpenGaussDataTypeOption.java
+++ b/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/option/OpenGaussDataTypeOption.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.database.opengauss.metadata.database.option;
 
 import com.cedarsoftware.util.CaseInsensitiveMap;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DefaultDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 
 import java.sql.Types;
@@ -28,6 +29,8 @@ import java.util.Optional;
  * Data type option for openGauss.
  */
 public final class OpenGaussDataTypeOption implements DialectDataTypeOption {
+    
+    private final DialectDataTypeOption dataTypeOption = new DefaultDataTypeOption();
     
     @Override
     public Map<String, Integer> getExtraDataTypes() {
@@ -47,5 +50,20 @@ public final class OpenGaussDataTypeOption implements DialectDataTypeOption {
     @Override
     public Optional<Class<?>> findExtraSQLTypeClass(final int dataType, final boolean unsigned) {
         return Optional.empty();
+    }
+    
+    @Override
+    public boolean isIntegerDataType(final int sqlType) {
+        return dataTypeOption.isIntegerDataType(sqlType);
+    }
+    
+    @Override
+    public boolean isStringDataType(final int sqlType) {
+        return dataTypeOption.isStringDataType(sqlType);
+    }
+    
+    @Override
+    public boolean isBinaryDataType(final int sqlType) {
+        return dataTypeOption.isBinaryDataType(sqlType);
     }
 }

--- a/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/option/OracleDataTypeOption.java
+++ b/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/option/OracleDataTypeOption.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.database.oracle.metadata.database.option;
 
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DefaultDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 
 import java.sql.Types;
@@ -28,6 +29,8 @@ import java.util.Optional;
  * Data type option for Oracle.
  */
 public final class OracleDataTypeOption implements DialectDataTypeOption {
+    
+    private final DialectDataTypeOption dataTypeOption = new DefaultDataTypeOption();
     
     @Override
     public Map<String, Integer> getExtraDataTypes() {
@@ -49,5 +52,20 @@ public final class OracleDataTypeOption implements DialectDataTypeOption {
     @Override
     public Optional<Class<?>> findExtraSQLTypeClass(final int dataType, final boolean unsigned) {
         return Optional.empty();
+    }
+    
+    @Override
+    public boolean isIntegerDataType(final int sqlType) {
+        return dataTypeOption.isIntegerDataType(sqlType);
+    }
+    
+    @Override
+    public boolean isStringDataType(final int sqlType) {
+        return dataTypeOption.isStringDataType(sqlType);
+    }
+    
+    @Override
+    public boolean isBinaryDataType(final int sqlType) {
+        return dataTypeOption.isBinaryDataType(sqlType);
     }
 }

--- a/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/option/PostgreSQLDataTypeOption.java
+++ b/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/option/PostgreSQLDataTypeOption.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.database.postgresql.metadata.database.option;
 
 import com.cedarsoftware.util.CaseInsensitiveMap;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DefaultDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 
 import java.sql.Types;
@@ -28,6 +29,8 @@ import java.util.Optional;
  * Data type option for PostgreSQL.
  */
 public final class PostgreSQLDataTypeOption implements DialectDataTypeOption {
+    
+    private final DialectDataTypeOption dataTypeOption = new DefaultDataTypeOption();
     
     @Override
     public Map<String, Integer> getExtraDataTypes() {
@@ -50,5 +53,20 @@ public final class PostgreSQLDataTypeOption implements DialectDataTypeOption {
             return Optional.of(Integer.class);
         }
         return Optional.empty();
+    }
+    
+    @Override
+    public boolean isIntegerDataType(final int sqlType) {
+        return dataTypeOption.isIntegerDataType(sqlType);
+    }
+    
+    @Override
+    public boolean isStringDataType(final int sqlType) {
+        return dataTypeOption.isStringDataType(sqlType);
+    }
+    
+    @Override
+    public boolean isBinaryDataType(final int sqlType) {
+        return dataTypeOption.isBinaryDataType(sqlType);
     }
 }

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineJdbcUtilsTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineJdbcUtilsTest.java
@@ -21,44 +21,13 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Types;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PipelineJdbcUtilsTest {
-    
-    @Test
-    void assertIsIntegerColumn() {
-        assertTrue(PipelineJdbcUtils.isIntegerColumn(Types.INTEGER));
-        assertTrue(PipelineJdbcUtils.isIntegerColumn(Types.BIGINT));
-        assertTrue(PipelineJdbcUtils.isIntegerColumn(Types.SMALLINT));
-        assertTrue(PipelineJdbcUtils.isIntegerColumn(Types.TINYINT));
-        assertFalse(PipelineJdbcUtils.isIntegerColumn(Types.VARCHAR));
-    }
-    
-    @Test
-    void assertIsStringColumn() {
-        assertTrue(PipelineJdbcUtils.isStringColumn(Types.CHAR));
-        assertTrue(PipelineJdbcUtils.isStringColumn(Types.VARCHAR));
-        assertTrue(PipelineJdbcUtils.isStringColumn(Types.LONGVARCHAR));
-        assertTrue(PipelineJdbcUtils.isStringColumn(Types.NCHAR));
-        assertTrue(PipelineJdbcUtils.isStringColumn(Types.NVARCHAR));
-        assertTrue(PipelineJdbcUtils.isStringColumn(Types.LONGNVARCHAR));
-        assertFalse(PipelineJdbcUtils.isStringColumn(Types.INTEGER));
-    }
-    
-    @Test
-    void assertIsBinaryColumn() {
-        assertTrue(PipelineJdbcUtils.isBinaryColumn(Types.BINARY));
-        assertTrue(PipelineJdbcUtils.isBinaryColumn(Types.VARBINARY));
-        assertTrue(PipelineJdbcUtils.isBinaryColumn(Types.LONGVARBINARY));
-        assertFalse(PipelineJdbcUtils.isBinaryColumn(Types.VARCHAR));
-    }
     
     @Test
     void assertCancelStatementWhenIsClosed() throws SQLException {

--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/incremental/binlog/data/binary/MySQLBinlogBinaryStringHandler.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/incremental/binlog/data/binary/MySQLBinlogBinaryStringHandler.java
@@ -19,8 +19,10 @@ package org.apache.shardingsphere.data.pipeline.mysql.ingest.incremental.binlog.
 
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineColumnMetaData;
-import org.apache.shardingsphere.data.pipeline.core.util.PipelineJdbcUtils;
 import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.row.column.value.string.MySQLBinaryString;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 
 import java.io.Serializable;
 import java.nio.charset.Charset;
@@ -39,6 +41,8 @@ public final class MySQLBinlogBinaryStringHandler {
      * @return handled value
      */
     public static Serializable handle(final PipelineColumnMetaData columnMetaData, final MySQLBinaryString value) {
-        return PipelineJdbcUtils.isBinaryColumn(columnMetaData.getDataType()) ? value.getBytes() : new String(value.getBytes(), Charset.defaultCharset());
+        return new DatabaseTypeRegistry(TypedSPILoader.getService(DatabaseType.class, "MySQL")).getDialectDatabaseMetaData().getDataTypeOption().isBinaryDataType(columnMetaData.getDataType())
+                ? value.getBytes()
+                : new String(value.getBytes(), Charset.defaultCharset());
     }
 }


### PR DESCRIPTION
- Remove integer, string, and binary column type checks from PipelineJdbcUtils
- Add corresponding methods to DialectDataTypeOption interface
- Implement these methods in DefaultDataTypeOption and database-specific classes
- Update InventoryDumperContextSplitter and MySQLBinlogBinaryStringHandler to use new methods- Remove redundant tests from PipelineJdbcUtilsTest