### PR TITLE
Remove mysql-connector-j dependency

### DIFF
--- a/mode/type/standalone/repository/provider/jdbc/pom.xml
+++ b/mode/type/standalone/repository/provider/jdbc/pom.xml
@@ -55,11 +55,5 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
-        
-        <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
- Removed mysql-connector-j dependency from the standalone JDBC repository provider
- This change reduces the project's external dependencies and potential security vulnerabilities
