### PR TITLE
Optimize data type option implementations

### DIFF
--- a/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/option/MySQLDataTypeOption.java
+++ b/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/option/MySQLDataTypeOption.java
@@ -17,12 +17,12 @@
 
 package org.apache.shardingsphere.infra.database.mysql.metadata.database.option;
 
+import com.cedarsoftware.util.CaseInsensitiveMap;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DefaultDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 
 import java.math.BigInteger;
 import java.sql.Types;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -31,11 +31,16 @@ import java.util.Optional;
  */
 public final class MySQLDataTypeOption implements DialectDataTypeOption {
     
+    private static final Map<String, Integer> EXTRA_DATA_TYPES;
+    
     private final DialectDataTypeOption delegate = new DefaultDataTypeOption();
     
-    @Override
-    public Map<String, Integer> getExtraDataTypes() {
-        Map<String, Integer> result = new HashMap<>(10, 1F);
+    static {
+        EXTRA_DATA_TYPES = setUpExtraDataTypes();
+    }
+    
+    private static Map<String, Integer> setUpExtraDataTypes() {
+        Map<String, Integer> result = new CaseInsensitiveMap<>();
         result.put("JSON", Types.LONGVARCHAR);
         result.put("GEOMETRY", Types.BINARY);
         result.put("GEOMETRYCOLLECTION", Types.BINARY);
@@ -47,6 +52,11 @@ public final class MySQLDataTypeOption implements DialectDataTypeOption {
         result.put("LINESTRING", Types.BINARY);
         result.put("MULTILINESTRING", Types.BINARY);
         return result;
+    }
+    
+    @Override
+    public Map<String, Integer> getExtraDataTypes() {
+        return EXTRA_DATA_TYPES;
     }
     
     @Override

--- a/infra/database/type/opengauss/pom.xml
+++ b/infra/database/type/opengauss/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>shardingsphere-infra-database-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-database-postgresql</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>

--- a/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/option/OpenGaussDataTypeOption.java
+++ b/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/option/OpenGaussDataTypeOption.java
@@ -17,11 +17,9 @@
 
 package org.apache.shardingsphere.infra.database.opengauss.metadata.database.option;
 
-import com.cedarsoftware.util.CaseInsensitiveMap;
-import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DefaultDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
+import org.apache.shardingsphere.infra.database.postgresql.metadata.database.option.PostgreSQLDataTypeOption;
 
-import java.sql.Types;
 import java.util.Map;
 import java.util.Optional;
 
@@ -30,21 +28,11 @@ import java.util.Optional;
  */
 public final class OpenGaussDataTypeOption implements DialectDataTypeOption {
     
-    private final DialectDataTypeOption delegate = new DefaultDataTypeOption();
+    private final DialectDataTypeOption delegate = new PostgreSQLDataTypeOption();
     
     @Override
     public Map<String, Integer> getExtraDataTypes() {
-        Map<String, Integer> result = new CaseInsensitiveMap<>();
-        result.put("SMALLINT", Types.SMALLINT);
-        result.put("INT", Types.INTEGER);
-        result.put("INTEGER", Types.INTEGER);
-        result.put("BIGINT", Types.BIGINT);
-        result.put("DECIMAL", Types.DECIMAL);
-        result.put("NUMERIC", Types.NUMERIC);
-        result.put("REAL", Types.REAL);
-        result.put("BOOL", Types.BOOLEAN);
-        result.put("CHARACTER VARYING", Types.VARCHAR);
-        return result;
+        return delegate.getExtraDataTypes();
     }
     
     @Override

--- a/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/option/OracleDataTypeOption.java
+++ b/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/option/OracleDataTypeOption.java
@@ -17,11 +17,11 @@
 
 package org.apache.shardingsphere.infra.database.oracle.metadata.database.option;
 
+import com.cedarsoftware.util.CaseInsensitiveMap;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DefaultDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 
 import java.sql.Types;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -30,11 +30,16 @@ import java.util.Optional;
  */
 public final class OracleDataTypeOption implements DialectDataTypeOption {
     
+    private static final Map<String, Integer> EXTRA_DATA_TYPES;
+    
     private final DialectDataTypeOption delegate = new DefaultDataTypeOption();
     
-    @Override
-    public Map<String, Integer> getExtraDataTypes() {
-        Map<String, Integer> result = new HashMap<>(8);
+    static {
+        EXTRA_DATA_TYPES = setUpExtraDataTypes();
+    }
+    
+    private static Map<String, Integer> setUpExtraDataTypes() {
+        Map<String, Integer> result = new CaseInsensitiveMap<>();
         result.put("SMALLINT", Types.SMALLINT);
         result.put("TINYINT", Types.TINYINT);
         result.put("INT", Types.INTEGER);
@@ -47,6 +52,11 @@ public final class OracleDataTypeOption implements DialectDataTypeOption {
         result.put("BINARY_FLOAT", Types.FLOAT);
         result.put("NUMBER", Types.NUMERIC);
         return result;
+    }
+    
+    @Override
+    public Map<String, Integer> getExtraDataTypes() {
+        return EXTRA_DATA_TYPES;
     }
     
     @Override

--- a/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/option/PostgreSQLDataTypeOption.java
+++ b/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/option/PostgreSQLDataTypeOption.java
@@ -30,10 +30,15 @@ import java.util.Optional;
  */
 public final class PostgreSQLDataTypeOption implements DialectDataTypeOption {
     
+    private static final Map<String, Integer> EXTRA_DATA_TYPES;
+    
     private final DialectDataTypeOption delegate = new DefaultDataTypeOption();
     
-    @Override
-    public Map<String, Integer> getExtraDataTypes() {
+    static {
+        EXTRA_DATA_TYPES = setUpExtraDataTypes();
+    }
+    
+    private static Map<String, Integer> setUpExtraDataTypes() {
         Map<String, Integer> result = new CaseInsensitiveMap<>();
         result.put("SMALLINT", Types.SMALLINT);
         result.put("INT", Types.INTEGER);
@@ -45,6 +50,11 @@ public final class PostgreSQLDataTypeOption implements DialectDataTypeOption {
         result.put("BOOL", Types.BOOLEAN);
         result.put("CHARACTER VARYING", Types.VARCHAR);
         return result;
+    }
+    
+    @Override
+    public Map<String, Integer> getExtraDataTypes() {
+        return EXTRA_DATA_TYPES;
     }
     
     @Override


### PR DESCRIPTION
- MySQLDataTypeOption: Use a static final map for extra data types
- OpenGaussDataTypeOption: Delegate to PostgreSQLDataTypeOption
- OracleDataTypeOption: Use a static final map for extra data types
- PostgreSQLDataTypeOption: Use a static final map for extra data types