### PR TITLE
Support e2e sql execute proxy adapter sql in NATIVE mode

### DIFF
--- a/infra/database/type/presto/src/main/java/org/apache/shardingsphere/infra/database/presto/metadata/data/loader/PrestoMetaDataLoader.java
+++ b/infra/database/type/presto/src/main/java/org/apache/shardingsphere/infra/database/presto/metadata/data/loader/PrestoMetaDataLoader.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 /**
@@ -49,7 +50,7 @@ public final class PrestoMetaDataLoader implements DialectMetaDataLoader {
         Collection<TableMetaData> tableMetaDataList = new LinkedList<>();
         try (Connection connection = material.getDataSource().getConnection()) {
             Map<String, Collection<ColumnMetaData>> columnMetaDataMap = loadColumnMetaDataMap(connection, material.getActualTableNames());
-            for (Map.Entry<String, Collection<ColumnMetaData>> entry : columnMetaDataMap.entrySet()) {
+            for (Entry<String, Collection<ColumnMetaData>> entry : columnMetaDataMap.entrySet()) {
                 tableMetaDataList.add(new TableMetaData(entry.getKey(), entry.getValue(), Collections.emptyList(), Collections.emptyList()));
             }
         }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/ITContainers.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/ITContainers.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.test.e2e.env.container.atomic;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.impl.NativeStorageContainer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.governance.GovernanceContainer;
@@ -72,6 +73,9 @@ public final class ITContainers implements Startable {
             ((ComboITContainer) container).getContainers().forEach(this::registerContainer);
         } else if (container instanceof EmbeddedITContainer) {
             embeddedContainers.add((EmbeddedITContainer) container);
+        } else if (container instanceof NativeStorageContainer) {
+            String networkAlias = getNetworkAlias(container);
+            ((NativeStorageContainer) container).setNetworkAliases(Collections.singletonList(networkAlias));
         } else {
             DockerITContainer dockerContainer = (DockerITContainer) container;
             dockerContainer.setNetwork(network);

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/adapter/AdapterContainerFactory.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/adapter/AdapterContainerFactory.java
@@ -21,13 +21,15 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.config.AdaptorContainerConfiguration;
-import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereJdbcContainer;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereJdbcEmbeddedContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereMultiProxyClusterContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereProxyClusterContainer;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereProxyEmbeddedContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereProxyStandaloneContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.enums.AdapterMode;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.enums.AdapterType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.StorageContainer;
+import org.apache.shardingsphere.test.e2e.env.runtime.cluster.ClusterEnvironment;
 import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioCommonPath;
 
 /**
@@ -45,20 +47,24 @@ public final class AdapterContainerFactory {
      * @param scenario scenario
      * @param containerConfig adaptor container configuration
      * @param storageContainer storage container
+     * @param envType environment type
      * @return created instance
      * @throws RuntimeException runtime exception
      */
