### PR TITLE
Add Hive JDBC dependency for testing

### DIFF
--- a/infra/database/type/hive/pom.xml
+++ b/infra/database/type/hive/pom.xml
@@ -34,6 +34,13 @@
         </dependency>
         
         <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-jdbc</artifactId>
+            <version>${hive-jdbc.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.github.linghengqian</groupId>
             <artifactId>hive-server2-jdbc-driver-thin</artifactId>
             <version>${hive-server2-jdbc-driver-thin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
         <opengauss.version>3.1.0-og</opengauss.version>
         <mariadb-java-client.version>2.4.2</mariadb-java-client.version>
         <clickhouse-jdbc.version>0.6.3</clickhouse-jdbc.version>
+        <hive-jdbc.version>4.0.1</hive-jdbc.version>
         <hive-server2-jdbc-driver-thin.version>1.7.0</hive-server2-jdbc-driver-thin.version>
         <hadoop.version>3.3.6</hadoop.version>
         <presto.version>0.288.1</presto.version>
@@ -481,6 +482,12 @@
                 <artifactId>clickhouse-jdbc</artifactId>
                 <version>${clickhouse-jdbc.version}</version>
                 <classifier>http</classifier>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hive</groupId>
+                <artifactId>hive-jdbc</artifactId>
+                <version>${hive-jdbc.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
- Add Hive JDBC version 4.0.1 as a test dependency in pom.xml
- This change supports improved Hive integration and testing