### PR TITLE
Add parser dependencies for MySQL, OpenGauss and PostgreSQL

### DIFF
--- a/kernel/data-pipeline/dialect/mysql/pom.xml
+++ b/kernel/data-pipeline/dialect/mysql/pom.xml
@@ -37,6 +37,12 @@
             <artifactId>shardingsphere-mysql-protocol</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-parser-sql-mysql</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
         
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>

--- a/kernel/data-pipeline/dialect/opengauss/pom.xml
+++ b/kernel/data-pipeline/dialect/opengauss/pom.xml
@@ -32,6 +32,12 @@
             <artifactId>shardingsphere-data-pipeline-postgresql</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-parser-sql-opengauss</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
         
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>

--- a/kernel/data-pipeline/dialect/postgresql/pom.xml
+++ b/kernel/data-pipeline/dialect/postgresql/pom.xml
@@ -32,6 +32,12 @@
             <artifactId>shardingsphere-data-pipeline-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-parser-sql-postgresql</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
         
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>


### PR DESCRIPTION
- Add shardingsphere-parser-sql dependencies for MySQL, OpenGauss and PostgreSQL dialects
- Scope the new dependencies as 'runtime' to optimize class loading
