### PR TITLE
Fix the bug that the Linux Docker Image of Proxy Native cannot be built on Windows

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -133,8 +133,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push Docker Image
         run: |
-          ./mvnw -am -pl distribution/proxy-native -Prelease.native,default-dep,docker.buildx.push.native -B -T1C -DskipTests -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }} clean package
-  
+          ./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.push.native.linux" -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }} clean validate
+          ./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.push.native.linux" -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }}-mostly "-Dproxy.native.dockerfile=Dockerfile-linux-mostly" "-Dproxy.native.image.platform=linux/amd64" clean validate
+          ./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.push.native.linux" -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }}-static "-Dproxy.native.dockerfile=Dockerfile-linux-static" "-Dproxy.native.image.platform=linux/amd64" clean validate
+
   build-agent-image:
     if: github.repository == 'apache/shardingsphere'
     name: Build Agent Image

--- a/distribution/proxy-native/Dockerfile-linux-dynamic
+++ b/distribution/proxy-native/Dockerfile-linux-dynamic
@@ -14,9 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM container-registry.oracle.com/os/oraclelinux:9-slim
+
+FROM ghcr.io/graalvm/native-image-community:22.0.2 AS nativebuild
+WORKDIR /build
+COPY ./ .
+RUN --mount=type=cache,target=/root/.m2 ./mvnw -am -pl distribution/proxy-native -T1C -DskipTests "-Prelease.native" clean package
+
+FROM gcr.io/distroless/java-base-debian12:latest
 LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache.org"
-ENV LOCAL_PATH=/opt/shardingsphere-proxy-native-bin
-ARG OUTPUT_DIRECTORY_NAME
-COPY target/${OUTPUT_DIRECTORY_NAME} ${LOCAL_PATH}
-ENTRYPOINT ["${LOCAL_PATH}/proxy-native", "3307", "${LOCAL_PATH}/conf", "0.0.0.0", "false"]
+ENV LOCAL_PATH=/opt/shardingsphere-proxy
+ARG PROJECT_VERSION
+COPY --from=nativebuild /build/distribution/proxy-native/target/apache-shardingsphere-${PROJECT_VERSION}-shardingsphere-proxy-bin ${LOCAL_PATH}
+ENTRYPOINT ["${LOCAL_PATH}/bin/shardingsphere-proxy-native", "3307", "${LOCAL_PATH}/conf", "0.0.0.0"]

--- a/distribution/proxy-native/Dockerfile-linux-mostly
+++ b/distribution/proxy-native/Dockerfile-linux-mostly
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM ghcr.io/graalvm/native-image-community:22.0.2 AS nativebuild
+WORKDIR /build
+COPY ./ .
+RUN --mount=type=cache,target=/root/.m2 ./mvnw -am -pl distribution/proxy-native -T1C -DskipTests "-Prelease.native" "-DbuildArgs=-H:+AddAllCharsets,-H:+StaticExecutableWithDynamicLibC" clean package
+
+FROM gcr.io/distroless/base-debian12:latest
+LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache.org"
+ENV LOCAL_PATH=/opt/shardingsphere-proxy
+ARG PROJECT_VERSION
+COPY --from=nativebuild /build/distribution/proxy-native/target/apache-shardingsphere-${PROJECT_VERSION}-shardingsphere-proxy-bin ${LOCAL_PATH}
+ENTRYPOINT ["${LOCAL_PATH}/bin/shardingsphere-proxy-native", "3307", "${LOCAL_PATH}/conf", "0.0.0.0"]

--- a/distribution/proxy-native/Dockerfile-linux-static
+++ b/distribution/proxy-native/Dockerfile-linux-static
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM ghcr.io/graalvm/native-image-community:22.0.2-muslib AS nativebuild
+WORKDIR /build
+COPY ./ .
+RUN --mount=type=cache,target=/root/.m2 ./mvnw -am -pl distribution/proxy-native -T1C -DskipTests "-Prelease.native" "-DbuildArgs=-H:+AddAllCharsets,--static,--libc=musl" clean package
+
+FROM scratch
+LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache.org"
+ENV LOCAL_PATH=/opt/shardingsphere-proxy
+ARG PROJECT_VERSION
+COPY --from=nativebuild /build/distribution/proxy-native/target/apache-shardingsphere-${PROJECT_VERSION}-shardingsphere-proxy-bin ${LOCAL_PATH}
+ENTRYPOINT ["${LOCAL_PATH}/bin/shardingsphere-proxy-native", "3307", "${LOCAL_PATH}/conf", "0.0.0.0"]

--- a/distribution/proxy-native/pom.xml
+++ b/distribution/proxy-native/pom.xml
@@ -28,10 +28,12 @@
     <name>${project.artifactId}</name>
     
     <properties>
-        <proxy.native.image.name>proxy-native</proxy.native.image.name>
-        <proxy.native.image.platform>linux/amd64,linux/arm64</proxy.native.image.platform>
+        <proxy.native.image.filename>shardingsphere-proxy-native</proxy.native.image.filename>
+        <proxy.native.folder.prefix>apache-shardingsphere-${project.version}</proxy.native.folder.prefix>
+        <proxy.native.dockerfile>Dockerfile-linux-dynamic</proxy.native.dockerfile>
         <proxy.native.image.repository>apache/shardingsphere-proxy-native</proxy.native.image.repository>
         <proxy.native.image.tag>${project.version}</proxy.native.image.tag>
+        <proxy.native.image.platform>linux/amd64,linux/arm64/v8</proxy.native.image.platform>
     </properties>
     
     <dependencies>
@@ -68,7 +70,7 @@
         <profile>
             <id>release.native</id>
             <build>
-                <finalName>apache-shardingsphere-${project.version}</finalName>
+                <finalName>${proxy.native.folder.prefix}</finalName>
                 <plugins>
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
@@ -77,7 +79,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <mainClass>org.apache.shardingsphere.proxy.Bootstrap</mainClass>
-                            <imageName>${proxy.native.image.name}</imageName>
+                            <imageName>${proxy.native.image.filename}</imageName>
                             <buildArgs>
                                 <buildArg>-H:+AddAllCharsets</buildArg>
                             </buildArgs>
@@ -90,20 +92,13 @@
                                 </goals>
                                 <phase>package</phase>
                             </execution>
-                            <execution>
-                                <id>test-native</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>test</phase>
-                            </execution>
                         </executions>
                     </plugin>
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
                         <configuration>
                             <descriptors>
-                                <descriptor>src/main/assembly/shardingsphere-proxy-native-binary-distribution.xml</descriptor>
+                                <descriptor>src/assembly/shardingsphere-proxy-native-binary-distribution.xml</descriptor>
                             </descriptors>
                         </configuration>
                         <executions>
@@ -124,8 +119,9 @@
             </build>
         </profile>
         <profile>
-            <id>docker.native</id>
+            <id>docker.build.native.linux</id>
             <build>
+                <finalName>${proxy.native.folder.prefix}</finalName>
                 <plugins>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
@@ -137,18 +133,21 @@
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
-                                <phase>package</phase>
+                                <phase>validate</phase>
                                 <configuration>
                                     <executable>docker</executable>
                                     <arguments>
+                                        <argument>buildx</argument>
                                         <argument>build</argument>
                                         <argument>--build-arg</argument>
-                                        <argument>OUTPUT_DIRECTORY_NAME=${project.build.finalName}-shardingsphere-proxy-native-bin</argument>
-                                        <argument>.</argument>
+                                        <argument>PROJECT_VERSION=${project.version}</argument>
                                         <argument>-t</argument>
                                         <argument>${proxy.native.image.repository}:${proxy.native.image.tag}</argument>
                                         <argument>-t</argument>
                                         <argument>${proxy.native.image.repository}:latest</argument>
+                                        <argument>--file</argument>
+                                        <argument>${proxy.native.dockerfile}</argument>
+                                        <argument>../../</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -158,8 +157,9 @@
             </build>
         </profile>
         <profile>
-            <id>docker.buildx.push.native</id>
+            <id>docker.push.native.linux</id>
             <build>
+                <finalName>${proxy.native.folder.prefix}</finalName>
                 <plugins>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
