### PR TITLE
Update the outdated description of transaction support in Presto doc

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/presto/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/presto/_index.cn.md
@@ -175,7 +175,7 @@ ShardingSphere JDBC DataSource 尚不支持执行 Presto 的 `create table` 和 
 ### 事务限制
 
 Presto 不支持 ShardingSphere 集成级别的本地事务，XA 事务或 Seata 的 AT 模式事务。
-对于 Presto 在 ShardingSphere 集成级别的本地事务，在 ShardingSphere 一侧存在已知问题。
+Presto 自身的事务支持存在问题，参考 https://github.com/prestodb/presto/issues/25204 。
 
 ### 连接器限制
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/presto/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/presto/_index.en.md
@@ -176,8 +176,7 @@ ShardingSphere JDBC DataSource does not yet support the execution of Presto's `c
 ### Transaction Limitations
 
 Presto does not support local transactions, XA transactions, or Seata's AT mode transactions at the ShardingSphere integration level.
-
-There are known issues on the ShardingSphere side for Presto's local transactions at the ShardingSphere integration level.
+There are bugs with Presto's own transaction support, see https://github.com/prestodb/presto/issues/25204 .
 
 ### Connector Limitations
 

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/TestShardingService.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/TestShardingService.java
@@ -129,8 +129,8 @@ public final class TestShardingService {
     
     /**
      * Process success in Presto Iceberg Connector.
-     * TODO ShardingSphere's Presto integration has a bug in transaction support.
-     *  Can't execute {@code orderItemRepository.assertRollbackWithTransactions();} here.
+     * There are bugs with Presto's transaction support, see <a href="https://github.com/prestodb/presto/issues/25204">prestodb/presto#25204</a> .
+     * Can't execute {@code orderItemRepository.assertRollbackWithTransactions();} here.
      *
      * @throws SQLException SQL exception
      */


### PR DESCRIPTION
For #29052.

Changes proposed in this pull request:
  - Update the outdated description of transaction support in Presto doc.
  - There are bugs with Presto's own transaction support, see https://github.com/prestodb/presto/issues/25204 . This has nothing to do with shardingsphere or `org.apache.shardingsphere.test.natived.jdbc.databases.PrestoTest`.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
