### PR TITLE
Use loaded database type in front database protocol type to replace default definition

### DIFF
--- a/proxy/frontend/core/src/main/java/org/apache/shardingsphere/proxy/frontend/protocol/FrontDatabaseProtocolTypeFactory.java
+++ b/proxy/frontend/core/src/main/java/org/apache/shardingsphere/proxy/frontend/protocol/FrontDatabaseProtocolTypeFactory.java
@@ -21,11 +21,14 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
-import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngine;
 
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -33,8 +36,6 @@ import java.util.Optional;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class FrontDatabaseProtocolTypeFactory {
-    
-    private static final String DEFAULT_FRONTEND_DATABASE_PROTOCOL_TYPE = "MySQL";
     
     /**
      * Get front database protocol type.
@@ -46,14 +47,16 @@ public final class FrontDatabaseProtocolTypeFactory {
         if (configuredDatabaseType.isPresent()) {
             return configuredDatabaseType.get();
         }
+        Collection<DatabaseProtocolFrontendEngine> databaseProtocolFrontendEngine = ShardingSphereServiceLoader.getServiceInstances(DatabaseProtocolFrontendEngine.class);
+        ShardingSpherePreconditions.checkNotEmpty(databaseProtocolFrontendEngine,
+                () -> new IllegalArgumentException(String.format("Can not find any SPI implementation of `%s`.", DatabaseProtocolFrontendEngine.class.getName())));
+        DatabaseProtocolFrontendEngine defaultDatabaseProtocolFrontendEngine = databaseProtocolFrontendEngine.iterator().next();
         MetaDataContexts metaDataContexts = ProxyContext.getInstance().getContextManager().getMetaDataContexts();
         if (metaDataContexts.getMetaData().getAllDatabases().isEmpty()) {
-            return TypedSPILoader.getService(DatabaseType.class, DEFAULT_FRONTEND_DATABASE_PROTOCOL_TYPE);
+            return defaultDatabaseProtocolFrontendEngine.getType();
         }
         Optional<ShardingSphereDatabase> database = metaDataContexts.getMetaData().getAllDatabases().stream().filter(ShardingSphereDatabase::containsDataSource).findFirst();
-        return database.isPresent()
-                ? database.get().getResourceMetaData().getStorageUnits().values().iterator().next().getStorageType()
-                : TypedSPILoader.getService(DatabaseType.class, DEFAULT_FRONTEND_DATABASE_PROTOCOL_TYPE);
+        return database.isPresent() ? database.get().getResourceMetaData().getStorageUnits().values().iterator().next().getStorageType() : defaultDatabaseProtocolFrontendEngine.getType();
     }
     
     private static Optional<DatabaseType> findConfiguredDatabaseType() {

--- a/proxy/frontend/core/src/test/java/org/apache/shardingsphere/proxy/frontend/protocol/FrontDatabaseProtocolTypeFactoryTest.java
+++ b/proxy/frontend/core/src/test/java/org/apache/shardingsphere/proxy/frontend/protocol/FrontDatabaseProtocolTypeFactoryTest.java
@@ -43,7 +43,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Properties;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -58,16 +57,14 @@ class FrontDatabaseProtocolTypeFactoryTest {
     void assertGetDatabaseTypeWhenThrowShardingSphereConfigurationException() {
         ContextManager contextManager = mockContextManager(Collections.emptyList(), new Properties());
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
-        assertThat(FrontDatabaseProtocolTypeFactory.getDatabaseType().getType(), is("MySQL"));
+        assertThat(FrontDatabaseProtocolTypeFactory.getDatabaseType().getType(), is("FIXTURE"));
     }
     
     @Test
     void assertGetDatabaseTypeInstanceOfMySQLDatabaseTypeFromMetaDataContextsSchemaName() {
         ContextManager contextManager = mockContextManager(Collections.singleton(mockDatabase()), new Properties());
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
-        DatabaseType databaseType = FrontDatabaseProtocolTypeFactory.getDatabaseType();
-        assertThat(databaseType, instanceOf(DatabaseType.class));
-        assertThat(databaseType.getType(), is("MySQL"));
+        assertThat(FrontDatabaseProtocolTypeFactory.getDatabaseType().getType(), is("FIXTURE"));
     }
     
     @Test
@@ -75,9 +72,7 @@ class FrontDatabaseProtocolTypeFactoryTest {
         ContextManager contextManager = mockContextManager(Collections.singleton(mockDatabase()),
                 PropertiesBuilder.build(new Property(ConfigurationPropertyKey.PROXY_FRONTEND_DATABASE_PROTOCOL_TYPE.getKey(), "FIXTURE")));
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
-        DatabaseType databaseType = FrontDatabaseProtocolTypeFactory.getDatabaseType();
-        assertThat(databaseType, instanceOf(DatabaseType.class));
-        assertThat(databaseType.getType(), is("FIXTURE"));
+        assertThat(FrontDatabaseProtocolTypeFactory.getDatabaseType().getType(), is("FIXTURE"));
     }
     
     private ShardingSphereDatabase mockDatabase() {


### PR DESCRIPTION
- Remove static DEFAULT_FRONTEND_DATABASE_PROTOCOL_TYPE
- Use SPI to determine the default database protocol frontend engine
- Add error checking for empty SPI implementation
- Simplify code structure and improve readability