-    public static AdapterContainer newInstance(final AdapterMode mode, final AdapterType adapter, final DatabaseType databaseType,
-                                               final String scenario, final AdaptorContainerConfiguration containerConfig, final StorageContainer storageContainer) {
+    public static AdapterContainer newInstance(final AdapterMode mode, final AdapterType adapter, final DatabaseType databaseType, final String scenario,
+                                               final AdaptorContainerConfiguration containerConfig, final StorageContainer storageContainer, final String envType) {
         switch (adapter) {
             case PROXY:
+                if (ClusterEnvironment.Type.NATIVE.name().equalsIgnoreCase(envType)) {
+                    return new ShardingSphereProxyEmbeddedContainer(databaseType, containerConfig);
+                }
                 return AdapterMode.CLUSTER == mode
                         ? new ShardingSphereProxyClusterContainer(databaseType, containerConfig)
                         : new ShardingSphereProxyStandaloneContainer(databaseType, containerConfig);
             case PROXY_RANDOM:
                 return new ShardingSphereMultiProxyClusterContainer(databaseType, containerConfig);
             case JDBC:
-                return new ShardingSphereJdbcContainer(storageContainer, new ScenarioCommonPath(scenario).getRuleConfigurationFile(databaseType));
+                return new ShardingSphereJdbcEmbeddedContainer(storageContainer, new ScenarioCommonPath(scenario).getRuleConfigurationFile(databaseType));
             default:
                 throw new RuntimeException(String.format("Unknown adapter `%s`.", adapter));
         }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/adapter/impl/ShardingSphereJdbcEmbeddedContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/adapter/impl/ShardingSphereJdbcEmbeddedContainer.java
@@ -31,12 +31,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * ShardingSphere JDBC container.
+ * ShardingSphere JDBC embedded container.
  */
-public final class ShardingSphereJdbcContainer implements EmbeddedITContainer, AdapterContainer {
+public final class ShardingSphereJdbcEmbeddedContainer implements EmbeddedITContainer, AdapterContainer {
     
     private final StorageContainer storageContainer;
     
@@ -44,7 +45,7 @@ public final class ShardingSphereJdbcContainer implements EmbeddedITContainer, A
     
     private final String configPath;
     
-    public ShardingSphereJdbcContainer(final StorageContainer storageContainer, final String configPath) {
+    public ShardingSphereJdbcEmbeddedContainer(final StorageContainer storageContainer, final String configPath) {
         this.configPath = configPath;
         this.storageContainer = storageContainer;
     }
@@ -78,7 +79,7 @@ public final class ShardingSphereJdbcContainer implements EmbeddedITContainer, A
     private String processFile(final String filePath, final Map<String, String> replacements) throws IOException {
         Path path = Paths.get(filePath);
         String content = new String(Files.readAllBytes(path));
-        for (Map.Entry<String, String> entry : replacements.entrySet()) {
+        for (Entry<String, String> entry : replacements.entrySet()) {
             content = content.replace(entry.getKey(), entry.getValue());
         }
         File tempFile = File.createTempFile("shardingsphere_e2e_jdbc_tmp_config_", null);

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/NativeStorageContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/NativeStorageContainer.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.env.container.atomic.storage.impl;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.constants.StorageContainerConstants;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.StorageContainer;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.impl.StorageContainerConfigurationFactory;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.util.SQLScriptUtils;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.util.StorageContainerUtils;
+import org.apache.shardingsphere.test.e2e.env.runtime.DataSourceEnvironment;
+import org.apache.shardingsphere.test.e2e.env.runtime.E2ETestEnvironment;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+/**
+ * Native storage container.
+ */
+@Getter
+public final class NativeStorageContainer implements StorageContainer {
+    
+    private final DatabaseType databaseType;
+    
+    private final String scenario;
+    
+    private final Map<String, DataSource> actualDataSourceMap;
+    
+    private final Map<String, DataSource> expectedDataSourceMap;
+    
+    private final StorageContainerConfiguration storageContainerConfiguration;
+    
+    @Setter
+    private List<String> networkAliases;
+    
+    public NativeStorageContainer(final DatabaseType databaseType, final String scenario) {
+        this.databaseType = databaseType;
+        this.scenario = scenario;
+        storageContainerConfiguration = StorageContainerConfigurationFactory.newInstance(this.databaseType, this.scenario);
+        initDatabase();
+        actualDataSourceMap = createActualDataSourceMap();
+        expectedDataSourceMap = createExpectedDataSourceMap();
+    }
+    
+    private void initDatabase() {
+        DataSource dataSource = StorageContainerUtils.generateDataSource(
+                DataSourceEnvironment.getURL(databaseType, E2ETestEnvironment.getInstance().getNativeStorageHost(), Integer.parseInt(E2ETestEnvironment.getInstance().getNativeStoragePort())),
+                E2ETestEnvironment.getInstance().getNativeStorageUsername(), E2ETestEnvironment.getInstance().getNativeStoragePassword());
+        storageContainerConfiguration.getMountedResources().keySet().stream().filter(each -> each.toLowerCase().endsWith(".sql")).forEach(each -> SQLScriptUtils.execute(dataSource, each));
+    }
+    
+    private Map<String, DataSource> createActualDataSourceMap() {
+        Collection<String> databaseNames =
+                storageContainerConfiguration.getDatabaseTypes().entrySet().stream().filter(entry -> entry.getValue() == databaseType).map(Entry::getKey).collect(Collectors.toList());
+        return getDataSourceMap(databaseNames);
+    }
+    
+    private Map<String, DataSource> createExpectedDataSourceMap() {
+        Collection<String> databaseNames =
+                storageContainerConfiguration.getExpectedDatabaseTypes().entrySet().stream().filter(entry -> entry.getValue() == databaseType).map(Entry::getKey).collect(Collectors.toList());
+        return getDataSourceMap(databaseNames);
+    }
+    
+    private Map<String, DataSource> getDataSourceMap(final Collection<String> databaseNames) {
+        Map<String, DataSource> result = new HashMap<>();
+        for (String each : databaseNames) {
+            DataSource dataSource = StorageContainerUtils.generateDataSource(DataSourceEnvironment.getURL(databaseType, E2ETestEnvironment.getInstance().getNativeStorageHost(),
+                    Integer.parseInt(E2ETestEnvironment.getInstance().getNativeStoragePort()), each),
+                    E2ETestEnvironment.getInstance().getNativeStorageUsername(), E2ETestEnvironment.getInstance().getNativeStoragePassword());
+            result.put(each, dataSource);
+        }
+        return result;
+    }
+    
+    @Override
+    public String getAbbreviation() {
+        return databaseType.getType().toLowerCase();
+    }
+    
+    @Override
+    public Map<String, String> getLinkReplacements() {
+        Map<String, String> result = new HashMap<>();
+        for (String each : getNetworkAliases()) {
+            result.put(each + ":" + getExposedPort(), E2ETestEnvironment.getInstance().getNativeStorageHost() + ":" + E2ETestEnvironment.getInstance().getNativeStoragePort());
+        }
+        result.put(StorageContainerConstants.USERNAME, E2ETestEnvironment.getInstance().getNativeStorageUsername());
+        result.put(StorageContainerConstants.PASSWORD, E2ETestEnvironment.getInstance().getNativeStoragePassword());
+        return result;
+    }
+    
+    /**
+     * Get exposed port.
+     *
+     * @return exposed port
+     * @throws UnsupportedOperationException unsupported operation exception
+     */
+    public int getExposedPort() {
+        if ("MySQL".equalsIgnoreCase(databaseType.getType())) {
+            return 3306;
+        } else if ("PostgreSQL".equalsIgnoreCase(databaseType.getType())) {
+            return 5432;
+        } else if ("openGauss".equalsIgnoreCase(databaseType.getType())) {
+            return 5432;
+        } else {
+            throw new UnsupportedOperationException(String.format("Unsupported database type: %s.", databaseType.getType()));
+        }
+    }
+    
+    @Override
+    public void start() {
+    }
+}

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/OpenGaussContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/OpenGaussContainer.java
@@ -28,7 +28,7 @@ import org.apache.shardingsphere.test.e2e.env.runtime.DataSourceEnvironment;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
-import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -62,12 +62,12 @@ public final class OpenGaussContainer extends DockerStorageContainer {
     
     @Override
     protected Collection<String> getDatabaseNames() {
-        return storageContainerConfig.getDatabaseTypes().entrySet().stream().filter(entry -> entry.getValue() == getDatabaseType()).map(Map.Entry::getKey).collect(Collectors.toList());
+        return storageContainerConfig.getDatabaseTypes().entrySet().stream().filter(entry -> entry.getValue() == getDatabaseType()).map(Entry::getKey).collect(Collectors.toList());
     }
     
     @Override
     protected Collection<String> getExpectedDatabaseNames() {
-        return storageContainerConfig.getExpectedDatabaseTypes().entrySet().stream().filter(entry -> entry.getValue() == getDatabaseType()).map(Map.Entry::getKey).collect(Collectors.toList());
+        return storageContainerConfig.getExpectedDatabaseTypes().entrySet().stream().filter(entry -> entry.getValue() == getDatabaseType()).map(Entry::getKey).collect(Collectors.toList());
     }
     
     @Override

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/PostgreSQLContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/PostgreSQLContainer.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.DockerSto
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
 
 import java.util.Collection;
-import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -54,12 +54,12 @@ public final class PostgreSQLContainer extends DockerStorageContainer {
     
     @Override
     protected Collection<String> getDatabaseNames() {
-        return storageContainerConfig.getDatabaseTypes().entrySet().stream().filter(entry -> entry.getValue() == getDatabaseType()).map(Map.Entry::getKey).collect(Collectors.toList());
+        return storageContainerConfig.getDatabaseTypes().entrySet().stream().filter(entry -> entry.getValue() == getDatabaseType()).map(Entry::getKey).collect(Collectors.toList());
     }
     
     @Override
     protected Collection<String> getExpectedDatabaseNames() {
-        return storageContainerConfig.getExpectedDatabaseTypes().entrySet().stream().filter(entry -> entry.getValue() == getDatabaseType()).map(Map.Entry::getKey).collect(Collectors.toList());
+        return storageContainerConfig.getExpectedDatabaseTypes().entrySet().stream().filter(entry -> entry.getValue() == getDatabaseType()).map(Entry::getKey).collect(Collectors.toList());
     }
     
     @Override

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/runtime/E2ETestEnvironment.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/runtime/E2ETestEnvironment.java
@@ -46,6 +46,14 @@ public final class E2ETestEnvironment {
     
     private final boolean smoke;
     
+    private final String nativeStorageHost;
+    
+    private final String nativeStoragePort;
+    
+    private final String nativeStorageUsername;
+    
+    private final String nativeStoragePassword;
+    
     private E2ETestEnvironment() {
         Properties props = loadProperties();
         runModes = Splitter.on(",").trimResults().splitToList(props.getProperty("it.run.modes"));
@@ -54,6 +62,10 @@ public final class E2ETestEnvironment {
         scenarios = getScenarios(props);
         smoke = Boolean.parseBoolean(props.getProperty("it.run.smoke"));
         clusterEnvironment = new ClusterEnvironment(props);
+        nativeStorageHost = props.getProperty("it.native.storage.host");
+        nativeStoragePort = props.getProperty("it.native.storage.port");
+        nativeStorageUsername = props.getProperty("it.native.storage.username");
+        nativeStoragePassword = props.getProperty("it.native.storage.password");
     }
     
     @SuppressWarnings("AccessOfSystemProperties")

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/framework/container/compose/DockerContainerComposer.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/framework/container/compose/DockerContainerComposer.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.test.e2e.data.pipeline.framework.container.conf
 import org.apache.shardingsphere.test.e2e.data.pipeline.util.DockerImageVersion;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.config.AdaptorContainerConfiguration;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereProxyClusterContainer;
-import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereProxyContainer;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereProxyEmbeddedContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.governance.GovernanceContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.governance.impl.ZookeeperContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.DockerStorageContainer;
@@ -74,7 +74,7 @@ public final class DockerContainerComposer extends BaseContainerComposer {
         AdaptorContainerConfiguration containerConfig = PipelineProxyClusterContainerConfigurationFactory.newInstance(databaseType);
         DatabaseType proxyDatabaseType = "Oracle".equals(databaseType.getType()) ? TypedSPILoader.getService(DatabaseType.class, "MySQL") : databaseType;
         if (PipelineE2EEnvironment.getInstance().getItProxyType() == PipelineProxyTypeEnum.INTERNAL) {
-            ShardingSphereProxyContainer proxyContainer = new ShardingSphereProxyContainer(proxyDatabaseType, containerConfig);
+            ShardingSphereProxyEmbeddedContainer proxyContainer = new ShardingSphereProxyEmbeddedContainer(proxyDatabaseType, containerConfig);
             for (DockerStorageContainer each : storageContainers) {
                 proxyContainer.dependsOn(governanceContainer, each);
             }

--- a/test/e2e/operation/showprocesslist/src/test/java/org/apache/shardingsphere/test/e2e/showprocesslist/container/composer/ClusterShowProcessListContainerComposer.java
+++ b/test/e2e/operation/showprocesslist/src/test/java/org/apache/shardingsphere/test/e2e/showprocesslist/container/composer/ClusterShowProcessListContainerComposer.java
@@ -32,6 +32,7 @@ import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.StorageCo
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.StorageContainerFactory;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.impl.StorageContainerConfigurationFactory;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.util.AdapterContainerUtils;
+import org.apache.shardingsphere.test.e2e.showprocesslist.env.ShowProcessListEnvironment;
 import org.apache.shardingsphere.test.e2e.showprocesslist.parameter.ShowProcessListTestParameter;
 
 import javax.sql.DataSource;
@@ -60,10 +61,11 @@ public final class ClusterShowProcessListContainerComposer implements AutoClosea
         AdaptorContainerConfiguration containerConfig = new AdaptorContainerConfiguration(testParam.getScenario(), new LinkedList<>(),
                 getMountedResources(testParam.getScenario(), testParam.getDatabaseType(), testParam.getRunMode(), testParam.getGovernanceCenter()), AdapterContainerUtils.getAdapterContainerImage(),
                 "");
-        jdbcContainer = AdapterContainerFactory.newInstance(
-                AdapterMode.valueOf(testParam.getRunMode().toUpperCase()), AdapterType.JDBC, testParam.getDatabaseType(), testParam.getScenario(), containerConfig, storageContainer);
-        proxyContainer = AdapterContainerFactory.newInstance(
-                AdapterMode.valueOf(testParam.getRunMode().toUpperCase()), AdapterType.PROXY, testParam.getDatabaseType(), testParam.getScenario(), containerConfig, storageContainer);
+        String envType = ShowProcessListEnvironment.getInstance().getItEnvType().name();
+        jdbcContainer = AdapterContainerFactory.newInstance(AdapterMode.valueOf(testParam.getRunMode().toUpperCase()), AdapterType.JDBC, testParam.getDatabaseType(), testParam.getScenario(),
+                containerConfig, storageContainer, envType);
+        proxyContainer = AdapterContainerFactory.newInstance(AdapterMode.valueOf(testParam.getRunMode().toUpperCase()), AdapterType.PROXY, testParam.getDatabaseType(), testParam.getScenario(),
+                containerConfig, storageContainer, envType);
         if (proxyContainer instanceof DockerITContainer) {
             if (isClusterMode(testParam.getRunMode())) {
                 ((DockerITContainer) proxyContainer).dependsOn(governanceContainer);

--- a/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/framework/container/compose/DockerContainerComposer.java
+++ b/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/framework/container/compose/DockerContainerComposer.java
@@ -21,7 +21,7 @@ import com.google.common.base.Strings;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
-import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereJdbcContainer;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereJdbcEmbeddedContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereProxyClusterContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.enums.AdapterType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.governance.GovernanceContainer;
@@ -48,7 +48,7 @@ public final class DockerContainerComposer extends BaseContainerComposer {
     
     private final ShardingSphereProxyClusterContainer proxyContainer;
     
-    private final ShardingSphereJdbcContainer jdbcContainer;
+    private final ShardingSphereJdbcEmbeddedContainer jdbcContainer;
     
     private final DockerStorageContainer storageContainer;
     
@@ -66,7 +66,7 @@ public final class DockerContainerComposer extends BaseContainerComposer {
             getContainers().registerContainer(proxyContainer);
         } else {
             proxyContainer = null;
-            ShardingSphereJdbcContainer jdbcContainer = new ShardingSphereJdbcContainer(storageContainer,
+            ShardingSphereJdbcEmbeddedContainer jdbcContainer = new ShardingSphereJdbcEmbeddedContainer(storageContainer,
                     Objects.requireNonNull(getShardingSphereConfigResource(testParam)).getFile());
             this.jdbcContainer = getContainers().registerContainer(jdbcContainer);
         }

--- a/test/e2e/sql/src/test/resources/env/it-env.properties
+++ b/test/e2e/sql/src/test/resources/env/it-env.properties
@@ -33,3 +33,8 @@ it.cluster.adapters=proxy
 it.cluster.databases=MySQL
 
 #it.cluster.database.mysql.image=mysql:8.2.0
+
+it.native.storage.host=127.0.0.1
+it.native.storage.port=3306
+it.native.storage.username=root
+it.native.storage.password=root


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Support e2e sql execute proxy adapter sql in NATIVE mode

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
