### PR TITLE
Replace new OracleDatabaseType() with TypedSPILoader in RowNumberPaginationContextEngineTest

### DIFF
--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/pagination/engine/RowNumberPaginationContextEngineTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/pagination/engine/RowNumberPaginationContextEngineTest.java
@@ -22,7 +22,7 @@ import org.apache.shardingsphere.infra.binder.context.segment.select.projection.
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.ProjectionsContext;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ColumnProjection;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.database.oracle.type.OracleDatabaseType;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
@@ -50,11 +50,13 @@ class RowNumberPaginationContextEngineTest {
     
     private static final String ROW_NUMBER_COLUMN_ALIAS = "predicateRowNumberAlias";
     
+    private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "Oracle");
+    
     @Test
     void assertCreatePaginationContextWhenRowNumberAliasNotPresent() {
         ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.emptyList());
         PaginationContext paginationContext =
-                new RowNumberPaginationContextEngine(new OracleDatabaseType()).createPaginationContext(Collections.emptyList(), projectionsContext, Collections.emptyList());
+                new RowNumberPaginationContextEngine(databaseType).createPaginationContext(Collections.emptyList(), projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         assertFalse(paginationContext.getRowCountSegment().isPresent());
     }
@@ -64,7 +66,7 @@ class RowNumberPaginationContextEngineTest {
         Projection projectionWithRowNumberAlias = new ColumnProjection(null, ROW_NUMBER_COLUMN_NAME, ROW_NUMBER_COLUMN_ALIAS, mock(DatabaseType.class));
         ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projectionWithRowNumberAlias));
         PaginationContext paginationContext =
-                new RowNumberPaginationContextEngine(new OracleDatabaseType()).createPaginationContext(Collections.emptyList(), projectionsContext, Collections.emptyList());
+                new RowNumberPaginationContextEngine(databaseType).createPaginationContext(Collections.emptyList(), projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         assertFalse(paginationContext.getRowCountSegment().isPresent());
     }
@@ -97,8 +99,7 @@ class RowNumberPaginationContextEngineTest {
         ColumnSegment left = new ColumnSegment(0, 10, new IdentifierValue(ROW_NUMBER_COLUMN_NAME));
         BinaryOperationExpression predicateSegment = new BinaryOperationExpression(0, 0, left, null, null, null);
         andPredicate.getPredicates().add(predicateSegment);
-        PaginationContext paginationContext =
-                new RowNumberPaginationContextEngine(new OracleDatabaseType()).createPaginationContext(Collections.emptyList(), projectionsContext, Collections.emptyList());
+        PaginationContext paginationContext = new RowNumberPaginationContextEngine(databaseType).createPaginationContext(Collections.emptyList(), projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         assertFalse(paginationContext.getRowCountSegment().isPresent());
     }
@@ -110,7 +111,7 @@ class RowNumberPaginationContextEngineTest {
         ColumnSegment left = new ColumnSegment(0, 10, new IdentifierValue(ROW_NUMBER_COLUMN_NAME));
         ParameterMarkerExpressionSegment right = new ParameterMarkerExpressionSegment(0, 10, 0);
         BinaryOperationExpression expression = new BinaryOperationExpression(0, 0, left, right, ">", null);
-        PaginationContext paginationContext = new RowNumberPaginationContextEngine(new OracleDatabaseType())
+        PaginationContext paginationContext = new RowNumberPaginationContextEngine(databaseType)
                 .createPaginationContext(Collections.singletonList(expression), projectionsContext, Collections.singletonList(1));
         Optional<PaginationValueSegment> offSetSegmentPaginationValue = paginationContext.getOffsetSegment();
         assertTrue(offSetSegmentPaginationValue.isPresent());
@@ -124,8 +125,8 @@ class RowNumberPaginationContextEngineTest {
         ColumnSegment left = new ColumnSegment(0, 10, new IdentifierValue(ROW_NUMBER_COLUMN_NAME));
         LiteralExpressionSegment right = new LiteralExpressionSegment(0, 10, 100);
         BinaryOperationExpression expression = new BinaryOperationExpression(0, 0, left, right, operator, null);
-        PaginationContext paginationContext =
-                new RowNumberPaginationContextEngine(new OracleDatabaseType()).createPaginationContext(Collections.singletonList(expression), projectionsContext, Collections.emptyList());
+        PaginationContext paginationContext = new RowNumberPaginationContextEngine(databaseType)
+                .createPaginationContext(Collections.singletonList(expression), projectionsContext, Collections.emptyList());
         assertFalse(paginationContext.getOffsetSegment().isPresent());
         Optional<PaginationValueSegment> paginationValueSegment = paginationContext.getRowCountSegment();
         assertTrue(paginationValueSegment.isPresent());
@@ -141,7 +142,7 @@ class RowNumberPaginationContextEngineTest {
         ColumnSegment left = new ColumnSegment(0, 10, new IdentifierValue(ROW_NUMBER_COLUMN_NAME));
         LiteralExpressionSegment right = new LiteralExpressionSegment(0, 10, 100);
         BinaryOperationExpression expression = new BinaryOperationExpression(0, 0, left, right, operator, null);
-        PaginationContext rowNumberPaginationContextEngine = new RowNumberPaginationContextEngine(new OracleDatabaseType())
+        PaginationContext rowNumberPaginationContextEngine = new RowNumberPaginationContextEngine(databaseType)
                 .createPaginationContext(Collections.singletonList(expression), projectionsContext, Collections.emptyList());
         Optional<PaginationValueSegment> paginationValueSegment = rowNumberPaginationContextEngine.getOffsetSegment();
         assertTrue(paginationValueSegment.isPresent());


### PR DESCRIPTION
- Remove multiple instances of new OracleDatabaseType() in test cases
- Use TypedSPILoader.getService(DatabaseType.class, "Oracle") to get DatabaseType instance
- Update test methods to use the shared DatabaseType instance
- Improve code readability and maintainability by reducing redundancy