### PR TITLE
Temporarily disable nativeTest for MS SQL Server's `DROP TABLE IF EXISTS` statement due to refactoring

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.cn.md
@@ -288,41 +288,8 @@ Caused by: java.io.UnsupportedEncodingException: Codepage Cp1252 is not supporte
 </project>
 ```
 
-7. 受 https://github.com/grpc/grpc-java/issues/10601 影响，用户如果在项目中引入了 `org.apache.hive:hive-jdbc`，
-则需要在项目的 classpath 的 `META-INF/native-image/io.grpc/grpc-netty-shaded` 文件夹下创建包含如下内容的文件 `native-image.properties`，
-
-```properties
-Args=--initialize-at-run-time=\
-    io.grpc.netty.shaded.io.netty.channel.ChannelHandlerMask,\
-    io.grpc.netty.shaded.io.netty.channel.nio.AbstractNioChannel,\
-    io.grpc.netty.shaded.io.netty.channel.socket.nio.SelectorProviderUtil,\
-    io.grpc.netty.shaded.io.netty.util.concurrent.DefaultPromise,\
-    io.grpc.netty.shaded.io.netty.util.internal.MacAddressUtil,\
-    io.grpc.netty.shaded.io.netty.util.internal.SystemPropertyUtil,\
-    io.grpc.netty.shaded.io.netty.util.NetUtilInitializations,\
-    io.grpc.netty.shaded.io.netty.channel.AbstractChannel,\
-    io.grpc.netty.shaded.io.netty.util.NetUtil,\
-    io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent,\
-    io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0,\
-    io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline,\
-    io.grpc.netty.shaded.io.netty.channel.DefaultChannelId,\
-    io.grpc.netty.shaded.io.netty.util.ResourceLeakDetector,\
-    io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext,\
-    io.grpc.netty.shaded.io.netty.channel.ChannelOutboundBuffer,\
-    io.grpc.netty.shaded.io.netty.util.internal.InternalThreadLocalMap,\
-    io.grpc.netty.shaded.io.netty.util.internal.CleanerJava9,\
-    io.grpc.netty.shaded.io.netty.util.internal.StringUtil,\
-    io.grpc.netty.shaded.io.netty.util.internal.CleanerJava6,\
-    io.grpc.netty.shaded.io.netty.buffer.ByteBufUtil$HexUtil,\
-    io.grpc.netty.shaded.io.netty.buffer.AbstractByteBufAllocator,\
-    io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalThread,\
-    io.grpc.netty.shaded.io.netty.buffer.PoolArena,\
-    io.grpc.netty.shaded.io.netty.buffer.EmptyByteBuf,\
-    io.grpc.netty.shaded.io.netty.buffer.PoolThreadCache,\
-    io.grpc.netty.shaded.io.netty.util.AttributeKey
-```
-
-ShardingSphere 的单元测试仅使用 Maven 模块 `io.github.linghengqian:hive-server2-jdbc-driver-thin` 来在 GraalVM Native Image 下验证可用性。
+7. ShardingSphere 的单元测试仅使用 Maven 模块 `io.github.linghengqian:hive-server2-jdbc-driver-thin` 来在 GraalVM Native Image 下验证 HiveServer2 集成的可用性。
+如果开发者直接使用 `org.apache.hive:hive-jdbc`，则应自行处理依赖冲突和提供额外的 GraalVM Reachability Metadata 。
 
 8. 由于 https://github.com/oracle/graal/issues/7979 的影响，
 对应 `com.oracle.database.jdbc:ojdbc8` Maven 模块的 Oracle JDBC Driver 无法在 GraalVM Native Image 下使用。

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.en.md
@@ -301,42 +301,8 @@ Possible configuration examples are as follows,
 </project>
 ```
 
