### PR TITLE
Fix column length for PostgreSQLStringBinaryProtocolValue

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -70,6 +70,8 @@
 1. JDBC: Resolve statement manager leaks when creating multiple statements - [#35665](https://github.com/apache/shardingsphere/pull/35665)
 1. Kernel: Fix not return generate key when id set null - [35783](https://github.com/apache/shardingsphere/pull/35783)
 1. Encrypt: Resolve rewrite issue in nested concat function - [35815](https://github.com/apache/shardingsphere/pull/35815)
+1. JDBC: Fix the issue where cached connections in DriverDatabaseConnectionManager were not released in time - [35834](https://github.com/apache/shardingsphere/pull/35834)
+1. Proxy: Fix column length for PostgreSQL string binary protocol value - [35840](https://github.com/apache/shardingsphere/pull/35840)
 
 ### Change Logs
 

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacket.java
@@ -59,7 +59,7 @@ public final class PostgreSQLDataRowPacket extends PostgreSQLIdentifierPacket {
             return;
         }
         PostgreSQLBinaryProtocolValue binaryProtocolValue = PostgreSQLBinaryProtocolValueFactory.getBinaryProtocolValue(each.getColumnType());
-        payload.writeInt4(binaryProtocolValue.getColumnLength(value));
+        payload.writeInt4(binaryProtocolValue.getColumnLength(payload, value));
         binaryProtocolValue.write(payload, value);
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBinaryProtocolValue.java
@@ -27,10 +27,11 @@ public interface PostgreSQLBinaryProtocolValue {
     /**
      * Get column length.
      *
+     * @param payload payload operation for PostgreSQL packet
      * @param value value of column
      * @return column length
      */
-    int getColumnLength(Object value);
+    int getColumnLength(PostgreSQLPacketPayload payload, Object value);
     
     /**
      * Read binary protocol value.

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolArrayBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolArrayBinaryProtocolValue.java
@@ -28,7 +28,7 @@ public final class PostgreSQLBoolArrayBinaryProtocolValue implements PostgreSQLB
     private static final PostgreSQLArrayParameterDecoder ARRAY_PARAMETER_DECODER = new PostgreSQLArrayParameterDecoder();
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         throw new UnsupportedSQLOperationException("PostgreSQLBoolArrayBinaryProtocolValue.getColumnLength()");
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolBinaryProtocolValue.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
 public final class PostgreSQLBoolBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         return 1;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLByteaBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLByteaBinaryProtocolValue.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
 public final class PostgreSQLByteaBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         return ((byte[]) value).length;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLDateBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLDateBinaryProtocolValue.java
@@ -30,7 +30,7 @@ import java.sql.Date;
 public final class PostgreSQLDateBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         return 4;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLDoubleBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLDoubleBinaryProtocolValue.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
 public final class PostgreSQLDoubleBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         return 8;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLFloat4ArrayBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLFloat4ArrayBinaryProtocolValue.java
@@ -28,7 +28,7 @@ public final class PostgreSQLFloat4ArrayBinaryProtocolValue implements PostgreSQ
     private static final PostgreSQLArrayParameterDecoder ARRAY_PARAMETER_DECODER = new PostgreSQLArrayParameterDecoder();
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         throw new UnsupportedSQLOperationException("PostgreSQLFloat4ArrayBinaryProtocolValue.getColumnLength()");
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLFloat8ArrayBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLFloat8ArrayBinaryProtocolValue.java
@@ -28,7 +28,7 @@ public final class PostgreSQLFloat8ArrayBinaryProtocolValue implements PostgreSQ
     private static final PostgreSQLArrayParameterDecoder ARRAY_PARAMETER_DECODER = new PostgreSQLArrayParameterDecoder();
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         throw new UnsupportedSQLOperationException("PostgreSQLFloat8ArrayBinaryProtocolValue.getColumnLength()");
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLFloatBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLFloatBinaryProtocolValue.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
 public final class PostgreSQLFloatBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         return 4;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt2ArrayBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt2ArrayBinaryProtocolValue.java
@@ -28,7 +28,7 @@ public final class PostgreSQLInt2ArrayBinaryProtocolValue implements PostgreSQLB
     private static final PostgreSQLArrayParameterDecoder ARRAY_PARAMETER_DECODER = new PostgreSQLArrayParameterDecoder();
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         throw new UnsupportedSQLOperationException("PostgreSQLInt2ArrayBinaryProtocolValue.getColumnLength()");
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt2BinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt2BinaryProtocolValue.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
 public final class PostgreSQLInt2BinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         return 2;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt4ArrayBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt4ArrayBinaryProtocolValue.java
@@ -28,7 +28,7 @@ public final class PostgreSQLInt4ArrayBinaryProtocolValue implements PostgreSQLB
     private static final PostgreSQLArrayParameterDecoder ARRAY_PARAMETER_DECODER = new PostgreSQLArrayParameterDecoder();
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         throw new UnsupportedSQLOperationException("PostgreSQLInt4ArrayBinaryProtocolValue.getColumnLength()");
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt4BinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt4BinaryProtocolValue.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
 public final class PostgreSQLInt4BinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         return 4;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt8ArrayBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt8ArrayBinaryProtocolValue.java
@@ -28,7 +28,7 @@ public final class PostgreSQLInt8ArrayBinaryProtocolValue implements PostgreSQLB
     private static final PostgreSQLArrayParameterDecoder ARRAY_PARAMETER_DECODER = new PostgreSQLArrayParameterDecoder();
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         throw new UnsupportedSQLOperationException("PostgreSQLInt8ArrayBinaryProtocolValue.getColumnLength()");
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt8BinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt8BinaryProtocolValue.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
 public final class PostgreSQLInt8BinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         return 8;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLNumericBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLNumericBinaryProtocolValue.java
@@ -29,7 +29,7 @@ import java.nio.charset.StandardCharsets;
 public final class PostgreSQLNumericBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         return value instanceof BigDecimal ? ByteConverter.numeric((BigDecimal) value).length : value.toString().getBytes(StandardCharsets.UTF_8).length;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringArrayBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringArrayBinaryProtocolValue.java
@@ -28,7 +28,7 @@ public final class PostgreSQLStringArrayBinaryProtocolValue implements PostgreSQ
     private static final PostgreSQLArrayParameterDecoder ARRAY_PARAMETER_DECODER = new PostgreSQLArrayParameterDecoder();
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         throw new UnsupportedSQLOperationException("PostgreSQLStringArrayBinaryProtocolValue.getColumnLength()");
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringBinaryProtocolValue.java
@@ -25,8 +25,11 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
 public final class PostgreSQLStringBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
-        return value.toString().length();
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
+        if (value instanceof byte[]) {
+            return ((byte[]) value).length;
+        }
+        return value.toString().getBytes(payload.getCharset()).length;
     }
     
     @Override

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLTextArrayBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLTextArrayBinaryProtocolValue.java
@@ -40,7 +40,7 @@ public final class PostgreSQLTextArrayBinaryProtocolValue implements PostgreSQLB
     private static final int ARRAY_HEADER_LENGTH = 20;
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         throw new UnsupportedSQLOperationException("PostgreSQLTextArrayBinaryProtocolValue.getColumnLength()");
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLTimeBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLTimeBinaryProtocolValue.java
@@ -28,7 +28,7 @@ import java.sql.Timestamp;
 public final class PostgreSQLTimeBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         return 8;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValue.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 public final class PostgreSQLUUIDBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         return 16;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValue.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperation
 public final class PostgreSQLUnspecifiedBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     @Override
-    public int getColumnLength(final Object value) {
+    public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
         throw new UnsupportedSQLOperationException("getColumnLength");
     }
     

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolArrayBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolArrayBinaryProtocolValueTest.java
@@ -31,13 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PostgreSQLBoolArrayBinaryProtocolValueTest {
     
-    private PostgreSQLBinaryProtocolValue newInstance() {
-        return new PostgreSQLBoolArrayBinaryProtocolValue();
-    }
-    
     @Test
     void assertGetColumnLength() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().getColumnLength("val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLBoolArrayBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
     
     @Test
@@ -49,13 +45,13 @@ class PostgreSQLBoolArrayBinaryProtocolValueTest {
         byteBuf.writeCharSequence(parameterValue, StandardCharsets.ISO_8859_1);
         byteBuf.readInt();
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
-        Object actual = newInstance().read(payload, parameterValue.length());
+        Object actual = new PostgreSQLBoolArrayBinaryProtocolValue().read(payload, parameterValue.length());
         assertThat(actual, is(new boolean[]{true, false}));
         assertThat(byteBuf.readerIndex(), is(expectedLength));
     }
     
     @Test
     void assertWrite() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLBoolArrayBinaryProtocolValue().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
 }

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolBinaryProtocolValueTest.java
@@ -42,7 +42,7 @@ class PostgreSQLBoolBinaryProtocolValueTest {
     @Test
     void assertNewInstance() {
         PostgreSQLBoolBinaryProtocolValue actual = new PostgreSQLBoolBinaryProtocolValue();
-        assertThat(actual.getColumnLength(null), is(1));
+        assertThat(actual.getColumnLength(payload, null), is(1));
         when(payload.getByteBuf()).thenReturn(byteBuf);
         when(byteBuf.readBoolean()).thenReturn(true);
         assertTrue((boolean) actual.read(payload, 1));

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLByteaBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLByteaBinaryProtocolValueTest.java
@@ -31,7 +31,7 @@ class PostgreSQLByteaBinaryProtocolValueTest {
     
     @Test
     void assertGetColumnLength() {
-        assertThat(new PostgreSQLByteaBinaryProtocolValue().getColumnLength(new byte[10]), is(10));
+        assertThat(new PostgreSQLByteaBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), new byte[10]), is(10));
     }
     
     @Test

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLDateBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLDateBinaryProtocolValueTest.java
@@ -36,7 +36,7 @@ class PostgreSQLDateBinaryProtocolValueTest {
     
     @Test
     void assertGetColumnLength() {
-        assertThat(new PostgreSQLDateBinaryProtocolValue().getColumnLength(""), is(4));
+        assertThat(new PostgreSQLDateBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), ""), is(4));
     }
     
     @Test

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLDoubleBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLDoubleBinaryProtocolValueTest.java
@@ -39,7 +39,7 @@ class PostgreSQLDoubleBinaryProtocolValueTest {
     
     @Test
     void assertGetColumnLength() {
-        assertThat(new PostgreSQLDoubleBinaryProtocolValue().getColumnLength(""), is(8));
+        assertThat(new PostgreSQLDoubleBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), ""), is(8));
     }
     
     @Test

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLFloat4ArrayBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLFloat4ArrayBinaryProtocolValueTest.java
@@ -31,13 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PostgreSQLFloat4ArrayBinaryProtocolValueTest {
     
-    private PostgreSQLBinaryProtocolValue newInstance() {
-        return new PostgreSQLFloat4ArrayBinaryProtocolValue();
-    }
-    
     @Test
     void assertGetColumnLength() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().getColumnLength("val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLFloat4ArrayBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
     
     @Test
@@ -49,13 +45,13 @@ class PostgreSQLFloat4ArrayBinaryProtocolValueTest {
         byteBuf.writeCharSequence(parameterValue, StandardCharsets.ISO_8859_1);
         byteBuf.readInt();
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
-        Object actual = newInstance().read(payload, parameterValue.length());
+        Object actual = new PostgreSQLFloat4ArrayBinaryProtocolValue().read(payload, parameterValue.length());
         assertThat(actual, is(new float[]{11.1F, 12.1F}));
         assertThat(byteBuf.readerIndex(), is(expectedLength));
     }
     
     @Test
     void assertWrite() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLFloat4ArrayBinaryProtocolValue().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
 }

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLFloat8ArrayBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLFloat8ArrayBinaryProtocolValueTest.java
@@ -31,13 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PostgreSQLFloat8ArrayBinaryProtocolValueTest {
     
-    private PostgreSQLBinaryProtocolValue newInstance() {
-        return new PostgreSQLFloat8ArrayBinaryProtocolValue();
-    }
-    
     @Test
     void assertGetColumnLength() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().getColumnLength("val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLFloat8ArrayBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
     
     @Test
@@ -49,13 +45,13 @@ class PostgreSQLFloat8ArrayBinaryProtocolValueTest {
         byteBuf.writeCharSequence(parameterValue, StandardCharsets.ISO_8859_1);
         byteBuf.readInt();
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
-        Object actual = newInstance().read(payload, parameterValue.length());
+        Object actual = new PostgreSQLFloat8ArrayBinaryProtocolValue().read(payload, parameterValue.length());
         assertThat(actual, is(new double[]{11.1D, 12.1D}));
         assertThat(byteBuf.readerIndex(), is(expectedLength));
     }
     
     @Test
     void assertWrite() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLFloat8ArrayBinaryProtocolValue().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
 }

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLFloatBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLFloatBinaryProtocolValueTest.java
@@ -39,7 +39,7 @@ class PostgreSQLFloatBinaryProtocolValueTest {
     
     @Test
     void assertGetColumnLength() {
-        assertThat(new PostgreSQLFloatBinaryProtocolValue().getColumnLength(""), is(4));
+        assertThat(new PostgreSQLFloatBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), ""), is(4));
     }
     
     @Test

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt2ArrayBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt2ArrayBinaryProtocolValueTest.java
@@ -31,13 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PostgreSQLInt2ArrayBinaryProtocolValueTest {
     
-    private PostgreSQLBinaryProtocolValue newInstance() {
-        return new PostgreSQLInt2ArrayBinaryProtocolValue();
-    }
-    
     @Test
     void assertGetColumnLength() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().getColumnLength("val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLInt2ArrayBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
     
     @Test
@@ -49,13 +45,13 @@ class PostgreSQLInt2ArrayBinaryProtocolValueTest {
         byteBuf.writeCharSequence(parameterValue, StandardCharsets.ISO_8859_1);
         byteBuf.readInt();
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
-        Object actual = newInstance().read(payload, parameterValue.length());
+        Object actual = new PostgreSQLInt2ArrayBinaryProtocolValue().read(payload, parameterValue.length());
         assertThat(actual, is(new short[]{11, 12}));
         assertThat(byteBuf.readerIndex(), is(expectedLength));
     }
     
     @Test
     void assertWrite() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLInt2ArrayBinaryProtocolValue().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
 }

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt2BinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt2BinaryProtocolValueTest.java
@@ -30,7 +30,7 @@ class PostgreSQLInt2BinaryProtocolValueTest {
     
     @Test
     void assertGetColumnLength() {
-        assertThat(new PostgreSQLInt2BinaryProtocolValue().getColumnLength(null), is(2));
+        assertThat(new PostgreSQLInt2BinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), null), is(2));
     }
     
     @Test

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt4ArrayBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt4ArrayBinaryProtocolValueTest.java
@@ -31,13 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PostgreSQLInt4ArrayBinaryProtocolValueTest {
     
-    private PostgreSQLBinaryProtocolValue newInstance() {
-        return new PostgreSQLInt4ArrayBinaryProtocolValue();
-    }
-    
     @Test
     void assertGetColumnLength() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().getColumnLength("val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLInt4ArrayBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
     
     @Test
@@ -49,13 +45,13 @@ class PostgreSQLInt4ArrayBinaryProtocolValueTest {
         byteBuf.writeCharSequence(parameterValue, StandardCharsets.ISO_8859_1);
         byteBuf.readInt();
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
-        Object actual = newInstance().read(payload, parameterValue.length());
+        Object actual = new PostgreSQLInt4ArrayBinaryProtocolValue().read(payload, parameterValue.length());
         assertThat(actual, is(new int[]{11, 12}));
         assertThat(byteBuf.readerIndex(), is(expectedLength));
     }
     
     @Test
     void assertWrite() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLInt4ArrayBinaryProtocolValue().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
 }

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt4BinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt4BinaryProtocolValueTest.java
@@ -37,7 +37,7 @@ class PostgreSQLInt4BinaryProtocolValueTest {
     @Test
     void assertNewInstance() {
         PostgreSQLInt4BinaryProtocolValue actual = new PostgreSQLInt4BinaryProtocolValue();
-        assertThat(actual.getColumnLength(null), is(4));
+        assertThat(actual.getColumnLength(payload, null), is(4));
         when(payload.readInt4()).thenReturn(1);
         assertThat(actual.read(payload, 4), is(1));
         actual.write(payload, 1);

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt8ArrayBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt8ArrayBinaryProtocolValueTest.java
@@ -31,13 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PostgreSQLInt8ArrayBinaryProtocolValueTest {
     
-    private PostgreSQLBinaryProtocolValue newInstance() {
-        return new PostgreSQLInt8ArrayBinaryProtocolValue();
-    }
-    
     @Test
     void assertGetColumnLength() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().getColumnLength("val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLInt8ArrayBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
     
     @Test
@@ -49,13 +45,13 @@ class PostgreSQLInt8ArrayBinaryProtocolValueTest {
         byteBuf.writeCharSequence(parameterValue, StandardCharsets.ISO_8859_1);
         byteBuf.readInt();
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
-        Object actual = newInstance().read(payload, parameterValue.length());
+        Object actual = new PostgreSQLInt8ArrayBinaryProtocolValue().read(payload, parameterValue.length());
         assertThat(actual, is(new long[]{11L, 12L}));
         assertThat(byteBuf.readerIndex(), is(expectedLength));
     }
     
     @Test
     void assertWrite() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLInt8ArrayBinaryProtocolValue().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
 }

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt8BinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt8BinaryProtocolValueTest.java
@@ -34,7 +34,7 @@ class PostgreSQLInt8BinaryProtocolValueTest {
     
     @Test
     void assertGetColumnLength() {
-        assertThat(new PostgreSQLInt8BinaryProtocolValue().getColumnLength(1L), is(8));
+        assertThat(new PostgreSQLInt8BinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), 1L), is(8));
     }
     
     @Test

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLNumericBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLNumericBinaryProtocolValueTest.java
@@ -39,7 +39,7 @@ class PostgreSQLNumericBinaryProtocolValueTest {
     @ArgumentsSource(TestCaseArgumentsProvider.class)
     void assertGetColumnLength(final BigDecimal bigDecimal, final byte[] expected) {
         PostgreSQLNumericBinaryProtocolValue binaryProtocolValue = new PostgreSQLNumericBinaryProtocolValue();
-        assertThat(binaryProtocolValue.getColumnLength(bigDecimal), is(expected.length));
+        assertThat(binaryProtocolValue.getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), bigDecimal), is(expected.length));
     }
     
     @ParameterizedTest(name = "{0}")
@@ -59,7 +59,7 @@ class PostgreSQLNumericBinaryProtocolValueTest {
     @ArgumentsSource(TestCaseArgumentsProvider.class)
     void assertWrite(final BigDecimal bigDecimal, final byte[] expected) {
         PostgreSQLNumericBinaryProtocolValue binaryProtocolValue = new PostgreSQLNumericBinaryProtocolValue();
-        int columnLength = binaryProtocolValue.getColumnLength(bigDecimal);
+        int columnLength = binaryProtocolValue.getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), bigDecimal);
         ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(columnLength);
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
         binaryProtocolValue.write(payload, bigDecimal);

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringArrayBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringArrayBinaryProtocolValueTest.java
@@ -31,13 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PostgreSQLStringArrayBinaryProtocolValueTest {
     
-    private PostgreSQLBinaryProtocolValue newInstance() {
-        return new PostgreSQLStringArrayBinaryProtocolValue();
-    }
-    
     @Test
     void assertGetColumnLength() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().getColumnLength("val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLStringArrayBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
     
     @Test
@@ -49,13 +45,13 @@ class PostgreSQLStringArrayBinaryProtocolValueTest {
         byteBuf.writeCharSequence(parameterValue, StandardCharsets.ISO_8859_1);
         byteBuf.readInt();
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
-        Object actual = newInstance().read(payload, parameterValue.length());
+        Object actual = new PostgreSQLStringArrayBinaryProtocolValue().read(payload, parameterValue.length());
         assertThat(actual, is(new String[]{"a", "b"}));
         assertThat(byteBuf.readerIndex(), is(expectedLength));
     }
     
     @Test
     void assertWrite() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> newInstance().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLStringArrayBinaryProtocolValue().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
 }

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLStringBinaryProtocolValueTest.java
@@ -48,16 +48,28 @@ class PostgreSQLStringBinaryProtocolValueTest {
     }
     
     @Test
-    void assertNewInstance() {
+    void assertGetColumnLength() {
+        PostgreSQLStringBinaryProtocolValue actual = new PostgreSQLStringBinaryProtocolValue();
+        assertThat(actual.getColumnLength(payload, "English"), is(7));
+        assertThat(actual.getColumnLength(payload, "中文"), is(6));
+        assertThat(actual.getColumnLength(payload, new byte[]{1, 2, 3}), is(3));
+    }
+    
+    @Test
+    void assertRead() {
         doAnswer((Answer<ByteBuf>) invocation -> {
             ((byte[]) invocation.getArguments()[0])[0] = 'a';
             return byteBuf;
         }).when(byteBuf).readBytes(any(byte[].class));
         PostgreSQLStringBinaryProtocolValue actual = new PostgreSQLStringBinaryProtocolValue();
-        assertThat(actual.getColumnLength("str"), is("str".length()));
         assertThat(actual.read(payload, "a".length()), is("a"));
-        actual.write(payload, "a");
-        verify(byteBuf).writeBytes("a".getBytes(StandardCharsets.UTF_8));
+    }
+    
+    @Test
+    void assertWrite() {
+        PostgreSQLStringBinaryProtocolValue actual = new PostgreSQLStringBinaryProtocolValue();
+        actual.write(payload, "foo");
+        verify(byteBuf).writeBytes("foo".getBytes(StandardCharsets.UTF_8));
         actual.write(payload, new byte[1]);
         verify(byteBuf).writeBytes(new byte[1]);
     }

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLTimeBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLTimeBinaryProtocolValueTest.java
@@ -40,7 +40,7 @@ class PostgreSQLTimeBinaryProtocolValueTest {
     @Test
     void assertNewInstance() {
         PostgreSQLTimeBinaryProtocolValue actual = new PostgreSQLTimeBinaryProtocolValue();
-        assertThat(actual.getColumnLength(null), is(8));
+        assertThat(actual.getColumnLength(payload, null), is(8));
         when(payload.readInt8()).thenReturn(1L);
         assertThat(actual.read(payload, 8), is(1L));
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValueTest.java
@@ -33,7 +33,7 @@ class PostgreSQLUUIDBinaryProtocolValueTest {
     
     @Test
     void assertGetColumnLength() {
-        assertThat(new PostgreSQLUUIDBinaryProtocolValue().getColumnLength(UUID.fromString("00000000-000-0000-0000-000000000001")), is(16));
+        assertThat(new PostgreSQLUUIDBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), UUID.fromString("00000000-000-0000-0000-000000000001")), is(16));
     }
     
     @Test

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValueTest.java
@@ -36,7 +36,7 @@ class PostgreSQLUnspecifiedBinaryProtocolValueTest {
     
     @Test
     void assertGetColumnLength() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLUnspecifiedBinaryProtocolValue().getColumnLength("val"));
+        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLUnspecifiedBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
     }
     
     @Test


### PR DESCRIPTION
Fixes #35038.

The reason for the exception is that the length of the string is returned in the `getColumnLength` method, but the actual output data is of byte[] type.
When the value content is Chinese, the length of the byte[] obtained by the `getBytes` method is different from the length of the string.

Changes proposed in this pull request:
  - In the getColumnLength method, the length of the byte[] data obtained by getBytes is output
  - In order to obtain the correct charset, the payload object needs to be passed in the interface.
  - Update test cases

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
