### PR TITLE
Fix "show migration list" getting job sharding infos failure when job is inactive

### DIFF
--- a/kernel/data-pipeline/distsql/handler/src/main/java/org/apache/shardingsphere/data/pipeline/distsql/handler/migration/query/ShowMigrationListExecutor.java
+++ b/kernel/data-pipeline/distsql/handler/src/main/java/org/apache/shardingsphere/data/pipeline/distsql/handler/migration/query/ShowMigrationListExecutor.java
@@ -51,12 +51,23 @@ public final class ShowMigrationListExecutor implements DistSQLQueryExecutor<Sho
     }
     
     private LocalDataQueryResultRow getRow(final PipelineContextKey contextKey, final PipelineJobInfo jobInfo) {
-        return new LocalDataQueryResultRow(jobInfo.getJobMetaData().getJobId(), jobInfo.getTableName(), jobInfo.getJobMetaData().isActive(), jobInfo.getJobMetaData().getCreateTime(),
-                jobInfo.getJobMetaData().getStopTime(), jobInfo.getJobMetaData().getJobItemCount(), getJobShardingNodes(contextKey, jobInfo.getJobMetaData().getJobId()));
+        boolean active = jobInfo.getJobMetaData().isActive();
+        String jobShardingNodes = active ? getJobShardingNodes(contextKey, jobInfo.getJobMetaData().getJobId()) : "";
+        return new LocalDataQueryResultRow(jobInfo.getJobMetaData().getJobId(), jobInfo.getTableName(), active, jobInfo.getJobMetaData().getCreateTime(),
+                jobInfo.getJobMetaData().getStopTime(), jobInfo.getJobMetaData().getJobItemCount(), jobShardingNodes);
     }
     
     private String getJobShardingNodes(final PipelineContextKey contextKey, final String jobId) {
-        Collection<ShardingInfo> shardingInfos = pipelineJobManager.getJobShardingInfos(contextKey, jobId);
+        // SPEX CHANGED: BEGIN
+        Collection<ShardingInfo> shardingInfos;
+        try {
+            shardingInfos = pipelineJobManager.getJobShardingInfos(contextKey, jobId);
+            // CHECKSTYLE:OFF
+        } catch (final RuntimeException ignored) {
+            // CHECKSTYLE:ON
+            return "";
+        }
+        // SPEX CHANGED: END
         return shardingInfos.isEmpty() ? "" : getJobShardingNodes(shardingInfos);
     }
     


### PR DESCRIPTION
Related to #35053

Changes proposed in this pull request:
  - Fix "show migration list" getting job sharding infos failure when job is inactive

When job is inactive.
Before:
```
mysql> show migration list;
ERROR 30000 (HY000): Unknown exception.
More details: java.lang.NullPointerException: Cannot invoke "String.length()" because "s" is null
```
Current:
```
mysql> show migration list;
+--------------------------------------------+-------------------+--------+---------------------+---------------------+----------------+--------------------+
| id                                         | tables            | active | create_time         | stop_time           | job_item_count | job_sharding_nodes |
+--------------------------------------------+-------------------+--------+---------------------+---------------------+----------------+--------------------+
| j0102p0000121c6f038a087a54ec30336d9ee42f9e | ds_0.t_order_copy | false  | 2025-05-15 11:40:58 | 2025-05-15 11:57:39 | 1              |                    |
+--------------------------------------------+-------------------+--------+---------------------+---------------------+----------------+--------------------+
```
---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
