### PR TITLE
Implement write method in PostgreSQLBoolBinaryProtocolValue

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -48,6 +48,7 @@
 1. SQL Parser: Support mysql quantify operator parse and upgrade calcite to 1.40.0 - [#35675](https://github.com/apache/shardingsphere/pull/35675)
 1. SQL Parser: Support Oracle create table with lob storage clause sql parsing - [#35782](https://github.com/apache/shardingsphere/pull/35782)
 1. SQL Parser: Support Oracle multiple backslash literal parsing - [#35784](https://github.com/apache/shardingsphere/pull/35784)
+1. Proxy: Implement write method for PostgreSQL bool binary data type - [#35831](https://github.com/apache/shardingsphere/pull/35831)
 
 ### Bug Fixes
 

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolBinaryProtocolValue.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.ex
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
-import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
 
 /**
  * Binary protocol value for bool for PostgreSQL.
@@ -39,6 +38,6 @@ public final class PostgreSQLBoolBinaryProtocolValue implements PostgreSQLBinary
     
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
-        throw new UnsupportedSQLOperationException("PostgreSQLBoolBinaryProtocolValue.write()");
+        payload.getByteBuf().writeBoolean("t".equals(value.toString()));
     }
 }

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBinaryProtocolValueFactoryTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBinaryProtocolValueFactoryTest.java
@@ -87,6 +87,12 @@ class PostgreSQLBinaryProtocolValueFactoryTest {
     }
     
     @Test
+    void assertGetBoolBinaryProtocolValue() {
+        PostgreSQLBinaryProtocolValue binaryProtocolValue = PostgreSQLBinaryProtocolValueFactory.getBinaryProtocolValue(PostgreSQLColumnType.BOOL);
+        assertThat(binaryProtocolValue, instanceOf(PostgreSQLBoolBinaryProtocolValue.class));
+    }
+    
+    @Test
     void assertGetBinaryProtocolValueExThrown() {
         assertThrows(IllegalArgumentException.class, () -> PostgreSQLBinaryProtocolValueFactory.getBinaryProtocolValue(PostgreSQLColumnType.XML));
     }

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolBinaryProtocolValueTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.bind.protocol;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PostgreSQLBoolBinaryProtocolValueTest {
+    
+    @Mock
+    private PostgreSQLPacketPayload payload;
+    
+    @Mock
+    private ByteBuf byteBuf;
+    
+    @Test
+    void assertNewInstance() {
+        PostgreSQLBoolBinaryProtocolValue actual = new PostgreSQLBoolBinaryProtocolValue();
+        assertThat(actual.getColumnLength(null), is(1));
+        when(payload.getByteBuf()).thenReturn(byteBuf);
+        when(byteBuf.readBoolean()).thenReturn(true);
+        assertTrue((boolean) actual.read(payload, 1));
+        actual.write(payload, "f");
+        verify(payload.getByteBuf()).writeBoolean(false);
+    }
+}


### PR DESCRIPTION
For #35830.

### Test method:
1. Create a table with a bool column in PostgreSQL
```sql
CREATE TABLE IF NOT EXISTS member_summary (
    mid VARCHAR(9) PRIMARY KEY,
    nickname VARCHAR(63),
    previous_champions_season_id BIGINT NOT NULL,
    previous_champions_tier_id  BIGINT NOT NULL,
    account_level BIGINT NOT NULL,
    profile_id BIGINT NOT NULL,
    hide_champions_raid_tier_border boolean NOT NULL,
    title_id BIGINT NOT NULL,
    block_party_invite boolean NOT NULL
);
```
2. Insert some records
3. Use the Go client to query the bool column through Proxy
```sql
SELECT mid, hide_champions_raid_tier_border, title_id, block_party_invite from member_summary where mid = $1
```

### Before
![image](https://github.com/user-attachments/assets/eee77c39-85bb-4957-941e-7b59165982ef)


### After
![image](https://github.com/user-attachments/assets/35461bbe-dd9d-455b-85dd-b70973621ba3)

### FAQ
- Why not use the `Boolean.parseBoolean()` method?
Because `Boolean.parseBoolean()` only matches the case where the string is "true", and the default bool output by PostgreSQL is a single character "t" or "f";

![image](https://github.com/user-attachments/assets/1abb5da3-1860-41a5-92b5-4d6dc829067d)


If the output format is specified using `::TEXT` or `::INT`, the type does not meet the `Binary` type and will not be processed by `PostgreSQLBoolBinaryProtocolValue`.

Therefore, `PostgreSQLBoolBinaryProtocolValue` only needs to process the cases of "t" or "f".



