### PR TITLE
Use SQLFederationCacheOption to replace CacheOption in SQLFederationRuleConfiguration

### DIFF
--- a/kernel/sql-federation/api/src/main/java/org/apache/shardingsphere/sqlfederation/config/SQLFederationCacheOption.java
+++ b/kernel/sql-federation/api/src/main/java/org/apache/shardingsphere/sqlfederation/config/SQLFederationCacheOption.java
@@ -17,20 +17,24 @@
 
 package org.apache.shardingsphere.sqlfederation.config;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.infra.config.rule.scope.GlobalRuleConfiguration;
 
 /**
- * SQL federation rule configuration.
+ * SQL federation cache option.
  */
 @RequiredArgsConstructor
 @Getter
-public final class SQLFederationRuleConfiguration implements GlobalRuleConfiguration {
+@EqualsAndHashCode
+public final class SQLFederationCacheOption {
     
-    private final boolean sqlFederationEnabled;
+    private final int initialCapacity;
     
-    private final boolean allQueryUseSQLFederation;
+    private final long maximumSize;
     
-    private final SQLFederationCacheOption executionPlanCache;
+    @Override
+    public String toString() {
+        return String.format("initialCapacity: %d, maximumSize: %d", initialCapacity, maximumSize);
+    }
 }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/rule/builder/DefaultSQLFederationRuleConfigurationBuilder.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/rule/builder/DefaultSQLFederationRuleConfigurationBuilder.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.sqlfederation.rule.builder;
 
 import org.apache.shardingsphere.infra.rule.builder.global.DefaultGlobalRuleConfigurationBuilder;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
 import org.apache.shardingsphere.sqlfederation.constant.SQLFederationOrder;
 
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.sqlfederation.constant.SQLFederationOrder;
  */
 public final class DefaultSQLFederationRuleConfigurationBuilder implements DefaultGlobalRuleConfigurationBuilder<SQLFederationRuleConfiguration, SQLFederationRuleBuilder> {
     
-    public static final CacheOption DEFAULT_EXECUTION_PLAN_CACHE_OPTION = new CacheOption(2000, 65535L);
+    public static final SQLFederationCacheOption DEFAULT_EXECUTION_PLAN_CACHE_OPTION = new SQLFederationCacheOption(2000, 65535L);
     
     @Override
     public SQLFederationRuleConfiguration build() {

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/yaml/swapper/YamlSQLFederationExecutionPlanCacheConfigurationSwapper.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/yaml/swapper/YamlSQLFederationExecutionPlanCacheConfigurationSwapper.java
@@ -18,16 +18,16 @@
 package org.apache.shardingsphere.sqlfederation.yaml.swapper;
 
 import org.apache.shardingsphere.infra.util.yaml.swapper.YamlConfigurationSwapper;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationExecutionPlanCacheRuleConfiguration;
 
 /**
  * YAML SQL federation execution plan cache configuration swapper.
  */
-public final class YamlSQLFederationExecutionPlanCacheConfigurationSwapper implements YamlConfigurationSwapper<YamlSQLFederationExecutionPlanCacheRuleConfiguration, CacheOption> {
+public final class YamlSQLFederationExecutionPlanCacheConfigurationSwapper implements YamlConfigurationSwapper<YamlSQLFederationExecutionPlanCacheRuleConfiguration, SQLFederationCacheOption> {
     
     @Override
-    public YamlSQLFederationExecutionPlanCacheRuleConfiguration swapToYamlConfiguration(final CacheOption data) {
+    public YamlSQLFederationExecutionPlanCacheRuleConfiguration swapToYamlConfiguration(final SQLFederationCacheOption data) {
         YamlSQLFederationExecutionPlanCacheRuleConfiguration result = new YamlSQLFederationExecutionPlanCacheRuleConfiguration();
         result.setInitialCapacity(data.getInitialCapacity());
         result.setMaximumSize(data.getMaximumSize());
@@ -35,7 +35,7 @@ public final class YamlSQLFederationExecutionPlanCacheConfigurationSwapper imple
     }
     
     @Override
-    public CacheOption swapToObject(final YamlSQLFederationExecutionPlanCacheRuleConfiguration yamlConfig) {
-        return new CacheOption(yamlConfig.getInitialCapacity(), yamlConfig.getMaximumSize());
+    public SQLFederationCacheOption swapToObject(final YamlSQLFederationExecutionPlanCacheRuleConfiguration yamlConfig) {
+        return new SQLFederationCacheOption(yamlConfig.getInitialCapacity(), yamlConfig.getMaximumSize());
     }
 }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/yaml/swapper/YamlSQLFederationRuleConfigurationSwapper.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/yaml/swapper/YamlSQLFederationRuleConfigurationSwapper.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.sqlfederation.yaml.swapper;
 
 import org.apache.shardingsphere.infra.yaml.config.swapper.rule.YamlRuleConfigurationSwapper;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
 import org.apache.shardingsphere.sqlfederation.constant.SQLFederationOrder;
 import org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration;
@@ -41,7 +41,7 @@ public final class YamlSQLFederationRuleConfigurationSwapper implements YamlRule
     
     @Override
     public SQLFederationRuleConfiguration swapToObject(final YamlSQLFederationRuleConfiguration yamlConfig) {
-        CacheOption executionPlanCacheConfig = executionPlanCacheConfigSwapper.swapToObject(yamlConfig.getExecutionPlanCache());
+        SQLFederationCacheOption executionPlanCacheConfig = executionPlanCacheConfigSwapper.swapToObject(yamlConfig.getExecutionPlanCache());
         return new SQLFederationRuleConfiguration(yamlConfig.isSqlFederationEnabled(), yamlConfig.isAllQueryUseSQLFederation(), executionPlanCacheConfig);
     }
     

--- a/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/engine/SQLFederationEngineTest.java
+++ b/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/engine/SQLFederationEngineTest.java
@@ -28,7 +28,7 @@ import org.apache.shardingsphere.infra.metadata.statistics.ShardingSphereStatist
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
 import org.apache.shardingsphere.sqlfederation.engine.fixture.rule.SQLFederationDeciderRuleMatchFixture;
 import org.apache.shardingsphere.sqlfederation.engine.fixture.rule.SQLFederationDeciderRuleNotMatchFixture;
@@ -61,7 +61,7 @@ class SQLFederationEngineTest {
     @Test
     void assertDecideWhenSelectStatementContainsSystemSchema() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
-                Collections.singleton(new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, mock(CacheOption.class)), Collections.emptyList()));
+                Collections.singleton(new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getDatabaseType()).thenReturn(databaseType);
         when(sqlStatementContext.getTablesContext().getDatabaseNames()).thenReturn(Collections.singletonList("information_schema"));
@@ -85,7 +85,7 @@ class SQLFederationEngineTest {
     void assertDecideWhenNotConfigSqlFederationEnabled() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
                 Collections
-                        .singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, mock(CacheOption.class)), Collections.emptyList()));
+                        .singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
         SQLFederationEngine engine = createSQLFederationEngine(globalRules, Collections.emptyList());
         RuleMetaData globalRuleMetaData = new RuleMetaData(globalRules);
         assertFalse(engine.decide(mock(QueryContext.class), globalRuleMetaData));
@@ -95,7 +95,7 @@ class SQLFederationEngineTest {
     @Test
     void assertDecideWhenConfigAllQueryUseSQLFederation() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
-                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, true, mock(CacheOption.class)), Collections.emptyList()));
+                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, true, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db",
                 databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(globalRules), Collections.emptyList());
         SelectStatementContext selectStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
