### PR TITLE
Remove redundant SimpleTableSegment in SelectStatement

### DIFF
--- a/parser/sql/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/doris/visitor/statement/DorisStatementVisitor.java
+++ b/parser/sql/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/doris/visitor/statement/DorisStatementVisitor.java
@@ -771,7 +771,6 @@ public abstract class DorisStatementVisitor extends DorisStatementBaseVisitor<AS
                     (DorisSelectStatement) visit(ctx.queryExpressionBody(0)), getOriginalText(ctx.queryExpressionBody(0)));
             result.setProjections(left.getSelect().getProjections());
             left.getSelect().getFrom().ifPresent(result::setFrom);
-            ((DorisSelectStatement) left.getSelect()).getTable().ifPresent(result::setTable);
             result.setCombine(createCombineSegment(ctx, left));
             return result;
         }

--- a/parser/sql/dialect/hive/src/main/java/org/apache/shardingsphere/sql/parser/hive/visitor/statement/type/HiveDMLStatementVisitor.java
+++ b/parser/sql/dialect/hive/src/main/java/org/apache/shardingsphere/sql/parser/hive/visitor/statement/type/HiveDMLStatementVisitor.java
@@ -269,7 +269,6 @@ public final class HiveDMLStatementVisitor extends HiveStatementVisitor implemen
                     (HiveSelectStatement) visit(ctx.queryExpressionBody()), getOriginalText(ctx.queryExpressionBody()));
             result.setProjections(left.getSelect().getProjections());
             left.getSelect().getFrom().ifPresent(result::setFrom);
-            ((HiveSelectStatement) left.getSelect()).getTable().ifPresent(result::setTable);
             result.setCombine(createCombineSegment(ctx.combineClause(), left));
             return result;
         }
@@ -279,7 +278,6 @@ public final class HiveDMLStatementVisitor extends HiveStatementVisitor implemen
                     (HiveSelectStatement) visit(ctx.queryExpressionParens()), getOriginalText(ctx.queryExpressionParens()));
             result.setProjections(left.getSelect().getProjections());
             left.getSelect().getFrom().ifPresent(result::setFrom);
-            ((HiveSelectStatement) left.getSelect()).getTable().ifPresent(result::setTable);
             result.setCombine(createCombineSegment(ctx.combineClause(), left));
             return result;
         }
@@ -358,7 +356,7 @@ public final class HiveDMLStatementVisitor extends HiveStatementVisitor implemen
             result.setFrom(new SimpleTableSegment(new TableNameSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(),
                     new IdentifierValue(ctx.tableName().getText()))));
         } else {
-            result.setTable((SimpleTableSegment) visit(ctx.tableName()));
+            result.setFrom((SimpleTableSegment) visit(ctx.tableName()));
         }
         return result;
     }

--- a/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
+++ b/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
@@ -775,7 +775,6 @@ public abstract class MySQLStatementVisitor extends MySQLStatementBaseVisitor<AS
                     (MySQLSelectStatement) visit(ctx.queryExpressionBody(0)), getOriginalText(ctx.queryExpressionBody(0)));
             result.setProjections(left.getSelect().getProjections());
             left.getSelect().getFrom().ifPresent(result::setFrom);
-            ((MySQLSelectStatement) left.getSelect()).getTable().ifPresent(result::setTable);
             result.setCombine(createCombineSegment(ctx, left));
             return result;
         }

--- a/parser/sql/dialect/presto/src/main/java/org/apache/shardingsphere/sql/parser/presto/visitor/statement/type/PrestoDMLStatementVisitor.java
+++ b/parser/sql/dialect/presto/src/main/java/org/apache/shardingsphere/sql/parser/presto/visitor/statement/type/PrestoDMLStatementVisitor.java
@@ -265,7 +265,6 @@ public final class PrestoDMLStatementVisitor extends PrestoStatementVisitor impl
                     (PrestoSelectStatement) visit(ctx.queryExpressionBody()), getOriginalText(ctx.queryExpressionBody()));
             result.setProjections(left.getSelect().getProjections());
             left.getSelect().getFrom().ifPresent(result::setFrom);
-            ((PrestoSelectStatement) left.getSelect()).getTable().ifPresent(result::setTable);
             result.setCombine(createCombineSegment(ctx.combineClause(), left));
             return result;
         }
