### PR TITLE
Adjust parameter order in InsertStatementContext constructor

### DIFF
--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/fixture/EncryptGeneratorFixtureBuilder.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/fixture/EncryptGeneratorFixtureBuilder.java
@@ -117,7 +117,7 @@ public final class EncryptGeneratorFixtureBuilder {
         ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
         when(database.getSchema("foo_db")).thenReturn(schema);
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(ResourceMetaData.class), mock(RuleMetaData.class), mock(ConfigurationProperties.class));
-        return new InsertStatementContext(metaData, DATABASE_TYPE, params, createInsertStatement(), "foo_db");
+        return new InsertStatementContext(DATABASE_TYPE, createInsertStatement(), params, metaData, "foo_db");
     }
     
     private static InsertStatement createInsertStatement() {
@@ -222,6 +222,6 @@ public final class EncryptGeneratorFixtureBuilder {
         ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
         when(database.getSchema("foo_db")).thenReturn(schema);
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(ResourceMetaData.class), mock(RuleMetaData.class), mock(ConfigurationProperties.class));
-        return new InsertStatementContext(metaData, DATABASE_TYPE, params, createInsertSelectStatement(containsInsertColumns), "foo_db");
+        return new InsertStatementContext(DATABASE_TYPE, createInsertSelectStatement(containsInsertColumns), params, metaData, "foo_db");
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/checker/sql/ddl/ShardingInsertSupportedCheckerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/checker/sql/ddl/ShardingInsertSupportedCheckerTest.java
@@ -82,7 +82,7 @@ class ShardingInsertSupportedCheckerTest {
     private InsertStatementContext createInsertStatementContext(final List<Object> params, final InsertStatement insertStatement) {
         when(database.getName()).thenReturn("foo_db");
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock());
-        return new InsertStatementContext(metaData, databaseType, params, insertStatement, "foo_db");
+        return new InsertStatementContext(databaseType, insertStatement, params, metaData, "foo_db");
     }
     
     @Test

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/ShardingResultMergerEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/ShardingResultMergerEngineTest.java
@@ -89,7 +89,7 @@ class ShardingResultMergerEngineTest {
     private InsertStatementContext createInsertStatementContext(final InsertStatement insertStatement) {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("foo_db");
-        return new InsertStatementContext(new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock()), databaseType, Collections.emptyList(), insertStatement, "foo_db");
+        return new InsertStatementContext(databaseType, insertStatement, Collections.emptyList(), new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock()), "foo_db");
     }
     
     @Test

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/checker/dml/ShardingInsertRouteContextCheckerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/checker/dml/ShardingInsertRouteContextCheckerTest.java
@@ -98,7 +98,7 @@ class ShardingInsertRouteContextCheckerTest {
     private InsertStatementContext createInsertStatementContext(final List<Object> params, final InsertStatement insertStatement) {
         when(database.getName()).thenReturn("foo_db");
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock());
-        return new InsertStatementContext(metaData, databaseType, params, insertStatement, "foo_db");
+        return new InsertStatementContext(databaseType, insertStatement, params, metaData, "foo_db");
     }
     
     @Test

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/SQLStatementContextFactory.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/SQLStatementContextFactory.java
@@ -157,7 +157,7 @@ public final class SQLStatementContextFactory {
             return new DeleteStatementContext(databaseType, (DeleteStatement) sqlStatement);
         }
         if (sqlStatement instanceof InsertStatement) {
-            return new InsertStatementContext(metaData, databaseType, params, (InsertStatement) sqlStatement, currentDatabaseName);
+            return new InsertStatementContext(databaseType, (InsertStatement) sqlStatement, params, metaData, currentDatabaseName);
         }
         if (sqlStatement instanceof CopyStatement) {
             return new CopyStatementContext(databaseType, (CopyStatement) sqlStatement);

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/InsertStatementContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/InsertStatementContext.java
@@ -97,8 +97,8 @@ public final class InsertStatementContext extends CommonSQLStatementContext impl
     
     private GeneratedKeyContext generatedKeyContext;
     
-    public InsertStatementContext(final ShardingSphereMetaData metaData, final DatabaseType databaseType, final List<Object> params,
-                                  final InsertStatement sqlStatement, final String currentDatabaseName) {
+    public InsertStatementContext(final DatabaseType databaseType, final InsertStatement sqlStatement,
+                                  final List<Object> params, final ShardingSphereMetaData metaData, final String currentDatabaseName) {
         super(databaseType, sqlStatement);
         this.metaData = metaData;
         this.databaseType = databaseType;
@@ -106,7 +106,7 @@ public final class InsertStatementContext extends CommonSQLStatementContext impl
         valueExpressions = getAllValueExpressions(sqlStatement);
         AtomicInteger parametersOffset = new AtomicInteger(0);
         insertValueContexts = getInsertValueContexts(params, parametersOffset, valueExpressions);
-        insertSelectContext = getInsertSelectContext(metaData, params, parametersOffset, currentDatabaseName).orElse(null);
+        insertSelectContext = getInsertSelectContext(params, parametersOffset, metaData, currentDatabaseName).orElse(null);
         onDuplicateKeyUpdateValueContext = getOnDuplicateKeyUpdateValueContext(params, parametersOffset).orElse(null);
         tablesContext = new TablesContext(getAllSimpleTableSegments());
         List<String> insertColumnNames = getInsertColumnNames();
@@ -140,8 +140,8 @@ public final class InsertStatementContext extends CommonSQLStatementContext impl
         return result;
     }
     
-    private Optional<InsertSelectContext> getInsertSelectContext(final ShardingSphereMetaData metaData, final List<Object> params,
-                                                                 final AtomicInteger paramsOffset, final String currentDatabaseName) {
+    private Optional<InsertSelectContext> getInsertSelectContext(final List<Object> params, final AtomicInteger paramsOffset,
+                                                                 final ShardingSphereMetaData metaData, final String currentDatabaseName) {
         if (!getSqlStatement().getInsertSelect().isPresent()) {
             return Optional.empty();
         }

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dml/InsertStatementContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/dml/InsertStatementContextTest.java
@@ -87,7 +87,7 @@ class InsertStatementContextTest {
         when(schema.getName()).thenReturn("foo_db");
         when(schema.getVisibleColumnNames("tbl")).thenReturn(Arrays.asList("id", "name", "status"));
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.singleton(schema));
-        return new InsertStatementContext(new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock()), databaseType, params, insertStatement, "foo_db");
+        return new InsertStatementContext(databaseType, insertStatement, params, new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock()), "foo_db");
     }
     
     @Test

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxySQLExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxySQLExecutorTest.java
@@ -279,6 +279,6 @@ class ProxySQLExecutorTest {
         when(sqlStatement.getTable()).thenReturn(Optional.of(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")))));
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("foo_db");
-        return new InsertStatementContext(createShardingSphereMetaData(database), databaseType, Collections.emptyList(), sqlStatement, "foo_db");
+        return new InsertStatementContext(databaseType, sqlStatement, Collections.emptyList(), createShardingSphereMetaData(database), "foo_db");
     }
 }


### PR DESCRIPTION
- Reorder constructor parameters to improve readability and consistency
- Update related test cases and factories to reflect the new parameter order
- This change does not affect functionality but improves code maintainability