@@ -113,7 +113,7 @@ class SQLFederationEngineTest {
     @Test
     void assertDecideWhenExecuteNotSelectStatement() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
-                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, mock(CacheOption.class)), Collections.emptyList()));
+                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
         SQLFederationEngine engine = createSQLFederationEngine(globalRules, Collections.emptyList());
         RuleMetaData globalRuleMetaData = new RuleMetaData(globalRules);
         assertFalse(engine.decide(mock(QueryContext.class), globalRuleMetaData));
@@ -123,7 +123,7 @@ class SQLFederationEngineTest {
     @Test
     void assertDecideWhenConfigSingleMatchedRule() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
-                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, mock(CacheOption.class)), Collections.emptyList()));
+                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
         Collection<ShardingSphereRule> databaseRules = Collections.singletonList(new SQLFederationDeciderRuleMatchFixture());
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db",
                 databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(globalRules), Collections.emptyList());
@@ -142,7 +142,7 @@ class SQLFederationEngineTest {
     @Test
     void assertDecideWhenConfigSingleNotMatchedRule() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
-                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, mock(CacheOption.class)), Collections.emptyList()));
+                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
         Collection<ShardingSphereRule> databaseRules = Collections.singletonList(new SQLFederationDeciderRuleNotMatchFixture());
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db",
                 databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(databaseRules), Collections.emptyList());