@@ -275,7 +274,6 @@ public final class PrestoDMLStatementVisitor extends PrestoStatementVisitor impl
                     (PrestoSelectStatement) visit(ctx.queryExpressionParens()), getOriginalText(ctx.queryExpressionParens()));
             result.setProjections(left.getSelect().getProjections());
             left.getSelect().getFrom().ifPresent(result::setFrom);
-            ((PrestoSelectStatement) left.getSelect()).getTable().ifPresent(result::setTable);
             result.setCombine(createCombineSegment(ctx.combineClause(), left));
             return result;
         }
@@ -354,7 +352,7 @@ public final class PrestoDMLStatementVisitor extends PrestoStatementVisitor impl
             result.setFrom(new SimpleTableSegment(new TableNameSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(),
                     new IdentifierValue(ctx.tableName().getText()))));
         } else {
-            result.setTable((SimpleTableSegment) visit(ctx.tableName()));
+            result.setFrom((SimpleTableSegment) visit(ctx.tableName()));
         }
         return result;
     }

--- a/parser/sql/statement/type/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dml/DorisSelectStatement.java
+++ b/parser/sql/statement/type/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dml/DorisSelectStatement.java
@@ -21,7 +21,6 @@ import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.limit.LimitSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.LockSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.DorisStatement;
 
@@ -32,8 +31,6 @@ import java.util.Optional;
  */
 @Setter
 public final class DorisSelectStatement extends SelectStatement implements DorisStatement {
-    
-    private SimpleTableSegment table;
     
     private LimitSegment limit;
     
@@ -54,14 +51,5 @@ public final class DorisSelectStatement extends SelectStatement implements Doris
     @Override
     public Optional<WindowSegment> getWindow() {
         return Optional.ofNullable(window);
-    }
-    
-    /**
-     * Get simple table segment.
-     *
-     * @return simple table segment
-     */
-    public Optional<SimpleTableSegment> getTable() {
-        return Optional.ofNullable(table);
     }
 }

--- a/parser/sql/statement/type/hive/src/main/java/org/apache/shardingsphere/sql/parser/statement/hive/dml/HiveSelectStatement.java
+++ b/parser/sql/statement/type/hive/src/main/java/org/apache/shardingsphere/sql/parser/statement/hive/dml/HiveSelectStatement.java
@@ -21,7 +21,6 @@ import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.limit.LimitSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.LockSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.statement.hive.HiveStatement;
 
@@ -32,8 +31,6 @@ import java.util.Optional;
  */
 @Setter
 public final class HiveSelectStatement extends SelectStatement implements HiveStatement {
-    
-    private SimpleTableSegment table;
     
     private LimitSegment limit;
     
@@ -54,14 +51,5 @@ public final class HiveSelectStatement extends SelectStatement implements HiveSt
     @Override
     public Optional<WindowSegment> getWindow() {
         return Optional.ofNullable(window);
-    }
-    
-    /**
-     * Get simple table segment.
-     *
-     * @return simple table segment
-     */
-    public Optional<SimpleTableSegment> getTable() {
-        return Optional.ofNullable(table);
     }
 }

--- a/parser/sql/statement/type/mysql/src/main/java/org/apache/shardingsphere/sql/parser/statement/mysql/dml/MySQLSelectStatement.java
+++ b/parser/sql/statement/type/mysql/src/main/java/org/apache/shardingsphere/sql/parser/statement/mysql/dml/MySQLSelectStatement.java
@@ -21,7 +21,6 @@ import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.limit.LimitSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.LockSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.MySQLStatement;
 
@@ -32,8 +31,6 @@ import java.util.Optional;
  */
 @Setter
 public final class MySQLSelectStatement extends SelectStatement implements MySQLStatement {
-    
-    private SimpleTableSegment table;
     
     private LimitSegment limit;
     
@@ -54,14 +51,5 @@ public final class MySQLSelectStatement extends SelectStatement implements MySQL
     @Override
     public Optional<WindowSegment> getWindow() {
         return Optional.ofNullable(window);
-    }
-    
-    /**
-     * Get simple table segment.
-     *
-     * @return simple table segment
-     */
-    public Optional<SimpleTableSegment> getTable() {
-        return Optional.ofNullable(table);
     }
 }

