### PR TITLE
Fix CI failure for arm64 Image build of Proxy Native

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -114,28 +114,32 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'ubuntu-24.04-arm' ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-id }}
-      - uses: graalvm/setup-graalvm@v1
+      - uses: actions/setup-java@v4
         with:
-          java-version: '22.0.2'
-          distribution: 'graalvm-community'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          distribution: 'temurin'
+          java-version: 11
           cache: 'maven'
-          native-image-job-reports: 'true'
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.HUB }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push Docker Image
+      - name: Push Docker Image by arm64 or x64
         run: |
-          ./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.push.native.linux" -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }} clean validate
-          ./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.push.native.linux" -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }}-mostly "-Dproxy.native.dockerfile=Dockerfile-linux-mostly" "-Dproxy.native.image.platform=linux/amd64" clean validate
-          ./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.push.native.linux" -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }}-static "-Dproxy.native.dockerfile=Dockerfile-linux-static" "-Dproxy.native.image.platform=linux/amd64" clean validate
+          ./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.push.native.linux" -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }} "-DskipTests" clean package
+      - name: Push Docker Image by x64
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          ./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.push.native.linux" -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }}-mostly "-Dproxy.native.dockerfile=Dockerfile-linux-mostly" "-DskipTests" clean package
+          ./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.push.native.linux" -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }}-static "-Dproxy.native.dockerfile=Dockerfile-linux-static" "-DskipTests" clean package
 
   build-agent-image:
     if: github.repository == 'apache/shardingsphere'

--- a/distribution/proxy-native/pom.xml
+++ b/distribution/proxy-native/pom.xml
@@ -33,7 +33,6 @@
         <proxy.native.dockerfile>Dockerfile-linux-dynamic</proxy.native.dockerfile>
         <proxy.native.image.repository>apache/shardingsphere-proxy-native</proxy.native.image.repository>
         <proxy.native.image.tag>${project.version}</proxy.native.image.tag>
-        <proxy.native.image.platform>linux/amd64,linux/arm64/v8</proxy.native.image.platform>
     </properties>
     
     <dependencies>
@@ -167,25 +166,6 @@
                         <version>${exec-maven-plugin.version}</version>
                         <executions>
                             <execution>
-                                <id>create and use builder</id>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <phase>validate</phase>
-                                <configuration>
-                                    <executable>docker</executable>
-                                    <arguments>
-                                        <argument>buildx</argument>
-                                        <argument>create</argument>
-                                        <argument>--use</argument>
-                                        <argument>--driver</argument>
-                                        <argument>docker-container</argument>
-                                        <argument>--name</argument>
-                                        <argument>shardingsphere-builder</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                            <execution>
                                 <id>build and push docker image</id>
                                 <goals>
                                     <goal>exec</goal>
@@ -197,8 +177,6 @@
                                         <argument>buildx</argument>
                                         <argument>build</argument>
                                         <argument>--push</argument>
-                                        <argument>--platform</argument>
-                                        <argument>${proxy.native.image.platform}</argument>
                                         <argument>--build-arg</argument>
                                         <argument>PROJECT_VERSION=${project.version}</argument>
                                         <argument>-t</argument>
@@ -208,21 +186,6 @@
                                         <argument>--file</argument>
                                         <argument>${proxy.native.dockerfile}</argument>
                                         <argument>../../</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>cleanup builder</id>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <phase>validate</phase>
-                                <configuration>
-                                    <executable>docker</executable>
-                                    <arguments>
-                                        <argument>buildx</argument>
-                                        <argument>rm</argument>
-                                        <argument>shardingsphere-builder</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -195,7 +195,7 @@ wsl --install
 ```shell
 git clone git@github.com:apache/shardingsphere.git
 cd ./shardingsphere/
-./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" clean validate
+./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-DskipTests" clean package
 ```
 
 一个可能的 Docker Compose 示例为，
@@ -217,7 +217,7 @@ services:
 ```shell
 git clone git@github.com:apache/shardingsphere.git
 cd ./shardingsphere/
-./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-mostly" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-mostly" clean validate
+./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-mostly" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-mostly" "-DskipTests" clean package
 ```
 
 一个可能的 Docker Compose 示例为，
