### PR TITLE
Fix the connection leak caused by rollback failure in Proxy

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -72,6 +72,7 @@
 1. Encrypt: Resolve rewrite issue in nested concat function - [35815](https://github.com/apache/shardingsphere/pull/35815)
 1. JDBC: Fix the issue where cached connections in DriverDatabaseConnectionManager were not released in time - [35834](https://github.com/apache/shardingsphere/pull/35834)
 1. Proxy: Fix column length for PostgreSQL string binary protocol value - [35840](https://github.com/apache/shardingsphere/pull/35840)
+1. Proxy: Fix the connection leak caused by rollback failure in Proxy - [35867](https://github.com/apache/shardingsphere/pull/35867)
 
 ### Change Logs
 

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManager.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManager.java
@@ -341,7 +341,7 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
                         each.close();
                     } catch (final SQLException ex) {
                         if (!isClosed(each)) {
-                            log.error("Connection {} is not closed", each);
+                            log.warn("Close connection {} failed.", each, ex);
                         }
                         result.add(ex);
                     }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManager.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManager.java
@@ -22,6 +22,7 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMode;
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.DatabaseConnectionManager;
@@ -53,6 +54,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Database connection manager of ShardingSphere-Proxy.
  */
+@Slf4j
 @RequiredArgsConstructor
 @Getter
 public final class ProxyDatabaseConnectionManager implements DatabaseConnectionManager<Connection> {
@@ -70,6 +72,8 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
     private final ConnectionResourceLock connectionResourceLock = new ConnectionResourceLock();
     
     private final AtomicBoolean closed = new AtomicBoolean(false);
+    
+    private final Object closeLock = new Object();
     
     @SuppressWarnings("rawtypes")
     private final Map<ShardingSphereRule, TransactionHook> transactionHooks = OrderedSPILoader.getServices(
@@ -259,7 +263,7 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
      * @throws BackendConnectionException backend connection exception
      */
     public void closeExecutionResources() throws BackendConnectionException {
-        synchronized (this) {
+        synchronized (closeLock) {
             Collection<Exception> result = new LinkedList<>(closeHandlers(false));
             if (!connectionSession.getTransactionStatus().isInConnectionHeldTransaction(TransactionUtils.getTransactionType(connectionSession.getConnectionContext().getTransactionContext()))) {
                 result.addAll(closeHandlers(true));
@@ -277,12 +281,16 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
     
     /**
      * Close all resources.
+     *
+     * @return exceptions occurred during closing resources
      */
-    public void closeAllResources() {
-        synchronized (this) {
+    public Collection<SQLException> closeAllResources() {
+        synchronized (closeLock) {
             closed.set(true);
-            closeHandlers(true);
-            closeConnections(true);
+            Collection<SQLException> result = new LinkedList<>();
+            result.addAll(closeHandlers(true));
+            result.addAll(closeConnections(true));
+            return result;
         }
     }
     
@@ -326,9 +334,17 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
                     if (forceRollback && connectionSession.getTransactionStatus().isInTransaction()) {
                         each.rollback();
                     }
-                    each.close();
                 } catch (final SQLException ex) {
                     result.add(ex);
+                } finally {
+                    try {
+                        each.close();
+                    } catch (final SQLException ex) {
+                        if (!isClosed(each)) {
+                            log.error("Connection {} is not closed", each);
+                        }
+                        result.add(ex);
+                    }
                 }
             }
             cachedConnections.clear();
@@ -337,6 +353,16 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
             connectionPostProcessors.clear();
         }
         return result;
+    }
+    
+    private boolean isClosed(final Connection connection) {
+        try {
+            if (connection.isClosed()) {
+                return true;
+            }
+        } catch (final SQLException ignored) {
+        }
+        return false;
     }
     
     private void resetSessionVariablesIfNecessary(final Collection<Connection> values, final Collection<SQLException> exceptions) {


### PR DESCRIPTION
Fixes #35866.

Changes proposed in this pull request:
  - Make sure to call the `connection.close()` method in the finally block
  - If close fails, print a warn log

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