@@ -160,7 +160,7 @@ class SQLFederationEngineTest {
     @Test
     void assertDecideWhenConfigMultiRule() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
-                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, mock(CacheOption.class)), Collections.emptyList()));
+                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
         Collection<ShardingSphereRule> databaseRules = Arrays.asList(new SQLFederationDeciderRuleNotMatchFixture(),
                 new SQLFederationDeciderRuleMatchFixture());
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db",

--- a/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/engine/fixture/rule/SQLFederationDeciderRuleMatchFixture.java
+++ b/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/engine/fixture/rule/SQLFederationDeciderRuleMatchFixture.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.sqlfederation.engine.fixture.rule;
 
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
 
 import static org.mockito.Mockito.mock;
@@ -28,7 +28,7 @@ public final class SQLFederationDeciderRuleMatchFixture implements ShardingSpher
     
     @Override
     public RuleConfiguration getConfiguration() {
-        return new SQLFederationRuleConfiguration(true, false, mock(CacheOption.class));
+        return new SQLFederationRuleConfiguration(true, false, mock(SQLFederationCacheOption.class));
     }
     
     @Override

--- a/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/engine/fixture/rule/SQLFederationDeciderRuleNotMatchFixture.java
+++ b/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/engine/fixture/rule/SQLFederationDeciderRuleNotMatchFixture.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.sqlfederation.engine.fixture.rule;
 
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
 
 import static org.mockito.Mockito.mock;
@@ -28,7 +28,7 @@ public final class SQLFederationDeciderRuleNotMatchFixture implements ShardingSp
     
     @Override
     public RuleConfiguration getConfiguration() {
-        return new SQLFederationRuleConfiguration(false, false, mock(CacheOption.class));
+        return new SQLFederationRuleConfiguration(false, false, mock(SQLFederationCacheOption.class));
     }
     
     @Override

--- a/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/yaml/SQLFederationRuleConfigurationYamlIT.java
+++ b/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/yaml/SQLFederationRuleConfigurationYamlIT.java
@@ -17,13 +17,13 @@
 
 package org.apache.shardingsphere.sqlfederation.yaml;
 
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
 import org.apache.shardingsphere.test.it.yaml.YamlRuleConfigurationIT;
 
 class SQLFederationRuleConfigurationYamlIT extends YamlRuleConfigurationIT {
     
     SQLFederationRuleConfigurationYamlIT() {
-        super("yaml/sql-federation-rule.yaml", new SQLFederationRuleConfiguration(true, true, new CacheOption(128, 1024)));
+        super("yaml/sql-federation-rule.yaml", new SQLFederationRuleConfiguration(true, true, new SQLFederationCacheOption(128, 1024)));
     }
 }

--- a/kernel/sql-federation/distsql/handler/src/main/java/org/apache/shardingsphere/sqlfederation/distsql/handler/update/AlterSQLFederationRuleExecutor.java
+++ b/kernel/sql-federation/distsql/handler/src/main/java/org/apache/shardingsphere/sqlfederation/distsql/handler/update/AlterSQLFederationRuleExecutor.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.sqlfederation.distsql.handler.update;
 
 import lombok.Setter;
 import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.global.GlobalRuleDefinitionExecutor;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
 import org.apache.shardingsphere.sqlfederation.distsql.segment.CacheOptionSegment;
 import org.apache.shardingsphere.sqlfederation.distsql.statement.updatable.AlterSQLFederationRuleStatement;
