### PR TITLE
Reorganize schema option method in database metadata

### DIFF
--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/DialectDatabaseMetaData.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/DialectDatabaseMetaData.java
@@ -74,21 +74,21 @@ public interface DialectDatabaseMetaData extends DatabaseTypedSPI {
     }
     
     /**
-     * Get schema option.
-     *
-     * @return schema option
-     */
-    default DialectSchemaOption getSchemaOption() {
-        return new DefaultSchemaOption(false, null);
-    }
-    
-    /**
      * Get driver query system catalog option.
      *
      * @return driver query system catalog option
      */
     default Optional<DialectDriverQuerySystemCatalogOption> getDriverQuerySystemCatalogOption() {
         return Optional.empty();
+    }
+    
+    /**
+     * Get schema option.
+     *
+     * @return schema option
+     */
+    default DialectSchemaOption getSchemaOption() {
+        return new DefaultSchemaOption(false, null);
     }
     
     /**

--- a/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
+++ b/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
@@ -58,13 +58,13 @@ public final class OpenGaussDatabaseMetaData implements DialectDatabaseMetaData 
     }
     
     @Override
-    public DialectSchemaOption getSchemaOption() {
-        return new OpenGaussSchemaOption();
+    public Optional<DialectDriverQuerySystemCatalogOption> getDriverQuerySystemCatalogOption() {
+        return Optional.of(new OpenGaussDriverQuerySystemCatalogOption());
     }
     
     @Override
-    public Optional<DialectDriverQuerySystemCatalogOption> getDriverQuerySystemCatalogOption() {
-        return Optional.of(new OpenGaussDriverQuerySystemCatalogOption());
+    public DialectSchemaOption getSchemaOption() {
+        return new OpenGaussSchemaOption();
     }
     
     @Override


### PR DESCRIPTION
- Move getSchemaOption method to a more appropriate position in the DialectDatabaseMetaData class
- Update the implementation of getSchemaOption in OpenGaussDatabaseMetaData class