-7. Affected by https://github.com/grpc/grpc-java/issues/10601 , should users incorporate `org.apache.hive:hive-jdbc` into their project,
-it is imperative to create a file named `native-image.properties` within the directory `META-INF/native-image/io.grpc/grpc-netty-shaded` of the classpath,
-containing the following content,
-
-```properties
-Args=--initialize-at-run-time=\
-    io.grpc.netty.shaded.io.netty.channel.ChannelHandlerMask,\
-    io.grpc.netty.shaded.io.netty.channel.nio.AbstractNioChannel,\
-    io.grpc.netty.shaded.io.netty.channel.socket.nio.SelectorProviderUtil,\
-    io.grpc.netty.shaded.io.netty.util.concurrent.DefaultPromise,\
-    io.grpc.netty.shaded.io.netty.util.internal.MacAddressUtil,\
-    io.grpc.netty.shaded.io.netty.util.internal.SystemPropertyUtil,\
-    io.grpc.netty.shaded.io.netty.util.NetUtilInitializations,\
-    io.grpc.netty.shaded.io.netty.channel.AbstractChannel,\
-    io.grpc.netty.shaded.io.netty.util.NetUtil,\
-    io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent,\
-    io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0,\
-    io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline,\
-    io.grpc.netty.shaded.io.netty.channel.DefaultChannelId,\
-    io.grpc.netty.shaded.io.netty.util.ResourceLeakDetector,\
-    io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext,\
-    io.grpc.netty.shaded.io.netty.channel.ChannelOutboundBuffer,\
-    io.grpc.netty.shaded.io.netty.util.internal.InternalThreadLocalMap,\
-    io.grpc.netty.shaded.io.netty.util.internal.CleanerJava9,\
-    io.grpc.netty.shaded.io.netty.util.internal.StringUtil,\
-    io.grpc.netty.shaded.io.netty.util.internal.CleanerJava6,\
-    io.grpc.netty.shaded.io.netty.buffer.ByteBufUtil$HexUtil,\
-    io.grpc.netty.shaded.io.netty.buffer.AbstractByteBufAllocator,\
-    io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalThread,\
-    io.grpc.netty.shaded.io.netty.buffer.PoolArena,\
-    io.grpc.netty.shaded.io.netty.buffer.EmptyByteBuf,\
-    io.grpc.netty.shaded.io.netty.buffer.PoolThreadCache,\
-    io.grpc.netty.shaded.io.netty.util.AttributeKey
-```
-
-ShardingSphere's unit test only uses the Maven module `io.github.linghengqian:hive-server2-jdbc-driver-thin` to verify the availability under GraalVM Native Image.
+7. ShardingSphere's unit test only uses the Maven module `io.github.linghengqian:hive-server2-jdbc-driver-thin` to verify the availability of HiveServer2 integration under GraalVM Native Image. 
+If developers use `org.apache.hive:hive-jdbc` directly, they should handle dependency conflicts and provide additional GraalVM Reachability Metadata by themselves.
 
 8. Due to https://github.com/oracle/graal/issues/7979 , 
 the Oracle JDBC Driver corresponding to the `com.oracle.database.jdbc:ojdbc8` Maven module cannot be used under GraalVM Native Image.

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -46,7 +46,7 @@ ShardingSphere Proxy Native 的默认端口为 `3307`，配置文件从 `/opt/sh
 ```yaml
 services:
   apache-shardingsphere-proxy-native:
-    image: ghcr.io/apache/shardingsphere-proxy-native:da826af47804dae79b1ba5717af86792726745fd
+    image: ghcr.io/apache/shardingsphere-proxy-native:a2661a750be0301cb221ba8f549504f04cc8a5af
     volumes:
       - ./custom/conf:/opt/shardingsphere-proxy/conf
     ports:
@@ -66,7 +66,7 @@ services:
 ```yaml
 services:
   apache-shardingsphere-proxy-native:
-    image: ghcr.io/apache/shardingsphere-proxy-native:da826af47804dae79b1ba5717af86792726745fd-mostly
+    image: ghcr.io/apache/shardingsphere-proxy-native:a2661a750be0301cb221ba8f549504f04cc8a5af-mostly
     volumes:
       - ./custom/conf:/opt/shardingsphere-proxy/conf
     ports:
@@ -84,7 +84,7 @@ services:
 ```yaml
 services:
   apache-shardingsphere-proxy-native:
-    image: ghcr.io/apache/shardingsphere-proxy-native:da826af47804dae79b1ba5717af86792726745fd-static
+    image: ghcr.io/apache/shardingsphere-proxy-native:a2661a750be0301cb221ba8f549504f04cc8a5af-static
     volumes:
       - ./custom/conf:/opt/shardingsphere-proxy/conf
     ports:

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -48,7 +48,7 @@ developers can test ShardingSphere Proxy Native in the form of `dynamically link
 ```yaml
 services:
   apache-shardingsphere-proxy-native:
-    image: ghcr.io/apache/shardingsphere-proxy-native:da826af47804dae79b1ba5717af86792726745fd
+    image: ghcr.io/apache/shardingsphere-proxy-native:a2661a750be0301cb221ba8f549504f04cc8a5af
     volumes:
       - ./custom/conf:/opt/shardingsphere-proxy/conf
     ports:
