### PR TITLE
Update database protocol type test to use FIXTURE instead of PostgreSQL

### DIFF
--- a/proxy/frontend/core/pom.xml
+++ b/proxy/frontend/core/pom.xml
@@ -45,18 +45,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-infra-database-postgresql</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-infra-database-mysql</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
         
         <dependency>
             <groupId>io.netty</groupId>

--- a/proxy/frontend/core/src/test/java/org/apache/shardingsphere/proxy/frontend/protocol/FrontDatabaseProtocolTypeFactoryTest.java
+++ b/proxy/frontend/core/src/test/java/org/apache/shardingsphere/proxy/frontend/protocol/FrontDatabaseProtocolTypeFactoryTest.java
@@ -71,13 +71,13 @@ class FrontDatabaseProtocolTypeFactoryTest {
     }
     
     @Test
-    void assertGetDatabaseTypeOfPostgreSQLDatabaseTypeFromMetaDataContextsProps() {
+    void assertGetDatabaseTypeFromMetaDataContextsProps() {
         ContextManager contextManager = mockContextManager(Collections.singleton(mockDatabase()),
-                PropertiesBuilder.build(new Property(ConfigurationPropertyKey.PROXY_FRONTEND_DATABASE_PROTOCOL_TYPE.getKey(), "PostgreSQL")));
+                PropertiesBuilder.build(new Property(ConfigurationPropertyKey.PROXY_FRONTEND_DATABASE_PROTOCOL_TYPE.getKey(), "FIXTURE")));
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         DatabaseType databaseType = FrontDatabaseProtocolTypeFactory.getDatabaseType();
         assertThat(databaseType, instanceOf(DatabaseType.class));
-        assertThat(databaseType.getType(), is("PostgreSQL"));
+        assertThat(databaseType.getType(), is("FIXTURE"));
     }
     
     private ShardingSphereDatabase mockDatabase() {


### PR DESCRIPTION
- Changed test case to use FIXTURE database type instead of PostgreSQL
- Removed unnecessary test dependencies for PostgreSQL and MySQL database infrastructures
