### PR TITLE
Remove useless shardingsphere-proxy-frontend-core dependency

### DIFF
--- a/test/e2e/operation/pipeline/pom.xml
+++ b/test/e2e/operation/pipeline/pom.xml
@@ -33,11 +33,6 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-proxy-frontend-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-proxy-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/test/e2e/operation/transaction/pom.xml
+++ b/test/e2e/operation/transaction/pom.xml
@@ -33,11 +33,6 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-proxy-frontend-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-proxy-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
- Removed shardingsphere-proxy-frontend-core dependency from e2e operation pipeline and transaction modules
- This change simplifies the project structure and reduces redundant dependencies