### PR TITLE
Fix NoSuchElementException exception when execute MySQL SHOW VARIABLES without current database

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -59,6 +59,7 @@
 1. JDBC: Fix getting database name from sql statement context - [#34960](https://github.com/apache/shardingsphere/pull/34960)
 1. JDBC: Support set datasource properties type with java.time.Duration - [#35241](https://github.com/apache/shardingsphere/pull/35241)
 1. Proxy: Fix `show processlist` not wait for all nodes - [#35348](https://github.com/apache/shardingsphere/pull/35348)
+1. Proxy: Fix NoSuchElementException exception when execute MySQL SHOW VARIABLES without current database - [#35550](https://github.com/apache/shardingsphere/pull/35550)
 
 ### Change Logs
 

--- a/infra/session/src/main/java/org/apache/shardingsphere/infra/session/query/QueryContext.java
+++ b/infra/session/src/main/java/org/apache/shardingsphere/infra/session/query/QueryContext.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.type.TableAvailable;
 import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
+import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.database.NoDatabaseSelectedException;
 import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.database.UnknownDatabaseException;
 import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
@@ -92,7 +93,7 @@ public final class QueryContext {
     public ShardingSphereDatabase getUsedDatabase() {
         ShardingSpherePreconditions.checkState(usedDatabaseNames.size() <= 1,
                 () -> new UnsupportedSQLOperationException(String.format("Can not support multiple logic databases [%s]", Joiner.on(", ").join(usedDatabaseNames))));
-        String databaseName = usedDatabaseNames.iterator().next();
+        String databaseName = usedDatabaseNames.isEmpty() ? connectionContext.getCurrentDatabaseName().orElseThrow(NoDatabaseSelectedException::new) : usedDatabaseNames.iterator().next();
         ShardingSpherePreconditions.checkState(metaData.containsDatabase(databaseName), () -> new UnknownDatabaseException(databaseName));
         return metaData.getDatabase(databaseName);
     }

--- a/infra/session/src/test/java/org/apache/shardingsphere/infra/session/query/QueryContextTest.java
+++ b/infra/session/src/test/java/org/apache/shardingsphere/infra/session/query/QueryContextTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.session.query;
+
+import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
+import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.database.NoDatabaseSelectedException;
+import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.database.UnknownDatabaseException;
+import org.apache.shardingsphere.infra.hint.HintValueContext;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.session.connection.ConnectionContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class QueryContextTest {
+    
+    @Test
+    void assertGetUsedDatabase() {
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        when(connectionContext.getCurrentDatabaseName()).thenReturn(Optional.of("foo_db"));
+        ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class);
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
+        when(metaData.containsDatabase("foo_db")).thenReturn(true);
+        when(metaData.getDatabase("foo_db")).thenReturn(database);
+        QueryContext actual = new QueryContext(mock(SQLStatementContext.class), "SELECT 1", Collections.emptyList(), mock(HintValueContext.class), connectionContext, metaData);
+        assertThat(actual.getUsedDatabase(), is(database));
+    }
+    
+    @Test
+    void assertGetUsedDatabaseWhenNoDatabaseSelected() {
+        SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class);
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class);
+        when(connectionContext.getCurrentDatabaseName()).thenReturn(Optional.empty());
+        QueryContext queryContext = new QueryContext(sqlStatementContext, "SELECT 1", Collections.emptyList(), mock(HintValueContext.class), connectionContext, metaData);
+        assertThrows(NoDatabaseSelectedException.class, queryContext::getUsedDatabase);
+    }
+    
+    @Test
+    void assertGetUsedDatabaseWhenUseUnknownDatabase() {
+        SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class);
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class);
+        when(connectionContext.getCurrentDatabaseName()).thenReturn(Optional.of("unknown_db"));
+        QueryContext queryContext = new QueryContext(sqlStatementContext, "SELECT 1", Collections.emptyList(), mock(HintValueContext.class), connectionContext, metaData);
+        assertThrows(UnknownDatabaseException.class, queryContext::getUsedDatabase);
+    }
+}


### PR DESCRIPTION
Fixes #35546.

Changes proposed in this pull request:
  - Fix NoSuchElementException exception when execute MySQL SHOW VARIABLES without current database

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
