### PR TITLE
Update slf4j to 2.0.17 and logback to 1.3.15

### DIFF
--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -264,7 +264,7 @@ The text of each license is the standard Apache 2.0 license.
     jackson-dataformat-yaml 2.16.1: http://github.com/FasterXML/jackson, Apache 2.0
     jackson-datatype-jdk8 2.16.1: http://github.com/FasterXML/jackson-modules-java8, Apache 2.0
     jackson-datatype-jsr310 2.16.1: http://github.com/FasterXML/jackson, Apache 2.0
-    jcl-over-slf4j 1.7.36: https://github.com/qos-ch/slf4j, Apache 2.0
+    jcl-over-slf4j 2.0.17: https://github.com/qos-ch/slf4j, Apache 2.0
     jetcd-api 0.7.7: https://github.com/etcd-io/jetcd, Apache 2.0
     jetcd-common 0.7.7: https://github.com/etcd-io/jetcd, Apache 2.0
     jetcd-core 0.7.7: https://github.com/etcd-io/jetcd, Apache 2.0
@@ -348,8 +348,8 @@ The following components are provided under the EPL License. See project link fo
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
     jakarta.transaction-api 1.3.3: https://github.com/jakartaee/transactions, EPL 2.0
-    logback-classic 1.2.13: https://github.com/qos-ch/logback, EPL 1.0
-    logback-core 1.2.13: https://github.com/qos-ch/logback, EPL 1.0
+    logback-classic 1.3.15: https://github.com/qos-ch/logback, EPL 1.0
+    logback-core 1.3.15: https://github.com/qos-ch/logback, EPL 1.0
     mchange-commons-java 0.2.15: https://github.com/swaldman/mchange-commons-java, EPL 1.0
     h2 2.2.224: https://github.com/h2database/h2database, EPL 1.0
 
@@ -365,5 +365,5 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     bctls-jdk18on 1.78.1: https://www.bouncycastle.org, MIT
     bcutil-jdk18on 1.78.1: https://www.bouncycastle.org, MIT
     checker-qual 3.39.0: https://github.com/typetools/checker-framework/blob/master/checker-qual, MIT
-    jul-to-slf4j 1.7.36: https://www.slf4j.org, MIT
-    slf4j-api 1.7.36: https://www.slf4j.org, MIT
+    jul-to-slf4j 2.0.17: https://www.slf4j.org, MIT
+    slf4j-api 2.0.17: https://www.slf4j.org, MIT

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -45,7 +45,7 @@
         <postgresql.version>42.7.5</postgresql.version>
         <h2.version>2.2.224</h2.version>
         <slf4j.version>1.7.7</slf4j.version>
-        <logback.version>1.2.13</logback.version>
+        <logback.version>1.3.15</logback.version>
         <lombok.version>1.18.36</lombok.version>
         <mybatis.version>3.5.9</mybatis.version>
         <mybatis-spring.version>2.0.5</mybatis-spring.version>

--- a/examples/shardingsphere-jdbc-example-generator/src/main/resources/template/pom.ftl
+++ b/examples/shardingsphere-jdbc-example-generator/src/main/resources/template/pom.ftl
@@ -204,12 +204,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
+            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.13</version>
+            <version>1.3.15</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,8 @@
         
         <elasticjob.version>3.0.4</elasticjob.version>
         
-        <slf4j.version>1.7.36</slf4j.version>
-        <logback.version>1.2.13</logback.version>
+        <slf4j.version>2.0.17</slf4j.version>
+        <logback.version>1.3.15</logback.version>
         <commons-logging.version>1.2</commons-logging.version>
         
         <lombok.version>1.18.36</lombok.version>


### PR DESCRIPTION
- Update jcl-over-slf4j from 1.7.36 to 2.0.17
- Update logback-classic and logback-core from 1.2.13 to 1.3.15
- Update slf4j-api from 1.7.36 to 2.0.17
- Update jul-to-slf4j from 1.7.36 to 2.0.17