@@ -37,16 +37,16 @@ public final class AlterSQLFederationRuleExecutor implements GlobalRuleDefinitio
     public SQLFederationRuleConfiguration buildToBeAlteredRuleConfiguration(final AlterSQLFederationRuleStatement sqlStatement) {
         boolean sqlFederationEnabled = null == sqlStatement.getSqlFederationEnabled() ? rule.getConfiguration().isSqlFederationEnabled() : sqlStatement.getSqlFederationEnabled();
         boolean allQueryUseSQLFederation = null == sqlStatement.getAllQueryUseSQLFederation() ? rule.getConfiguration().isAllQueryUseSQLFederation() : sqlStatement.getAllQueryUseSQLFederation();
-        CacheOption executionPlanCache = null == sqlStatement.getExecutionPlanCache()
+        SQLFederationCacheOption executionPlanCache = null == sqlStatement.getExecutionPlanCache()
                 ? rule.getConfiguration().getExecutionPlanCache()
                 : createCacheOption(rule.getConfiguration().getExecutionPlanCache(), sqlStatement.getExecutionPlanCache());
         return new SQLFederationRuleConfiguration(sqlFederationEnabled, allQueryUseSQLFederation, executionPlanCache);
     }
     
-    private CacheOption createCacheOption(final CacheOption cacheOption, final CacheOptionSegment segment) {
+    private SQLFederationCacheOption createCacheOption(final SQLFederationCacheOption cacheOption, final CacheOptionSegment segment) {
         int initialCapacity = null == segment.getInitialCapacity() ? cacheOption.getInitialCapacity() : segment.getInitialCapacity();
         long maximumSize = null == segment.getMaximumSize() ? cacheOption.getMaximumSize() : segment.getMaximumSize();
-        return new CacheOption(initialCapacity, maximumSize);
+        return new SQLFederationCacheOption(initialCapacity, maximumSize);
     }
     
     @Override

--- a/kernel/sql-federation/distsql/handler/src/test/java/org/apache/shardingsphere/sqlfederation/distsql/handler/update/AlterSQLFederationRuleExecutorTest.java
+++ b/kernel/sql-federation/distsql/handler/src/test/java/org/apache/shardingsphere/sqlfederation/distsql/handler/update/AlterSQLFederationRuleExecutorTest.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.sqlfederation.distsql.handler.update;
 import org.apache.shardingsphere.distsql.statement.DistSQLStatement;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.rule.scope.GlobalRuleConfiguration;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
 import org.apache.shardingsphere.sqlfederation.distsql.segment.CacheOptionSegment;
 import org.apache.shardingsphere.sqlfederation.distsql.statement.updatable.AlterSQLFederationRuleStatement;
@@ -59,15 +59,15 @@ class AlterSQLFederationRuleExecutorTest extends GlobalRuleDefinitionExecutorTes
                     Arguments.arguments("normal",
                             new DefaultSQLFederationRuleConfigurationBuilder().build(),
                             new AlterSQLFederationRuleStatement(true, true, new CacheOptionSegment(64, 512L)),
-                            new SQLFederationRuleConfiguration(true, true, new CacheOption(64, 512L)), null),
+                            new SQLFederationRuleConfiguration(true, true, new SQLFederationCacheOption(64, 512L)), null),
                     Arguments.arguments("withNotExistedDistributedTransactionType",
                             new DefaultSQLFederationRuleConfigurationBuilder().build(),
                             new AlterSQLFederationRuleStatement(null, null, null),
-                            new SQLFederationRuleConfiguration(false, false, new CacheOption(2000, 65535L)), null),
+                            new SQLFederationRuleConfiguration(false, false, new SQLFederationCacheOption(2000, 65535L)), null),
                     Arguments.arguments("withNotExistedXATransactionProvider",
                             new DefaultSQLFederationRuleConfigurationBuilder().build(),
                             new AlterSQLFederationRuleStatement(null, null, new CacheOptionSegment(null, null)),
-                            new SQLFederationRuleConfiguration(false, false, new CacheOption(2000, 65535L)), null));
+                            new SQLFederationRuleConfiguration(false, false, new SQLFederationCacheOption(2000, 65535L)), null));
         }
     }
 }

