### PR TITLE
Remove unused MySQL dependency

### DIFF
--- a/db-protocol/core/pom.xml
+++ b/db-protocol/core/pom.xml
@@ -41,13 +41,6 @@
         </dependency>
         
         <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-infra-database-mysql</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        
-        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
         </dependency>


### PR DESCRIPTION
- Removed the 'shardingsphere-infra-database-mysql' dependency from the 'db-protocol/core' module
- This dependency was only used for testing and has been removed to simplify the project structure