@@ -167,22 +167,21 @@
                         <version>${exec-maven-plugin.version}</version>
                         <executions>
                             <execution>
-                                <id>create builder</id>
+                                <id>create and use builder</id>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
-                                <phase>package</phase>
+                                <phase>validate</phase>
                                 <configuration>
                                     <executable>docker</executable>
                                     <arguments>
                                         <argument>buildx</argument>
                                         <argument>create</argument>
+                                        <argument>--use</argument>
                                         <argument>--driver</argument>
                                         <argument>docker-container</argument>
                                         <argument>--name</argument>
                                         <argument>shardingsphere-builder</argument>
-                                        <argument>--platform</argument>
-                                        <argument>${proxy.native.image.platform}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -191,24 +190,24 @@
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
-                                <phase>package</phase>
+                                <phase>validate</phase>
                                 <configuration>
                                     <executable>docker</executable>
                                     <arguments>
                                         <argument>buildx</argument>
                                         <argument>build</argument>
                                         <argument>--push</argument>
-                                        <argument>--builder</argument>
-                                        <argument>shardingsphere-builder</argument>
                                         <argument>--platform</argument>
                                         <argument>${proxy.native.image.platform}</argument>
                                         <argument>--build-arg</argument>
-                                        <argument>OUTPUT_DIRECTORY_NAME=${project.build.finalName}-shardingsphere-proxy-native-bin</argument>
-                                        <argument>.</argument>
+                                        <argument>PROJECT_VERSION=${project.version}</argument>
                                         <argument>-t</argument>
                                         <argument>${proxy.native.image.repository}:${proxy.native.image.tag}</argument>
                                         <argument>-t</argument>
                                         <argument>${proxy.native.image.repository}:latest</argument>
+                                        <argument>--file</argument>
+                                        <argument>${proxy.native.dockerfile}</argument>
+                                        <argument>../../</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -217,7 +216,7 @@
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
-                                <phase>package</phase>
+                                <phase>validate</phase>
                                 <configuration>
                                     <executable>docker</executable>
                                     <arguments>

--- a/distribution/proxy-native/src/assembly/shardingsphere-proxy-native-binary-distribution.xml
+++ b/distribution/proxy-native/src/assembly/shardingsphere-proxy-native-binary-distribution.xml
@@ -17,7 +17,7 @@
 
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
-    <id>shardingsphere-proxy-native-bin</id>
+    <id>shardingsphere-proxy-bin</id>
     <formats>
         <format>dir</format>
         <format>tar.gz</format>
@@ -28,10 +28,14 @@
         <fileSet>
             <directory>${project.build.directory}</directory>
             <includes>
-                <include>${proxy.native.image.name}</include>
+                <!--dynamic linked, mostly static linked, or fully static linked GraalVM Native Image compiled by Linux-->
+                <include>${proxy.native.image.filename}</include>
                 <include>*.so</include>
+                <!--dynamic linked GraalVM Native Image compiled by Windows-->
+                <include>${proxy.native.image.filename}.exe</include>
+                <include>*.dll</include>
             </includes>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>bin</outputDirectory>
             <fileMode>0755</fileMode>
         </fileSet>
         <fileSet>

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/presto/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/presto/_index.cn.md
@@ -59,9 +59,9 @@ hive.metastore=file
 hive.metastore.catalog.dir=file:/home/iceberg_data
 ```
 
-### 创建业务相关的 schema，库和表
+### 创建业务相关的 schema 和表
 
-通过第三方工具在 Presto 内创建业务相关的 schema，库和表。
+通过第三方工具在 Presto 内创建业务相关的 schema 和表。
 以 DBeaver Community 为例，若使用 Ubuntu 22.04.5，可通过 Snapcraft 快速安装，
 
 ```shell

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/presto/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/presto/_index.en.md
@@ -60,9 +60,9 @@ hive.metastore=file
 hive.metastore.catalog.dir=file:/home/iceberg_data
 ```
 
-### Create business-related schemas, databases, and tables
+### Create business-related schemas and tables
 
-Use third-party tools to create business-related schemas, databases, and tables in Presto.
+Use third-party tools to create business-related schemas and tables in Presto.
 Taking DBeaver Community as an example, if you use Ubuntu 24.04, you can quickly install it through Snapcraft.
 
 ```shell

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -5,204 +5,373 @@ weight = 2
 
 ## 背景信息
 
-本节主要介绍如何通过 `GraalVM` 的 `native-image` 命令行工具构建 ShardingSphere Proxy 的 `GraalVM Native Image`，
-以及包含此 `GraalVM Native Image` 的 `Docker Image`。
+本节主要介绍如何通过 `GraalVM CE` 的 `native-image` 命令行工具构建 ShardingSphere Proxy 的 `GraalVM Native Image`，
+以及包含此 `GraalVM Native Image` 的 `Docker Image`。ShardingSphere Proxy 的 `GraalVM Native Image` 在本文即指代 ShardingSphere Proxy Native。
 
-ShardingSphere Proxy 的 `GraalVM Native Image` 在本文即指代 ShardingSphere Proxy Native。
-
-GraalVM Native Image 的背景信息可参考 https://www.graalvm.org 。
-
-## 注意事项
-
-本节涉及的所有 Docker Image 均不通过 https://downloads.apache.org ，https://repository.apache.org 等 ASF 官方渠道进行分发。
+本节内容涉及的所有 Docker Image 均不通过 https://downloads.apache.org ，https://repository.apache.org 等 ASF 官方渠道进行分发。
 Docker Image 仅在 `GitHub Packages`，`Docker Hub` 等下游渠道提供以方便使用。
 
-Proxy 的 Native Image 产物在 https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-proxy-native 存在每夜构建。
-假设存在包含 `global.yaml` 的 `conf` 文件夹为 `./custom/conf`，你可通过如下的 `docker-compose.yml` 文件进行测试。
-
-```yaml
-services:
-  apache-shardingsphere-proxy-native:
-    image: ghcr.io/apache/shardingsphere-proxy-native:latest
-    volumes:
-      - ./custom/conf:/opt/shardingsphere-proxy-native/conf
-    ports:
-      - "3307:3307"
-```
-
 ShardingSphere Proxy Native 可执行 DistSQL，这意味着实际上不需要任何定义逻辑数据库的 YAML 文件。
+默认情况下，ShardingSphere Proxy Native 中仅包含，
 
-默认情况下，ShardingSphere Proxy Native 的 GraalVM Native Image 中仅包含，
+1. 与 ShardingSphere Proxy 默认配置一致的，一系列 JAR 的编译后产物
+2. ShardingSphere 维护的自有及部分第三方依赖的 GraalVM Reachability Metadata
 
-1. ShardingSphere 维护的自有及部分第三方依赖的 GraalVM Reachability Metadata
-2. H2database, OpenGauss 和 PostgreSQL 的 JDBC Driver
-3. HikariCP 的数据库连接池
-4. Logback 的日志框架
-
-如果用户需要在 ShardingSphere Proxy Native 中使用第三方 JAR，则需要修改 `distribution/proxy-native/pom.xml` 的内容，以构建以下的任意输出，
-
-1. 自定义的 GraalVM Native Image
-2. 包含自定义的 GraalVM Native Image 的自定义 Docker Image
-
-本节假定处于以下的系统环境之一，
+本节内容假定处于以下的系统环境之一，
 
 1. Linux（amd64，aarch64）
 2. MacOS（amd64，aarch64/M1）
 3. Windows（amd64）
 
-若处于 Linux（riscv64）等 Graal compiler 不支持的系统环境，
-请根据 https://medium.com/graalvm/graalvm-native-image-meets-risc-v-899be38eddd9 的内容启用 LLVM backend 来使用 LLVM compiler。
+本节内容依然受到 ShardingSphere JDBC 一侧的 [GraalVM Native Image](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image) 的已记录内容的限制。
 