--- a/kernel/sql-federation/optimizer/pom.xml
+++ b/kernel/sql-federation/optimizer/pom.xml
@@ -33,6 +33,11 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-sql-federation-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-sql-parser-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/SQLFederationCompilerEngine.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/SQLFederationCompilerEngine.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.sqlfederation.optimizer;
 
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.optimizer.planner.cache.ExecutionPlanCacheKey;
 import org.apache.shardingsphere.sqlfederation.optimizer.statement.SQLStatementCompilerEngine;
 import org.apache.shardingsphere.sqlfederation.optimizer.statement.SQLStatementCompilerEngineFactory;
@@ -29,7 +29,7 @@ public final class SQLFederationCompilerEngine {
     
     private final SQLStatementCompilerEngine sqlStatementCompilerEngine;
     
-    public SQLFederationCompilerEngine(final String databaseName, final String schemaName, final CacheOption cacheOption) {
+    public SQLFederationCompilerEngine(final String databaseName, final String schemaName, final SQLFederationCacheOption cacheOption) {
         sqlStatementCompilerEngine = SQLStatementCompilerEngineFactory.getSQLStatementCompilerEngine(databaseName, schemaName, cacheOption);
     }
     

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/planner/cache/ExecutionPlanCacheBuilder.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/planner/cache/ExecutionPlanCacheBuilder.java
@@ -21,7 +21,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.optimizer.SQLFederationExecutionPlan;
 
 /**
@@ -36,7 +36,7 @@ public final class ExecutionPlanCacheBuilder {
      * @param executionPlanCache execution plan cache option
      * @return built execution plan cache
      */
-    public static LoadingCache<ExecutionPlanCacheKey, SQLFederationExecutionPlan> build(final CacheOption executionPlanCache) {
+    public static LoadingCache<ExecutionPlanCacheKey, SQLFederationExecutionPlan> build(final SQLFederationCacheOption executionPlanCache) {
         return Caffeine.newBuilder().softValues().initialCapacity(executionPlanCache.getInitialCapacity()).maximumSize(executionPlanCache.getMaximumSize()).build(new ExecutionPlanCacheLoader());
     }
 }

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/statement/SQLStatementCompilerEngine.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/statement/SQLStatementCompilerEngine.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.sqlfederation.optimizer.statement;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.optimizer.SQLFederationExecutionPlan;
 import org.apache.shardingsphere.sqlfederation.optimizer.planner.cache.ExecutionPlanCacheBuilder;
 import org.apache.shardingsphere.sqlfederation.optimizer.planner.cache.ExecutionPlanCacheKey;
@@ -30,7 +30,7 @@ public final class SQLStatementCompilerEngine {
     
     private final LoadingCache<ExecutionPlanCacheKey, SQLFederationExecutionPlan> executionPlanCache;
     
-    public SQLStatementCompilerEngine(final CacheOption cacheOption) {
+    public SQLStatementCompilerEngine(final SQLFederationCacheOption cacheOption) {
         executionPlanCache = ExecutionPlanCacheBuilder.build(cacheOption);
     }
     

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/statement/SQLStatementCompilerEngineFactory.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/statement/SQLStatementCompilerEngineFactory.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.sqlfederation.optimizer.statement;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,7 +40,7 @@ public final class SQLStatementCompilerEngineFactory {
      * @param cacheOption execution plan cache option
      * @return SQL statement compiler engine
      */
-    public static SQLStatementCompilerEngine getSQLStatementCompilerEngine(final String databaseName, final String schemaName, final CacheOption cacheOption) {
+    public static SQLStatementCompilerEngine getSQLStatementCompilerEngine(final String databaseName, final String schemaName, final SQLFederationCacheOption cacheOption) {
         String cacheKey = databaseName + "." + schemaName;
         SQLStatementCompilerEngine result = COMPILER_ENGINES.get(cacheKey);
         if (null == result) {

--- a/proxy/backend/type/opengauss/src/test/java/org/apache/shardingsphere/proxy/backend/opengauss/handler/admin/OpenGaussSystemCatalogAdminQueryExecutorTest.java
+++ b/proxy/backend/type/opengauss/src/test/java/org/apache/shardingsphere/proxy/backend/opengauss/handler/admin/OpenGaussSystemCatalogAdminQueryExecutorTest.java
@@ -33,7 +33,6 @@ import org.apache.shardingsphere.infra.session.connection.ConnectionContext;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.FunctionSegment;
@@ -47,6 +46,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.statement.opengauss.dml.OpenGaussSelectStatement;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
 import org.apache.shardingsphere.sqlfederation.rule.SQLFederationRule;
 import org.apache.shardingsphere.test.mock.AutoMockExtension;
@@ -87,7 +87,7 @@ class OpenGaussSystemCatalogAdminQueryExecutorTest {
         ConnectionContext connectionContext = mock(ConnectionContext.class);
         when(connectionSession.getConnectionContext()).thenReturn(connectionContext);
         Collection<ShardingSphereDatabase> databases = Collections.singleton(createDatabase());
-        SQLFederationRule sqlFederationRule = new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, new CacheOption(1, 1L)), databases);
+        SQLFederationRule sqlFederationRule = new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, new SQLFederationCacheOption(1, 1L)), databases);
         when(ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getGlobalRuleMetaData()).thenReturn(mock(RuleMetaData.class));
         OpenGaussSelectStatement sqlStatement = createSelectStatementForPgDatabase();
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(databases,
@@ -150,7 +150,7 @@ class OpenGaussSystemCatalogAdminQueryExecutorTest {
         ConfigurationProperties props = new ConfigurationProperties(new Properties());
         when(ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getProps()).thenReturn(props);
         Collection<ShardingSphereDatabase> databases = Collections.singleton(createDatabase());
-        SQLFederationRule sqlFederationRule = new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, new CacheOption(1, 1L)), databases);
+        SQLFederationRule sqlFederationRule = new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, new SQLFederationCacheOption(1, 1L)), databases);
         OpenGaussSelectStatement sqlStatement = createSelectStatementForVersion();
         ShardingSphereMetaData metaData =
                 new ShardingSphereMetaData(databases, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(Collections.singletonList(sqlFederationRule)), props);
@@ -186,7 +186,7 @@ class OpenGaussSystemCatalogAdminQueryExecutorTest {
         ConfigurationProperties props = new ConfigurationProperties(new Properties());
         when(ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getProps()).thenReturn(props);
         Collection<ShardingSphereDatabase> databases = Collections.singleton(createDatabase());
-        SQLFederationRule sqlFederationRule = new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, new CacheOption(1, 1L)), databases);
+        SQLFederationRule sqlFederationRule = new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, new SQLFederationCacheOption(1, 1L)), databases);
         OpenGaussSelectStatement sqlStatement = createSelectStatementForGsPasswordDeadlineAndIntervalToNum();
         ShardingSphereMetaData metaData =
                 new ShardingSphereMetaData(databases, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(Collections.singletonList(sqlFederationRule)), props);
@@ -224,7 +224,7 @@ class OpenGaussSystemCatalogAdminQueryExecutorTest {
         ConfigurationProperties props = new ConfigurationProperties(new Properties());
         when(ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getProps()).thenReturn(props);
         Collection<ShardingSphereDatabase> databases = Collections.singleton(createDatabase());
-        SQLFederationRule sqlFederationRule = new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, new CacheOption(1, 1L)), databases);
+        SQLFederationRule sqlFederationRule = new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, new SQLFederationCacheOption(1, 1L)), databases);
         OpenGaussSelectStatement sqlStatement = createSelectStatementForGsPasswordNotifyTime();
         ShardingSphereMetaData metaData =
                 new ShardingSphereMetaData(databases, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(Collections.singletonList(sqlFederationRule)), props);


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Use SQLFederationCacheOption to replace CacheOption in SQLFederationRuleConfiguration

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
