### PR TITLE
Add databaseType parameter to federation metadata refresher methods

### DIFF
--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/FederationMetaDataRefreshEngine.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/FederationMetaDataRefreshEngine.java
@@ -53,7 +53,7 @@ public final class FederationMetaDataRefreshEngine {
     @SuppressWarnings("unchecked")
     public void refresh(final SQLStatementContext sqlStatementContext) {
         Class<?> sqlStatementClass = sqlStatementContext.getSqlStatement().getClass().getSuperclass();
-        TypedSPILoader.findService(FederationMetaDataRefresher.class, sqlStatementClass).ifPresent(
-                optional -> optional.refresh(metaDataManagerPersistService, database, SchemaRefreshUtils.getSchemaName(database, sqlStatementContext), sqlStatementContext.getSqlStatement()));
+        TypedSPILoader.findService(FederationMetaDataRefresher.class, sqlStatementClass).ifPresent(optional -> optional.refresh(metaDataManagerPersistService,
+                sqlStatementContext.getDatabaseType(), database, SchemaRefreshUtils.getSchemaName(database, sqlStatementContext), sqlStatementContext.getSqlStatement()));
     }
 }

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/FederationMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/FederationMetaDataRefresher.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mode.metadata.refresher.federation;
 
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPI;
@@ -35,11 +36,12 @@ public interface FederationMetaDataRefresher<T extends SQLStatement> extends Typ
      * Refresh schema.
      *
      * @param metaDataManagerPersistService meta data manager persist service
+     * @param databaseType databaseType
      * @param database database
      * @param schemaName schema name
      * @param sqlStatement SQL statement
      */
