### PR TITLE
Replace MySQLDatabaseType with DatabaseType in tests

### DIFF
--- a/proxy/backend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowProcessListExecutorTest.java
+++ b/proxy/backend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowProcessListExecutorTest.java
@@ -18,9 +18,10 @@
 package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor;
 
 import io.netty.util.DefaultAttributeMap;
-import org.apache.shardingsphere.infra.database.mysql.type.MySQLDatabaseType;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.executor.sql.process.Process;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
@@ -45,13 +46,15 @@ import static org.mockito.Mockito.when;
 @StaticMockSettings(ProxyContext.class)
 class ShowProcessListExecutorTest {
     
+    private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
+    
     @Test
     void assertExecute() throws SQLException {
         ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         when(contextManager.getPersistServiceFacade().getModeFacade().getProcessService().getProcessList()).thenReturn(mockProcessList());
         ShowProcessListExecutor showProcessListExecutor = new ShowProcessListExecutor(false);
-        showProcessListExecutor.execute(new ConnectionSession(mock(MySQLDatabaseType.class), new DefaultAttributeMap()));
+        showProcessListExecutor.execute(new ConnectionSession(databaseType, new DefaultAttributeMap()));
         assertThat(showProcessListExecutor.getQueryResultMetaData().getColumnCount(), is(8));
         MergedResult mergedResult = showProcessListExecutor.getMergedResult();
         while (mergedResult.next()) {

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/MariaDBContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/MariaDBContainer.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.test.e2e.env.container.atomic.storage.impl;
 
 import com.google.common.base.Strings;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.database.mysql.type.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.DockerStorageContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
@@ -56,13 +55,13 @@ public final class MariaDBContainer extends DockerStorageContainer {
     @Override
     protected Collection<String> getDatabaseNames() {
         return storageContainerConfig.getDatabaseTypes().entrySet().stream()
-                .filter(entry -> entry.getValue() instanceof MySQLDatabaseType).map(Entry::getKey).collect(Collectors.toList());
+                .filter(entry -> entry.getValue() == getDatabaseType()).map(Entry::getKey).collect(Collectors.toList());
     }
     
     @Override
     protected Collection<String> getExpectedDatabaseNames() {
         return storageContainerConfig.getExpectedDatabaseTypes().entrySet().stream()
-                .filter(entry -> entry.getValue() instanceof MySQLDatabaseType).map(Entry::getKey).collect(Collectors.toList());
+                .filter(entry -> entry.getValue() == getDatabaseType()).map(Entry::getKey).collect(Collectors.toList());
     }
     
     @Override

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/MySQLContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/MySQLContainer.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.test.e2e.env.container.atomic.storage.impl;
 
 import com.google.common.base.Strings;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.database.mysql.type.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.DockerStorageContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
@@ -59,13 +58,13 @@ public final class MySQLContainer extends DockerStorageContainer {
     @Override
     protected Collection<String> getDatabaseNames() {
         return storageContainerConfig.getDatabaseTypes().entrySet().stream()
-                .filter(entry -> entry.getValue() instanceof MySQLDatabaseType).map(Entry::getKey).collect(Collectors.toList());
+                .filter(entry -> entry.getValue() == getDatabaseType()).map(Entry::getKey).collect(Collectors.toList());
     }
     
     @Override
     protected Collection<String> getExpectedDatabaseNames() {
         return storageContainerConfig.getExpectedDatabaseTypes().entrySet().stream()
-                .filter(entry -> entry.getValue() instanceof MySQLDatabaseType).map(Entry::getKey).collect(Collectors.toList());
+                .filter(entry -> entry.getValue() == getDatabaseType()).map(Entry::getKey).collect(Collectors.toList());
     }
     
     @Override


### PR DESCRIPTION
- Use DatabaseType interface instead of MySQLDatabaseType implementation
- Utilize TypedSPILoader to get MySQL DatabaseType instance- Update related test classes to use the new DatabaseType reference
- This change is part of a larger effort to decouple the codebase from specific database implementations