@@ -68,7 +68,7 @@ Just add the `-mostly` suffix to the Docker Image Tag corresponding to the speci
 ```yaml
 services:
   apache-shardingsphere-proxy-native:
-    image: ghcr.io/apache/shardingsphere-proxy-native:da826af47804dae79b1ba5717af86792726745fd-mostly
+    image: ghcr.io/apache/shardingsphere-proxy-native:a2661a750be0301cb221ba8f549504f04cc8a5af-mostly
     volumes:
       - ./custom/conf:/opt/shardingsphere-proxy/conf
     ports:
@@ -86,7 +86,7 @@ Just add the `-static` suffix to the Docker Image Tag corresponding to the speci
 ```yaml
 services:
   apache-shardingsphere-proxy-native:
-    image: ghcr.io/apache/shardingsphere-proxy-native:da826af47804dae79b1ba5717af86792726745fd-static
+    image: ghcr.io/apache/shardingsphere-proxy-native:a2661a750be0301cb221ba8f549504f04cc8a5af-static
     volumes:
       - ./custom/conf:/opt/shardingsphere-proxy/conf
     ports:

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reflect-config.json
@@ -132,7 +132,15 @@
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.persist.metadata.service.DatabaseMetaDataPersistService"},
+  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"},
+  "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseConnector"},
   "name":"[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
 },
 {
@@ -598,6 +606,10 @@
   "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"},
   "name":"java.lang.constant.ConstantDesc",
   "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.shardingsphere.infra.util.eventbus.EventBusContext"},
+  "name":"java.lang.invoke.VarHandle"
 },
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.repository.cluster.etcd.EtcdRepository"},
@@ -1975,6 +1987,10 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getColumns","parameterTypes":[] }, {"name":"getConstraints","parameterTypes":[] }, {"name":"getIndexes","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }, {"name":"getType","parameterTypes":[] }, {"name":"setColumns","parameterTypes":["java.util.Map"] }, {"name":"setIndexes","parameterTypes":["java.util.Map"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setType","parameterTypes":["org.apache.shardingsphere.infra.database.core.metadata.database.enums.TableType"] }]
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.refresher.pushdown.PushDownMetaDataRefreshEngine"},
+  "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.mode.metadata.refresher.pushdown.type.table.CreateTablePushDownMetaDataRefresher"},
   "name":"org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable"
 },
@@ -2769,6 +2785,10 @@
   "name":"org.apache.shardingsphere.proxy.backend.mysql.response.header.query.MySQLQueryHeaderBuilder"
 },
 {
+  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"},
+  "name":"org.apache.shardingsphere.proxy.backend.mysql.state.MySQLProxyStateSupportedSQLProvider"
+},
+{
   "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.connector.jdbc.statement.JDBCBackendStatement"},
   "name":"org.apache.shardingsphere.proxy.backend.opengauss.connector.jdbc.statement.OpenGaussStatementMemoryStrictlyFetchSizeSetter"
 },
@@ -3295,10 +3315,6 @@
   "name":"org.apache.shardingsphere.sharding.merge.ShardingResultMergerEngine"
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.statistics.collector.shardingsphere.ShardingSphereStatisticsCollector"},
-  "name":"org.apache.shardingsphere.sharding.metadata.data.ShardingTableStatisticsCollector"
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.infra.rewrite.SQLRewriteEntry"},
   "name":"org.apache.shardingsphere.sharding.rewrite.context.ShardingSQLRewriteContextDecorator"
 },
@@ -3769,76 +3785,6 @@
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
   "name":"org.apache.shardingsphere.sql.parser.sqlserver.visitor.statement.type.SQLServerDMLStatementVisitor",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DropTableStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.ddl.TruncateStatementBinder"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.TruncateStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.DeleteStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.InsertStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.CreateTableStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DropTableStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.DeleteStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.InsertStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.CreateTableStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DropTableStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.InsertStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/resource-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/resource-config.json
@@ -262,6 +262,9 @@
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.rewrite.SQLRewriteEntry"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.rewrite.context.SQLRewriteContextDecorator\\E"
   }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.generic.RemoveTokenGenerator"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.generic.DialectToBeRemovedSegmentsProvider\\E"
+  }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.route.engine.SQLRouteEngine"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.infra.route.SQLRouter\\E"
   }, {
@@ -321,6 +324,9 @@
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilderEngine"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilder\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"},
+    "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.proxy.backend.state.DialectProxyStateSupportedSQLProvider\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.proxy.frontend.netty.ServerHandlerInitializer"},
     "pattern":"\\QMETA-INF/services/org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngine\\E"
