### PR TITLE
Move table collection to LockStatement

### DIFF
--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/tcl/LockStatement.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/tcl/LockStatement.java
@@ -17,10 +17,18 @@
 
 package org.apache.shardingsphere.sql.parser.statement.core.statement.tcl;
 
+import lombok.Getter;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.AbstractSQLStatement;
+
+import java.util.Collection;
+import java.util.LinkedList;
 
 /**
  * Lock statement.
  */
+@Getter
 public abstract class LockStatement extends AbstractSQLStatement implements TCLStatement {
+    
+    private final Collection<SimpleTableSegment> tables = new LinkedList<>();
 }

--- a/parser/sql/statement/type/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/tcl/DorisLockStatement.java
+++ b/parser/sql/statement/type/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/tcl/DorisLockStatement.java
@@ -17,21 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.statement.doris.tcl;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.tcl.LockStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.DorisStatement;
-
-import java.util.Collection;
-import java.util.LinkedList;
 
 /**
  * Doris lock statement.
  */
-@Getter
-@Setter
 public final class DorisLockStatement extends LockStatement implements DorisStatement {
-    
-    private final Collection<SimpleTableSegment> tables = new LinkedList<>();
 }

--- a/parser/sql/statement/type/mysql/src/main/java/org/apache/shardingsphere/sql/parser/statement/mysql/tcl/MySQLLockStatement.java
+++ b/parser/sql/statement/type/mysql/src/main/java/org/apache/shardingsphere/sql/parser/statement/mysql/tcl/MySQLLockStatement.java
@@ -17,21 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.statement.mysql.tcl;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.tcl.LockStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.MySQLStatement;
-
-import java.util.Collection;
-import java.util.LinkedList;
 
 /**
  * MySQL lock statement.
  */
-@Getter
-@Setter
 public final class MySQLLockStatement extends LockStatement implements MySQLStatement {
-    
-    private final Collection<SimpleTableSegment> tables = new LinkedList<>();
 }

--- a/parser/sql/statement/type/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/statement/postgresql/tcl/PostgreSQLLockStatement.java
+++ b/parser/sql/statement/type/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/statement/postgresql/tcl/PostgreSQLLockStatement.java
@@ -17,21 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.statement.postgresql.tcl;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.tcl.LockStatement;
 import org.apache.shardingsphere.sql.parser.statement.postgresql.PostgreSQLStatement;
-
-import java.util.Collection;
-import java.util.LinkedList;
 
 /**
  * PostgreSQL lock statement.
  */
-@Getter
-@Setter
 public final class PostgreSQLLockStatement extends LockStatement implements PostgreSQLStatement {
-    
-    private final Collection<SimpleTableSegment> tables = new LinkedList<>();
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/tcl/impl/LockStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/tcl/impl/LockStatementAssert.java
@@ -21,8 +21,6 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.tcl.LockStatement;
-import org.apache.shardingsphere.sql.parser.statement.mysql.tcl.MySQLLockStatement;
-import org.apache.shardingsphere.sql.parser.statement.postgresql.tcl.PostgreSQLLockStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.table.TableAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.tcl.LockStatementTestCase;
@@ -46,15 +44,11 @@ public final class LockStatementAssert {
      * @param expected expected lock statement test case
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final LockStatement actual, final LockStatementTestCase expected) {
-        if (actual instanceof MySQLLockStatement) {
-            assertIs(assertContext, ((MySQLLockStatement) actual).getTables(), expected);
-        } else if (actual instanceof PostgreSQLLockStatement) {
-            assertIs(assertContext, ((PostgreSQLLockStatement) actual).getTables(), expected);
-        }
+        assertIs(assertContext, actual.getTables(), expected);
     }
     
     private static void assertIs(final SQLCaseAssertContext assertContext, final Collection<SimpleTableSegment> actual, final LockStatementTestCase expected) {
-        if (null == expected.getTables() || expected.getTables().isEmpty()) {
+        if (expected.getTables().isEmpty()) {
             assertTrue(actual.isEmpty(), assertContext.getText("Actual lock statement should not exist."));
             return;
         }


### PR DESCRIPTION
- Move tables collection from DorisLockStatement, MySQLLockStatement, and PostgreSQLLockStatement to LockStatement
- Update LockStatement to include tables collection
- Adjust LockStatementAssert to handle tables collection directly
- Remove redundant code and simplify table assertion logic