-用户必须对需要运行 GraalVM Native Image 的每个目标操作系统和目标体系结构，来独立构建不同的 GraalVM Native Image。
-用户可以考虑通过 Docker Image 来部分绕开此限制。
+如果用户需要在 ShardingSphere Proxy Native 中使用第三方 JAR，或者使用 UPX 压缩编译后的 GraalVM Native Image，
+则需要修改 Maven 模块 `org.apache.shardingsphere:shardingsphere-proxy-native-distribution` 的源码。
+参考下文的`从源码构建`一节。
 
-本节依然受到 ShardingSphere JDBC 一侧的 [GraalVM Native Image](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image) 的已记录内容的限制。
+若不需要修改 ShardingSphere Proxy Native 的默认配置，开发者可从`通过夜间构建的 Docker Image 使用`一节开始处理。
 
-## 前提条件
+## 通过夜间构建的 Docker Image 使用
 
-1. 根据 https://www.graalvm.org/downloads/ 要求安装和配置 JDK 22 对应的 `GraalVM Community Edition` 或 `GraalVM Community Edition` 的下游发行版。
-若使用 `SDKMAN!`，
+包含 ShardingSphere Proxy Native 的 Docker Image 在 https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-proxy-native 存在每夜构建。
+ShardingSphere Proxy Native 的默认端口为 `3307`，配置文件从 `/opt/shardingsphere-proxy/conf` 加载。
 
-```shell
-sdk install java 22.0.2-graalce
-sdk use java 22.0.2-graalce
+夜间构建的 Docker Image 存在多种形态的 GraalVM Native Image 的变体 Docker Image Tag。
+
+### 动态链接的 GraalVM Native Image
+
+假设存在包含 `global.yaml` 的 `conf` 文件夹为 `./custom/conf`，
+开发者可通过如下的 Docker Compose 文件对 `动态链接的 GraalVM Native Image` 形态的 ShardingSphere Proxy Native 进行测试。
+
+```yaml
+services:
+  apache-shardingsphere-proxy-native:
+    image: ghcr.io/apache/shardingsphere-proxy-native:da826af47804dae79b1ba5717af86792726745fd
+    volumes:
+      - ./custom/conf:/opt/shardingsphere-proxy/conf
+    ports:
+      - "3307:3307"
 ```
 
-2. 根据 https://www.graalvm.org/jdk23/reference-manual/native-image/#prerequisites 的要求安装本地工具链。
+作为补充，`ghcr.io/apache/shardingsphere-proxy-native:latest`的 Docker Image Tag 将指向 `动态链接的 GraalVM Native Image`。 
 
-3. 如果需要构建 Docker Image， 确保 `Docker Engine` 已安装。
+### 大部分静态链接的 GraalVM Native Image
 
-## 操作步骤
+此节内容仅限于支持运行 `linux/amd64` OS/Arch Containers 的 Container Runtime 使用。
 
-1. 获取 Apache ShardingSphere Git Source
+假设存在包含 `global.yaml` 的 `conf` 文件夹为 `./custom/conf`，
+开发者可通过如下的 Docker Compose 文件对 `大部分静态链接的 GraalVM Native Image` 形态的 ShardingSphere Proxy Native 进行测试。
+只需为特定的，`动态链接的 GraalVM Native Image` 对应的 Docker Image Tag 加上 `-mostly` 后缀。
 
-在[下载页面](https://shardingsphere.apache.org/document/current/en/downloads/)或 https://github.com/apache/shardingsphere/tree/master 获取。
-
-2. 在命令行构建产物, 分两种情形。
-
-情形一：不需要使用存在自定义 SPI 实现的 JAR 或第三方依赖的 JAR 。在 Git Source 同级目录下执行如下命令, 直接完成 Native Image 的构建。
-
-```bash
-cd ./shardingsphere/
-./mvnw -am -pl distribution/proxy-native -T1C -Prelease.native,default-dep -DskipTests clean package
+```yaml
+services:
+  apache-shardingsphere-proxy-native:
+    image: ghcr.io/apache/shardingsphere-proxy-native:da826af47804dae79b1ba5717af86792726745fd-mostly
+    volumes:
+      - ./custom/conf:/opt/shardingsphere-proxy/conf
+    ports:
+      - "3307:3307"
 ```
 
-情形二：需要使用存在自定义 SPI 实现的 JAR 或第三方依赖的 JAR。在 `distribution/proxy-native/pom.xml` 的 `dependencies` 加入如下选项之一，
+### 完全静态链接的 GraalVM Native Image
 
-(1) 存在 SPI 实现的 JAR
-(2) 第三方依赖的 JAR
+此节内容仅限于支持运行 `linux/amd64` OS/Arch Containers 的 Container Runtime 使用。
 
-示例如下，这些 JAR 应预先置入本地 Maven 仓库或 Maven Central 等远程 Maven 仓库。
+假设存在包含 `global.yaml` 的 `conf` 文件夹为 `./custom/conf`，
+开发者可通过如下的 Docker Compose 文件对 `完全静态链接的 GraalVM Native Image` 形态的 ShardingSphere Proxy Native 进行测试。
+只需为特定的，`动态链接的 GraalVM Native Image` 对应的 Docker Image Tag 加上 `-static` 后缀。
+
+```yaml
+services:
+  apache-shardingsphere-proxy-native:
+    image: ghcr.io/apache/shardingsphere-proxy-native:da826af47804dae79b1ba5717af86792726745fd-static
+    volumes:
+      - ./custom/conf:/opt/shardingsphere-proxy/conf
+    ports:
+      - "3307:3307"
+```
+
+## 从源码构建
+
+若从源码构建，开发者有2种选择，
+
+1. 在不安装本地工具链的情况下，构建包含 ShardingSphere Proxy Native 产物的 `Linux Docker Image`
+2. 在安装本地工具链的情况下，构建包含 ShardingSphere Proxy Native 产物。对于 Windows，可通过此途径创建`.exe`形态的 GraalVM Native Image
+
+### 使用存在自定义 SPI 实现的 JAR 或第三方依赖的 JAR
+
+开发者可能需要使用存在自定义 SPI 实现的 JAR 或第三方依赖的 JAR。可在从源码构建前，修改 `distribution/proxy-native/pom.xml` 文件的 `dependencies` 部分。
+一个添加 MySQL JDBC Driver 依赖的示例如下，相关 JAR 应预先置入本地 Maven 仓库或 Maven Central 等远程 Maven 仓库。
 
 ```xml
 <dependencies>
     <dependency>
         <groupId>com.mysql</groupId>
         <artifactId>mysql-connector-j</artifactId>
-        <version>9.0.0</version>
+        <version>9.3.0</version>
     </dependency>
 </dependencies>
 ```
 
-随后通过命令行构建 GraalVM Native Image。
+### 构建 Linux Docker Image
 
-```bash
-cd ./shardingsphere/
-./mvnw -am -pl distribution/proxy-native -T1C -Prelease.native,default-dep -DskipTests clean package
-```
+#### 前提条件
 
-3. 通过命令行启动 Native Image, 需要带上 3 个参数，
-   第 1 个参数为 ShardingSphere Proxy Native 使用的端口，
-   第 2 个参数为用户编写的包含 `global.yaml` 配置文件的文件夹，
-   第 3 个参数为要侦听的主机，如果为 `0.0.0.0` 则允许任意数据库客户端均可访问 ShardingSphere Proxy Native。
+贡献者必须在设备安装，
 
-已完成构建的 GraalVM Native Image 的二进制文件仅可设置命令行参数。这意味着，
+1. OpenJDK 11 或更高版本
+2. 可运行 Linux Containers 的 Docker Engine
 
-(1) 用户仅可在构建 GraalVM Native Image 的过程中设置 JVM 参数
-(2) 用户无法针对已完成构建的 GraalVM Native Image 的二进制文件设置 JVM 参数
+下文分别讨论在 Ubuntu 与 Windows 下可能的所需操作。
 
-假设已存在文件夹`/customAbsolutePath/conf`，示例为，
+##### Ubuntu
 