-    void refresh(MetaDataManagerPersistService metaDataManagerPersistService, ShardingSphereDatabase database, String schemaName, T sqlStatement);
+    void refresh(MetaDataManagerPersistService metaDataManagerPersistService, DatabaseType databaseType, ShardingSphereDatabase database, String schemaName, T sqlStatement);
     
     @Override
     Class<T> getType();

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/AlterViewFederationMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/AlterViewFederationMetaDataRefresher.java
@@ -36,7 +36,8 @@ import java.util.Optional;
 public final class AlterViewFederationMetaDataRefresher implements FederationMetaDataRefresher<AlterViewStatement> {
     
     @Override
-    public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService, final DatabaseType databaseType, final ShardingSphereDatabase database, final String schemaName, final AlterViewStatement sqlStatement) {
+    public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService,
+                        final DatabaseType databaseType, final ShardingSphereDatabase database, final String schemaName, final AlterViewStatement sqlStatement) {
         String viewName = TableRefreshUtils.getTableName(sqlStatement.getView().getTableName().getIdentifier(), databaseType);
         Optional<SimpleTableSegment> renameView = sqlStatement.getRenameView();
         Collection<ShardingSphereView> alteredViews = new LinkedList<>();

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/AlterViewFederationMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/AlterViewFederationMetaDataRefresher.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mode.metadata.refresher.federation.type;
 
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereView;
 import org.apache.shardingsphere.mode.metadata.refresher.federation.FederationMetaDataRefresher;
@@ -35,8 +36,8 @@ import java.util.Optional;
 public final class AlterViewFederationMetaDataRefresher implements FederationMetaDataRefresher<AlterViewStatement> {
     
     @Override
-    public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService, final ShardingSphereDatabase database, final String schemaName, final AlterViewStatement sqlStatement) {
-        String viewName = TableRefreshUtils.getTableName(sqlStatement.getView().getTableName().getIdentifier(), sqlStatement.getDatabaseType());
+    public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService, final DatabaseType databaseType, final ShardingSphereDatabase database, final String schemaName, final AlterViewStatement sqlStatement) {
+        String viewName = TableRefreshUtils.getTableName(sqlStatement.getView().getTableName().getIdentifier(), databaseType);
         Optional<SimpleTableSegment> renameView = sqlStatement.getRenameView();
         Collection<ShardingSphereView> alteredViews = new LinkedList<>();
         Collection<String> droppedViews = new LinkedList<>();

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/CreateViewFederationMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/CreateViewFederationMetaDataRefresher.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mode.metadata.refresher.federation.type;
 
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereView;
 import org.apache.shardingsphere.mode.metadata.refresher.federation.FederationMetaDataRefresher;
@@ -32,8 +33,8 @@ import java.util.Collections;
 public final class CreateViewFederationMetaDataRefresher implements FederationMetaDataRefresher<CreateViewStatement> {
     
     @Override
-    public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService, final ShardingSphereDatabase database, final String schemaName, final CreateViewStatement sqlStatement) {
-        String viewName = TableRefreshUtils.getTableName(sqlStatement.getView().getTableName().getIdentifier(), sqlStatement.getDatabaseType());
+    public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService, final DatabaseType databaseType, final ShardingSphereDatabase database, final String schemaName, final CreateViewStatement sqlStatement) {
+        String viewName = TableRefreshUtils.getTableName(sqlStatement.getView().getTableName().getIdentifier(), databaseType);
         metaDataManagerPersistService.alterViews(database, schemaName, Collections.singleton(new ShardingSphereView(viewName, sqlStatement.getViewDefinition())));
     }
     

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/CreateViewFederationMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/CreateViewFederationMetaDataRefresher.java
@@ -33,7 +33,8 @@ import java.util.Collections;
 public final class CreateViewFederationMetaDataRefresher implements FederationMetaDataRefresher<CreateViewStatement> {
     
     @Override
-    public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService, final DatabaseType databaseType, final ShardingSphereDatabase database, final String schemaName, final CreateViewStatement sqlStatement) {
+    public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService,
+                        final DatabaseType databaseType, final ShardingSphereDatabase database, final String schemaName, final CreateViewStatement sqlStatement) {
         String viewName = TableRefreshUtils.getTableName(sqlStatement.getView().getTableName().getIdentifier(), databaseType);
         metaDataManagerPersistService.alterViews(database, schemaName, Collections.singleton(new ShardingSphereView(viewName, sqlStatement.getViewDefinition())));
     }

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/DropViewFederationMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/DropViewFederationMetaDataRefresher.java
@@ -32,7 +32,8 @@ import java.util.stream.Collectors;
 public final class DropViewFederationMetaDataRefresher implements FederationMetaDataRefresher<DropViewStatement> {
     
     @Override
-    public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService, final DatabaseType databaseType, final ShardingSphereDatabase database, final String schemaName, final DropViewStatement sqlStatement) {
+    public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService,
+                        final DatabaseType databaseType, final ShardingSphereDatabase database, final String schemaName, final DropViewStatement sqlStatement) {
         Collection<String> droppedViews = sqlStatement.getViews().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList());
         metaDataManagerPersistService.dropViews(database, schemaName, droppedViews);
     }

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/DropViewFederationMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/DropViewFederationMetaDataRefresher.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mode.metadata.refresher.federation.type;
 
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.mode.metadata.refresher.federation.FederationMetaDataRefresher;
 import org.apache.shardingsphere.mode.persist.service.MetaDataManagerPersistService;
@@ -31,7 +32,7 @@ import java.util.stream.Collectors;
 public final class DropViewFederationMetaDataRefresher implements FederationMetaDataRefresher<DropViewStatement> {
     
     @Override
-    public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService, final ShardingSphereDatabase database, final String schemaName, final DropViewStatement sqlStatement) {
+    public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService, final DatabaseType databaseType, final ShardingSphereDatabase database, final String schemaName, final DropViewStatement sqlStatement) {
         Collection<String> droppedViews = sqlStatement.getViews().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList());
         metaDataManagerPersistService.dropViews(database, schemaName, droppedViews);
     }


### PR DESCRIPTION
- Add DatabaseType parameter to refresh methods in AlterView, CreateView, and DropView federated metadata refresher classes
- Update FederationMetaDataRefresher interface to include DatabaseType parameter
- Modify FederationMetaDataRefreshEngine to pass DatabaseType to refresher methods
- This change allows for more flexible and database-aware metadata refreshing in federated queries