### PR TITLE
Replace mock(DatabaseType.class) with databaseType in test cases

### DIFF
--- a/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/generic/SubstitutableColumnNameTokenTest.java
+++ b/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/generic/SubstitutableColumnNameTokenTest.java
@@ -42,21 +42,21 @@ class SubstitutableColumnNameTokenTest {
     
     @Test
     void assertToString() {
-        Collection<Projection> projections = Collections.singletonList(new ColumnProjection(null, "id", null, mock(DatabaseType.class)));
+        Collection<Projection> projections = Collections.singletonList(new ColumnProjection(null, "id", null, databaseType));
         assertThat(new SubstitutableColumnNameToken(0, 1, projections, databaseType).toString(mock(RouteUnit.class)), is("id"));
     }
     
     @Test
     void assertToStringWithQuote() {
         Collection<Projection> projections = Collections.singletonList(new ColumnProjection(null,
-                new IdentifierValue("id", QuoteCharacter.BACK_QUOTE), new IdentifierValue("id", QuoteCharacter.BACK_QUOTE), mock(DatabaseType.class)));
+                new IdentifierValue("id", QuoteCharacter.BACK_QUOTE), new IdentifierValue("id", QuoteCharacter.BACK_QUOTE), databaseType));
         assertThat(new SubstitutableColumnNameToken(0, 1, projections, databaseType).toString(mock(RouteUnit.class)), is("id AS id"));
     }
     
     @Test
     void assertToStringWithOwnerQuote() {
         Collection<Projection> projectionsWithOwnerQuote = Collections.singletonList(new ColumnProjection(new IdentifierValue("temp", QuoteCharacter.BACK_QUOTE),
-                new IdentifierValue("id", QuoteCharacter.BACK_QUOTE), new IdentifierValue("id", QuoteCharacter.BACK_QUOTE), mock(DatabaseType.class)));
+                new IdentifierValue("id", QuoteCharacter.BACK_QUOTE), new IdentifierValue("id", QuoteCharacter.BACK_QUOTE), databaseType));
         assertThat(new SubstitutableColumnNameToken(0, 1, projectionsWithOwnerQuote, databaseType).toString(mock(RouteUnit.class)), is("temp.id AS id"));
         Collection<Projection> projectionsWithoutOwnerQuote = Collections.singletonList(new ColumnProjection(new IdentifierValue("temp", QuoteCharacter.NONE),
                 new IdentifierValue("id", QuoteCharacter.BACK_QUOTE), new IdentifierValue("id", QuoteCharacter.BACK_QUOTE), databaseType));
@@ -68,7 +68,7 @@ class SubstitutableColumnNameTokenTest {
         Collection<Projection> projections = Arrays.asList(new ColumnProjection(new IdentifierValue("temp", QuoteCharacter.BACK_QUOTE),
                 new IdentifierValue("id", QuoteCharacter.BACK_QUOTE), new IdentifierValue("id", QuoteCharacter.BACK_QUOTE), databaseType),
                 new SubqueryProjection(new SubqueryProjectionSegment(null, "(SELECT name FROM t_order)"),
-                        new ColumnProjection(null, "name", null, databaseType), new IdentifierValue("name"), mock(DatabaseType.class)));
+                        new ColumnProjection(null, "name", null, databaseType), new IdentifierValue("name"), databaseType));
         assertThat(new SubstitutableColumnNameToken(0, 1, projections, databaseType).toString(mock(RouteUnit.class)), is("temp.id AS id, name"));
     }
 }


### PR DESCRIPTION
- Remove unnecessary mock creation for DatabaseType
- Use the existing databaseType instance variable in test cases
- Improve code readability and reduce test complexity