-```bash
-cd ./shardingsphere/
-cd ./distribution/proxy-native/target/apache-shardingsphere-5.5.2-shardingsphere-proxy-native-bin/
-./proxy-native "3307" "/customAbsolutePath/conf" "0.0.0.0"
-```
-
-4. 如果需要构建 Docker Image, 在添加存在 SPI 实现的依赖或第三方依赖后, 在命令行执行如下命令，
+假设贡献者处于新的 Ubuntu 22.04.5 LTS 实例下，且已配置 git。
+可在 bash 通过如下命令利用 `SDKMAN!` 安装 OpenJDK 21。
 
 ```shell
-cd ./shardingsphere/
-./mvnw -am -pl distribution/proxy-native -T1C -Prelease.native,default-dep,docker.native -DskipTests clean package
+sudo apt install unzip zip -y
+curl -s "https://get.sdkman.io" | bash
+source "$HOME/.sdkman/bin/sdkman-init.sh"
+sdk install java 21.0.7-ms
+sdk use java 21.0.7-ms
 ```
 
-假设存在包含 `global.yaml` 的 `conf` 文件夹为 `./custom/conf`，可通过如下的 `docker-compose.yml` 文件启动包含 GraalVM Native Image 的 Docker Image。
+可在 bash 通过如下命令安装 Rootful 模式的 Docker Engine。本文不讨论更改 `/etc/docker/daemon.json` 的默认 logging driver。
+
+```shell
+sudo apt update && sudo apt upgrade -y
+sudo apt-get remove docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc
+cd /tmp/
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+sudo groupadd docker
+sudo usermod -aG docker $USER
+newgrp docker
+```
+
+##### Windows
+
+假设贡献者处于新的 Windows 11 Home 24H2 实例下，且已安装和配置 `git-for-windows/git` 和 `PowerShell/PowerShell`。
+
+可在 Powershell 7 通过如下命令利用 `version-fox/vfox` 安装 OpenJDK 21。
+
+```shell
+winget install version-fox.vfox
+if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
+# 此时需要打开新的 Powershell 7 终端
+vfox add java
+vfox install java@21.0.7-ms
+vfox use --global java@21.0.7-ms
+```
+
+当 Windows 弹出窗口，要求允许类似 `C:\users\lingh\.version-fox\cache\java\v-21.0.7-ms\java-21.0.7-ms\bin\java.exe` 路径的应用通过 Windows 防火墙时，
+应当批准。 
+背景参考 https://support.microsoft.com/en-us/windows/risks-of-allowing-apps-through-windows-firewall-654559af-3f54-3dcf-349f-71ccd90bcc5c 。
+
+可在 Powershell 7 通过如下命令启用 WSL2 并设置 `Ubuntu WSL` 为默认 Linux 发行版。
+
+```shell
+wsl --install
+```
+
+完成 WSL2 的启用后，在 https://rancherdesktop.io/ 下载和安装 `rancher-sandbox/rancher-desktop`，并设置使用 `dockerd(moby)` 的 `Container Engine`。
+本文不讨论更改 Linux 发行版 `rancher-desktop` 的 `/etc/docker/daemon.json` 的默认 logging driver。
+
+#### 构建包含动态链接的 GraalVM Native Image 的 Docker Image
+
+可执行如下命令构建。
+
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" clean validate
+```
+
+一个可能的 Docker Compose 示例为，
 
 ```yaml
 services:
   apache-shardingsphere-proxy-native:
-    image: apache/shardingsphere-proxy-native:latest
+    image: apache/shardingsphere-proxy-native:5.5.3-SNAPSHOT
     volumes:
-      - ./custom/conf:/opt/shardingsphere-proxy-native/conf
+      - ./custom/conf:/opt/shardingsphere-proxy/conf
     ports:
       - "3307:3307"
 ```
 
-如果用户不对 Git Source 做任何更改，
-上文提及的命令将使用 https://yum.oracle.com/oracle-linux-downloads.html 中的 `container-registry.oracle.com/os/oraclelinux:9-slim` 作为 Base Docker Image。
-但如果用户希望使用 `scratch`，`alpine:3`，`gcr.io/distroless/base-debian12`，
-`gcr.io/distroless/java-base-debian12` 或 `gcr.io/distroless/static-debian12` 等更小体积的 Docker Image 作为 Base Docker Image，
-用户可能需要根据 https://www.graalvm.org/jdk23/reference-manual/native-image/guides/build-static-executables/ 的要求，
-做为 `pom.xml`的 `Maven Profile` 添加 `--static`，`--libc=musl` 或 `--static-nolibc` 的 `buildArgs` 等操作。
+#### 构建包含大部分静态链接的 GraalVM Native Image 的 Docker Image
 
-构建静态链接的 GraalVM Native Image 需要更多系统依赖，且目前不支持为 Linux（aarch64）等环境构建静态链接的 GraalVM Native Image。
-完全静态链接的 GraalVM Native Image 采用的是 musl libc。
-大多数 Linux 系统内置的 musl 已过时，比如 Ubuntu 22.04.5 LTS 使用的 [musl (1.2.2-4) unstable](https://packages.ubuntu.com/jammy/musl)。
-用户总是需要从源代码构建和安装新版本的 musl。
+可执行如下命令构建。
 
-另请注意，某些第三方 Maven 依赖将需要在 `Dockerfile` 安装更多系统库，
-因此请确保根据使用情况调整 `distribution/proxy-native` 下的 `pom.xml` 和 `Dockerfile` 的内容。
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-mostly" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-mostly" clean validate
+```
 
-## 可观察性
+一个可能的 Docker Compose 示例为，
 
-针对 GraalVM Native Image 形态的 ShardingSphere Proxy，其提供的可观察性的能力与[可观察性](/cn/user-manual/shardingsphere-proxy/observability)并不一致。
+```yaml
+services:
+  apache-shardingsphere-proxy-native:
+    image: apache/shardingsphere-proxy-native:5.5.3-SNAPSHOT-mostly
+    volumes:
+      - ./custom/conf:/opt/shardingsphere-proxy/conf
+    ports:
+      - "3307:3307"
+```
 
