### PR TITLE
Add generated key support check for database dialects

### DIFF
--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/DialectDatabaseMetaData.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/DialectDatabaseMetaData.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.index.DialectIndexOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.join.DialectJoinOption;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.keygen.DialectGeneratedKeyOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DefaultSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.table.DialectDriverQuerySystemCatalogOption;
@@ -135,6 +136,15 @@ public interface DialectDatabaseMetaData extends DatabaseTypedSPI {
      */
     default DialectJoinOption getJoinOption() {
         return new DialectJoinOption(false, false);
+    }
+    
+    /**
+     * Get generated key option.
+     * 
+     * @return generated key option
+     */
+    default DialectGeneratedKeyOption getGeneratedKeyOption() {
+        return new DialectGeneratedKeyOption(false);
     }
     
     /**

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/DialectDatabaseMetaData.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/DialectDatabaseMetaData.java
@@ -140,7 +140,7 @@ public interface DialectDatabaseMetaData extends DatabaseTypedSPI {
     
     /**
      * Get generated key option.
-     * 
+     *
      * @return generated key option
      */
     default DialectGeneratedKeyOption getGeneratedKeyOption() {

--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/keygen/DialectGeneratedKeyOption.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/metadata/database/metadata/option/keygen/DialectGeneratedKeyOption.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.keygen;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Dialect generated key option.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class DialectGeneratedKeyOption {
+    
+    private final boolean isSupportReturnGeneratedKeys;
+}

--- a/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/MySQLDatabaseMetaData.java
+++ b/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/MySQLDatabaseMetaData.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.connection.DialectConnectionOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.join.DialectJoinOption;
+import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.keygen.DialectGeneratedKeyOption;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
 import org.apache.shardingsphere.infra.database.mysql.metadata.database.option.MySQLDataTypeOption;
 
@@ -73,6 +74,11 @@ public final class MySQLDatabaseMetaData implements DialectDatabaseMetaData {
     @Override
     public DialectJoinOption getJoinOption() {
         return new DialectJoinOption(true, true);
+    }
+    
+    @Override
+    public  DialectGeneratedKeyOption getGeneratedKeyOption() {
+        return new DialectGeneratedKeyOption(true);
     }
     
     @Override

--- a/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/MySQLDatabaseMetaData.java
+++ b/infra/database/type/mysql/src/main/java/org/apache/shardingsphere/infra/database/mysql/metadata/database/MySQLDatabaseMetaData.java
@@ -77,7 +77,7 @@ public final class MySQLDatabaseMetaData implements DialectDatabaseMetaData {
     }
     
     @Override
-    public  DialectGeneratedKeyOption getGeneratedKeyOption() {
+    public DialectGeneratedKeyOption getGeneratedKeyOption() {
         return new DialectGeneratedKeyOption(true);
     }
     


### PR DESCRIPTION
- Introduce DialectGeneratedKeyOption to indicate generated key support
- Add getGeneratedKeyOption method to DialectDatabaseMetaData
- Update MySQLDatabaseMetaData to support generated keys
- Modify ProxySQLExecutor and StandardDatabaseConnector to use the new generated key option
