### PR TITLE
Rename table name pattern to identifier pattern

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/enums/EncryptDerivedColumnSuffix.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/enums/EncryptDerivedColumnSuffix.java
@@ -42,6 +42,6 @@ public enum EncryptDerivedColumnSuffix {
      * @return derived column name
      */
     public String getDerivedColumnName(final String columnName, final DatabaseType databaseType) {
-        return String.format("%s%s", columnName, new DatabaseTypeRegistry(databaseType).formatTableNamePattern(suffix));
+        return String.format("%s%s", columnName, new DatabaseTypeRegistry(databaseType).formatIdentifierPattern(suffix));
     }
 }

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/data/loader/type/TableMetaDataLoader.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/data/loader/type/TableMetaDataLoader.java
@@ -48,7 +48,7 @@ public final class TableMetaDataLoader {
      */
     public static Optional<TableMetaData> load(final DataSource dataSource, final String tableNamePattern, final DatabaseType databaseType) throws SQLException {
         try (MetaDataLoaderConnection connection = new MetaDataLoaderConnection(databaseType, dataSource.getConnection())) {
-            String formattedTableNamePattern = new DatabaseTypeRegistry(databaseType).formatTableNamePattern(tableNamePattern);
+            String formattedTableNamePattern = new DatabaseTypeRegistry(databaseType).formatIdentifierPattern(tableNamePattern);
             return isTableExist(connection, formattedTableNamePattern)
                     ? Optional.of(new TableMetaData(tableNamePattern, ColumnMetaDataLoader.load(
                             connection, formattedTableNamePattern, databaseType), IndexMetaDataLoader.load(connection, formattedTableNamePattern), Collections.emptyList()))

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/DialectDatabaseMetaData.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/DialectDatabaseMetaData.java
@@ -29,7 +29,7 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DefaultSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.table.DialectDriverQuerySystemCatalogOption;
-import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.table.TableNamePatternType;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierNamePatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
 import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPI;
 import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
@@ -103,12 +103,12 @@ public interface DialectDatabaseMetaData extends DatabaseTypedSPI {
     }
     
     /**
-     * Get table name pattern type.
+     * Get identifier pattern type.
      *
-     * @return table name pattern type
+     * @return identifier pattern type
      */
-    default TableNamePatternType getTableNamePatternType() {
-        return TableNamePatternType.KEEP_ORIGIN;
+    default IdentifierNamePatternType getIdentifierPatternType() {
+        return IdentifierNamePatternType.KEEP_ORIGIN;
     }
     
     /**

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/IdentifierNamePatternType.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/IdentifierNamePatternType.java
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.table;
+package org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option;
 
 /**
- * Table name pattern type.
+ * Identifier name pattern type.
  */
-public enum TableNamePatternType {
+public enum IdentifierNamePatternType {
     
     UPPER_CASE, LOWER_CASE, KEEP_ORIGIN
 }

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/type/DatabaseTypeRegistry.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/type/DatabaseTypeRegistry.java
@@ -61,21 +61,21 @@ public final class DatabaseTypeRegistry {
     }
     
     /**
-     * Format table name pattern.
+     * Format identifier pattern.
      *
-     * @param tableNamePattern table name pattern
-     * @return formatted table name pattern
+     * @param identifierPattern identifier pattern
+     * @return formatted identifier pattern
      */
-    public String formatTableNamePattern(final String tableNamePattern) {
+    public String formatIdentifierPattern(final String identifierPattern) {
         DatabaseType databaseType = this.databaseType.getTrunkDatabaseType().orElse(this.databaseType);
-        switch (DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, databaseType).getTableNamePatternType()) {
+        switch (DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, databaseType).getIdentifierPatternType()) {
             case UPPER_CASE:
-                return tableNamePattern.toUpperCase();
+                return identifierPattern.toUpperCase();
             case LOWER_CASE:
-                return tableNamePattern.toLowerCase();
+                return identifierPattern.toLowerCase();
             case KEEP_ORIGIN:
             default:
-                return tableNamePattern;
+                return identifierPattern;
         }
     }
 }

--- a/infra/database/type/firebird/src/main/java/org/apache/shardingsphere/infra/database/firebird/metadata/database/FirebirdDatabaseMetaData.java
+++ b/infra/database/type/firebird/src/main/java/org/apache/shardingsphere/infra/database/firebird/metadata/database/FirebirdDatabaseMetaData.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.infra.database.firebird.metadata.database;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
-import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.table.TableNamePatternType;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierNamePatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
 
 /**
@@ -39,8 +39,8 @@ public final class FirebirdDatabaseMetaData implements DialectDatabaseMetaData {
     }
     
     @Override
-    public TableNamePatternType getTableNamePatternType() {
-        return TableNamePatternType.UPPER_CASE;
+    public IdentifierNamePatternType getIdentifierPatternType() {
+        return IdentifierNamePatternType.UPPER_CASE;
     }
     
     @Override

--- a/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
+++ b/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.index.DialectIndexOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.table.DialectDriverQuerySystemCatalogOption;
-import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.table.TableNamePatternType;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierNamePatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
 import org.apache.shardingsphere.infra.database.opengauss.metadata.database.option.OpenGaussDataTypeOption;
 import org.apache.shardingsphere.infra.database.opengauss.metadata.database.option.OpenGaussSchemaOption;
@@ -73,8 +73,8 @@ public final class OpenGaussDatabaseMetaData implements DialectDatabaseMetaData 
     }
     
     @Override
-    public TableNamePatternType getTableNamePatternType() {
-        return TableNamePatternType.LOWER_CASE;
+    public IdentifierNamePatternType getIdentifierPatternType() {
+        return IdentifierNamePatternType.LOWER_CASE;
     }
     
     @Override

--- a/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/OracleDatabaseMetaData.java
+++ b/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/OracleDatabaseMetaData.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.index.DialectIndexOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
-import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.table.TableNamePatternType;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierNamePatternType;
 import org.apache.shardingsphere.infra.database.oracle.metadata.database.option.OracleDataTypeOption;
 import org.apache.shardingsphere.infra.database.oracle.metadata.database.option.OracleSchemaOption;
 
@@ -62,8 +62,8 @@ public final class OracleDatabaseMetaData implements DialectDatabaseMetaData {
     }
     
     @Override
-    public TableNamePatternType getTableNamePatternType() {
-        return TableNamePatternType.UPPER_CASE;
+    public IdentifierNamePatternType getIdentifierPatternType() {
+        return IdentifierNamePatternType.UPPER_CASE;
     }
     
     @Override

--- a/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/PostgreSQLDatabaseMetaData.java
+++ b/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/PostgreSQLDatabaseMetaData.java
@@ -23,7 +23,7 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.index.DialectIndexOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
-import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.table.TableNamePatternType;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierNamePatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
 import org.apache.shardingsphere.infra.database.postgresql.metadata.database.option.PostgreSQLDataTypeOption;
 import org.apache.shardingsphere.infra.database.postgresql.metadata.database.option.PostgreSQLSchemaOption;
@@ -59,8 +59,8 @@ public final class PostgreSQLDatabaseMetaData implements DialectDatabaseMetaData
     }
     
     @Override
-    public TableNamePatternType getTableNamePatternType() {
-        return TableNamePatternType.LOWER_CASE;
+    public IdentifierNamePatternType getIdentifierPatternType() {
+        return IdentifierNamePatternType.LOWER_CASE;
     }
     
     @Override

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtils.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtils.java
@@ -53,7 +53,7 @@ public final class TableRefreshUtils {
      */
     public static String getTableName(final IdentifierValue tableIdentifierValue, final DatabaseType databaseType) {
         return QuoteCharacter.NONE == tableIdentifierValue.getQuoteCharacter()
-                ? new DatabaseTypeRegistry(databaseType).formatTableNamePattern(tableIdentifierValue.getValue())
+                ? new DatabaseTypeRegistry(databaseType).formatIdentifierPattern(tableIdentifierValue.getValue())
                 : tableIdentifierValue.getValue();
     }
     

--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/env/DataSetEnvironmentManager.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/env/DataSetEnvironmentManager.java
@@ -236,7 +236,7 @@ public final class DataSetEnvironmentManager {
         
         private String getQuotedTableName(final String tableName, final DatabaseType databaseType) {
             DatabaseTypeRegistry databaseTypeRegistry = new DatabaseTypeRegistry(databaseType);
-            return databaseTypeRegistry.getDialectDatabaseMetaData().getQuoteCharacter().wrap(databaseTypeRegistry.formatTableNamePattern(tableName));
+            return databaseTypeRegistry.getDialectDatabaseMetaData().getQuoteCharacter().wrap(databaseTypeRegistry.formatIdentifierPattern(tableName));
         }
     }
 }


### PR DESCRIPTION
- Rename TableNamePatternType to IdentifierNamePatternType
- Update related methods and classes to use the new IdentifierNamePatternType
- Modify the formatTableNamePattern method to formatIdentifierPattern