-用户可以使用 https://www.graalvm.org/jdk23/tools/ 提供的一系列命令行工具或可视化工具观察 GraalVM Native Image 的内部行为，
+#### 构建包含完全静态链接的 GraalVM Native Image 的 Docker Image
+
+可执行如下命令构建。
+
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-static" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-static" clean validate
+```
+
+一个可能的 Docker Compose 示例为，
+
+```yaml
+services:
+  apache-shardingsphere-proxy-native:
+    image: apache/shardingsphere-proxy-native:5.5.3-SNAPSHOT-static
+    volumes:
+      - ./custom/conf:/opt/shardingsphere-proxy/conf
+    ports:
+      - "3307:3307"
+```
+
+### 仅构建产物
+
+#### 前提条件
+
+贡献者必须在设备安装，
+
+1. GraalVM CE 22.0.2，或与 GraalVM CE 22.0.2 兼容的 GraalVM 下游发行版。以 [GraalVM Native Image](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image) 为准。
+2. 编译 GraalVM Native Image 所需要的本地工具链。以 https://www.graalvm.org/latest/reference-manual/native-image/#prerequisites 为准。
+3. 可运行 Linux Containers 的 Docker Engine
+
+在 Ubuntu 与 Windows 下可能的所需操作与[开发和测试](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image/development)一致。
+
+##### 静态编译所需的本地工具链
+
+开发者如需构建 `大部分静态链接的 GraalVM Native Image` 或 `完全静态链接的 GraalVM Native Image`，
+则需要按 https://www.graalvm.org/latest/reference-manual/native-image/guides/build-static-executables/ 要求，从源代码构建 musl。
+
+#### 构建动态链接的 GraalVM Native Image
+
+可执行如下命令构建。
+
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/proxy-native -T1C -DskipTests "-Prelease.native" clean package
+```
+
+#### 构建大部分静态链接的 GraalVM Native Image
+
+可执行如下命令构建。
+
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/proxy-native -T1C -DskipTests "-Prelease.native" "-DbuildArgs=-H:+AddAllCharsets,-H:+StaticExecutableWithDynamicLibC" clean package
+```
+
+#### 构建完全静态链接的 GraalVM Native Image
+
+可执行如下命令构建。
+
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/proxy-native -T1C -DskipTests "-Prelease.native" "-DbuildArgs=-H:+AddAllCharsets,--static,--libc=musl" clean package
+```
+
+#### 使用 GraalVM Native Image
+
+无论 GraalVM Native Image 属于什么变体，通过命令行启动 Native Image, 都需要带上 3 个参数，
+
+1. 第 1 个参数为 ShardingSphere Proxy Native 使用的端口，
+2. 第 2 个参数为用户编写的包含 `global.yaml` 配置文件的文件夹，
+3. 第 3 个参数为要侦听的主机，如果为 `0.0.0.0` 则允许任意数据库客户端均可访问 ShardingSphere Proxy Native。
+
+已完成构建的 GraalVM Native Image 的二进制文件仅可设置命令行参数。这意味着，
+
+1. 用户仅可在构建 GraalVM Native Image 的过程中设置 JVM 参数
+2. 用户无法针对已完成构建的 GraalVM Native Image 的二进制文件设置 JVM 参数
+
+Ubuntu 下假设已存在包含 `global.yaml` 的 `conf` 文件夹为 `/tmp/conf`，可能的示例为，
+
+```bash
+cd ./shardingsphere/
+cd ./distribution/proxy-native/target/apache-shardingsphere-5.5.3-SNAPSHOT-shardingsphere-proxy-bin/bin
+./proxy-native "3307" "/tmp/conf" "0.0.0.0"
+```
+
+Windows 下假设已存在包含 `global.yaml` 的 `conf` 文件夹为 `C:\Users\shard\Downloads\conf`，可能的示例为，
+
+```bash
+cd ./shardingsphere/
+cd ./distribution/proxy-native/target/apache-shardingsphere-5.5.3-SNAPSHOT-shardingsphere-proxy-bin/bin
+./proxy-native.exe "3307" "C:\Users\shard\Downloads\conf" "0.0.0.0"
+```
+
+## 使用限制
+
+### GraalVM Native Image 变体选择
+
+一般情况下开发者仅需使用`动态链接的 GraalVM Native Image`。
+
+当开发者仅使用可运行 `linux/amd64` OS/Arch Containers 的 Container Runtime，并希望获得更小体积的 Docker Image 时，
+可考虑使用 `大部分静态链接的 GraalVM Native Image` 或 `完全静态链接的 GraalVM Native Image`。
+背景参考 https://www.graalvm.org/latest/reference-manual/native-image/guides/build-static-executables/ 和 https://github.com/oracle/graal/issues/2589 。
+大部分静态链接的可执行文件，是 `golang/go` 推广的，针对静态链接 musl libc 实现的另一种替代方案。
+
+### 可观察性
+
+针对 ShardingSphere Proxy Native，其提供的可观察性的能力与[可观察性](/cn/user-manual/shardingsphere-proxy/observability)并不一致。
+
+用户可以使用 https://www.graalvm.org/latest/reference-manual/tools/ 提供的一系列命令行工具或可视化工具观察 GraalVM Native Image 的内部行为，
 并根据其要求在 Linux 下使用 VSCode 完成 Debug 工作。如果用户正在使用 IntelliJ IDEA 并且希望调试生成的 GraalVM Native Image，
 用户可以关注 https://blog.jetbrains.com/idea/2022/06/intellij-idea-2022-2-eap-5/#Experimental_GraalVM_Native_Debugger_for_Java 及其后继。
-
 如果用户使用的不是 Linux，则无法对 GraalVM Native Image 进行 Debug，请关注尚未关闭的 https://github.com/oracle/graal/issues/5648 。
 
 对于使用 `ShardingSphere Agent` 等 Java Agent 的情形， GraalVM 的 `native-image` 组件尚未完全支持在构建 Native Image 时使用 javaagent，
 用户需要关注尚未关闭的 https://github.com/oracle/graal/issues/8177 。
-
 若用户期望在 ShardingSphere Proxy Native 下使用这类 Java Agent，则需要关注 https://github.com/oracle/graal/pull/8077 涉及的变动。
 
-## Seata AT 模式集成
+### `linux/riscv64` OS/Arch 限制
 
-对于 GraalVM Native Image 形态的 ShardingSphere Proxy Native，
-用户始终需要修改 ShardingSphere 源代码以添加 Seata Client 和 Seata 集成的 Maven 模块，并编译为 GraalVM Native Image。
-GraalVM Native Image 形态的 ShardingSphere Proxy Native 无法识别额外添加的 JAR 文件。
+当前，ShardingSphere Proxy Native 未提供在 `linux/riscv64` OS/Arch 上的可用性。如果开发者使用 `linux/riscv64` 设备，
+应参考 https://medium.com/graalvm/graalvm-native-image-meets-risc-v-899be38eddd9 的处理修改 Proxy Native 的构建配置。
 
-```xml
-<project>
-    <dependencies>
-      <dependency>
-         <groupId>org.apache.shardingsphere</groupId>
-         <artifactId>shardingsphere-transaction-base-seata-at</artifactId>
-         <version>${shardingsphere.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.seata</groupId>
-         <artifactId>seata-all</artifactId>
-         <version>2.3.0</version>
-         <exclusions>
-            <exclusion>
-               <groupId>org.antlr</groupId>
-               <artifactId>antlr4-runtime</artifactId>
-            </exclusion>
-         </exclusions>
-      </dependency>
-    </dependencies>
-</project>
-```
+自 https://github.com/oracle/graal/issues/6855 开始，`LLVM backend` 需要从 GraalVM 的源码构建才可使用。
+参考 https://github.com/oracle/graal/blob/master/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMBackend.md 。
+
+### Windows Containers 限制
+
+ShardingSphere Proxy Native 可通过包含 `Microsoft.VisualStudio.2022.Community` 的本地工具链，在 Windows 上开箱即用地构建 GraalVM Native Image。
+
+当前受 https://github.com/graalvm/container/issues/106 影响，
+ShardingSphere 暂时不为通过 Windows 编译的 `动态链接的 GraalVM Native Image` 提供构建 Docker Image 所需的构建配置。
+
+### Wasm 模块限制
+
+尽管 `Oracle GraalVM Early Access Builds For JDK 25 EA 24` 已支持构建 `Wasm 模块`形态的 GraalVM Native Image，
+但 ShardingSphere 尚未准备好在 OpenJDK 25 下测试 CI。
+
+当前，ShardingSphere Proxy Native 未提供编译为 `Wasm 模块` 所需的构建配置。

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -3,213 +3,382 @@ title = "Build GraalVM Native Image(Alpha)"
 weight = 2
 +++
 
-## Background
+## Background information
 
-This section mainly introduces it how to build the `GraalVM Native Image` of ShardingSphere Proxy through the `native-image` command line tool of `GraalVM`,
-and the `Docker Image` containing this `GraalVM Native Image`.
+This section mainly introduces how to build the `GraalVM Native Image` of ShardingSphere Proxy through the `native-image` command line tool of `GraalVM CE`,
+and the `Docker Image` containing this `GraalVM Native Image`. The `GraalVM Native Image` of ShardingSphere Proxy refers to ShardingSphere Proxy Native in this article.
 
-The `GraalVM Native Image` of ShardingSphere Proxy refers to ShardingSphere Proxy Native in this article.
+All Docker Images involved in this section are not distributed through ASF official channels such as https://downloads.apache.org and https://repository.apache.org.
 
-For background information about GraalVM Native Image, please refer to https://www.graalvm.org .
+Docker Images are only provided in downstream channels such as `GitHub Packages` and `Docker Hub` for easy use.
 
-## Notice
+ShardingSphere Proxy Native can execute DistSQL, which means that no YAML file defining the logical database is actually required.
+By default, ShardingSphere Proxy Native only contains,
 
-All Docker images mentioned in this section are not distributed through ASF official channels such as https://downloads.apache.org and https://repository.apache.org .
-Docker images are only provided in downstream channels such as `GitHub Packages` and `Docker Hub` for easy use.
+1. A series of JAR compiled products consistent with the default configuration of ShardingSphere Proxy
+2. ShardingSphere's own and some third-party dependent GraalVM Reachability Metadata
 
