### PR TITLE
Move getIdentifierPatternType method

### DIFF
--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/DialectDatabaseMetaData.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/DialectDatabaseMetaData.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.database.core.metadata.database.metadata
 
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.altertable.DialectAlterTableOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.column.DialectColumnOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.connection.DialectConnectionOption;
@@ -29,7 +30,6 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DefaultSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.table.DialectDriverQuerySystemCatalogOption;
-import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
 import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPI;
 import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
@@ -48,6 +48,13 @@ public interface DialectDatabaseMetaData extends DatabaseTypedSPI {
      * @return quote character
      */
     QuoteCharacter getQuoteCharacter();
+    
+    /**
+     * Get identifier pattern type.
+     *
+     * @return identifier pattern type
+     */
+    IdentifierPatternType getIdentifierPatternType();
     
     /**
      * Get default nulls order type.
@@ -100,15 +107,6 @@ public interface DialectDatabaseMetaData extends DatabaseTypedSPI {
      */
     default DialectIndexOption getIndexOption() {
         return new DialectIndexOption(false);
-    }
-    
-    /**
-     * Get identifier pattern type.
-     *
-     * @return identifier pattern type
-     */
-    default IdentifierPatternType getIdentifierPatternType() {
-        return IdentifierPatternType.KEEP_ORIGIN;
     }
     
     /**

--- a/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/metadata/database/fixture/BranchDialectDatabaseMetaData.java
+++ b/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/metadata/database/fixture/BranchDialectDatabaseMetaData.java
@@ -20,12 +20,18 @@ package org.apache.shardingsphere.infra.database.core.metadata.database.fixture;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 
 public final class BranchDialectDatabaseMetaData implements DialectDatabaseMetaData {
     
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.NONE;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.KEEP_ORIGIN;
     }
     
     @Override

--- a/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/metadata/database/fixture/TrunkDialectDatabaseMetaData.java
+++ b/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/metadata/database/fixture/TrunkDialectDatabaseMetaData.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.database.core.metadata.database.fixture;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DefaultSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 
@@ -28,6 +29,11 @@ public final class TrunkDialectDatabaseMetaData implements DialectDatabaseMetaDa
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.NONE;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.KEEP_ORIGIN;
     }
     
     @Override

--- a/infra/database/type/clickhouse/src/main/java/org/apache/shardingsphere/infra/database/clickhouse/metadata/database/ClickHouseDatabaseMetaData.java
+++ b/infra/database/type/clickhouse/src/main/java/org/apache/shardingsphere/infra/database/clickhouse/metadata/database/ClickHouseDatabaseMetaData.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.database.clickhouse.metadata.database;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 
 /**
  * Database meta data of ClickHouse.
@@ -29,6 +30,11 @@ public final class ClickHouseDatabaseMetaData implements DialectDatabaseMetaData
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.QUOTE;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.KEEP_ORIGIN;
     }
     
     @Override

--- a/infra/database/type/firebird/src/main/java/org/apache/shardingsphere/infra/database/firebird/metadata/database/FirebirdDatabaseMetaData.java
+++ b/infra/database/type/firebird/src/main/java/org/apache/shardingsphere/infra/database/firebird/metadata/database/FirebirdDatabaseMetaData.java
@@ -34,13 +34,13 @@ public final class FirebirdDatabaseMetaData implements DialectDatabaseMetaData {
     }
     
     @Override
-    public NullsOrderType getDefaultNullsOrderType() {
-        return NullsOrderType.LOW;
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.UPPER_CASE;
     }
     
     @Override
-    public IdentifierPatternType getIdentifierPatternType() {
-        return IdentifierPatternType.UPPER_CASE;
+    public NullsOrderType getDefaultNullsOrderType() {
+        return NullsOrderType.LOW;
     }
     
     @Override

--- a/infra/database/type/h2/src/main/java/org/apache/shardingsphere/infra/database/h2/metadata/database/H2DatabaseMetaData.java
+++ b/infra/database/type/h2/src/main/java/org/apache/shardingsphere/infra/database/h2/metadata/database/H2DatabaseMetaData.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.database.h2.metadata.database;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 
 /**
  * Database meta data of H2.
@@ -29,6 +30,11 @@ public final class H2DatabaseMetaData implements DialectDatabaseMetaData {
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.QUOTE;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.KEEP_ORIGIN;
     }
     
     @Override

--- a/infra/database/type/hive/src/main/java/org/apache/shardingsphere/infra/database/hive/metadata/database/HiveDatabaseMetaData.java
+++ b/infra/database/type/hive/src/main/java/org/apache/shardingsphere/infra/database/hive/metadata/database/HiveDatabaseMetaData.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.database.hive.metadata.database;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DefaultSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 
@@ -31,6 +32,11 @@ public final class HiveDatabaseMetaData implements DialectDatabaseMetaData {
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.BACK_QUOTE;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.KEEP_ORIGIN;
     }
     
     @Override

--- a/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/MySQLDatabaseMetaData.java
+++ b/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/MySQLDatabaseMetaData.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.database.mysql.metadata.database;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.column.DialectColumnOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.connection.DialectConnectionOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
@@ -35,6 +36,11 @@ public final class MySQLDatabaseMetaData implements DialectDatabaseMetaData {
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.BACK_QUOTE;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.KEEP_ORIGIN;
     }
     
     @Override

--- a/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
+++ b/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
@@ -20,15 +20,15 @@ package org.apache.shardingsphere.infra.database.opengauss.metadata.database;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.index.DialectIndexOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.table.DialectDriverQuerySystemCatalogOption;
-import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
 import org.apache.shardingsphere.infra.database.opengauss.metadata.database.option.OpenGaussDataTypeOption;
-import org.apache.shardingsphere.infra.database.opengauss.metadata.database.option.OpenGaussSchemaOption;
 import org.apache.shardingsphere.infra.database.opengauss.metadata.database.option.OpenGaussDriverQuerySystemCatalogOption;
+import org.apache.shardingsphere.infra.database.opengauss.metadata.database.option.OpenGaussSchemaOption;
 
 import java.util.Optional;
 
@@ -40,6 +40,11 @@ public final class OpenGaussDatabaseMetaData implements DialectDatabaseMetaData 
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.QUOTE;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.LOWER_CASE;
     }
     
     @Override
@@ -70,11 +75,6 @@ public final class OpenGaussDatabaseMetaData implements DialectDatabaseMetaData 
     @Override
     public DialectTransactionOption getTransactionOption() {
         return new DialectTransactionOption(true, false, false, true, false);
-    }
-    
-    @Override
-    public IdentifierPatternType getIdentifierPatternType() {
-        return IdentifierPatternType.LOWER_CASE;
     }
     
     @Override

--- a/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/OracleDatabaseMetaData.java
+++ b/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/OracleDatabaseMetaData.java
@@ -20,12 +20,12 @@ package org.apache.shardingsphere.infra.database.oracle.metadata.database;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.altertable.DialectAlterTableOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.connection.DialectConnectionOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.index.DialectIndexOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
-import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.oracle.metadata.database.option.OracleDataTypeOption;
 import org.apache.shardingsphere.infra.database.oracle.metadata.database.option.OracleSchemaOption;
 
@@ -39,6 +39,11 @@ public final class OracleDatabaseMetaData implements DialectDatabaseMetaData {
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.QUOTE;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.UPPER_CASE;
     }
     
     @Override
@@ -59,11 +64,6 @@ public final class OracleDatabaseMetaData implements DialectDatabaseMetaData {
     @Override
     public DialectIndexOption getIndexOption() {
         return new DialectIndexOption(true);
-    }
-    
-    @Override
-    public IdentifierPatternType getIdentifierPatternType() {
-        return IdentifierPatternType.UPPER_CASE;
     }
     
     @Override

--- a/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/PostgreSQLDatabaseMetaData.java
+++ b/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/PostgreSQLDatabaseMetaData.java
@@ -20,10 +20,10 @@ package org.apache.shardingsphere.infra.database.postgresql.metadata.database;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.index.DialectIndexOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
-import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
 import org.apache.shardingsphere.infra.database.postgresql.metadata.database.option.PostgreSQLDataTypeOption;
 import org.apache.shardingsphere.infra.database.postgresql.metadata.database.option.PostgreSQLSchemaOption;
@@ -36,6 +36,11 @@ public final class PostgreSQLDatabaseMetaData implements DialectDatabaseMetaData
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.QUOTE;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.LOWER_CASE;
     }
     
     @Override
@@ -56,11 +61,6 @@ public final class PostgreSQLDatabaseMetaData implements DialectDatabaseMetaData
     @Override
     public DialectIndexOption getIndexOption() {
         return new DialectIndexOption(true);
-    }
-    
-    @Override
-    public IdentifierPatternType getIdentifierPatternType() {
-        return IdentifierPatternType.LOWER_CASE;
     }
     
     @Override

--- a/infra/database/type/presto/src/main/java/org/apache/shardingsphere/infra/database/presto/metadata/database/PrestoDatabaseMetaData.java
+++ b/infra/database/type/presto/src/main/java/org/apache/shardingsphere/infra/database/presto/metadata/database/PrestoDatabaseMetaData.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.database.presto.metadata.database;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DefaultSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 
@@ -31,6 +32,11 @@ public final class PrestoDatabaseMetaData implements DialectDatabaseMetaData {
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.QUOTE;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.KEEP_ORIGIN;
     }
     
     @Override

--- a/infra/database/type/sql92/src/main/java/org/apache/shardingsphere/infra/database/sql92/metadata/database/SQL92DatabaseMetaData.java
+++ b/infra/database/type/sql92/src/main/java/org/apache/shardingsphere/infra/database/sql92/metadata/database/SQL92DatabaseMetaData.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.database.sql92.metadata.database;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 
 /**
  * Database meta data of SQL92.
@@ -29,6 +30,11 @@ public final class SQL92DatabaseMetaData implements DialectDatabaseMetaData {
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.QUOTE;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.KEEP_ORIGIN;
     }
     
     @Override

--- a/infra/database/type/sqlserver/src/main/java/org/apache/shardingsphere/infra/database/sqlserver/metadata/database/SQLServerDatabaseMetaData.java
+++ b/infra/database/type/sqlserver/src/main/java/org/apache/shardingsphere/infra/database/sqlserver/metadata/database/SQLServerDatabaseMetaData.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.database.sqlserver.metadata.database;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.altertable.DialectAlterTableOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DefaultSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
@@ -34,6 +35,11 @@ public final class SQLServerDatabaseMetaData implements DialectDatabaseMetaData 
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.BRACKETS;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.KEEP_ORIGIN;
     }
     
     @Override

--- a/test/fixture/database/src/main/java/org/apache/shardingsphere/test/fixture/database/DialectDatabaseMetaDataFixture.java
+++ b/test/fixture/database/src/main/java/org/apache/shardingsphere/test/fixture/database/DialectDatabaseMetaDataFixture.java
@@ -20,12 +20,18 @@ package org.apache.shardingsphere.test.fixture.database;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.DialectDatabaseMetaData;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 
 public final class DialectDatabaseMetaDataFixture implements DialectDatabaseMetaData {
     
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.NONE;
+    }
+    
+    @Override
+    public IdentifierPatternType getIdentifierPatternType() {
+        return IdentifierPatternType.KEEP_ORIGIN;
     }
     
     @Override


### PR DESCRIPTION
- Move getIdentifierPatternType method from DialectDatabaseMetaData to individual database metadata classes
- Update ClickHouse, Firebird, H2, Hive, MySQL, OpenGauss, Oracle, PostgreSQL, Presto, SQL92, and SQLServer database metadata classes
- Remove default implementation from DialectDatabaseMetaData