### PR TITLE
Support parse the port in IPv6 jdbcUrl (#35289)

### DIFF
--- a/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/connector/url/StandardJdbcUrlParserTest.java
+++ b/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/connector/url/StandardJdbcUrlParserTest.java
@@ -81,4 +81,13 @@ class StandardJdbcUrlParserTest {
     void assertParseIncorrectURL() {
         assertThrows(UnrecognizedDatabaseURLException.class, () -> new StandardJdbcUrlParser().parse("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL"));
     }
+    
+    @Test
+    void assertParseMySQLJdbcUrlWithIPV6() {
+        JdbcUrl actual = new StandardJdbcUrlParser().parse("jdbc:mysql://[fe80::d114:22b3:a0d9:2b3]:3306/db_test");
+        assertThat(actual.getHostname(), is("fe80::d114:22b3:a0d9:2b3"));
+        assertThat(actual.getPort(), is(3306));
+        assertThat(actual.getDatabase(), is("db_test"));
+        assertTrue(actual.getQueryProperties().isEmpty());
+    }
 }


### PR DESCRIPTION
Fixes #35289.

Changes proposed in this pull request:
  - Support parse the port in IPv6 jdbcUrl

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