-Native Image products of Proxy exist in nightly builds at https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-proxy-native .
-Assuming that there is a `conf` folder containing `global.yaml` as `./custom/conf`, you can test it with the following `docker-compose.yml` file.
-
-```yaml
-services:
-  apache-shardingsphere-proxy-native:
-    image: ghcr.io/apache/shardingsphere-proxy-native:latest
-    volumes:
-      - ./custom/conf:/opt/shardingsphere-proxy-native/conf
-    ports:
-      - "3307:3307"
-```
-
-ShardingSphere Proxy Native can execute DistSQL, which means that no YAML file that defines the logical database is actually required.
-
-By default, the GraalVM Native Image of ShardingSphere Proxy Native only contains,
-
-1. GraalVM Reachability Metadata maintained by ShardingSphere and some third-party dependencies
-2. JDBC Driver for H2database, OpenGauss and PostgreSQL
-3. HikariCP database connection pool
-4. Logback logging framework
-
-If the user needs to use third-party JAR in ShardingSphere Proxy Native,
-the content of `distribution/proxy-native/pom.xml` needs to be modified to build any of the following outputs,
-
-1. Customized GraalVM Native Image
-2. Customized Docker Image containing customized GraalVM Native Image
-
-This section assumes that you are in one of the following system environments:
+This section assumes one of the following system environments,
 
 1. Linux (amd64, aarch64)
 2. MacOS (amd64, aarch64/M1)
 3. Windows (amd64)
 
-If you are in a system environment that Graal compiler does not support, such as Linux (riscv64),
-please enable LLVM backend according to the content of https://medium.com/graalvm/graalvm-native-image-meets-risc-v-899be38eddd9 to use the LLVM compiler.
+This section is still limited by the recorded content of [GraalVM Native Image](/en/user-manual/shardingsphere-jdbc/graalvm-native-image) on the ShardingSphere JDBC side.
 
-Users must build the different GraalVM Native Image for each target operating system and target architecture that they need to run the GraalVM Native Image on.
-Users can consider partially circumventing this limitation by using Docker Image.
+If users need to use third-party JAR in ShardingSphere Proxy Native, or use UPX to compress and compile GraalVM Native Image,
+then they need to modify the source code of the Maven module `org.apache.shardingsphere:shardingsphere-proxy-native-distribution`.
+Refer to the `Build from source code` section below.
 
-This section is still limited by the documented content of the [GraalVM Native Image](/en/user-manual/shardingsphere-jdbc/graalvm-native-image) on the ShardingSphere JDBC side.
+If you do not need to modify the default configuration of ShardingSphere Proxy Native, developers can start from the `Use through the nightly built Docker Image` section.
 
-## Premise
+## Use through nightly built Docker Image
 
-1. Install and configure `GraalVM Community Edition` or a downstream distribution of `GraalVM Community Edition` for JDK 22 according to https://www.graalvm.org/downloads/ .
-   If using `SDKMAN!`,
+The Docker Image containing ShardingSphere Proxy Native is built nightly at https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-proxy-native .
 
-```shell
-sdk install java 22.0.2-graalce
-sdk use java 22.0.2-graalce
+The default port of ShardingSphere Proxy Native is `3307`, and the configuration file is loaded from `/opt/shardingsphere-proxy/conf`.
+
+The nightly built Docker Image has multiple variant Docker Image Tags of GraalVM Native Image.
+
+### Dynamically linked GraalVM Native Image
+
+Assuming that there is a `conf` folder containing `global.yaml` as `./custom/conf`,
+developers can test ShardingSphere Proxy Native in the form of `dynamically linked GraalVM Native Image` through the following Docker Compose file.
+
+```yaml
+services:
+  apache-shardingsphere-proxy-native:
+    image: ghcr.io/apache/shardingsphere-proxy-native:da826af47804dae79b1ba5717af86792726745fd
+    volumes:
+      - ./custom/conf:/opt/shardingsphere-proxy/conf
+    ports:
+      - "3307:3307"
 ```
 
-2. Install the native toolchain according to https://www.graalvm.org/jdk23/reference-manual/native-image/#prerequisites .
+As a supplement, the Docker Image Tag of `ghcr.io/apache/shardingsphere-proxy-native:latest` will point to the `dynamically linked GraalVM Native Image`.
 
-3. If you need to build a Docker Image, make sure `Docker Engine` is installed.
+### Mostly statically linked GraalVM Native Image
 
-## Steps
+This section is limited to the Container Runtime that supports running `linux/amd64` OS/Arch Containers.
 
-1. Get Apache ShardingSphere Git Source
+Assuming that there is a `conf` folder containing `global.yaml` as `./custom/conf`,
+developers can test ShardingSphere Proxy Native in the form of `mostly statically linked GraalVM Native Image` through the following Docker Compose file.
+Just add the `-mostly` suffix to the Docker Image Tag corresponding to the specific, `dynamically linked GraalVM Native Image`.
 
-Get it from [Download page](https://shardingsphere.apache.org/document/current/en/downloads/) or https://github.com/apache/shardingsphere/tree/master .
-
-2. Build the product in the command line, divided into two cases.
-
-Case 1: No need to use JAR with custom SPI implementation or third-party dependent JAR. Execute the following command in the same directory as Git Source to directly complete the construction of Native Image.
-
-```bash
-cd ./shardingsphere/
-./mvnw -am -pl distribution/proxy-native -T1C -Prelease.native,default-dep -DskipTests clean package
+```yaml
+services:
+  apache-shardingsphere-proxy-native:
+    image: ghcr.io/apache/shardingsphere-proxy-native:da826af47804dae79b1ba5717af86792726745fd-mostly
+    volumes:
+      - ./custom/conf:/opt/shardingsphere-proxy/conf
+    ports:
+      - "3307:3307"
 ```
 
-Case 2: Need to use JAR with custom SPI implementation or third-party dependent JAR. Add one of the following options to the `dependencies` of `distribution/proxy-native/pom.xml`:
+### Fully statically linked GraalVM Native Image
 
-(1) JARs with SPI implementations
-(2) JARs with third-party dependencies
+This section is limited to Container Runtime that supports running `linux/amd64` OS/Arch Containers.
 
-The examples are as follows.
-These JARs should be pre-placed in the local Maven repository or a remote Maven repository such as Maven Central.
+Assuming that there is a `conf` folder containing `global.yaml` as `./custom/conf`,
+Developers can test ShardingSphere Proxy Native in the form of `fully statically linked GraalVM Native Image` through the following Docker Compose file.
+Just add the `-static` suffix to the Docker Image Tag corresponding to the specific, `dynamically linked GraalVM Native Image`.
+
+```yaml
+services:
+  apache-shardingsphere-proxy-native:
+    image: ghcr.io/apache/shardingsphere-proxy-native:da826af47804dae79b1ba5717af86792726745fd-static
+    volumes:
+      - ./custom/conf:/opt/shardingsphere-proxy/conf
+    ports:
+      - "3307:3307"
+```
+
+## Build from source code
+
+If you build from source code, developers have two options,
+
+1. Build a `Linux Docker Image` containing ShardingSphere Proxy Native products without installing a local toolchain
+
+2. Build a ShardingSphere Proxy Native product with a local toolchain installed. For Windows, you can create a GraalVM Native Image in the form of `.exe` in this way
+
+### Use JARs with custom SPI implementations or third-party dependent JARs
+
+Developers may need to use JARs with custom SPI implementations or third-party dependent JARs. Before building from source code, modify the `dependencies` section of the `distribution/proxy-native/pom.xml` file.
+An example of adding a MySQL JDBC Driver dependency is as follows. The relevant JAR should be pre-placed in the local Maven repository or a remote Maven repository such as Maven Central.
 
 ```xml
 <dependencies>
     <dependency>
         <groupId>com.mysql</groupId>
         <artifactId>mysql-connector-j</artifactId>
-        <version>9.0.0</version>
+        <version>9.3.0</version>
     </dependency>
 </dependencies>
 ```
 
-Then build the GraalVM Native Image through the command line.
+### Build Linux Docker Image
 
-```bash
-cd ./shardingsphere/
-./mvnw -am -pl distribution/proxy-native -T1C -Prelease.native,default-dep -DskipTests clean package
-```
+#### Prerequisites
 
