### PR TITLE
Correct SQL state and error message for MySQL duplicate entry errors

### DIFF
--- a/infra/exception/dialect/type/mysql/src/main/java/org/apache/shardingsphere/infra/exception/mysql/vendor/MySQLVendorError.java
+++ b/infra/exception/dialect/type/mysql/src/main/java/org/apache/shardingsphere/infra/exception/mysql/vendor/MySQLVendorError.java
@@ -50,9 +50,9 @@ public enum MySQLVendorError implements VendorError {
     
     ER_TABLE_EXISTS_ERROR(XOpenSQLState.DUPLICATE, 1050, "Table '%s' already exists"),
     
-    ER_DUP_ENTRY(XOpenSQLState.SYNTAX_ERROR, 1062, "%s near '%s' at line %d"),
+    ER_DUP_ENTRY(XOpenSQLState.INTEGRITY_CONSTRAINT_VIOLATION, 1062, "Duplicate entry '%s' for key %d"),
     
-    ER_PARSE_ERROR(XOpenSQLState.INTEGRITY_CONSTRAINT_VIOLATION, 1064, "Duplicate entry '%s' for key %d"),
+    ER_PARSE_ERROR(XOpenSQLState.SYNTAX_ERROR, 1064, "%s near '%s' at line %d"),
     
     ER_UNKNOWN_CHARACTER_SET(XOpenSQLState.SYNTAX_ERROR, 1115, "Unknown character set: '%s'"),
     


### PR DESCRIPTION
- Update SQL state for ER_DUP_ENTRY from INTEGRITY_CONSTRAINT_VIOLATION to SYNTAX_ERROR
- Update SQL state for ER_PARSE_ERROR from INTEGRITY_CONSTRAINT_VIOLATION to SYNTAX_ERROR
- Correct error message format for ER_DUP_ENTRY
- Correct error message format for ER_PARSE_ERROR

Fixes issue which came from #35321
