### PR TITLE
Abstract default system schema logic

### DIFF
--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/schema/DefaultSchemaOption.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/schema/DefaultSchemaOption.java
@@ -49,4 +49,9 @@ public final class DefaultSchemaOption implements DialectSchemaOption {
     public Optional<String> getDefaultSchema() {
         return Optional.ofNullable(defaultSchema);
     }
+    
+    @Override
+    public  Optional<String> getDefaultSystemSchema() {
+        return Optional.empty();
+    }
 }

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/schema/DefaultSchemaOption.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/schema/DefaultSchemaOption.java
@@ -51,7 +51,7 @@ public final class DefaultSchemaOption implements DialectSchemaOption {
     }
     
     @Override
-    public  Optional<String> getDefaultSystemSchema() {
+    public Optional<String> getDefaultSystemSchema() {
         return Optional.empty();
     }
 }

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/schema/DialectSchemaOption.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/schema/DialectSchemaOption.java
@@ -52,7 +52,5 @@ public interface DialectSchemaOption {
      *
      * @return default system schema name
      */
-    default Optional<String> getDefaultSystemSchema() {
-        return Optional.empty();
-    }
+    Optional<String> getDefaultSystemSchema();
 }

--- a/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/option/OpenGaussSchemaOption.java
+++ b/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/option/OpenGaussSchemaOption.java
@@ -17,8 +17,8 @@
 
 package org.apache.shardingsphere.infra.database.opengauss.metadata.database.option;
 
-import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DefaultSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
+import org.apache.shardingsphere.infra.database.postgresql.metadata.database.option.PostgreSQLSchemaOption;
 
 import java.sql.Connection;
 import java.util.Optional;
@@ -28,25 +28,25 @@ import java.util.Optional;
  */
 public final class OpenGaussSchemaOption implements DialectSchemaOption {
     
-    private final DialectSchemaOption defaultSchemaOption = new DefaultSchemaOption(true, "public");
+    private final DialectSchemaOption delegate = new PostgreSQLSchemaOption();
     
     @Override
     public boolean isSchemaAvailable() {
-        return defaultSchemaOption.isSchemaAvailable();
+        return delegate.isSchemaAvailable();
     }
     
     @Override
     public String getSchema(final Connection connection) {
-        return defaultSchemaOption.getSchema(connection);
+        return delegate.getSchema(connection);
     }
     
     @Override
     public Optional<String> getDefaultSchema() {
-        return defaultSchemaOption.getDefaultSchema();
+        return delegate.getDefaultSchema();
     }
     
     @Override
     public Optional<String> getDefaultSystemSchema() {
-        return Optional.of("pg_catalog");
+        return delegate.getDefaultSystemSchema();
     }
 }

--- a/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/option/OracleSchemaOption.java
+++ b/infra/database/type/oracle/src/main/java/org/apache/shardingsphere/infra/database/oracle/metadata/database/option/OracleSchemaOption.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.database.oracle.metadata.database.option;
 
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DefaultSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 
 import java.sql.Connection;
@@ -28,9 +29,11 @@ import java.util.Optional;
  */
 public final class OracleSchemaOption implements DialectSchemaOption {
     
+    private final DialectSchemaOption delegate = new DefaultSchemaOption(true, null);
+    
     @Override
     public boolean isSchemaAvailable() {
-        return true;
+        return delegate.isSchemaAvailable();
     }
     
     @Override
@@ -44,6 +47,11 @@ public final class OracleSchemaOption implements DialectSchemaOption {
     
     @Override
     public Optional<String> getDefaultSchema() {
-        return Optional.empty();
+        return delegate.getDefaultSchema();
+    }
+    
+    @Override
+    public Optional<String> getDefaultSystemSchema() {
+        return delegate.getDefaultSystemSchema();
     }
 }

--- a/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/option/PostgreSQLSchemaOption.java
+++ b/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/option/PostgreSQLSchemaOption.java
@@ -28,21 +28,21 @@ import java.util.Optional;
  */
 public final class PostgreSQLSchemaOption implements DialectSchemaOption {
     
-    private final DialectSchemaOption defaultSchemaOption = new DefaultSchemaOption(true, "public");
+    private final DialectSchemaOption delegate = new DefaultSchemaOption(true, "public");
     
     @Override
     public boolean isSchemaAvailable() {
-        return defaultSchemaOption.isSchemaAvailable();
+        return delegate.isSchemaAvailable();
     }
     
     @Override
     public String getSchema(final Connection connection) {
-        return defaultSchemaOption.getSchema(connection);
+        return delegate.getSchema(connection);
     }
     
     @Override
     public Optional<String> getDefaultSchema() {
-        return defaultSchemaOption.getDefaultSchema();
+        return delegate.getDefaultSchema();
     }
     
     @Override


### PR DESCRIPTION
- Move default system schema logic from OpenGaussSchemaOption to PostgreSQLSchemaOption
- Update OpenGaussSchemaOption to delegate schema-related methods to PostgreSQLSchemaOption
- Modify OracleSchemaOption to use DefaultSchemaOption for default schema logic
- Refactor DefaultSchemaOption to implement default system schema method
- Adjust DialectSchemaOption interface to make default system schema method non-default