-3. To start Native Image through the command line, you need to bring 3 parameters.
-   The first parameter is the port used by ShardingSphere Proxy Native.
-   The second parameter is the folder containing the `global.yaml` configuration file written by the user.
-   The third parameter is the host to listen to. If it is `0.0.0.0`, any database client is allowed to access ShardingSphere Proxy Native.
+Contributors must have installed on their devices,
 
-Only command line parameters can be set for binaries of built GraalVM Native Images. This means that:
+1. OpenJDK 11 or higher
 
-(1) Users can only set JVM parameters during the process of building a GraalVM Native Image
-(2) Users cannot set JVM parameters for binaries of built GraalVM Native Images
+2. Docker Engine that can run Linux Containers
 
-Assuming the folder `/customAbsolutePath/conf` already exists, the example is.
+The following sections discuss possible required operations under Ubuntu and Windows respectively.
 
-```bash
-cd ./shardingsphere/
-cd ./distribution/proxy-native/target/apache-shardingsphere-5.5.2-shardingsphere-proxy-native-bin/
-./proxy-native "3307" "/customAbsolutePath/conf" "0.0.0.0"
-```
+##### Ubuntu
 
-4. If you need to build a Docker Image, after adding the dependencies that have SPI implementation or third-party dependencies,
-   execute the following command in the command line:
+It is assumed that the contributor is on a fresh Ubuntu 22.04.5 LTS instance with git configured.
+
+OpenJDK 21 can be installed using `SDKMAN!` in bash using the following command.
 
 ```shell
-cd ./shardingsphere/
-./mvnw -am -pl distribution/proxy-native -T1C -Prelease.native,default-dep,docker.native -DskipTests clean package
+sudo apt install unzip zip -y
+curl -s "https://get.sdkman.io" | bash
+source "$HOME/.sdkman/bin/sdkman-init.sh"
+sdk install java 21.0.7-ms
+sdk use java 21.0.7-ms
 ```
 
-Assuming that there is a conf folder called `./custom/conf` containing `global.yaml`,
-you can start the Docker Image containing the GraalVM Native Image using the following `docker-compose.yml` file,
+You can install Docker Engine in rootful mode by running the following command in bash. This article does not discuss changing the default logging driver in `/etc/docker/daemon.json`.
+
+```shell
+sudo apt update && sudo apt upgrade -y
+sudo apt-get remove docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc
+cd /tmp/
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+sudo groupadd docker
+sudo usermod -aG docker $USER
+newgrp docker
+```
+
+##### Windows
+
+Assuming the contributor is on a fresh Windows 11 Home 24H2 instance with `git-for-windows/git` and `PowerShell/PowerShell` installed and configured.
+
+OpenJDK 21 can be installed using `version-fox/vfox` in Powershell 7 using the following command.
+
+```shell
+winget install version-fox.vfox
+if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
+# At this time, you need to open a new Powershell 7 terminal
+vfox add java
+vfox install java@21.0.7-ms
+vfox use --global java@21.0.7-ms
+```
+
+When Windows pops up a window asking you to allow an application with a path like `C:\users\lingh\.version-fox\cache\java\v-21.0.7-ms\java-21.0.7-ms\bin\java.exe` to pass through Windows Firewall,
+you should approve it.
+Background reference https://support.microsoft.com/en-us/windows/risks-of-allowing-apps-through-windows-firewall-654559af-3f54-3dcf-349f-71ccd90bcc5c .
+
+You can enable WSL2 and set `Ubuntu WSL` as the default Linux distribution in Powershell 7 with the following command.
+
+```shell
+wsl --install
+```
+
+After enabling WSL2, download and install `rancher-sandbox/rancher-desktop` from https://rancherdesktop.io/ and set up `Container Engine` using `dockerd(moby)`.
+This article does not discuss changing the default logging driver in `/etc/docker/daemon.json` of the Linux distribution `rancher-desktop`.
+
+#### Build a Docker Image with a dynamically linked GraalVM Native Image
+
+You can execute the following command to build.
+
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" clean validate
+```
+
+A possible Docker Compose example is,
 
 ```yaml
 services:
   apache-shardingsphere-proxy-native:
-    image: apache/shardingsphere-proxy-native:latest
+    image: apache/shardingsphere-proxy-native:5.5.3-SNAPSHOT
     volumes:
