### PR TITLE
Optimize ShardingSQLFederationDecider logic to pass sql with same condition to kernel

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/decider/ShardingSQLFederationDecider.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/decider/ShardingSQLFederationDecider.java
@@ -28,6 +28,9 @@ import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperation
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.sharding.constant.ShardingOrder;
+import org.apache.shardingsphere.sharding.route.engine.condition.ShardingCondition;
+import org.apache.shardingsphere.sharding.route.engine.condition.ShardingConditions;
+import org.apache.shardingsphere.sharding.route.engine.condition.engine.ShardingConditionEngine;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sqlfederation.spi.SQLFederationDecider;
 
@@ -45,23 +48,27 @@ public final class ShardingSQLFederationDecider implements SQLFederationDecider<
     public boolean decide(final SQLStatementContext sqlStatementContext, final List<Object> parameters,
                           final RuleMetaData globalRuleMetaData, final ShardingSphereDatabase database, final ShardingRule rule, final Collection<DataNode> includedDataNodes) {
         if (sqlStatementContext instanceof SelectStatementContext) {
-            return decide0((SelectStatementContext) sqlStatementContext, database, rule, includedDataNodes);
+            return decide0((SelectStatementContext) sqlStatementContext, parameters, globalRuleMetaData, database, rule, includedDataNodes);
         } else if (sqlStatementContext instanceof ExplainStatementContext) {
             ExplainStatementContext explainStatementContext = (ExplainStatementContext) sqlStatementContext;
             ShardingSpherePreconditions.checkState(explainStatementContext.getExplainableSQLStatementContext() instanceof SelectStatementContext,
                     () -> new UnsupportedSQLOperationException(
                             String.format("unsupported Explain %s statement in sql federation", explainStatementContext.getSqlStatement().getExplainableSQLStatement())));
-            return decide0((SelectStatementContext) explainStatementContext.getExplainableSQLStatementContext(), database, rule, includedDataNodes);
+            return decide0((SelectStatementContext) explainStatementContext.getExplainableSQLStatementContext(), parameters, globalRuleMetaData, database, rule, includedDataNodes);
         }
         throw new UnsupportedSQLOperationException(String.format("unsupported SQL statement %s in sql federation", sqlStatementContext.getSqlStatement()));
     }
     
-    private boolean decide0(final SelectStatementContext selectStatementContext, final ShardingSphereDatabase database, final ShardingRule rule, final Collection<DataNode> includedDataNodes) {
+    private boolean decide0(final SelectStatementContext selectStatementContext, final List<Object> parameters, final RuleMetaData globalRuleMetaData, final ShardingSphereDatabase database,
+                            final ShardingRule rule, final Collection<DataNode> includedDataNodes) {
         Collection<String> tableNames = rule.getShardingLogicTableNames(selectStatementContext.getTablesContext().getTableNames());
         if (tableNames.isEmpty()) {
             return false;
         }
         includedDataNodes.addAll(getTableDataNodes(rule, database, tableNames));
+        if (isAllShardingTables(selectStatementContext, tableNames) && isAllSameShardingConditions(selectStatementContext, parameters, globalRuleMetaData, database, rule)) {
+            return false;
+        }
         if (selectStatementContext.isContainsSubquery() || selectStatementContext.isContainsHaving()
                 || selectStatementContext.isContainsCombine() || selectStatementContext.isContainsPartialDistinctAggregation()) {
             return true;
@@ -73,6 +80,26 @@ public final class ShardingSQLFederationDecider implements SQLFederationDecider<
             return true;
         }
         return tableNames.size() > 1 && !rule.isBindingTablesUseShardingColumnsJoin(selectStatementContext, tableNames);
+    }
+    
+    private boolean isAllSameShardingConditions(final SelectStatementContext selectStatementContext, final List<Object> parameters, final RuleMetaData globalRuleMetaData,
+                                                final ShardingSphereDatabase database, final ShardingRule rule) {
+        ShardingConditions shardingConditions = createShardingConditions(selectStatementContext, parameters, globalRuleMetaData, database, rule);
+        return shardingConditions.isSameShardingCondition();
+    }
+    
+    private boolean isAllShardingTables(final SelectStatementContext selectStatementContext, final Collection<String> tableNames) {
+        return tableNames.size() == selectStatementContext.getTablesContext().getTableNames().size();
+    }
+    
+    private ShardingConditions createShardingConditions(final SelectStatementContext selectStatementContext, final List<Object> parameters, final RuleMetaData globalRuleMetaData,
+                                                        final ShardingSphereDatabase database, final ShardingRule rule) {
+        List<ShardingCondition> shardingConditions = new ShardingConditionEngine(globalRuleMetaData, database, rule).createShardingConditions(selectStatementContext, parameters);
+        ShardingConditions result = new ShardingConditions(shardingConditions, selectStatementContext, rule);
+        if (result.isNeedMerge()) {
+            result.merge();
+        }
+        return result;
     }
     
     private boolean isSelfJoinWithoutShardingColumn(final SelectStatementContext selectStatementContext, final ShardingRule rule, final Collection<String> tableNames) {

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/decider/ShardingSQLFederationDeciderTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/decider/ShardingSQLFederationDeciderTest.java
@@ -194,6 +194,7 @@ class ShardingSQLFederationDeciderTest {
         SelectStatementContext result = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(result.getTablesContext().getTableNames()).thenReturn(Arrays.asList("foo_tbl", "bar_tbl"));
         when(result.getDatabaseType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+        when(result.getSubqueryContexts().values()).thenReturn(Collections.emptyList());
         return result;
     }
     


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Optimize ShardingSQLFederationDecider logic to pass sql with same condition to kernel

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
