### PR TITLE
Removed documentation information about sharding_table_statistics

### DIFF
--- a/docs/document/content/reference/management/_index.cn.md
+++ b/docs/document/content/reference/management/_index.cn.md
@@ -95,13 +95,12 @@ namespace
    ├    ├     ├──${databaseName.groupName.dataSourceName} 
    ├    ├     ├──${databaseName.groupName.dataSourceName}
    ├──statistics
-   ├    ├──shardingsphere
-   ├    ├     ├──schemas
-   ├    ├     ├     ├──shardingsphere
-   ├    ├     ├     ├     ├──tables             # 系统表
-   ├    ├     ├     ├     ├     ├──sharding_table_statistics    # 分片统计表数据
-   ├    ├     ├     ├     ├     ├     ├──8a2dcb0d97c3d86ef77b3d4651a1d7d0  # md5
-   ├    ├     ├     ├     ├     ├──cluster_information    # 集群信息表
+   ├    ├──databases
+   ├    ├     ├──shardingsphere
+   ├    ├     ├     ├──schemas
+   ├    ├     ├     ├     ├──shardingsphere
+   ├    ├     ├     ├     ├     ├──tables # 系统表
+   ├    ├     ├     ├     ├     ├   ├──cluster_information    # 集群信息表
 ```
 
 ### /rules

--- a/docs/document/content/reference/management/_index.en.md
+++ b/docs/document/content/reference/management/_index.en.md
@@ -95,13 +95,12 @@ namespace
    ├    ├     ├──${databaseName.groupName.dataSourceName}
    ├    ├     ├──${databaseName.groupName.dataSourceName}
    ├──statistics
-   ├    ├──shardingsphere
-   ├    ├     ├──schemas
-   ├    ├     ├     ├──shardingsphere
-   ├    ├     ├     ├     ├──tables             # system tables
-   ├    ├     ├     ├     ├     ├──sharding_table_statistics    # sharding statistics table
-   ├    ├     ├     ├     ├     ├     ├──8a2dcb0d97c3d86ef77b3d4651a1d7d0  # md5
-   ├    ├     ├     ├     ├     ├──cluster_information    # cluster information table
+   ├    ├──databases
+   ├    ├     ├──shardingsphere
+   ├    ├     ├     ├──schemas
+   ├    ├     ├     ├     ├──shardingsphere
+   ├    ├     ├     ├     ├     ├──tables # system tables
+   ├    ├     ├     ├     ├     ├   ├──cluster_information    # cluster information table
 ```
 
 ### /rules


### PR DESCRIPTION
Fixes #35563.

Changes proposed in this pull request:
  - Removed documentation information about sharding_table_statistics

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