--- a/parser/sql/statement/type/presto/src/main/java/org/apache/shardingsphere/sql/parser/statement/presto/dml/PrestoSelectStatement.java
+++ b/parser/sql/statement/type/presto/src/main/java/org/apache/shardingsphere/sql/parser/statement/presto/dml/PrestoSelectStatement.java
@@ -21,7 +21,6 @@ import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.limit.LimitSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.LockSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.statement.presto.PrestoStatement;
 
@@ -32,8 +31,6 @@ import java.util.Optional;
  */
 @Setter
 public final class PrestoSelectStatement extends SelectStatement implements PrestoStatement {
-    
-    private SimpleTableSegment table;
     
     private LimitSegment limit;
     
@@ -55,9 +52,5 @@ public final class PrestoSelectStatement extends SelectStatement implements Pres
     @Override
     public Optional<WindowSegment> getWindow() {
         return Optional.ofNullable(window);
-    }
-    
-    public Optional<SimpleTableSegment> getTable() {
-        return Optional.ofNullable(table);
     }
 }

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/sane/SaneQueryResultEngineTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/sane/SaneQueryResultEngineTest.java
@@ -21,7 +21,7 @@ import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.ExecuteResult;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.raw.type.RawMemoryQueryResult;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
-import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.statement.sql92.dml.SQL92SelectStatement;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -37,8 +37,7 @@ class SaneQueryResultEngineTest {
     @Test
     void assertGetSaneQueryResultForSelectStatement() {
         SaneQueryResultEngine saneQueryResultEngine = new SaneQueryResultEngine(TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
-        Optional<ExecuteResult> actual = saneQueryResultEngine.getSaneQueryResult(new SelectStatement() {
-        }, null);
+        Optional<ExecuteResult> actual = saneQueryResultEngine.getSaneQueryResult(new SQL92SelectStatement(), null);
         assertTrue(actual.isPresent());
         assertThat(actual.get(), instanceOf(RawMemoryQueryResult.class));
         RawMemoryQueryResult actualResult = (RawMemoryQueryResult) actual.get();

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dml/impl/SelectStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dml/impl/SelectStatementAssert.java
@@ -25,10 +25,8 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.ModelSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WithSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement;
-import org.apache.shardingsphere.sql.parser.statement.mysql.dml.MySQLSelectStatement;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.groupby.GroupByClauseAssert;
@@ -112,15 +110,6 @@ public final class SelectStatementAssert {
         } else {
             assertTrue(actual.getFrom().isPresent(), assertContext.getText("Actual from segment should exist."));
             TableAssert.assertIs(assertContext, actual.getFrom().get(), expected.getFrom());
-        }
-        if (actual instanceof MySQLSelectStatement) {
-            if (null == expected.getSimpleTable()) {
-                assertFalse(((MySQLSelectStatement) actual).getTable().isPresent(), assertContext.getText("Actual simple-table should not exist."));
-            } else {
-                Optional<SimpleTableSegment> table = ((MySQLSelectStatement) actual).getTable();
-                assertTrue(table.isPresent(), assertContext.getText("Actual table segment should exist."));
-                TableAssert.assertIs(assertContext, table.orElse(null), expected.getSimpleTable());
-            }
         }
     }
     

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dml/SelectStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dml/SelectStatementTestCase.java
@@ -19,19 +19,18 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.having.ExpectedHavingClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.limit.ExpectedLimitClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.lock.ExpectedLockClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.model.ExpectedModelClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.orderby.ExpectedOrderByClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.projection.ExpectedProjections;
-import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedSimpleTable;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedTable;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.union.ExpectedCombine;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.where.ExpectedWhereClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.window.ExpectedWindowClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.with.ExpectedWithClause;
-import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
 
 import javax.xml.bind.annotation.XmlElement;
 
@@ -44,9 +43,6 @@ public final class SelectStatementTestCase extends SQLParserTestCase {
     
     @XmlElement
     private ExpectedTable from;
-    
-    @XmlElement(name = "simple-table")
-    private ExpectedSimpleTable simpleTable;
     
     @XmlElement
     private final ExpectedProjections projections = new ExpectedProjections();


### PR DESCRIPTION
- Remove SimpleTableSegment from DorisSelectStatement, HiveSelectStatement, MySQLSelectStatement, and PrestoSelectStatement
- Update related test cases and assertions to remove checks for simpleTable
- This change simplifies the SelectStatement structure and reduces redundancy