### PR TITLE
Remove unused shardingsphere-db-protocol-core dependency

### DIFF
--- a/proxy/bootstrap/pom.xml
+++ b/proxy/bootstrap/pom.xml
@@ -29,11 +29,6 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-db-protocol-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-proxy-frontend-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/proxy/frontend/core/pom.xml
+++ b/proxy/frontend/core/pom.xml
@@ -29,17 +29,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-db-protocol-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-proxy-frontend-spi</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-proxy-backend-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/proxy/frontend/spi/pom.xml
+++ b/proxy/frontend/spi/pom.xml
@@ -29,11 +29,6 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-db-protocol-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-proxy-backend-core</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
- Removed shardingsphere-db-protocol-core dependency from proxy-bootstrap, proxy-frontend-core, and proxy-frontend-spi modules