### PR TITLE
Move common methods to SQLStatement interface

### DIFF
--- a/parser/sql/engine/src/main/java/org/apache/shardingsphere/sql/parser/api/SQLStatementVisitorEngine.java
+++ b/parser/sql/engine/src/main/java/org/apache/shardingsphere/sql/parser/api/SQLStatementVisitorEngine.java
@@ -57,7 +57,7 @@ public final class SQLStatementVisitorEngine {
     private <T> void appendSQLComments(final ParseASTNode parseASTNode, final T visitResult) {
         if (visitResult instanceof AbstractSQLStatement) {
             for (Token each : parseASTNode.getHiddenTokens()) {
-                ((AbstractSQLStatement) visitResult).getCommentSegments().add(new CommentSegment(each.getText(), each.getStartIndex(), each.getStopIndex()));
+                ((SQLStatement) visitResult).getCommentSegments().add(new CommentSegment(each.getText(), each.getStartIndex(), each.getStopIndex()));
             }
         }
     }

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/AbstractSQLStatement.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/AbstractSQLStatement.java
@@ -33,25 +33,21 @@ import java.util.LinkedList;
 @Getter
 public class AbstractSQLStatement implements SQLStatement {
     
-    private final Collection<ParameterMarkerSegment> parameterMarkerSegments = new LinkedHashSet<>();
-    
     private final Collection<Integer> uniqueParameterIndexes = new HashSet<>();
     
-    private final Collection<CommentSegment> commentSegments = new LinkedList<>();
+    private final Collection<ParameterMarkerSegment> parameterMarkerSegments = new LinkedHashSet<>();
     
     private final Collection<String> variableNames = new CaseInsensitiveSet<>();
     
+    private final Collection<CommentSegment> commentSegments = new LinkedList<>();
+    
     @Override
-    public int getParameterCount() {
+    public final int getParameterCount() {
         return uniqueParameterIndexes.size();
     }
     
-    /**
-     * Add parameter marker segment.
-     *
-     * @param parameterMarkerSegments parameter marker segment collection
-     */
-    public void addParameterMarkerSegments(final Collection<ParameterMarkerSegment> parameterMarkerSegments) {
+    @Override
+    public final void addParameterMarkerSegments(final Collection<ParameterMarkerSegment> parameterMarkerSegments) {
         for (ParameterMarkerSegment each : parameterMarkerSegments) {
             this.parameterMarkerSegments.add(each);
             uniqueParameterIndexes.add(each.getParameterIndex());

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/SQLStatement.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/SQLStatement.java
@@ -18,6 +18,8 @@
 package org.apache.shardingsphere.sql.parser.statement.core.statement;
 
 import org.apache.shardingsphere.sql.parser.api.ASTNode;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.CommentSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.ParameterMarkerSegment;
 
 import java.util.Collection;
 
@@ -34,9 +36,30 @@ public interface SQLStatement extends ASTNode {
     int getParameterCount();
     
     /**
+     * Get parameter marker segments.
+     *
+     * @return parameter marker segments
+     */
+    Collection<ParameterMarkerSegment> getParameterMarkerSegments();
+    
+    /**
+     * Add parameter marker segment.
+     *
+     * @param parameterMarkerSegments parameter marker segment collection
+     */
+    void addParameterMarkerSegments(Collection<ParameterMarkerSegment> parameterMarkerSegments);
+    
+    /**
      * Get variable names.
      *
      * @return variable names
      */
     Collection<String> getVariableNames();
+    
+    /**
+     * Get comment segments.
+     *
+     * @return comment segments
+     */
+    Collection<CommentSegment> getCommentSegments();
 }

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/dal/EmptyStatement.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/dal/EmptyStatement.java
@@ -23,9 +23,4 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.AbstractSQL
  * Empty statement.
  */
 public final class EmptyStatement extends AbstractSQLStatement implements DALStatement {
-    
-    @Override
-    public int getParameterCount() {
-        return 0;
-    }
 }

--- a/parser/sql/statement/type/oracle/src/main/java/org/apache/shardingsphere/sql/parser/statement/oracle/ddl/OraclePLSQLBlockStatement.java
+++ b/parser/sql/statement/type/oracle/src/main/java/org/apache/shardingsphere/sql/parser/statement/oracle/ddl/OraclePLSQLBlockStatement.java
@@ -24,9 +24,4 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DDLStat
  * PLSQL block statement for Oracle.
  */
 public final class OraclePLSQLBlockStatement extends AbstractSQLStatement implements DDLStatement {
-    
-    @Override
-    public int getParameterCount() {
-        return 0;
-    }
 }

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
@@ -52,7 +52,6 @@ import org.apache.shardingsphere.proxy.frontend.mysql.command.ServerStatusFlagCa
 import org.apache.shardingsphere.proxy.frontend.mysql.command.query.binary.MySQLServerPreparedStatement;
 import org.apache.shardingsphere.proxy.frontend.mysql.command.query.binary.MySQLStatementIdGenerator;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.ParameterMarkerSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.statement.AbstractSQLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 
 import java.util.ArrayList;
@@ -128,7 +127,7 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
                                                                              final MySQLServerPreparedStatement serverPreparedStatement) {
         List<ShardingSphereColumn> columnsOfParameterMarkers =
                 MySQLComStmtPrepareParameterMarkerExtractor.findColumnsOfParameterMarkers(sqlStatementContext.getSqlStatement(), getSchema(sqlStatementContext));
-        Collection<ParameterMarkerSegment> parameterMarkerSegments = ((AbstractSQLStatement) sqlStatementContext.getSqlStatement()).getParameterMarkerSegments();
+        Collection<ParameterMarkerSegment> parameterMarkerSegments = sqlStatementContext.getSqlStatement().getParameterMarkerSegments();
         Collection<MySQLPacket> result = new ArrayList<>(parameterMarkerSegments.size());
         Collection<Integer> paramColumnDefinitionFlags = new ArrayList<>(parameterMarkerSegments.size());
         for (int index = 0; index < parameterMarkerSegments.size(); index++) {

--- a/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/parse/PostgreSQLComParseExecutor.java
+++ b/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/parse/PostgreSQLComParseExecutor.java
@@ -37,7 +37,6 @@ import org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extende
 import org.apache.shardingsphere.sql.parser.statement.core.enums.ParameterMarkerType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.SQLSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.ParameterMarkerSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.statement.AbstractSQLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.DMLStatement;
 
@@ -71,7 +70,7 @@ public final class PostgreSQLComParseExecutor implements CommandExecutor {
         }
         List<Integer> actualParameterMarkerIndexes = new ArrayList<>();
         if (sqlStatement.getParameterCount() > 0) {
-            List<ParameterMarkerSegment> parameterMarkerSegments = new ArrayList<>(((AbstractSQLStatement) sqlStatement).getParameterMarkerSegments());
+            List<ParameterMarkerSegment> parameterMarkerSegments = new ArrayList<>(sqlStatement.getParameterMarkerSegments());
             for (ParameterMarkerSegment each : parameterMarkerSegments) {
                 actualParameterMarkerIndexes.add(each.getParameterIndex());
             }

--- a/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/parse/PostgreSQLComParseExecutor.java
+++ b/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/parse/PostgreSQLComParseExecutor.java
@@ -68,7 +68,7 @@ public final class PostgreSQLComParseExecutor implements CommandExecutor {
             sqlStatement = sqlParserEngine.parse(escapedSql, true);
             sql = escapedSql;
         }
-        List<Integer> actualParameterMarkerIndexes = new ArrayList<>();
+        List<Integer> actualParameterMarkerIndexes = new ArrayList<>(sqlStatement.getParameterMarkerSegments().size());
         if (sqlStatement.getParameterCount() > 0) {
             List<ParameterMarkerSegment> parameterMarkerSegments = new ArrayList<>(sqlStatement.getParameterMarkerSegments());
             for (ParameterMarkerSegment each : parameterMarkerSegments) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/comment/CommentAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/comment/CommentAssert.java
@@ -56,14 +56,14 @@ public final class CommentAssert {
     
     private static void assertEmptyComment(final SQLCaseAssertContext assertContext, final SQLStatement actual) {
         if (actual instanceof AbstractSQLStatement) {
-            assertTrue(((AbstractSQLStatement) actual).getCommentSegments().isEmpty(), assertContext.getText("Comment should be empty."));
+            assertTrue(actual.getCommentSegments().isEmpty(), assertContext.getText("Comment should be empty."));
         }
     }
     
     private static void assertCorrectComment(final SQLCaseAssertContext assertContext, final SQLStatement actual, final SQLParserTestCase expected) {
         assertInstanceOf(AbstractSQLStatement.class, actual, assertContext.getText("Comment should exist."));
-        assertThat(assertContext.getText("Comments size assertion error: "), ((AbstractSQLStatement) actual).getCommentSegments().size(), is(expected.getComments().size()));
-        Iterator<CommentSegment> actualIterator = ((AbstractSQLStatement) actual).getCommentSegments().iterator();
+        assertThat(assertContext.getText("Comments size assertion error: "), actual.getCommentSegments().size(), is(expected.getComments().size()));
+        Iterator<CommentSegment> actualIterator = actual.getCommentSegments().iterator();
         for (ExpectedComment each : expected.getComments()) {
             assertThat(assertContext.getText("Comments assertion error: "), actualIterator.next().getText(), is(each.getText()));
         }


### PR DESCRIPTION
- Move getParameterCount, getParameterMarkerSegments, addParameterMarkerSegments, getVariableNames, and getCommentSegments to SQLStatement interface
- Implement these methods in AbstractSQLStatement
- Update related test cases and classes to use the new interface methods
- Remove redundant implementations in EmptyStatement and OraclePLSQLBlockStatement