### PR TITLE
Optimize Oracle database handling in container composers

### DIFF
--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/PipelineContainerComposer.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/PipelineContainerComposer.java
@@ -218,9 +218,9 @@ public final class PipelineContainerComposer implements AutoCloseable {
         if (PipelineEnvTypeEnum.NATIVE != PipelineE2EEnvironment.getInstance().getItEnvType()) {
             return;
         }
+        DatabaseTypeRegistry databaseTypeRegistry = new DatabaseTypeRegistry(databaseType);
         for (String each : Arrays.asList(DS_0, DS_1, DS_2, DS_3, DS_4)) {
-            String databaseName = databaseType instanceof OracleDatabaseType ? each.toUpperCase() : each;
-            containerComposer.cleanUpDatabase(databaseName);
+            containerComposer.cleanUpDatabase(databaseTypeRegistry.formatIdentifierPattern(each));
         }
     }
     

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/framework/container/compose/DockerContainerComposer.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/framework/container/compose/DockerContainerComposer.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.test.e2e.data.pipeline.framework.container.com
 import lombok.Getter;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.mysql.type.MySQLDatabaseType;
-import org.apache.shardingsphere.infra.database.oracle.type.OracleDatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.e2e.data.pipeline.env.PipelineE2EEnvironment;
 import org.apache.shardingsphere.test.e2e.data.pipeline.env.enums.PipelineProxyTypeEnum;
@@ -73,7 +72,7 @@ public final class DockerContainerComposer extends BaseContainerComposer {
             storageContainers.add(storageContainer);
         }
         AdaptorContainerConfiguration containerConfig = PipelineProxyClusterContainerConfigurationFactory.newInstance(databaseType);
-        DatabaseType proxyDatabaseType = databaseType instanceof OracleDatabaseType ? TypedSPILoader.getService(DatabaseType.class, "MySQL") : databaseType;
+        DatabaseType proxyDatabaseType = "Oracle".equals(databaseType.getType()) ? TypedSPILoader.getService(DatabaseType.class, "MySQL") : databaseType;
         if (PipelineE2EEnvironment.getInstance().getItProxyType() == PipelineProxyTypeEnum.INTERNAL) {
             ShardingSphereProxyContainer proxyContainer = new ShardingSphereProxyContainer(proxyDatabaseType, containerConfig);
             for (DockerStorageContainer each : storageContainers) {
@@ -100,9 +99,7 @@ public final class DockerContainerComposer extends BaseContainerComposer {
             host = proxyContainer.getHost();
             port = proxyContainer.getFirstMappedPort();
         }
-        if (databaseType instanceof OracleDatabaseType) {
-            return DataSourceEnvironment.getURL(TypedSPILoader.getService(DatabaseType.class, "MySQL"), host, port, databaseName);
-        }
+        DatabaseType databaseType = "Oracle".equals(this.databaseType.getType()) ? TypedSPILoader.getService(DatabaseType.class, "MySQL") : this.databaseType;
         return DataSourceEnvironment.getURL(databaseType, host, port, databaseName);
     }
     

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/framework/container/compose/NativeContainerComposer.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/framework/container/compose/NativeContainerComposer.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.test.e2e.data.pipeline.framework.container.com
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.infra.database.core.connector.url.JdbcUrlAppender;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.database.oracle.type.OracleDatabaseType;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.e2e.data.pipeline.env.PipelineE2EEnvironment;
 import org.apache.shardingsphere.test.e2e.env.runtime.DataSourceEnvironment;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
@@ -120,9 +120,7 @@ public final class NativeContainerComposer extends BaseContainerComposer {
     
     @Override
     public String getProxyJdbcUrl(final String databaseName) {
-        if (databaseType instanceof OracleDatabaseType) {
-            return String.format("jdbc:mysql://localhost:3307/%s?useSSL=false", databaseName);
-        }
+        DatabaseType databaseType = "Oracle".equals(this.databaseType.getType()) ? TypedSPILoader.getService(DatabaseType.class, "MySQL") : this.databaseType;
         return DataSourceEnvironment.getURL(databaseType, "localhost", 3307, databaseName);
     }
     


### PR DESCRIPTION
- Remove unused import of OracleDatabaseType
- Simplify Oracle-specific logic in DockerContainerComposer and NativeContainerComposer
- Use string comparison instead of instance check for Oracle database type
- Refactor PipelineContainerComposer to use DatabaseTypeRegistry for identifier formatting