### PR TITLE
Remove unused constructor from SQLStatementBinderContext

### DIFF
--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/SQLStatementBinderContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/SQLStatementBinderContext.java
@@ -59,8 +59,4 @@ public final class SQLStatementBinderContext {
     private final Multimap<CaseInsensitiveString, TableSegmentBinderContext> externalTableBinderContexts = LinkedHashMultimap.create();
     
     private final Collection<String> pivotColumnNames = new CaseInsensitiveSet<>();
-    
-    public SQLStatementBinderContext(final ShardingSphereMetaData metaData, final String currentDatabaseName, final HintValueContext hintValueContext, final SQLStatement sqlStatement) {
-        this(metaData, currentDatabaseName, hintValueContext, sqlStatement.getDatabaseType(), sqlStatement);
-    }
 }


### PR DESCRIPTION
- Removed the unused constructor that took SQLStatement as a parameter
- This change simplifies the class structure and removes unnecessary code
