### PR TITLE
Rename dataTypeOption to delegate in DataTypeOption classes

### DIFF
--- a/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/option/MySQLDataTypeOption.java
+++ b/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/option/MySQLDataTypeOption.java
@@ -31,7 +31,7 @@ import java.util.Optional;
  */
 public final class MySQLDataTypeOption implements DialectDataTypeOption {
     
-    private final DialectDataTypeOption dataTypeOption = new DefaultDataTypeOption();
+    private final DialectDataTypeOption delegate = new DefaultDataTypeOption();
     
     @Override
     public Map<String, Integer> getExtraDataTypes() {
@@ -65,16 +65,16 @@ public final class MySQLDataTypeOption implements DialectDataTypeOption {
     
     @Override
     public boolean isIntegerDataType(final int sqlType) {
-        return dataTypeOption.isIntegerDataType(sqlType);
+        return delegate.isIntegerDataType(sqlType);
     }
     
     @Override
     public boolean isStringDataType(final int sqlType) {
-        return dataTypeOption.isStringDataType(sqlType);
+        return delegate.isStringDataType(sqlType);
     }
     
     @Override
     public boolean isBinaryDataType(final int sqlType) {
-        return dataTypeOption.isBinaryDataType(sqlType);
+        return delegate.isBinaryDataType(sqlType);
     }
 }

--- a/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/option/OpenGaussDataTypeOption.java
+++ b/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/option/OpenGaussDataTypeOption.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  */
 public final class OpenGaussDataTypeOption implements DialectDataTypeOption {
     
-    private final DialectDataTypeOption dataTypeOption = new DefaultDataTypeOption();
+    private final DialectDataTypeOption delegate = new DefaultDataTypeOption();
     
     @Override
     public Map<String, Integer> getExtraDataTypes() {
@@ -54,16 +54,16 @@ public final class OpenGaussDataTypeOption implements DialectDataTypeOption {
     
     @Override
     public boolean isIntegerDataType(final int sqlType) {
-        return dataTypeOption.isIntegerDataType(sqlType);
+        return delegate.isIntegerDataType(sqlType);
     }
     
     @Override
     public boolean isStringDataType(final int sqlType) {
-        return dataTypeOption.isStringDataType(sqlType);
+        return delegate.isStringDataType(sqlType);
     }
     
     @Override
     public boolean isBinaryDataType(final int sqlType) {
-        return dataTypeOption.isBinaryDataType(sqlType);
+        return delegate.isBinaryDataType(sqlType);
     }
 }

--- a/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/option/OracleDataTypeOption.java
+++ b/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/option/OracleDataTypeOption.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  */
 public final class OracleDataTypeOption implements DialectDataTypeOption {
     
-    private final DialectDataTypeOption dataTypeOption = new DefaultDataTypeOption();
+    private final DialectDataTypeOption delegate = new DefaultDataTypeOption();
     
     @Override
     public Map<String, Integer> getExtraDataTypes() {
@@ -56,16 +56,16 @@ public final class OracleDataTypeOption implements DialectDataTypeOption {
     
     @Override
     public boolean isIntegerDataType(final int sqlType) {
-        return dataTypeOption.isIntegerDataType(sqlType);
+        return delegate.isIntegerDataType(sqlType);
     }
     
     @Override
     public boolean isStringDataType(final int sqlType) {
-        return dataTypeOption.isStringDataType(sqlType);
+        return delegate.isStringDataType(sqlType);
     }
     
     @Override
     public boolean isBinaryDataType(final int sqlType) {
-        return dataTypeOption.isBinaryDataType(sqlType);
+        return delegate.isBinaryDataType(sqlType);
     }
 }

--- a/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/option/PostgreSQLDataTypeOption.java
+++ b/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/option/PostgreSQLDataTypeOption.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  */
 public final class PostgreSQLDataTypeOption implements DialectDataTypeOption {
     
-    private final DialectDataTypeOption dataTypeOption = new DefaultDataTypeOption();
+    private final DialectDataTypeOption delegate = new DefaultDataTypeOption();
     
     @Override
     public Map<String, Integer> getExtraDataTypes() {
@@ -57,16 +57,16 @@ public final class PostgreSQLDataTypeOption implements DialectDataTypeOption {
     
     @Override
     public boolean isIntegerDataType(final int sqlType) {
-        return dataTypeOption.isIntegerDataType(sqlType);
+        return delegate.isIntegerDataType(sqlType);
     }
     
     @Override
     public boolean isStringDataType(final int sqlType) {
-        return dataTypeOption.isStringDataType(sqlType);
+        return delegate.isStringDataType(sqlType);
     }
     
     @Override
     public boolean isBinaryDataType(final int sqlType) {
-        return dataTypeOption.isBinaryDataType(sqlType);
+        return delegate.isBinaryDataType(sqlType);
     }
 }


### PR DESCRIPTION
- Renamed dataTypeOption to delegate in MySQLDataTypeOption, OpenGaussDataTypeOption, OracleDataTypeOption, and PostgreSQLDataTypeOption classes
- Updated method calls to use the new delegate variable
- This change improves code readability and consistency across database type implementations