### PR TITLE
Add default isolation level for databases

### DIFF
--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/DialectDatabaseMetaData.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/DialectDatabaseMetaData.java
@@ -34,6 +34,7 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.
 import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPI;
 import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
 
+import java.sql.Connection;
 import java.util.Optional;
 
 /**
@@ -124,7 +125,7 @@ public interface DialectDatabaseMetaData extends DatabaseTypedSPI {
      * @return transaction option
      */
     default DialectTransactionOption getTransactionOption() {
-        return new DialectTransactionOption(false, false, false, false, true);
+        return new DialectTransactionOption(false, false, false, false, true, Connection.TRANSACTION_READ_COMMITTED);
     }
     
     /**

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/transaction/DialectTransactionOption.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/transaction/DialectTransactionOption.java
@@ -37,4 +37,6 @@ public final class DialectTransactionOption {
     
     // TODO Investgate the reason of some databases cannot support meta data refreshed in transaction. The method should be removed finally after metadata refresh supported for all database.
     private final boolean isSupportMetaDataRefreshInTransaction;
+    
+    private final int defaultIsolationLevel;
 }

--- a/infra/database/type/firebird/src/main/java/org/apache/shardingsphere/infra/database/firebird/metadata/database/FirebirdDatabaseMetaData.java
+++ b/infra/database/type/firebird/src/main/java/org/apache/shardingsphere/infra/database/firebird/metadata/database/FirebirdDatabaseMetaData.java
@@ -23,6 +23,8 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
 
+import java.sql.Connection;
+
 /**
  * Database metadata of Firebird.
  */
@@ -45,7 +47,7 @@ public final class FirebirdDatabaseMetaData implements DialectDatabaseMetaData {
     
     @Override
     public DialectTransactionOption getTransactionOption() {
-        return new DialectTransactionOption(false, true, false, false, true);
+        return new DialectTransactionOption(false, true, false, false, true, Connection.TRANSACTION_READ_COMMITTED);
     }
     
     @Override

--- a/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/MySQLDatabaseMetaData.java
+++ b/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/MySQLDatabaseMetaData.java
@@ -28,6 +28,8 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
 import org.apache.shardingsphere.infra.database.mysql.metadata.database.option.MySQLDataTypeOption;
 
+import java.sql.Connection;
+
 /**
  * Database meta data of MySQL.
  */
@@ -65,7 +67,7 @@ public final class MySQLDatabaseMetaData implements DialectDatabaseMetaData {
     
     @Override
     public DialectTransactionOption getTransactionOption() {
-        return new DialectTransactionOption(false, false, true, false, true);
+        return new DialectTransactionOption(false, false, true, false, true, Connection.TRANSACTION_REPEATABLE_READ);
     }
     
     @Override

--- a/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
+++ b/infra/database/type/opengauss/src/main/java/org/apache/shardingsphere/infra/database/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
@@ -30,6 +30,7 @@ import org.apache.shardingsphere.infra.database.opengauss.metadata.database.opti
 import org.apache.shardingsphere.infra.database.opengauss.metadata.database.option.OpenGaussDriverQuerySystemCatalogOption;
 import org.apache.shardingsphere.infra.database.opengauss.metadata.database.option.OpenGaussSchemaOption;
 
+import java.sql.Connection;
 import java.util.Optional;
 
 /**
@@ -74,7 +75,7 @@ public final class OpenGaussDatabaseMetaData implements DialectDatabaseMetaData 
     
     @Override
     public DialectTransactionOption getTransactionOption() {
-        return new DialectTransactionOption(true, false, false, true, false);
+        return new DialectTransactionOption(true, false, false, true, false, Connection.TRANSACTION_READ_COMMITTED);
     }
     
     @Override

--- a/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/PostgreSQLDatabaseMetaData.java
+++ b/infra/database/type/postgresql/src/main/java/org/apache/shardingsphere/infra/database/postgresql/metadata/database/PostgreSQLDatabaseMetaData.java
@@ -28,6 +28,8 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.
 import org.apache.shardingsphere.infra.database.postgresql.metadata.database.option.PostgreSQLDataTypeOption;
 import org.apache.shardingsphere.infra.database.postgresql.metadata.database.option.PostgreSQLSchemaOption;
 
+import java.sql.Connection;
+
 /**
  * Database meta data of PostgreSQL.
  */
@@ -65,7 +67,7 @@ public final class PostgreSQLDatabaseMetaData implements DialectDatabaseMetaData
     
     @Override
     public DialectTransactionOption getTransactionOption() {
-        return new DialectTransactionOption(false, false, false, true, false);
+        return new DialectTransactionOption(false, false, false, true, false, Connection.TRANSACTION_READ_COMMITTED);
     }
     
     @Override

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/tcl/SetTransactionHandler.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/tcl/SetTransactionHandler.java
@@ -18,6 +18,8 @@
 package org.apache.shardingsphere.proxy.backend.handler.tcl;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
@@ -26,10 +28,7 @@ import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.util.TransactionUtils;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.TransactionAccessType;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.tcl.SetTransactionStatement;
-import org.apache.shardingsphere.sql.parser.statement.mysql.MySQLStatement;
 import org.apache.shardingsphere.transaction.exception.SwitchTypeInTransactionException;
-
-import java.sql.Connection;
 
 /**
  * Transaction set handler.
@@ -64,9 +63,8 @@ public final class SetTransactionHandler implements ProxyBackendHandler {
         if (!sqlStatement.getIsolationLevel().isPresent()) {
             return;
         }
-        connectionSession.setDefaultIsolationLevel(sqlStatement instanceof MySQLStatement
-                ? TransactionUtils.getTransactionIsolationLevel(Connection.TRANSACTION_REPEATABLE_READ)
-                : TransactionUtils.getTransactionIsolationLevel(Connection.TRANSACTION_READ_COMMITTED));
+        DialectTransactionOption transactionOption = new DatabaseTypeRegistry(sqlStatement.getDatabaseType()).getDialectDatabaseMetaData().getTransactionOption();
+        connectionSession.setDefaultIsolationLevel(TransactionUtils.getTransactionIsolationLevel(transactionOption.getDefaultIsolationLevel()));
         connectionSession.setIsolationLevel(sqlStatement.getIsolationLevel().get());
     }
 }


### PR DESCRIPTION
- Add default isolation level to DialectTransactionOption
- Update getTransactionOption() for Firebird, MySQL, OpenGauss, and PostgreSQL
- Modify SetTransactionHandler to use default isolation level based on database type