### PR TITLE
Replace MySQL-specific show statement classes with core show statement classes

### DIFF
--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/data/DatabaseBackendHandlerFactory.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/data/DatabaseBackendHandlerFactory.java
@@ -28,11 +28,11 @@ import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.DALStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.SetStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.ShowCreateTableStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.ShowTableStatusStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.dal.ShowTablesStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.DoStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement;
-import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLShowCreateTableStatement;
-import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLShowTableStatusStatement;
-import org.apache.shardingsphere.sql.parser.statement.mysql.dal.MySQLShowTablesStatement;
 
 /**
  * Database backend handler factory.
@@ -65,6 +65,6 @@ public final class DatabaseBackendHandlerFactory {
     }
     
     private static boolean isDatabaseRequiredDALStatement(final SQLStatement sqlStatement) {
-        return sqlStatement instanceof MySQLShowTablesStatement || sqlStatement instanceof MySQLShowTableStatusStatement || sqlStatement instanceof MySQLShowCreateTableStatement;
+        return sqlStatement instanceof ShowTablesStatement || sqlStatement instanceof ShowTableStatusStatement || sqlStatement instanceof ShowCreateTableStatement;
     }
 }


### PR DESCRIPTION
- Replace MySQLShowTablesStatement with ShowTablesStatement
- Replace MySQLShowTableStatusStatement with ShowTableStatusStatement
- Replace MySQLShowCreateTableStatement with ShowCreateTableStatement
- Update isDatabaseRequiredDALStatement to use core show statement classes