-      - ./custom/conf:/opt/shardingsphere-proxy-native/conf
+      - ./custom/conf:/opt/shardingsphere-proxy/conf
     ports:
       - "3307:3307"
 ```
 
-If the user does not make any changes to the Git Source,
-the above mentioned command will use `container-registry.oracle.com/os/oraclelinux:9-slim` in https://yum.oracle.com/oracle-linux-downloads.html as the Base Docker Image.
-But if the user wants to use a smaller Docker Image such as `scratch`, `alpine:3`, `gcr.io/distroless/base-debian12`,
-`gcr.io/distroless/java-base-debian12` or `gcr.io/distroless/static-debian12` as the Base Docker Image,
-the user may need to add `--static`,
-`--libc=musl` or `--static-nolibc` to the `Maven Profile` of `pom.xml` as required by https://www.graalvm.org/jdk23/reference-manual/native-image/guides/build-static-executables/ and other operations such as `buildArgs`.
+#### Build a Docker Image containing most of the statically linked GraalVM Native Image
 
-Building a statically linked GraalVM Native Image requires more system dependencies,
-and currently does not support building statically linked GraalVM Native Images for environments such as Linux (aarch64).
-Fully statically linked GraalVM Native Images use musl libc.
-Most Linux systems come with outdated musl, such as Ubuntu 22.04.5 LTS which uses [musl (1.2.2-4) unstable](https://packages.ubuntu.com/jammy/musl).
-Users always need to build and install a new version of musl from source.
+You can execute the following command to build.
 
-Also note that some third-party Maven dependencies will require more system libraries to be installed in the `Dockerfile`,
-so make sure to adjust the contents of `pom.xml` and `Dockerfile` under `distribution/proxy-native` according to your usage.
-
-## Observability
-
-The observability provided by ShardingSphere Proxy in the form of GraalVM Native Image is not consistent with [observability](/cn/user-manual/shardingsphere-proxy/observability).
-
-Users can use a series of command-line tools or visualization tools provided by https://www.graalvm.org/jdk23/tools/ to observe the internal behavior of GraalVM Native Image,
-and use VSCode under Linux to complete debugging work according to their requirements.
-If the user is using IntelliJ IDEA and wants to debug the generated GraalVM Native Image,
-the user can follow https://blog.jetbrains.com/idea/2022/06/intellij-idea-2022-2-eap-5/#Experimental_GraalVM_Native_Debugger_for_Java and its successors.
-
-If the user is not using Linux, the GraalVM Native Image cannot be debugged.
-Please follow https://github.com/oracle/graal/issues/5648 which has not been closed.
-
-For Java Agents such as `ShardingSphere Agent`, the `native-image` component of GraalVM does not fully support the use of javaagent when building Native Image.
-Users need to pay attention to https://github.com/oracle/graal/issues/8177 which has not been closed.
-
-If users expect to use such Java Agents under ShardingSphere Proxy Native, they need to pay attention to the changes involved in https://github.com/oracle/graal/pull/8077 .
-
-## Seata AT mode integration
-
-For ShardingSphere Proxy Native in GraalVM Native Image,
-Users always need to modify the ShardingSphere source code to add the Seata Client and Seata integrated Maven modules and compile them into GraalVM Native Image.
-ShardingSphere Proxy Native in GraalVM Native Image cannot recognize the additional JAR files.
-
-```xml
-<project>
-    <dependencies>
-      <dependency>
-         <groupId>org.apache.shardingsphere</groupId>
-         <artifactId>shardingsphere-transaction-base-seata-at</artifactId>
-         <version>${shardingsphere.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.seata</groupId>
-         <artifactId>seata-all</artifactId>
-         <version>2.3.0</version>
-         <exclusions>
-            <exclusion>
-               <groupId>org.antlr</groupId>
-               <artifactId>antlr4-runtime</artifactId>
-            </exclusion>
-         </exclusions>
-      </dependency>
-    </dependencies>
-</project>
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-mostly" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-mostly" clean validate
 ```
+
+A possible Docker Compose example is,
+
+```yaml
+services:
+  apache-shardingsphere-proxy-native:
+    image: apache/shardingsphere-proxy-native:5.5.3-SNAPSHOT-mostly
+    volumes:
+      - ./custom/conf:/opt/shardingsphere-proxy/conf
+    ports:
+      - "3307:3307"
+```
+
+#### Build a Docker Image containing a fully statically linked GraalVM Native Image
+
+You can execute the following command to build.
+
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-static" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-static" clean validate
+```
+
+A possible Docker Compose example is,
+
+```yaml
+services:
+  apache-shardingsphere-proxy-native:
+    image: apache/shardingsphere-proxy-native:5.5.3-SNAPSHOT-static
+    volumes:
+      - ./custom/conf:/opt/shardingsphere-proxy/conf
+    ports:
+      - "3307:3307"
+```
+
+### Build only
+
+#### Prerequisites
+
+Contributors must have installed on their devices,
+
+1. GraalVM CE 22.0.2, or a GraalVM downstream distribution compatible with GraalVM CE 22.0.2. Refer to [GraalVM Native Image](/en/user-manual/shardingsphere-jdbc/graalvm-native-image).
+2. The native toolchain required to compile GraalVM Native Image. Refer to https://www.graalvm.org/latest/reference-manual/native-image/#prerequisites .
+3. Docker Engine that can run Linux Containers
+
+The possible required operations under Ubuntu and Windows are consistent with [Development and test](/en/user-manual/shardingsphere-jdbc/graalvm-native-image/development).
+
+##### Native toolchain for static compilation
+
+Developers who want to build a `mostly statically linked GraalVM Native Image` or a `fully statically linked GraalVM Native Image`,
+will need to build musl from source as described in https://www.graalvm.org/latest/reference-manual/native-image/guides/build-static-executables/ .
+
+#### Build a dynamically linked GraalVM Native Image
+
+You can execute the following command to build it.
+
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/proxy-native -T1C -DskipTests "-Prelease.native" clean package
+```
+
+#### Build most statically linked GraalVM Native Images
+
+You can execute the following command to build.
+
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/proxy-native -T1C -DskipTests "-Prelease.native" "-DbuildArgs=-H:+AddAllCharsets,-H:+StaticExecutableWithDynamicLibC" clean package
+```
+
+#### Build a fully statically linked GraalVM Native Image
+
+You can execute the following command to build.
+
+```shell
+git clone git@github.com:apache/shardingsphere.git
+cd ./shardingsphere/
+./mvnw -am -pl distribution/proxy-native -T1C -DskipTests "-Prelease.native" "-DbuildArgs=-H:+AddAllCharsets,--static,--libc=musl" clean package
+```
+
+#### Use GraalVM Native Image
+
+No matter what variant the GraalVM Native Image is, you need to bring 3 parameters to start the Native Image through the command line.
+
+1. The first parameter is the port used by ShardingSphere Proxy Native,
+2. The second parameter is the folder containing the `global.yaml` configuration file written by the user,
+3. The third parameter is the host to listen to. If it is `0.0.0.0`, any database client can access ShardingSphere Proxy Native.
+
+The binary file of the built GraalVM Native Image can only set command line parameters. This means that,
+
+1. Users can only set JVM parameters during the process of building GraalVM Native Image
+2. Users cannot set JVM parameters for the binary file of the built GraalVM Native Image
+
+On Ubuntu, assuming that the `conf` folder containing `global.yaml` is `/tmp/conf`, possible example is,
+
+```bash
+cd ./shardingsphere/
+cd ./distribution/proxy-native/target/apache-shardingsphere-5.5.3-SNAPSHOT-shardingsphere-proxy-bin/bin
+./proxy-native "3307" "/tmp/conf" "0.0.0.0"
+```
+
+On Windows, assuming that a `conf` folder containing `global.yaml` already exists at `C:\Users\shard\Downloads\conf`, a possible example is,
+
+```bash
+cd ./shardingsphere/
+cd ./distribution/proxy-native/target/apache-shardingsphere-5.5.3-SNAPSHOT-shardingsphere-proxy-bin/bin
+./proxy-native.exe "3307" "C:\Users\shard\Downloads\conf" "0.0.0.0"
+```
+
+## Usage restrictions
+
+### GraalVM Native Image variant selection
+
+In general, developers only need to use `dynamically linked GraalVM Native Image`.
+
+When developers only use the Container Runtime that can run `linux/amd64` OS/Arch Containers and want to get a smaller Docker Image,
+consider using `mostly statically linked GraalVM Native Image` or `fully statically linked GraalVM Native Image`.
+
+For background, see https://www.graalvm.org/latest/reference-manual/native-image/guides/build-static-executables/ and https://github.com/oracle/graal/issues/2589.
+Mostly statically linked executables are an alternative to statically linked musl libc implementations promoted by `golang/go`.
+
+### Observability
+
+For ShardingSphere Proxy Native, the observability capabilities it provides are not consistent with [Observability](/en/user-manual/shardingsphere-proxy/observability).
+
+Users can use a series of command-line tools or visualization tools provided by https://www.graalvm.org/latest/reference-manual/tools/ to observe the internal behavior of GraalVM Native Image,
+and use VSCode under Linux to complete the debugging work according to their requirements. If the user is using IntelliJ IDEA and wants to debug the generated GraalVM Native Image,
+the user can follow https://blog.jetbrains.com/idea/2022/06/intellij-idea-2022-2-eap-5/#Experimental_GraalVM_Native_Debugger_for_Java and its successors.
+If the user is not using Linux, the GraalVM Native Image cannot be debugged. Please pay attention to https://github.com/oracle/graal/issues/5648 which has not been closed.
+
+For the use of Java Agents such as `ShardingSphere Agent`, the `native-image` component of GraalVM does not fully support the use of javaagent when building Native Image.
+Users need to pay attention to https://github.com/oracle/graal/issues/8177 which has not been closed.
+If users expect to use such Java Agents under ShardingSphere Proxy Native, they need to pay attention to the changes involved in https://github.com/oracle/graal/pull/8077.
+
+### `linux/riscv64` OS/Arch limitation
+
+Currently, ShardingSphere Proxy Native does not provide availability on `linux/riscv64` OS/Arch. If developers use the `linux/riscv64` device,
+they should refer to https://medium.com/graalvm/graalvm-native-image-meets-risc-v-899be38eddd9 to modify the build configuration of Proxy Native.
+
+Since https://github.com/oracle/graal/issues/6855, `LLVM backend` needs to be built from the source code of GraalVM to be used.
+
+See https://github.com/oracle/graal/blob/master/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMBackend.md .
+
+### Windows Containers Limitations
+
+ShardingSphere Proxy Native can build GraalVM Native Image on Windows out of the box with a local toolchain containing `Microsoft.VisualStudio.2022.Community`.
+
+Currently affected by https://github.com/graalvm/container/issues/106,
+ShardingSphere does not provide the build configuration required to build Docker Image for `Dynamically Linked GraalVM Native Image` compiled through Windows.
+
+### Wasm Module Limitations
+
+Although `Oracle GraalVM Early Access Builds For JDK 25 EA 24` already supports building GraalVM Native Image in the form of `Wasm Module`,
+ShardingSphere is not yet ready to test CI under OpenJDK 25.
+
+Currently, ShardingSphere Proxy Native does not provide the build configuration required to compile to `Wasm Module`.


### PR DESCRIPTION
For #35052.

Changes proposed in this pull request:
  - Fix the bug that the Linux Docker Image of Proxy Native cannot be built on Windows. Previously, Proxy Native had a logic vulnerability when compiled on Windows. It was built as an executable file that was only available on Windows, but it was tried to be put into a Linux container. 
  - In Dockerfile, continue to remove `Force Start` which was not removed cleanly in #35566 .
  - Starting from the current PR, it is supported to build mostly statically linked or fully static Linux Docker Images on Windows or Linux out of the box.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