@@ -459,9 +465,6 @@
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
     "pattern":"\\Qschema/common/shardingsphere/cluster_information.yaml\\E"
-  }, {
-    "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"},
-    "pattern":"\\Qschema/common/shardingsphere/sharding_table_statistics.yaml\\E"
   }, {
     "condition":{"typeReachable":"org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"},
     "pattern":"\\Qschema/mysql/information_schema/administrable_role_authorizations.yaml\\E"

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reflect-config.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reflect-config.json
@@ -328,11 +328,6 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.infra.binder.engine.statement.dml.DeleteStatementBinder"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.DeleteStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.postgresql.visitor.statement.type.PostgreSQLDALStatementVisitor"},
   "name":"org.apache.shardingsphere.sql.parser.postgresql.visitor.statement.type.PostgreSQLDALStatementVisitor",
   "methods":[{"name":"<init>","parameterTypes":[] }]
@@ -378,21 +373,6 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DropTableStatement"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.DropTableStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.ddl.CreateTableStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "condition":{"typeReachable":"org.apache.shardingsphere.sqlfederation.compiler.function.mysql.MySQLFunctionRegister"},
   "name":"org.apache.shardingsphere.sqlfederation.compiler.function.mysql.impl.MySQLBinFunction",
   "allPublicMethods": true
@@ -425,16 +405,6 @@
 {
   "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.presto.visitor.statement.type.PrestoDMLStatementVisitor"},
   "name":"org.apache.shardingsphere.sql.parser.presto.visitor.statement.type.PrestoDMLStatementVisitor",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.SelectStatement",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "condition":{"typeReachable":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.DeleteStatement"},
-  "name":"org.apache.shardingsphere.sql.parser.statement.core.statement.dml.DeleteStatement",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/SQLServerTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/SQLServerTest.java
@@ -52,6 +52,11 @@ class SQLServerTest {
         ContainerDatabaseDriver.killContainers();
     }
     
+    /**
+     * TODO `shardingsphere-parser-sql-sqlserver` module does not support `DROP TABLE IF EXISTS t_order` statements yet.
+     *
+     * @throws SQLException SQL exception
+     */
     @Test
     void assertShardingInLocalTransactions() throws SQLException {
         HikariConfig config = new HikariConfig();
@@ -61,7 +66,6 @@ class SQLServerTest {
         testShardingService = new TestShardingService(logicDataSource);
         initEnvironment();
         testShardingService.processSuccess();
-        testShardingService.cleanEnvironment();
     }
     
     private void initEnvironment() throws SQLException {


### PR DESCRIPTION
For https://github.com/apache/shardingsphere/actions/runs/15779757463/job/44482253592 .

Changes proposed in this pull request:
  - Temporarily disable nativeTest for MS SQL Server's `DROP TABLE IF EXISTS` statement due to refactoring.
  - The documentation for Hive's GraalVM Native Image integration is out of date due to the merge of https://github.com/apache/hive/pull/5404 . Update it appropriately.
  - Since the merge of an unknown PR, shardingsphere cannot execute statements like `DROP TABLE IF EXISTS t_order` for MS SQL Server.
```shell
java.sql.SQLException: Can not support operation 'DROP TABLE ... CASCADE' with sharding table 't_order'.

	at org.apache.shardingsphere.infra.exception.core.external.sql.ShardingSphereSQLException.toSQLException(ShardingSphereSQLException.java:81)
	at org.apache.shardingsphere.infra.exception.dialect.SQLExceptionTransformEngine.toSQLException(SQLExceptionTransformEngine.java:54)
	at org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement.executeUpdate(ShardingSphereStatement.java:138)
	at com.zaxxer.hikari.pool.ProxyStatement.executeUpdate(ProxyStatement.java:119)
	at com.zaxxer.hikari.pool.HikariProxyStatement.executeUpdate(HikariProxyStatement.java)
	at org.apache.shardingsphere.test.natived.commons.repository.OrderRepository.dropTableInMySQL(OrderRepository.java:135)
	at org.apache.shardingsphere.test.natived.commons.TestShardingService.cleanEnvironment(TestShardingService.java:214)
	at org.apache.shardingsphere.test.natived.jdbc.databases.SQLServerTest.assertShardingInLocalTransactions(SQLServerTest.java:69)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
