### PR TITLE
Remove unused parserDatabaseType parameter

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/generator/PipelineDDLDecorator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/generator/PipelineDDLDecorator.java
@@ -64,25 +64,24 @@ public final class PipelineDDLDecorator {
      * @param schemaName schema name
      * @param targetTableName target table name
      * @param parserEngine parser engine
-     * @param parserDatabaseType parser database type
      * @param sql SQL
      * @return decorated SQL
      */
     public Optional<String> decorate(final DatabaseType databaseType, final String targetDatabaseName, final String schemaName, final String targetTableName,
-                                     final SQLParserEngine parserEngine, final DatabaseType parserDatabaseType, final String sql) {
+                                     final SQLParserEngine parserEngine, final String sql) {
         if (Strings.isNullOrEmpty(sql)) {
             return Optional.empty();
         }
-        String result = decorateActualSQL(targetDatabaseName, targetTableName, parserEngine, parserDatabaseType, sql.trim());
+        String result = decorateActualSQL(targetDatabaseName, targetTableName, parserEngine, databaseType, sql.trim());
         // TODO remove it after set search_path is supported.
         if ("openGauss".equals(databaseType.getType())) {
-            return decorateOpenGauss(targetDatabaseName, schemaName, result, parserEngine, parserDatabaseType);
+            return decorateOpenGauss(targetDatabaseName, schemaName, result, parserEngine, databaseType);
         }
         return Optional.of(result);
     }
     
-    private String decorateActualSQL(final String databaseName, final String targetTableName, final SQLParserEngine parserEngine, final DatabaseType parserDatabaseType, final String sql) {
-        SQLStatementContext sqlStatementContext = parseSQL(databaseName, parserEngine, parserDatabaseType, sql);
+    private String decorateActualSQL(final String databaseName, final String targetTableName, final SQLParserEngine parserEngine, final DatabaseType databaseType, final String sql) {
+        SQLStatementContext sqlStatementContext = parseSQL(databaseName, parserEngine, databaseType, sql);
         Map<SQLSegment, String> replaceMap = new TreeMap<>(Comparator.comparing(SQLSegment::getStartIndex));
         if (sqlStatementContext instanceof CreateTableStatementContext) {
             appendFromIndexAndConstraint(replaceMap, targetTableName, sqlStatementContext);
@@ -102,8 +101,8 @@ public final class PipelineDDLDecorator {
         return doDecorateActualTable(replaceMap, sql);
     }
     
-    private SQLStatementContext parseSQL(final String currentDatabaseName, final SQLParserEngine parserEngine, final DatabaseType parserDatabaseType, final String sql) {
-        return new SQLBindEngine(metaData, currentDatabaseName, new HintValueContext()).bind(parserDatabaseType, parserEngine.parse(sql, true), Collections.emptyList());
+    private SQLStatementContext parseSQL(final String currentDatabaseName, final SQLParserEngine parserEngine, final DatabaseType databaseType, final String sql) {
+        return new SQLBindEngine(metaData, currentDatabaseName, new HintValueContext()).bind(databaseType, parserEngine.parse(sql, true), Collections.emptyList());
     }
     
     private void appendFromIndexAndConstraint(final Map<SQLSegment, String> replaceMap, final String targetTableName, final SQLStatementContext sqlStatementContext) {
@@ -151,15 +150,15 @@ public final class PipelineDDLDecorator {
     
     // TODO remove it after set search_path is supported.
     private Optional<String> decorateOpenGauss(final String databaseName, final String schemaName, final String queryContext,
-                                               final SQLParserEngine parserEngine, final DatabaseType parserDatabaseType) {
+                                               final SQLParserEngine parserEngine, final DatabaseType databaseType) {
         if (queryContext.toLowerCase().startsWith(SET_SEARCH_PATH_PREFIX)) {
             return Optional.empty();
         }
-        return Optional.of(replaceTableNameWithPrefix(queryContext, schemaName, databaseName, parserEngine, parserDatabaseType));
+        return Optional.of(replaceTableNameWithPrefix(queryContext, schemaName, databaseName, parserEngine, databaseType));
     }
     
-    private String replaceTableNameWithPrefix(final String sql, final String schemaName, final String databaseName, final SQLParserEngine parserEngine, final DatabaseType parserDatabaseType) {
-        SQLStatementContext sqlStatementContext = parseSQL(databaseName, parserEngine, parserDatabaseType, sql);
+    private String replaceTableNameWithPrefix(final String sql, final String schemaName, final String databaseName, final SQLParserEngine parserEngine, final DatabaseType databaseType) {
+        SQLStatementContext sqlStatementContext = parseSQL(databaseName, parserEngine, databaseType, sql);
         if (sqlStatementContext instanceof CreateTableStatementContext || sqlStatementContext instanceof CommentStatementContext
                 || sqlStatementContext instanceof CreateIndexStatementContext || sqlStatementContext instanceof AlterTableStatementContext) {
             if (((TableAvailable) sqlStatementContext).getTablesContext().getSimpleTables().isEmpty()) {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/datasource/PipelineJobDataSourcePreparer.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/datasource/PipelineJobDataSourcePreparer.java
@@ -119,7 +119,7 @@ public final class PipelineJobDataSourcePreparer {
                 List<String> createTargetTableSQL = getCreateTargetTableSQL(each, dataSourceManager);
                 for (String sql : createTargetTableSQL) {
                     ShardingSphereMetaData metaData = ((ShardingSphereConnection) targetConnection).getContextManager().getMetaDataContexts().getMetaData();
-                    Optional<String> decoratedSQL = decorateTargetTableSQL(each, param.getSqlParserEngine(), databaseType, metaData, param.getTargetDatabaseName(), sql);
+                    Optional<String> decoratedSQL = decorateTargetTableSQL(each, param.getSqlParserEngine(), metaData, param.getTargetDatabaseName(), sql);
                     if (decoratedSQL.isPresent()) {
                         executeTargetTableSQL(targetConnection, addIfNotExistsForCreateTableSQL(decoratedSQL.get()));
                     }
@@ -139,10 +139,10 @@ public final class PipelineJobDataSourcePreparer {
     }
     
     private Optional<String> decorateTargetTableSQL(final CreateTableConfiguration createTableConfig, final SQLParserEngine sqlParserEngine,
-                                                    final DatabaseType parserDatabaseType, final ShardingSphereMetaData metaData, final String targetDatabaseName, final String sql) {
+                                                    final ShardingSphereMetaData metaData, final String targetDatabaseName, final String sql) {
         String schemaName = createTableConfig.getSourceName().getSchemaName();
         String targetTableName = createTableConfig.getTargetName().getTableName();
-        Optional<String> decoratedSQL = new PipelineDDLDecorator(metaData).decorate(databaseType, targetDatabaseName, schemaName, targetTableName, sqlParserEngine, parserDatabaseType, sql);
+        Optional<String> decoratedSQL = new PipelineDDLDecorator(metaData).decorate(databaseType, targetDatabaseName, schemaName, targetTableName, sqlParserEngine, sql);
         return decoratedSQL.map(String::trim).filter(trimmedSql -> !Strings.isNullOrEmpty(trimmedSql));
     }
     


### PR DESCRIPTION
- Remove parserDatabaseType parameter from PipelineDDLDecorator methods
- Update method signatures and internal logic to use databaseType instead
- Simplify code by reducing the number of parameters passed around