### PR TITLE
Remove redundant database type mocks

### DIFF
--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/ddl/ShardingDDLResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/ddl/ShardingDDLResultMergerTest.java
@@ -97,7 +97,6 @@ class ShardingDDLResultMergerTest {
         SelectStatement result = mock(SelectStatement.class, RETURNS_DEEP_STUBS);
         when(result.getFrom()).thenReturn(Optional.of(new SimpleTableSegment(new TableNameSegment(10, 13, new IdentifierValue("tbl")))));
         when(result.getProjections()).thenReturn(new ProjectionsSegment(0, 0));
-        when(result.getDatabaseType()).thenReturn(databaseType);
         return result;
     }
     

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/ddl/fetch/FetchStreamMergedResultTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/ddl/fetch/FetchStreamMergedResultTest.java
@@ -110,7 +110,6 @@ class FetchStreamMergedResultTest {
         CursorStatement cursorStatement = mock(CursorStatement.class);
         SelectStatement selectStatement = mockSelectStatement();
         when(cursorStatement.getSelect()).thenReturn(selectStatement);
-        when(cursorStatement.getDatabaseType()).thenReturn(DATABASE_TYPE);
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("foo_db");
         return new CursorStatementContext(new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock()), Collections.emptyList(), cursorStatement, "foo_db");
@@ -120,7 +119,6 @@ class FetchStreamMergedResultTest {
         SelectStatement result = mock(SelectStatement.class);
         when(result.getProjections()).thenReturn(new ProjectionsSegment(0, 0));
         when(result.getFrom()).thenReturn(Optional.of(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("foo_tbl")))));
-        when(result.getDatabaseType()).thenReturn(DATABASE_TYPE);
         return result;
     }
     

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/tcl/SetTransactionHandler.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/tcl/SetTransactionHandler.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.proxy.backend.handler.tcl;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.database.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
@@ -39,6 +40,8 @@ public final class SetTransactionHandler implements ProxyBackendHandler {
     private final SetTransactionStatement sqlStatement;
     
     private final ConnectionSession connectionSession;
+    
+    private final DatabaseType databaseType;
     
     @Override
     public ResponseHeader execute() {
@@ -63,7 +66,7 @@ public final class SetTransactionHandler implements ProxyBackendHandler {
         if (!sqlStatement.getIsolationLevel().isPresent()) {
             return;
         }
-        DialectTransactionOption transactionOption = new DatabaseTypeRegistry(sqlStatement.getDatabaseType()).getDialectDatabaseMetaData().getTransactionOption();
+        DialectTransactionOption transactionOption = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getTransactionOption();
         connectionSession.setDefaultIsolationLevel(TransactionUtils.getTransactionIsolationLevel(transactionOption.getDefaultIsolationLevel()));
         connectionSession.setIsolationLevel(sqlStatement.getIsolationLevel().get());
     }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/tcl/TCLBackendHandlerFactory.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/tcl/TCLBackendHandlerFactory.java
@@ -78,7 +78,7 @@ public final class TCLBackendHandlerFactory {
                     : new TCLBackendHandler(tclStatement, TransactionOperationType.ROLLBACK, connectionSession);
         }
         if (tclStatement instanceof SetTransactionStatement && OperationScope.GLOBAL != ((SetTransactionStatement) tclStatement).getScope()) {
-            return new SetTransactionHandler((SetTransactionStatement) tclStatement, connectionSession);
+            return new SetTransactionHandler((SetTransactionStatement) tclStatement, connectionSession, sqlStatementContext.getDatabaseType());
         }
         if (tclStatement instanceof XAStatement) {
             return new XATCLHandler(sqlStatementContext, sql, connectionSession);


### PR DESCRIPTION
- Remove unnecessary database type mocking from FetchStreamMergedResultTest and ShardingDDLResultMergerTest
- This change simplifies the test setup by removing redundant mock configurations