### PR TITLE
Add optional module for Jakarta Transactions impl of Jakarta EE 9 Spec

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,7 @@
 1. Decouple features as pluggable [#36086](https://github.com/apache/shardingsphere/pull/36086)
 1. Decouple mode repositories as pluggable [#36087](https://github.com/apache/shardingsphere/pull/36087)
 1. Firebird: Support Firebird Proxy [#35937](https://github.com/apache/shardingsphere/pull/35937)
+1. Add optional module for Jakarta Transactions impl of Jakarta EE 9 Spec [#35810](https://github.com/apache/shardingsphere/pull/35810)
 
 ### Enhancements
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/jakarta-transactions/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/jakarta-transactions/_index.cn.md
@@ -1,0 +1,292 @@
++++
+title = "Jakarta EE 9 Spec 的 Jakarta Transactions"
+weight = 6
++++
+
+## 背景信息
+
+本页文档所涉及的可选模块均采用 Jakarta EE 9 Spec 的 Jakarta Transactions，兼容 Jakarta EE 9，Jakarta EE 9.1 或 Jakarta EE 10。
+本页文档所涉及的可选模块，旨在解决可选模块 `shardingsphere-transaction-xa` 无法在 Spring Boot 3，Quarkus 3，
+Micronaut Framework 4 或 Helidon 3 等其他基于 Jakarta EE 9+ 的 Web Framework 下使用的问题。
+
+本页文档所涉及的可选模块与 `shardingsphere-transaction-xa` 的约定配置基本一致。
+但相关可选模块无法与 `shardingsphere-transaction-xa` 在同一 classpath，或在同一 Maven 模块使用。
+Java EE 8 或 Jakarta EE 8 不属于本页文档所涉及的可选模块的支持范围，对于类似的情况应考虑使用 `shardingsphere-transaction-xa`。
+
+## JDBC
+
+### Atomikos
+
+#### 前提条件
+
+要在 ShardingSphere 的配置文件中配置 Atomikos 作为 Jakarta EE 9 Spec 的 Jakarta Transactions 实现，
+可能的 Maven 依赖关系如下，
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-jdbc</artifactId>
+        <version>${shardingsphere.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-core</artifactId>
+        <version>${shardingsphere.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>jakarta.transaction</groupId>
+        <artifactId>jakarta.transaction-api</artifactId>
+        <version>2.0.0</version>
+    </dependency>
+</dependencies>
+```
+
+#### 配置
+
+与 `org.apache.shardingsphere:shardingsphere-transaction-xa-core` 一致，可以通过在项目的 classpath 中添加 `jta.properties` 来定制化 Atomikos 配置项。
+
+在 ShardingSphere 的配置文件中，可能的配置项如下，
+
+```yaml
+transaction:
+  defaultType: XA
+  providerType: Atomikos
+```
+
+### Narayana
+
+要在 ShardingSphere 的配置文件中配置 Narayana 作为 Jakarta EE 9 Spec 的 Jakarta Transactions 实现，
+可能的 Maven 依赖关系如下，
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-jdbc</artifactId>
+        <version>${shardingsphere.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-core</artifactId>
+        <version>${shardingsphere.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-narayana</artifactId>
+        <version>${shardingsphere.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>jakarta.transaction</groupId>
+        <artifactId>jakarta.transaction-api</artifactId>
+        <version>2.0.0</version>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.narayana.jta</groupId>
+        <artifactId>narayana-jta-jakarta</artifactId>
+        <version>5.12.7.Final</version>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.narayana.jts</groupId>
+        <artifactId>narayana-jts-integration-jakarta</artifactId>
+        <version>5.12.7.Final</version>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+        <version>3.4.3.Final</version>
+    </dependency>
+</dependencies>
+```
+
+#### 配置
+
+与 `org.apache.shardingsphere:shardingsphere-transaction-xa-narayana` 一致，可以通过在项目的 classpath 中添加 `jbossts-properties.xml` 来定制化 Atomikos 配置项。
+
+对于 `jbossts-properties.xml` 的最小配置，ShardingSphere 要求定义 Narayana 的 `CoreEnvironmentBean.nodeIdentifier` 属性。 
+如果 Narayana 的 object store 并非在不同的 Narayana 实例之间共享，你可以将此值设置为 `1`。一个可能的 `jbossts-properties.xml` 配置如下，
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+    <entry key="CoreEnvironmentBean.nodeIdentifier">1</entry>
+</properties>
+```
+
+在特定情况下，开发者可能不会希望使用 XML 文件，那开发者需要在自有 Java 项目的启动类手动设置 `CoreEnvironmentBean.nodeIdentifier`。 可参考如下方法调用 Narayana Java API。
+
+```java
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
+
+public class ExampleUtils {
+    public void initNarayanaInstance() {
+        try {
+            arjPropertyManager.getCoreEnvironmentBean().setNodeIdentifier("1");
+        } catch (CoreEnvironmentBeanException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+```
+
+在 ShardingSphere 的配置文件中，可能的配置项如下，
+
+```yaml
+transaction:
+  defaultType: XA
+  providerType: Narayana
+```
+
+## Proxy
+
+注意：本小节内容可能在未来进行更改，以简化使用。以下内容仅作为 ShardingSphere 默认 Maven Profile 的构建配置的参考。
+
+引入前提，ShardingSphere Proxy 默认情况下使用 Jakarta EE 8 Spec 的 Jakarta Transactions 实现。
+
+### Atomikos
+
+如果需要使用 Jakarta EE 9 Spec 的 Jakarta Transactions 的 Atomikos 实现，
+需要更改源代码，并手动编译 binary 或 Linux Container。
+
+对于 `distribution/proxy/pom.xml` 文件的如下部分，
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-proxy-bootstrap</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+</dependencies>
+```
+
+需更改为，
+
+```xml
+<properties>
+    <jakarta.jakartaee-bom.version>9.0.0</jakarta.jakartaee-bom.version>
+    <glassfish-jaxb.version>3.0.2</glassfish-jaxb.version>
+    <jboss-logging.version>3.4.3.Final</jboss-logging.version>
+</properties>
+
+<dependencies>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-proxy-bootstrap</artifactId>
+        <version>${project.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.apache.shardingsphere</groupId>
+                <artifactId>shardingsphere-transaction-xa-core</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-core</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+</dependencies>
+```
+
+对于 Proxy 的 `global.yaml`, 可能的配置项如下，
+
+```yaml
+transaction:
+  defaultType: XA
+  providerType: Atomikos
+```
+
+### Narayana
+
+如果需要使用 Jakarta EE 9 Spec 的 Jakarta Transactions 的 Narayana 实现，需要更改源代码，并手动编译 binary 或 Linux Container。
+
+对于 `distribution/proxy/pom.xml` 文件的如下部分，
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-proxy-bootstrap</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+</dependencies>
+```
+
+需更改为，
+
+```xml
+<properties>
+    <jakarta.jakartaee-bom.version>9.0.0</jakarta.jakartaee-bom.version>
+    <glassfish-jaxb.version>3.0.2</glassfish-jaxb.version>
+    <jboss-logging.version>3.4.3.Final</jboss-logging.version>
+</properties>
+
+<dependencies>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-proxy-bootstrap</artifactId>
+        <version>${project.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.apache.shardingsphere</groupId>
+                <artifactId>shardingsphere-transaction-xa-core</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-core</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-narayana</artifactId>
+        <version>${shardingsphere.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>jakarta.transaction</groupId>
+        <artifactId>jakarta.transaction-api</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.narayana.jta</groupId>
+        <artifactId>narayana-jta-jakarta</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.narayana.jts</groupId>
+        <artifactId>narayana-jts-integration-jakarta</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+    </dependency>
+</dependencies>
+```
+
+对于 Proxy 的 `global.yaml`, 可能的配置项如下，
+
+```yaml
+transaction:
+  defaultType: XA
+  providerType: Narayana
+```
+
+对于最小配置，仍需通过与 `global.yaml` 处于同一目录的 `jbossts-properties.xml` 配置 Narayana 的 `CoreEnvironmentBean.nodeIdentifier` 属性。
+
+## Proxy Native
+
+处理方式与 ShardingSphere Proxy 一致。

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/jakarta-transactions/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/jakarta-transactions/_index.en.md
@@ -1,0 +1,301 @@
++++
+title = "Jakarta Transactions of Jakarta EE 9 Spec"
+weight = 6
++++
+
+## Background Information
+
+The optional modules mentioned in this document all use Jakarta Transactions of Jakarta EE 9 Spec and are compatible with Jakarta EE 9, 
+Jakarta EE 9.1 or Jakarta EE 10.
+The optional modules mentioned in this document are designed to solve the problem that the optional module `shardingsphere-transaction-xa` cannot be used in other Web Frameworks based on Jakarta EE 9+, 
+such as Spring Boot 3, Quarkus 3, Micronaut Framework 4 or Helidon 3.
+
+The optional modules mentioned in this document are basically consistent with the agreed configuration of `shardingsphere-transaction-xa`.
+However, the relevant optional modules cannot be used in the same classpath or in the same Maven module as `shardingsphere-transaction-xa`.
+Java EE 8 or Jakarta EE 8 are not supported by the optional modules mentioned in this document. For similar situations, you should consider using `shardingsphere-transaction-xa`.
+
+## JDBC
+
+### Atomikos
+
+#### Prerequisites
+
+To configure Atomikos as the Jakarta Transactions implementation of the Jakarta EE 9 Spec in the ShardingSphere configuration file,
+the possible Maven dependencies are as follows,
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-jdbc</artifactId>
+        <version>${shardingsphere.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-core</artifactId>
+        <version>${shardingsphere.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>jakarta.transaction</groupId>
+        <artifactId>jakarta.transaction-api</artifactId>
+        <version>2.0.0</version>
+    </dependency>
+</dependencies>
+```
+
+#### Configuration
+
+As with `org.apache.shardingsphere:shardingsphere-transaction-xa-core`, 
+you can customize Atomikos configuration items by adding `jta.properties` to the project's classpath.
+
+In the ShardingSphere configuration file, possible configuration items are as follows,
+
+```yaml
+transaction:
+  defaultType: XA
+  providerType: Atomikos
+```
+
+### Narayana
+
+To configure Narayana as the Jakarta Transactions implementation of the Jakarta EE 9 Spec in ShardingSphere's configuration file,
+the possible Maven dependencies are as follows,
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-jdbc</artifactId>
+        <version>${shardingsphere.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-core</artifactId>
+        <version>${shardingsphere.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-narayana</artifactId>
+        <version>${shardingsphere.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>jakarta.transaction</groupId>
+        <artifactId>jakarta.transaction-api</artifactId>
+        <version>2.0.0</version>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.narayana.jta</groupId>
+        <artifactId>narayana-jta-jakarta</artifactId>
+        <version>5.12.7.Final</version>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.narayana.jts</groupId>
+        <artifactId>narayana-jts-integration-jakarta</artifactId>
+        <version>5.12.7.Final</version>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+        <version>3.4.3.Final</version>
+    </dependency>
+</dependencies>
+```
+
+#### Configuration
+
+In line with `org.apache.shardingsphere:shardingsphere-transaction-xa-narayana`, 
+Atomikos configuration items can be customized by adding `jbossts-properties.xml` to the project's classpath.
+
+For the minimal configuration of `jbossts-properties.xml`, ShardingSphere requires the definition of Narayana's `CoreEnvironmentBean.nodeIdentifier` property.
+If Narayana's object store is not shared between different Narayana instances, you can set this value to `1`. 
+A possible `jbossts-properties.xml` configuration is as follows,
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+    <entry key="CoreEnvironmentBean.nodeIdentifier">1</entry>
+</properties>
+```
+
+In certain cases, developers may not want to use XML files, 
+then developers need to manually set `CoreEnvironmentBean.nodeIdentifier` in the startup class of their own Java project. 
+You can refer to the following method to call the Narayana Java API.
+
+```java
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
+
+public class ExampleUtils {
+    public void initNarayanaInstance() {
+        try {
+            arjPropertyManager.getCoreEnvironmentBean().setNodeIdentifier("1");
+        } catch (CoreEnvironmentBeanException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+```
+
+In the ShardingSphere configuration file, possible configuration items are as follows:
+
+```yaml
+transaction:
+  defaultType: XA
+  providerType: Narayana
+```
+
+## Proxy
+
+Note: This section may be changed in the future to simplify usage. 
+The following content is only a reference for the build configuration of ShardingSphere's default Maven Profile.
+
+Introduction premise, ShardingSphere Proxy uses the Jakarta Transactions implementation of the Jakarta EE 8 Spec by default.
+
+### Atomikos
+
+If you need to use the Atomikos implementation of Jakarta Transactions of the Jakarta EE 9 Spec,
+you need to change the source code and manually compile the binary or Linux Container.
+
+For the following part of the `distribution/proxy/pom.xml` file,
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-proxy-bootstrap</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+</dependencies>
+```
+
+Need to be changed to,
+
+```xml
+<properties>
+    <jakarta.jakartaee-bom.version>9.0.0</jakarta.jakartaee-bom.version>
+    <glassfish-jaxb.version>3.0.2</glassfish-jaxb.version>
+    <jboss-logging.version>3.4.3.Final</jboss-logging.version>
+</properties>
+
+<dependencies>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-proxy-bootstrap</artifactId>
+        <version>${project.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.apache.shardingsphere</groupId>
+                <artifactId>shardingsphere-transaction-xa-core</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-core</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+</dependencies>
+```
+
+For Proxy's `global.yaml`, possible configuration items are as follows,
+
+```yaml
+transaction:
+  defaultType: XA
+  providerType: Atomikos
+```
+
+### Narayana
+
+If you need to use the Narayana implementation of Jakarta Transactions with the Jakarta EE 9 Spec, 
+you need to modify the source code and manually compile the binary or Linux Container.
+
+For the following part of the `distribution/proxy/pom.xml` file,
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-proxy-bootstrap</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+</dependencies>
+```
+
+Need to be changed to,
+
+```xml
+<properties>
+    <jakarta.jakartaee-bom.version>9.0.0</jakarta.jakartaee-bom.version>
+    <glassfish-jaxb.version>3.0.2</glassfish-jaxb.version>
+    <jboss-logging.version>3.4.3.Final</jboss-logging.version>
+</properties>
+
+<dependencies>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-proxy-bootstrap</artifactId>
+        <version>${project.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.apache.shardingsphere</groupId>
+                <artifactId>shardingsphere-transaction-xa-core</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-core</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-narayana</artifactId>
+        <version>${shardingsphere.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>jakarta.transaction</groupId>
+        <artifactId>jakarta.transaction-api</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.narayana.jta</groupId>
+        <artifactId>narayana-jta-jakarta</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.narayana.jts</groupId>
+        <artifactId>narayana-jts-integration-jakarta</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+    </dependency>
+</dependencies>
+```
+
+For Proxy's `global.yaml`, possible configuration items are as follows,
+
+```yaml
+transaction:
+  defaultType: XA
+  providerType: Narayana
+```
+
+For a minimal configuration, 
+you still need to configure Narayana's `CoreEnvironmentBean.nodeIdentifier` property via `jbossts-properties.xml` in the same directory as `global.yaml`.
+
+## Proxy Native
+
+The processing method is the same as ShardingSphere Proxy.

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.cn.md
@@ -35,12 +35,7 @@ spring.datasource.url=jdbc:shardingsphere:classpath:xxx.yaml
 
 直接使用该数据源；或者将 ShardingSphereDataSource 配置在 JPA、Hibernate、MyBatis 等 ORM 框架中配合使用。
 
-## 针对 Spring Boot OSS 3 的处理
-
-Spring Boot OSS 3 对 Jakarta EE 和 Java 17 进行了 “大爆炸” 升级，涉及大量复杂情况。
-
-ShardingSphere 的 XA 分布式事务尚未在 Spring Boot OSS 3 上就绪，此限制同样适用于其他基于 Jakarta EE 9+ 的 Web Framework，如
-Quarkus 3，Micronaut Framework 4 和 Helidon 3。
+## 针对 Spring Boot 3 的处理
 
 用户仅需要配置如下。
 
@@ -56,9 +51,13 @@ Quarkus 3，Micronaut Framework 4 和 Helidon 3。
 </project>
 ```
 
-## 针对低版本的 Spring Boot OSS 2 的特殊处理
+若需要在 Spring Boot 3 下使用 ShardingSphere 的 XA 分布式事务，
+需参考 [Jakarta EE 9 Spec 的 Jakarta Transactions](/cn/user-manual/shardingsphere-jdbc/optional-plugins/jakarta-transactions)。
+此要求同样适用于其他基于 Jakarta EE 9+ 的 Web Framework，如 Quarkus 3，Micronaut Framework 4 和 Helidon 3。
 
-ShardingSphere 的所有特性均可在 Spring Boot OSS 2 上使用，但低版本的 Spring Boot OSS 可能需要手动指定 SnakeYAML 的版本为 2.2 。 
+## 针对低版本的 Spring Boot 2 的特殊处理
+
+ShardingSphere 的所有特性均可在 Spring Boot 2 上使用，但低版本的 Spring Boot 可能需要手动指定 SnakeYAML 的版本为 2.2 。 
 这在 Maven 的 `pom.xml` 体现为如下内容。
 
 ```xml

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.en.md
@@ -35,12 +35,7 @@ The YAML configuration file in 'spring.datasource.url' currently support in mult
 
 Use this data source directly; or configure ShardingSphereDataSource to be used in conjunction with ORM frameworks such as JPA, Hibernate, and MyBatis.
 
-## Handling for Spring Boot OSS 3
-
-Spring Boot OSS 3 has made a "big bang" upgrade to Jakarta EE and Java 17, with all complications involved.
-
-ShardingSphere's XA distributed transactions are not yet ready on Spring Boot OSS 3. This limitation also applies to other 
-Jakarta EE 9+ based Web Frameworks, such as Quarkus 3, Micronaut Framework 4 and Helidon 3.
+## Handling for Spring Boot 3
 
 Users only need to configure as follows.
 
@@ -56,9 +51,13 @@ Users only need to configure as follows.
 </project>
 ```
 
-## Special handling for earlier versions of Spring Boot OSS 2
+If you need to use ShardingSphere's XA distributed transactions under Spring Boot 3,
+please refer to [Jakarta Transactions of Jakarta EE 9 Spec](/en/user-manual/shardingsphere-jdbc/optional-plugins/jakarta-transactions).
+This requirement also applies to other Web Frameworks based on Jakarta EE 9+, such as Quarkus 3, Micronaut Framework 4, and Helidon 3.
 
-All features of ShardingSphere are available on Spring Boot OSS 2, but earlier versions of Spring Boot OSS may require 
+## Special handling for earlier versions of Spring Boot 2
+
+All features of ShardingSphere are available on Spring Boot 2, but earlier versions of Spring Boot may require 
 manually specifying version 2.2 for SnakeYAML.
 This is reflected in Maven's `pom.xml` as follows.
 

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/com.microsoft.sqlserver/mssql-jdbc/12.10.1.jre8/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/com.microsoft.sqlserver/mssql-jdbc/12.10.1.jre8/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.microsoft.sqlserver.jdbc.ConfigurableRetryLogic"
+      },
+      "type": "com.microsoft.sqlserver.jdbc.ConfigurableRetryLogic"
+    }
+  ]
+}

--- a/kernel/transaction/type/xa-jakarta/core/pom.xml
+++ b/kernel/transaction/type/xa-jakarta/core/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta</artifactId>
+        <version>5.5.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>shardingsphere-transaction-xa-jakarta-core</artifactId>
+    <name>${project.artifactId}</name>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-transaction-xa-jakarta-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-transaction-xa-jakarta-atomikos</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.transformer</groupId>
+                <artifactId>transformer-maven-plugin</artifactId>
+                <version>${transformer-maven-plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <rules>
+                        <jakartaDefaults>true</jakartaDefaults>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <artifact>
+                                <groupId>org.apache.shardingsphere</groupId>
+                                <artifactId>shardingsphere-transaction-xa-core</artifactId>
+                                <version>${project.version}</version>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>javadoc-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <skip>${maven.javadoc.skip}</skip>
+                            <artifact>
+                                <groupId>org.apache.shardingsphere</groupId>
+                                <artifactId>shardingsphere-transaction-xa-core</artifactId>
+                                <version>${project.version}</version>
+                                <classifier>javadoc</classifier>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>source-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <artifact>
+                                <groupId>org.apache.shardingsphere</groupId>
+                                <artifactId>shardingsphere-transaction-xa-core</artifactId>
+                                <version>${project.version}</version>
+                                <classifier>sources</classifier>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kernel/transaction/type/xa-jakarta/pom.xml
+++ b/kernel/transaction/type/xa-jakarta/pom.xml
@@ -20,16 +20,26 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
-        <artifactId>shardingsphere-transaction</artifactId>
+        <artifactId>shardingsphere-transaction-type</artifactId>
         <version>5.5.3-SNAPSHOT</version>
     </parent>
-    <artifactId>shardingsphere-transaction-type</artifactId>
+    <artifactId>shardingsphere-transaction-xa-jakarta</artifactId>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     
     <modules>
-        <module>xa</module>
-        <module>xa-jakarta</module>
-        <module>base</module>
+        <module>spi</module>
+        <module>provider</module>
+        <module>core</module>
     </modules>
+    
+    <properties>
+        <!--
+        As a workaround for https://github.com/apache/shardingsphere/issues/26041 ,
+        versions of Jakarta EE Spec dependencies are maintained separately in this module and its submodules.
+        -->
+        <jakarta.jakartaee-bom.version>9.0.0</jakarta.jakartaee-bom.version>
+        <glassfish-jaxb.version>3.0.2</glassfish-jaxb.version>
+        <jboss-logging.version>3.4.3.Final</jboss-logging.version>
+    </properties>
 </project>

--- a/kernel/transaction/type/xa-jakarta/provider/atomikos/pom.xml
+++ b/kernel/transaction/type/xa-jakarta/provider/atomikos/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-provider</artifactId>
+        <version>5.5.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>shardingsphere-transaction-xa-jakarta-atomikos</artifactId>
+    <name>${project.artifactId}</name>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-transaction-xa-jakarta-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.atomikos</groupId>
+            <artifactId>transactions-jta</artifactId>
+            <version>${atomikos.version}</version>
+            <classifier>jakarta</classifier>
+        </dependency>
+        <dependency>
+            <groupId>com.atomikos</groupId>
+            <artifactId>transactions-jdbc</artifactId>
+            <version>${atomikos.version}</version>
+            <classifier>jakarta</classifier>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.transformer</groupId>
+                <artifactId>transformer-maven-plugin</artifactId>
+                <version>${transformer-maven-plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <rules>
+                        <jakartaDefaults>true</jakartaDefaults>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <artifact>
+                                <groupId>org.apache.shardingsphere</groupId>
+                                <artifactId>shardingsphere-transaction-xa-atomikos</artifactId>
+                                <version>${project.version}</version>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>javadoc-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <skip>${maven.javadoc.skip}</skip>
+                            <artifact>
+                                <groupId>org.apache.shardingsphere</groupId>
+                                <artifactId>shardingsphere-transaction-xa-atomikos</artifactId>
+                                <version>${project.version}</version>
+                                <classifier>javadoc</classifier>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>source-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <artifact>
+                                <groupId>org.apache.shardingsphere</groupId>
+                                <artifactId>shardingsphere-transaction-xa-atomikos</artifactId>
+                                <version>${project.version}</version>
+                                <classifier>sources</classifier>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kernel/transaction/type/xa-jakarta/provider/narayana/pom.xml
+++ b/kernel/transaction/type/xa-jakarta/provider/narayana/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta-provider</artifactId>
+        <version>5.5.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>shardingsphere-transaction-xa-jakarta-narayana</artifactId>
+    <name>${project.artifactId}</name>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-transaction-xa-jakarta-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.jboss.narayana.jta</groupId>
+            <artifactId>narayana-jta-jakarta</artifactId>
+            <version>${narayana.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.narayana.jts</groupId>
+            <artifactId>narayana-jts-integration-jakarta</artifactId>
+            <version>${narayana.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>${jboss-logging.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.transformer</groupId>
+                <artifactId>transformer-maven-plugin</artifactId>
+                <version>${transformer-maven-plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <rules>
+                        <jakartaDefaults>true</jakartaDefaults>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <artifact>
+                                <groupId>org.apache.shardingsphere</groupId>
+                                <artifactId>shardingsphere-transaction-xa-narayana</artifactId>
+                                <version>${project.version}</version>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>javadoc-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <skip>${maven.javadoc.skip}</skip>
+                            <artifact>
+                                <groupId>org.apache.shardingsphere</groupId>
+                                <artifactId>shardingsphere-transaction-xa-narayana</artifactId>
+                                <version>${project.version}</version>
+                                <classifier>javadoc</classifier>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>source-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <artifact>
+                                <groupId>org.apache.shardingsphere</groupId>
+                                <artifactId>shardingsphere-transaction-xa-narayana</artifactId>
+                                <version>${project.version}</version>
+                                <classifier>sources</classifier>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kernel/transaction/type/xa-jakarta/provider/pom.xml
+++ b/kernel/transaction/type/xa-jakarta/provider/pom.xml
@@ -20,16 +20,14 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
-        <artifactId>shardingsphere-transaction</artifactId>
+        <artifactId>shardingsphere-transaction-xa-jakarta</artifactId>
         <version>5.5.3-SNAPSHOT</version>
     </parent>
-    <artifactId>shardingsphere-transaction-type</artifactId>
+    <artifactId>shardingsphere-transaction-xa-jakarta-provider</artifactId>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
-    
     <modules>
-        <module>xa</module>
-        <module>xa-jakarta</module>
-        <module>base</module>
+        <module>atomikos</module>
+        <module>narayana</module>
     </modules>
 </project>

--- a/kernel/transaction/type/xa-jakarta/spi/pom.xml
+++ b/kernel/transaction/type/xa-jakarta/spi/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-transaction-xa-jakarta</artifactId>
+        <version>5.5.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>shardingsphere-transaction-xa-jakarta-spi</artifactId>
+    <name>${project.artifactId}</name>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-transaction-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.transformer</groupId>
+                <artifactId>transformer-maven-plugin</artifactId>
+                <version>${transformer-maven-plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <rules>
+                        <jakartaDefaults>true</jakartaDefaults>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <artifact>
+                                <groupId>org.apache.shardingsphere</groupId>
+                                <artifactId>shardingsphere-transaction-xa-spi</artifactId>
+                                <version>${project.version}</version>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>javadoc-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <skip>${maven.javadoc.skip}</skip>
+                            <artifact>
+                                <groupId>org.apache.shardingsphere</groupId>
+                                <artifactId>shardingsphere-transaction-xa-spi</artifactId>
+                                <version>${project.version}</version>
+                                <classifier>javadoc</classifier>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>source-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <artifact>
+                                <groupId>org.apache.shardingsphere</groupId>
+                                <artifactId>shardingsphere-transaction-xa-spi</artifactId>
+                                <version>${project.version}</version>
+                                <classifier>sources</classifier>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         
         <postgresql.version>42.7.5</postgresql.version>
         <mysql-connector-java.version>8.3.0</mysql-connector-java.version>
-        <mssql.version>6.1.7.jre8-preview</mssql.version>
+        <mssql.version>12.10.1.jre8</mssql.version>
         <h2.version>2.2.224</h2.version>
         <opengauss.version>3.1.0-og</opengauss.version>
         <mariadb-java-client.version>2.4.2</mariadb-java-client.version>
@@ -160,6 +160,7 @@
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
         <os-detector-maven-plugin.version>0.3.1</os-detector-maven-plugin.version>
         <native-maven-plugin.version>0.11.0</native-maven-plugin.version>
+        <transformer-maven-plugin.version>0.5.0</transformer-maven-plugin.version>
         
         <!-- Compile plugin versions -->
         <templating-maven-plugin.version>1.0.0</templating-maven-plugin.version>
@@ -1074,6 +1075,16 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+        <profile>
+            <id>jdk17+</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <properties>
+                <!--TODO See https://github.com/eclipse-transformer/transformer/issues/475 -->
+                <transformer-maven-plugin.version>1.0.0</transformer-maven-plugin.version>
+            </properties>
         </profile>
         <profile>
             <id>generateMetadata</id>


### PR DESCRIPTION
Fixes #26041 .

Changes proposed in this pull request:
  - Add optional module for Jakarta Transactions impl of Jakarta EE 9 Spec. This is an alternative to #27976 . The main difference is that the current PR does not switch the JAXB version used by the test suite.
  - `shardingsphere-transaction-xa-jakarta` basically reuses all the definitions of `shardingsphere-transaction-xa`, but switches `javax.transaction` java package to `jakarta.transaction` java package, and uses a different set of third-party dependencies.
  -  It is intentional that the Jakarta EE 8 namespace counterpart `org.apache.shardingsphere.transaction.api.TransactionType#XA` is still used, because `org.apache.shardingsphere:shardingsphere-transaction-xa-jakarta-core` and `org.apache.shardingsphere:shardingsphere-transaction-xa-jakarta-core` cannot be used in the same Maven module at the same time, as the two modules use different versions of the same set of third-party dependencies. Of course I know that there are new major impacts in https://github.com/spring-projects/spring-framework/issues/34011 on the Spring Boot 4 milestone. But we should always take it one step at a time, right?
  - Add GraalVM Reachability Metadata for `com.microsoft.sqlserver:mssql-jdbc:12.10.1.jre8`. For #29052 .
  - Bump the MS SQL Server JDBC used in the tests to `12.10.1.jre8`. I can't understand why `com.microsoft.sqlserver:mssql-jdbc:6.1.7.jre8-preview` would depend on Jakarta EE 8's JAXB API.🫠
```shell
java.lang.NoClassDefFoundError: javax/xml/bind/DatatypeConverter

	at com.microsoft.sqlserver.jdbc.SQLServerConnection.sendLogon(SQLServerConnection.java:3984)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.logon(SQLServerConnection.java:3097)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.access$100(SQLServerConnection.java:82)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection$LogonCommand.doExecute(SQLServerConnection.java:3061)
	at com.microsoft.sqlserver.jdbc.TDSCommand.execute(IOBuffer.java:7137)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.executeCommand(SQLServerConnection.java:2417)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.connectHelper(SQLServerConnection.java:1999)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.login(SQLServerConnection.java:1668)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.connectInternal(SQLServerConnection.java:1511)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.connect(SQLServerConnection.java:864)
	at com.microsoft.sqlserver.jdbc.SQLServerDriver.connect(SQLServerDriver.java:569)
	at org.testcontainers.containers.JdbcDatabaseContainer.createConnection(JdbcDatabaseContainer.java:287)
	at org.testcontainers.containers.JdbcDatabaseContainer.createConnection(JdbcDatabaseContainer.java:252)
	at org.testcontainers.containers.JdbcDatabaseContainer.waitUntilContainerStarted(JdbcDatabaseContainer.java:192)
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:492)
	at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:346)
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:336)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:322)
	at org.testcontainers.jdbc.ContainerDatabaseDriver.connect(ContainerDatabaseDriver.java:134)
	at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:121)
	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:364)
	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:206)
	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:476)
	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:561)
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:115)
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:112)
	at org.apache.shardingsphere.infra.database.DatabaseTypeEngine.getStorageType(DatabaseTypeEngine.java:113)
	at org.apache.shardingsphere.infra.database.DatabaseTypeEngine.getProtocolType(DatabaseTypeEngine.java:80)
	at org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory.create(ShardingSphereDatabasesFactory.java:80)
	at org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory.create(LocalConfigurationMetaDataContextsInitFactory.java:55)
	at org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory.create(MetaDataContextsFactory.java:75)
	at org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder.build(StandaloneContextManagerBuilder.java:52)
	at org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource.createContextManager(ShardingSphereDataSource.java:77)
	at org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource.<init>(ShardingSphereDataSource.java:65)
	at org.apache.shardingsphere.driver.api.ShardingSphereDataSourceFactory.createDataSource(ShardingSphereDataSourceFactory.java:95)
	at org.apache.shardingsphere.driver.api.yaml.YamlShardingSphereDataSourceFactory.createDataSource(YamlShardingSphereDataSourceFactory.java:136)
	at org.apache.shardingsphere.driver.api.yaml.YamlShardingSphereDataSourceFactory.createDataSource(YamlShardingSphereDataSourceFactory.java:71)
	at org.apache.shardingsphere.driver.jdbc.core.driver.DriverDataSourceCache.createDataSource(DriverDataSourceCache.java:57)
	at org.apache.shardingsphere.driver.jdbc.core.driver.DriverDataSourceCache.lambda$get$0(DriverDataSourceCache.java:50)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1710)
	at org.apache.shardingsphere.driver.jdbc.core.driver.DriverDataSourceCache.get(DriverDataSourceCache.java:50)
	at org.apache.shardingsphere.driver.ShardingSphereDriver.connect(ShardingSphereDriver.java:57)
	at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:121)
	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:364)
	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:206)
	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:476)
	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:561)
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:115)
	at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:81)
	at org.apache.shardingsphere.test.natived.jdbc.databases.SQLServerTest.assertShardingInLocalTransactions(SQLServerTest.java:65)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
	Suppressed: java.lang.NullPointerException: Cannot invoke "javax.sql.DataSource.getConnection()" because "this.logicDataSource" is null
		at org.apache.shardingsphere.test.natived.jdbc.databases.SQLServerTest.afterEach(SQLServerTest.java:45)
		... 3 more
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 54 more
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
