### PR TITLE
Optimize DataSourcePoolPropertiesValidator to ensure that storage units can be connected

### DIFF
--- a/infra/data-source-pool/core/src/main/java/org/apache/shardingsphere/infra/datasource/pool/props/validator/DataSourcePoolPropertiesValidator.java
+++ b/infra/data-source-pool/core/src/main/java/org/apache/shardingsphere/infra/datasource/pool/props/validator/DataSourcePoolPropertiesValidator.java
@@ -77,8 +77,8 @@ public final class DataSourcePoolPropertiesValidator {
         DataSource dataSource = null;
         try {
             dataSource = DataSourcePoolCreator.create(props);
+            checkFailFast(dataSource);
             if (expectedPrivileges.isEmpty() || expectedPrivileges.contains(PrivilegeCheckType.NONE)) {
-                checkFailFast(dataSource);
                 return;
             }
             checkPrivileges(dataSource, props, expectedPrivileges);


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Optimize DataSourcePoolPropertiesValidator to ensure that storage units can be connected

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