@@ -239,7 +239,7 @@ services:
 ```shell
 git clone git@github.com:apache/shardingsphere.git
 cd ./shardingsphere/
-./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-static" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-static" clean validate
+./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-static" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-static" "-DskipTests" clean package
 ```
 
 一个可能的 Docker Compose 示例为，
@@ -262,9 +262,9 @@ services:
 
 1. GraalVM CE 22.0.2，或与 GraalVM CE 22.0.2 兼容的 GraalVM 下游发行版。以 [GraalVM Native Image](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image) 为准。
 2. 编译 GraalVM Native Image 所需要的本地工具链。以 https://www.graalvm.org/latest/reference-manual/native-image/#prerequisites 为准。
-3. 可运行 Linux Containers 的 Docker Engine
 
 在 Ubuntu 与 Windows 下可能的所需操作与[开发和测试](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image/development)一致。
+但不需要安装 Container Runtime。
 
 ##### 静态编译所需的本地工具链
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -200,7 +200,7 @@ You can execute the following command to build.
 ```shell
 git clone git@github.com:apache/shardingsphere.git
 cd ./shardingsphere/
-./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" clean validate
+./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-DskipTests" clean package
 ```
 
 A possible Docker Compose example is,
@@ -222,7 +222,7 @@ You can execute the following command to build.
 ```shell
 git clone git@github.com:apache/shardingsphere.git
 cd ./shardingsphere/
-./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-mostly" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-mostly" clean validate
+./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-mostly" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-mostly" "-DskipTests" clean package
 ```
 
 A possible Docker Compose example is,
@@ -244,7 +244,7 @@ You can execute the following command to build.
 ```shell
 git clone git@github.com:apache/shardingsphere.git
 cd ./shardingsphere/
-./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-static" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-static" clean validate
+./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-static" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-static" "-DskipTests" clean package
 ```
 
 A possible Docker Compose example is,
@@ -267,9 +267,9 @@ Contributors must have installed on their devices,
 
 1. GraalVM CE 22.0.2, or a GraalVM downstream distribution compatible with GraalVM CE 22.0.2. Refer to [GraalVM Native Image](/en/user-manual/shardingsphere-jdbc/graalvm-native-image).
 2. The native toolchain required to compile GraalVM Native Image. Refer to https://www.graalvm.org/latest/reference-manual/native-image/#prerequisites .
-3. Docker Engine that can run Linux Containers
 
 The possible required operations under Ubuntu and Windows are consistent with [Development and test](/en/user-manual/shardingsphere-jdbc/graalvm-native-image/development).
+However, it is not necessary to install Container Runtime.
 
 ##### Native toolchain for static compilation
 


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/actions/runs/15422331873/job/43400481456 .

Changes proposed in this pull request:
  - Fix CI failure for arm64 Image build of Proxy Native.
  - Although it is possible to start QEMU emulation directly on the x64 actions runner using `docker/setup-qemu-action@v3`, I noticed from https://github.com/linghengqian/shardingsphere/actions/runs/15435456332/job/43440876993 that QEMU emulation to build docker images will easily exceed the 90 minute CI timeout. I prefer to use the arm64 actions runner directly. A build result without timeout comes from https://github.com/linghengqian/shardingsphere/actions/runs/15437501326/job/43447197500 . One reason why the use of QEMU causes a timeout is that the construction of the GraalVM Native Image goes through QEMU, which places requirements on SKU performance.
  - Even if QEMU is ignored, on the other hand, for multi-platform builds, the logic of manually creating and destroying the buildkit builder also has potential problems. For the local environment, once the build fails, the newly created buildkit builder will not be destroyed normally. It is an option to require developers to manually turn on containerd-snapshotter through `docker/setup-docker-action@v4` or in the documentation, but I prefer to delay this decision. Because in docker engine 29.0.0, containerd snapshotters will become the default image backend. Refer to https://github.com/moby/moby/issues/49872 . This will happen soon.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
