### PR TITLE
Unify the version of commons-pool2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <commons-lang3.version>3.15.0</commons-lang3.version>
         <commons-codec.version>1.16.0</commons-codec.version>
         <commons-math3.version>3.6.1</commons-math3.version>
+        <commons-pool2.version>2.12.0</commons-pool2.version>
         <caffeine.version>2.9.3</caffeine.version>
         <transmittable-thread-local.version>2.14.2</transmittable-thread-local.version>
         <java-util.version>2.4.0</java-util.version>
@@ -320,6 +321,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-math3</artifactId>
                 <version>${commons-math3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-pool2</artifactId>
+                <version>${commons-pool2.version}</version>
             </dependency>
             
             <dependency>


### PR DESCRIPTION
### Check command
```shell
mvn -Dverbose dependency:tree | grep commons-pool2
```

### Before
There are both 2.11.1 and 2.12.0
<img width="682" alt="image" src="https://github.com/user-attachments/assets/efa66f87-5fe4-4260-a041-fe3fa41fbaf4" />

### After
2.12.0 only
<img width="895" alt="image" src="https://github.com/user-attachments/assets/6f928767-da74-4e9c-bc69-3d2c8deeafeb" />


