### PR TITLE
Add new streaming query impl in DATA_MATCH consistency check for sharding table on MySQL

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordSingleTableInventoryCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordSingleTableInventoryCalculator.java
@@ -65,10 +65,6 @@ public final class RecordSingleTableInventoryCalculator extends AbstractStreamin
     
     private final EqualsBuilder equalsBuilder = new EqualsBuilder();
     
-    public RecordSingleTableInventoryCalculator(final int chunkSize) {
-        this(chunkSize, DEFAULT_STREAMING_CHUNK_COUNT, StreamingRangeType.SMALL);
-    }
-    
     public RecordSingleTableInventoryCalculator(final int chunkSize, final StreamingRangeType streamingRangeType) {
         this(chunkSize, DEFAULT_STREAMING_CHUNK_COUNT, streamingRangeType);
     }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordSingleTableInventoryCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordSingleTableInventoryCalculator.java
@@ -55,15 +55,22 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public final class RecordSingleTableInventoryCalculator extends AbstractStreamingSingleTableInventoryCalculator {
     
+    private static final int DEFAULT_STREAMING_CHUNK_COUNT = 100;
+    
     private final int chunkSize;
     
     private final int streamingChunkCount;
     
+    private final StreamingRangeType streamingRangeType;
+    
     private final EqualsBuilder equalsBuilder = new EqualsBuilder();
     
     public RecordSingleTableInventoryCalculator(final int chunkSize) {
-        this.chunkSize = chunkSize;
-        streamingChunkCount = 100;
+        this(chunkSize, DEFAULT_STREAMING_CHUNK_COUNT, StreamingRangeType.SMALL);
+    }
+    
+    public RecordSingleTableInventoryCalculator(final int chunkSize, final StreamingRangeType streamingRangeType) {
+        this(chunkSize, DEFAULT_STREAMING_CHUNK_COUNT, streamingRangeType);
     }
     
     @Override
@@ -84,6 +91,9 @@ public final class RecordSingleTableInventoryCalculator extends AbstractStreamin
         try {
             if (QueryType.POINT_QUERY == param.getQueryType()) {
                 return pointQuery(param, columnValueReaderEngine);
+            }
+            if (StreamingRangeType.LARGE == streamingRangeType) {
+                return allQuery(param, columnValueReaderEngine);
             }
             if (param.getUniqueKeys().size() <= 1) {
                 return rangeQueryWithSingleColumUniqueKey(param, columnValueReaderEngine, 1);
@@ -108,6 +118,26 @@ public final class RecordSingleTableInventoryCalculator extends AbstractStreamin
             ShardingSpherePreconditions.checkState(!isCanceling(), () -> new PipelineJobCancelingException("Calculate chunk canceled, qualified table: %s", param.getTable()));
             Map<String, Object> record = readRecord(columnValueReaderEngine, resultSet, resultSetMetaData);
             result.add(record);
+        }
+        return result;
+    }
+    
+    private List<Map<String, Object>> allQuery(final SingleTableInventoryCalculateParameter param,
+                                               final InventoryColumnValueReaderEngine columnValueReaderEngine) throws SQLException {
+        List<Map<String, Object>> result = new LinkedList<>();
+        CalculationContext calculationContext = prepareCalculationContext(param);
+        prepareDatabaseResources(calculationContext, param);
+        ResultSet resultSet = calculationContext.getResultSet();
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+        while (resultSet.next()) {
+            ShardingSpherePreconditions.checkState(!isCanceling(), () -> new PipelineJobCancelingException("Calculate chunk canceled, qualified table: %s", param.getTable()));
+            result.add(readRecord(columnValueReaderEngine, resultSet, resultSetMetaData));
+            if (result.size() == chunkSize) {
+                break;
+            }
+        }
+        if (result.isEmpty()) {
+            QuietlyCloser.close(calculationContext);
         }
         return result;
     }
@@ -231,13 +261,14 @@ public final class RecordSingleTableInventoryCalculator extends AbstractStreamin
     }
     
     private String getQuerySQL(final SingleTableInventoryCalculateParameter param) {
-        ShardingSpherePreconditions.checkState(param.getUniqueKeys() != null && !param.getUniqueKeys().isEmpty() && null != param.getFirstUniqueKey(),
+        ShardingSpherePreconditions.checkState(null != param.getUniqueKeys() && !param.getUniqueKeys().isEmpty() && null != param.getFirstUniqueKey(),
                 () -> new UnsupportedOperationException("Record inventory calculator does not support table without unique key and primary key now."));
         PipelineDataConsistencyCalculateSQLBuilder pipelineSQLBuilder = new PipelineDataConsistencyCalculateSQLBuilder(param.getDatabaseType());
         Collection<String> columnNames = param.getColumnNames().isEmpty() ? Collections.singleton("*") : param.getColumnNames();
         switch (param.getQueryType()) {
             case RANGE_QUERY:
-                return pipelineSQLBuilder.buildQueryRangeOrderingSQL(param.getTable(), columnNames, param.getUniqueKeysNames(), param.getQueryRange(), param.getShardingColumnsNames());
+                return pipelineSQLBuilder.buildQueryRangeOrderingSQL(param.getTable(), columnNames, param.getUniqueKeysNames(), param.getQueryRange(),
+                        StreamingRangeType.SMALL == streamingRangeType, param.getShardingColumnsNames());
             case POINT_QUERY:
                 return pipelineSQLBuilder.buildPointQuerySQL(param.getTable(), columnNames, param.getUniqueKeysNames(), param.getShardingColumnsNames());
             default:
@@ -258,7 +289,9 @@ public final class RecordSingleTableInventoryCalculator extends AbstractStreamin
             if (null != queryRange.getUpper()) {
                 preparedStatement.setObject(parameterIndex++, queryRange.getUpper());
             }
-            preparedStatement.setObject(parameterIndex, chunkSize * streamingChunkCount);
+            if (StreamingRangeType.SMALL == streamingRangeType) {
+                preparedStatement.setObject(parameterIndex, chunkSize * streamingChunkCount);
+            }
         } else if (queryType == QueryType.POINT_QUERY) {
             Collection<Object> uniqueKeysValues = param.getUniqueKeysValues();
             ShardingSpherePreconditions.checkNotNull(uniqueKeysValues,

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/StreamingRangeType.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/StreamingRangeType.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator;
+
+/**
+ * Streaming range type.
+ */
+public enum StreamingRangeType {
+    
+    SMALL, LARGE
+}

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineDataConsistencyCalculateSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineDataConsistencyCalculateSQLBuilder.java
@@ -51,12 +51,14 @@ public final class PipelineDataConsistencyCalculateSQLBuilder {
      * @param columnNames column names
      * @param uniqueKeys unique keys, it may be primary key, not null
      * @param queryRange query range
+     * @param pageQuery whether it is page query
      * @param shardingColumnsNames sharding columns names
      * @return built SQL
      */
     public String buildQueryRangeOrderingSQL(final QualifiedTable qualifiedTable, final Collection<String> columnNames, final List<String> uniqueKeys, final QueryRange queryRange,
-                                             final List<String> shardingColumnsNames) {
-        return dialectSQLBuilder.wrapWithPageQuery(buildQueryRangeOrderingSQL0(qualifiedTable, columnNames, uniqueKeys, queryRange, shardingColumnsNames));
+                                             final boolean pageQuery, final List<String> shardingColumnsNames) {
+        String result = buildQueryRangeOrderingSQL0(qualifiedTable, columnNames, uniqueKeys, queryRange, shardingColumnsNames);
+        return pageQuery ? dialectSQLBuilder.wrapWithPageQuery(result) : result;
     }
     
     private String buildQueryRangeOrderingSQL0(final QualifiedTable qualifiedTable, final Collection<String> columnNames, final List<String> uniqueKeys, final QueryRange queryRange,

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/DataMatchTableDataConsistencyCheckerTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/DataMatchTableDataConsistencyCheckerTest.java
@@ -33,26 +33,48 @@ class DataMatchTableDataConsistencyCheckerTest {
     
     @SneakyThrows(ReflectiveOperationException.class)
     @Test
-    void assertInitSuccess() {
+    void assertChunkSizeInitSuccess() {
         for (String each : Arrays.asList("1", "1000")) {
             DataMatchTableDataConsistencyChecker checker = new DataMatchTableDataConsistencyChecker();
-            checker.init(buildAlgorithmProperties(each));
+            checker.init(buildChunkSizeProperties(each));
             String actual = Plugins.getMemberAccessor().get(DataMatchTableDataConsistencyChecker.class.getDeclaredField("chunkSize"), checker).toString();
             assertThat(actual, is(each));
         }
     }
     
     @Test
-    void assertInitFailure() {
-        assertThrows(PipelineInvalidParameterException.class, () -> new DataMatchTableDataConsistencyChecker().init(buildAlgorithmProperties("xyz")));
+    void assertChunkSizeInitFailure() {
+        assertThrows(PipelineInvalidParameterException.class, () -> new DataMatchTableDataConsistencyChecker().init(buildChunkSizeProperties("xyz")));
         for (String each : Arrays.asList("0", "-1")) {
-            assertThrows(PipelineInvalidParameterException.class, () -> new DataMatchTableDataConsistencyChecker().init(buildAlgorithmProperties(each)));
+            assertThrows(PipelineInvalidParameterException.class, () -> new DataMatchTableDataConsistencyChecker().init(buildChunkSizeProperties(each)));
         }
     }
     
-    private Properties buildAlgorithmProperties(final String chunkSize) {
+    @SneakyThrows(ReflectiveOperationException.class)
+    @Test
+    void assertStreamingRangeTypeInitSuccess() {
+        for (String each : Arrays.asList("small", "large", "SMALL", "LARGE")) {
+            DataMatchTableDataConsistencyChecker checker = new DataMatchTableDataConsistencyChecker();
+            checker.init(buildStreamingRangeTypeProperties(each));
+            String actual = Plugins.getMemberAccessor().get(DataMatchTableDataConsistencyChecker.class.getDeclaredField("streamingRangeType"), checker).toString();
+            assertThat(actual, is(each.toUpperCase()));
+        }
+    }
+    
+    @Test
+    void assertStreamingRangeTypeInitFailure() {
+        assertThrows(PipelineInvalidParameterException.class, () -> new DataMatchTableDataConsistencyChecker().init(buildStreamingRangeTypeProperties("xyz")));
+    }
+    
+    private Properties buildChunkSizeProperties(final String chunkSize) {
         Properties result = new Properties();
         result.put("chunk-size", chunkSize);
+        return result;
+    }
+    
+    private Properties buildStreamingRangeTypeProperties(final String streamingRangeType) {
+        Properties result = new Properties();
+        result.put("streaming-range-type", streamingRangeType);
         return result;
     }
 }

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/fixture/FixturePipelineSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/fixture/FixturePipelineSQLBuilder.java
@@ -43,7 +43,7 @@ public final class FixturePipelineSQLBuilder implements DialectPipelineSQLBuilde
     
     @Override
     public String wrapWithPageQuery(final String sql) {
-        return sql;
+        return sql + " LIMIT ?";
     }
     
     @Override

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineDataConsistencyCalculateSQLBuilderTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineDataConsistencyCalculateSQLBuilderTest.java
@@ -43,21 +43,40 @@ class PipelineDataConsistencyCalculateSQLBuilderTest {
     private final PipelineDataConsistencyCalculateSQLBuilder sqlBuilder = new PipelineDataConsistencyCalculateSQLBuilder(TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
     
     @Test
-    void assertBuildQueryRangeOrderingSQLWithoutQueryCondition() {
+    void assertBuildQueryRangeOrderingSQLPageQuery() {
         String actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(1, true, 5), SHARDING_COLUMNS_NAMES);
+                new QueryRange(1, true, 5), true, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? AND order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
+        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(1, false, 5), true, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? AND order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
+        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(1, false, null), true, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
+        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(null, false, 5), true, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
+        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(null, false, null), true, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
+    }
+    
+    @Test
+    void assertBuildQueryRangeOrderingSQLNotPageQuery() {
+        String actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(1, true, 5), false, SHARDING_COLUMNS_NAMES);
         assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? AND order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC"));
         actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(1, false, 5), SHARDING_COLUMNS_NAMES);
+                new QueryRange(1, false, 5), false, SHARDING_COLUMNS_NAMES);
         assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? AND order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC"));
         actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(1, false, null), SHARDING_COLUMNS_NAMES);
+                new QueryRange(1, false, null), false, SHARDING_COLUMNS_NAMES);
         assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? ORDER BY order_id ASC, status ASC, user_id ASC"));
         actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(null, false, 5), SHARDING_COLUMNS_NAMES);
+                new QueryRange(null, false, 5), false, SHARDING_COLUMNS_NAMES);
         assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC"));
         actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(null, false, null), SHARDING_COLUMNS_NAMES);
+                new QueryRange(null, false, null), false, SHARDING_COLUMNS_NAMES);
         assertThat(actual, is("SELECT order_id,user_id,status FROM t_order ORDER BY order_id ASC, status ASC, user_id ASC"));
     }
     

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineInventoryDumpSQLBuilderTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineInventoryDumpSQLBuilderTest.java
@@ -34,17 +34,17 @@ class PipelineInventoryDumpSQLBuilderTest {
     @Test
     void assertBuildDivisibleSQL() {
         String actual = sqlBuilder.buildDivisibleSQL(new BuildDivisibleSQLParameter(null, "t_order", Arrays.asList("order_id", "user_id", "status"), "order_id", true, true));
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? AND order_id<=? ORDER BY order_id ASC"));
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? AND order_id<=? ORDER BY order_id ASC LIMIT ?"));
         actual = sqlBuilder.buildDivisibleSQL(new BuildDivisibleSQLParameter(null, "t_order", Arrays.asList("order_id", "user_id", "status"), "order_id", false, true));
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? AND order_id<=? ORDER BY order_id ASC"));
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? AND order_id<=? ORDER BY order_id ASC LIMIT ?"));
     }
     
     @Test
     void assertBuildUnlimitedDivisibleSQL() {
         String actual = sqlBuilder.buildDivisibleSQL(new BuildDivisibleSQLParameter(null, "t_order", Arrays.asList("order_id", "user_id", "status"), "order_id", true, false));
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? ORDER BY order_id ASC"));
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? ORDER BY order_id ASC LIMIT ?"));
         actual = sqlBuilder.buildDivisibleSQL(new BuildDivisibleSQLParameter(null, "t_order", Arrays.asList("order_id", "user_id", "status"), "order_id", false, false));
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? ORDER BY order_id ASC"));
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? ORDER BY order_id ASC LIMIT ?"));
     }
     
     @Test

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/AbstractMigrationE2EIT.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/AbstractMigrationE2EIT.java
@@ -189,4 +189,15 @@ public abstract class AbstractMigrationE2EIT {
                 + "))";
         return String.format(sql, jobId, algorithmType);
     }
+    
+    protected Properties convertToProperties(final Map<String, String> map) {
+        Properties result = new Properties();
+        if (null == map || map.isEmpty()) {
+            return result;
+        }
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            result.setProperty(entry.getKey(), entry.getValue());
+        }
+        return result;
+    }
 }

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLMigrationGeneralE2EIT.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLMigrationGeneralE2EIT.java
@@ -37,6 +37,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -90,11 +91,9 @@ class MySQLMigrationGeneralE2EIT extends AbstractMigrationE2EIT {
             DataSource jdbcDataSource = containerComposer.generateShardingSphereDataSourceFromProxy();
             containerComposer.assertOrderRecordExist(jdbcDataSource, "t_order", 10000);
             containerComposer.assertOrderRecordExist(jdbcDataSource, "t_order_item", 10000);
-            Properties algorithmProps = new Properties();
-            algorithmProps.setProperty("chunk-size", "300");
-            assertMigrationSuccessById(containerComposer, orderJobId, "DATA_MATCH", algorithmProps);
+            assertMigrationSuccessById(containerComposer, orderJobId, "DATA_MATCH", convertToProperties(ImmutableMap.of("chunk-size", "300", "streaming-range-type", "SMALL")));
             String orderItemJobId = getJobIdByTableName(containerComposer, "ds_0.t_order_item");
-            assertMigrationSuccessById(containerComposer, orderItemJobId, "DATA_MATCH", algorithmProps);
+            assertMigrationSuccessById(containerComposer, orderItemJobId, "DATA_MATCH", convertToProperties(ImmutableMap.of("chunk-size", "300", "streaming-range-type", "LARGE")));
             Awaitility.await().pollDelay(2L, TimeUnit.SECONDS).until(() -> true);
             assertMigrationSuccessById(containerComposer, orderItemJobId, "CRC32_MATCH", new Properties());
             for (String each : listJobId(containerComposer)) {

--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordSingleTableInventoryCalculatorTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordSingleTableInventoryCalculatorTest.java
@@ -195,9 +195,9 @@ class RecordSingleTableInventoryCalculatorTest {
     }
     
     @ParameterizedTest
-    @CsvSource({"100", "2", "3"})
-    void assertCalculateOfRangeQueryAllWithOrderIdUniqueKeyWith3x(final int streamingChunkCount) {
-        RecordSingleTableInventoryCalculator calculator = new RecordSingleTableInventoryCalculator(3, streamingChunkCount);
+    @CsvSource({"100,SMALL", "2,SMALL", "3,SMALL", "100,LARGE", "2,LARGE", "3,LARGE"})
+    void assertCalculateOfRangeQueryAllWithOrderIdUniqueKeyWith3x(final int streamingChunkCount, final String streamingRangeType) {
+        RecordSingleTableInventoryCalculator calculator = new RecordSingleTableInventoryCalculator(3, streamingChunkCount, StreamingRangeType.valueOf(streamingRangeType));
         SingleTableInventoryCalculateParameter param = new SingleTableInventoryCalculateParameter(dataSource, new QualifiedTable(null, "t_order"),
                 Collections.emptyList(), buildOrderIdUniqueKey(), QueryType.RANGE_QUERY);
         param.setQueryRange(new QueryRange(null, false, null));
@@ -232,9 +232,10 @@ class RecordSingleTableInventoryCalculatorTest {
         QuietlyCloser.close(param.getCalculationContext());
     }
     
-    @Test
-    void assertCalculateOfRangeQueryAllWithMultiColumnUniqueKeysWith50x100() {
-        RecordSingleTableInventoryCalculator calculator = new RecordSingleTableInventoryCalculator(50, 100);
+    @ParameterizedTest
+    @CsvSource({"SMALL", "LARGE"})
+    void assertCalculateOfRangeQueryAllWithMultiColumnUniqueKeysWith50x100(final String streamingRangeType) {
+        RecordSingleTableInventoryCalculator calculator = new RecordSingleTableInventoryCalculator(50, 100, StreamingRangeType.valueOf(streamingRangeType));
         SingleTableInventoryCalculateParameter param = new SingleTableInventoryCalculateParameter(dataSource, new QualifiedTable(null, "t_order"),
                 Collections.emptyList(), buildMultiColumnUniqueKeys(), QueryType.RANGE_QUERY);
         param.setQueryRange(new QueryRange(null, false, null));
@@ -258,9 +259,9 @@ class RecordSingleTableInventoryCalculatorTest {
     }
     
     @ParameterizedTest
-    @CsvSource({"100", "2", "3"})
-    void assertCalculateOfRangeQueryAllWithMultiColumnUniqueKeysWith3x(final int streamingChunkCount) {
-        RecordSingleTableInventoryCalculator calculator = new RecordSingleTableInventoryCalculator(3, streamingChunkCount);
+    @CsvSource({"100,SMALL", "2,SMALL", "3,SMALL", "100,LARGE", "2,LARGE", "3,LARGE"})
+    void assertCalculateOfRangeQueryAllWithMultiColumnUniqueKeysWith3x(final int streamingChunkCount, final String streamingRangeType) {
+        RecordSingleTableInventoryCalculator calculator = new RecordSingleTableInventoryCalculator(3, streamingChunkCount, StreamingRangeType.valueOf(streamingRangeType));
         SingleTableInventoryCalculateParameter param = new SingleTableInventoryCalculateParameter(dataSource, new QualifiedTable(null, "t_order"),
                 Collections.emptyList(), buildMultiColumnUniqueKeys(), QueryType.RANGE_QUERY);
         param.setQueryRange(new QueryRange(null, false, null));
@@ -296,9 +297,9 @@ class RecordSingleTableInventoryCalculatorTest {
     }
     
     @ParameterizedTest
-    @CsvSource({"100", "3", "4"})
-    void assertCalculateOfRangeQueryAllWithMultiColumnUniqueKeysWith2x(final int streamingChunkCount) {
-        RecordSingleTableInventoryCalculator calculator = new RecordSingleTableInventoryCalculator(2, streamingChunkCount);
+    @CsvSource({"100,SMALL", "3,SMALL", "4,SMALL", "100,LARGE", "3,LARGE", "4,LARGE"})
+    void assertCalculateOfRangeQueryAllWithMultiColumnUniqueKeysWith2x(final int streamingChunkCount, final String streamingRangeType) {
+        RecordSingleTableInventoryCalculator calculator = new RecordSingleTableInventoryCalculator(2, streamingChunkCount, StreamingRangeType.valueOf(streamingRangeType));
         SingleTableInventoryCalculateParameter param = new SingleTableInventoryCalculateParameter(dataSource, new QualifiedTable(null, "t_order"),
                 Collections.emptyList(), buildMultiColumnUniqueKeys(), QueryType.RANGE_QUERY);
         param.setQueryRange(new QueryRange(null, false, null));

--- a/test/it/pipeline/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordSingleTableInventoryCalculatorTest.java
+++ b/test/it/pipeline/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordSingleTableInventoryCalculatorTest.java
@@ -31,7 +31,6 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.infra.util.close.QuietlyCloser;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 


### PR DESCRIPTION

Changes proposed in this pull request:
  - Add large range streaming query in RecordSingleTableInventoryCalculator
  - Add streaming-range-type prop for DATA_MATCH consistency check
  - Add more RecordSingleTableInventoryCalculator test cases; Update SQL builder test cases

---
`ResultSet.close()` disadvantage of MySQL JDBC driver on streaming mode: It'll "drain the rest of the records" before close.

Related stack trace:
```
	  at com.mysql.cj.protocol.a.result.ResultsetRowsStreaming.close(ResultsetRowsStreaming.java:124)
	  - locked <0x27f9> (a com.mysql.cj.jdbc.ConnectionImpl)
	  at com.mysql.cj.jdbc.result.ResultSetImpl.realClose(ResultSetImpl.java:1874)
	  at com.mysql.cj.jdbc.result.ResultSetImpl.close(ResultSetImpl.java:560)
	  at com.zaxxer.hikari.pool.HikariProxyResultSet.close(HikariProxyResultSet.java:-1)
```

ResultsetRowsStreaming.close source code (mysql-connector-j : 8.3.0)
![image](https://github.com/user-attachments/assets/9561a7b6-14d4-467a-a7ea-b01ff8f18da7)

It'll hurt performance in some degree when query on sharding table.
e.g. target table `sbtest1` with 10 shards, sharding rule:
```
CREATE SHARDING TABLE RULE sbtest1(
STORAGE_UNITS(target_ds_0),
SHARDING_COLUMN=id,
TYPE(NAME="hash_mod",PROPERTIES("sharding-count"="10"))
);
```
Ordering query on target ('chunk-size'='1000'):
Logic SQL: select * from sbtest1 order by id asc limit 100000;
Actual SQL: 10 actual SQLs on every shard
- select * from sbtest1_0 order by id asc limit 100000;
- select * from sbtest1_K order by id asc limit 100000;
- select * from sbtest1_9 order by id asc limit 100000;
10 actual SQLs fetch more rows (10_0000 * 10) than declared limit 10_0000 in logic SQL. So it'll emit "drain the rest of the records" in `ResultsetRowsStreaming.close`.

And "drain the rest of the records" in ResultsetRowsStreaming.close could not be improve for now. See related issues:
- https://bugs.mysql.com/bug.php?id=90653
- https://bugs.mysql.com/bug.php?id=95763

So we'll add new streaming query impl, it won't use `LIMIT` clause on MySQL. Logic SQL examples:
- select * from sbtest1 order by id asc; (First query)
- select * from sbtest1 where id>=? order by id asc; (Query on breakpoint resumption)

<p/>
And a new DATA_MATCH property `streaming-range-type` is added, options: SMALL (default value), LARGE.

| streaming-range-type | Advantage | Disadvantage | Logic query SQL example                                                 |
|-----------------|-----------|---------------|-------------------------------------------------------------|
| SMALL      | Every SQL could be executed quickly.       | Sharding table query performance will be affected on MySQL.          | select * from sbtest1 order by id asc limit 100000; |
| LARGE      | Better sharding table query performance on MySQL.       | It's better not limit innodb_thread_concurrency variable value on MySQL, else it might block other query SQLs.          | select * from sbtest1 order by id asc; |


---
Usage example:
```
CHECK MIGRATION j0102p000017bdff3f7acd10373694e80e3ffda542 BY TYPE (NAME='DATA_MATCH', PROPERTIES('chunk-size'='1000','streaming-range-type'='LARGE'));

CHECK MIGRATION j0102p000017bdff3f7acd10373694e80e3ffda542 BY TYPE (NAME='DATA_MATCH', PROPERTIES('chunk-size'='1000','streaming-range-type'='SMALL'));
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
