### PR TITLE
Optimize exception for close cached connections in proxy

### DIFF
--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManager.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManager.java
@@ -334,16 +334,15 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
                     if (forceRollback && connectionSession.getTransactionStatus().isInTransaction()) {
                         each.rollback();
                     }
-                } catch (final SQLException ex) {
-                    result.add(ex);
+                } catch (final SQLException ignored) {
                 } finally {
                     try {
                         each.close();
                     } catch (final SQLException ex) {
                         if (!isClosed(each)) {
                             log.warn("Close connection {} failed.", each, ex);
+                            result.add(ex);
                         }
-                        result.add(ex);
                     }
                 }
             }


### PR DESCRIPTION
Releated to  #35867.

Changes proposed in this pull request:
  - Ignore SQLException for rollback
  - If connection is closed, do not add exception to result

