### PR TITLE
Remove useless Etcd dependency from e2e test fixture

### DIFF
--- a/test/e2e/fixture/pom.xml
+++ b/test/e2e/fixture/pom.xml
@@ -333,12 +333,6 @@
                     <version>${project.version}</version>
                     <scope>runtime</scope>
                 </dependency>
-                <dependency>
-                    <groupId>org.apache.shardingsphere</groupId>
-                    <artifactId>shardingsphere-cluster-mode-repository-etcd</artifactId>
-                    <version>${project.version}</version>
-                    <scope>runtime</scope>
-                </dependency>
                 
                 <dependency>
                     <groupId>org.postgresql</groupId>


### PR DESCRIPTION
- Removed the shardingsphere-cluster-mode-repository-etcd dependency from the pom.xml file
- This change reduces the complexity of the project's dependencies