### PR TITLE
Remove useless test fixture database dependency

### DIFF
--- a/proxy/backend/type/postgresql/pom.xml
+++ b/proxy/backend/type/postgresql/pom.xml
@@ -49,11 +49,5 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-test-fixture-database</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/proxy/frontend/type/mysql/pom.xml
+++ b/proxy/frontend/type/mysql/pom.xml
@@ -49,11 +49,5 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-test-fixture-database</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
- Removed shardingsphere-test-fixture-database dependency from PostgreSQL and MySQL backend modules
- This change simplifies the project structure and reduces unnecessary dependencies