### PR TITLE
fix:Support for three-level naming of table-valued function

### DIFF
--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
@@ -133,7 +133,7 @@ schemaName
     ;
 
 functionName
-    : (owner DOT_)? name
+    : ((databaseName DOT_)? (owner DOT_))? name
     ;
 
 procedureName
@@ -467,7 +467,7 @@ regularFunction
     ;
 
 regularFunctionName
-    : (owner DOT_)? identifier | IF | LOCALTIME | LOCALTIMESTAMP | INTERVAL
+    : ((databaseName DOT_)? (owner DOT_))? identifier | IF | LOCALTIME | LOCALTIMESTAMP | INTERVAL
     ;
 
 caseExpression

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -10897,4 +10897,19 @@
             </expression-projection>
         </projections>
     </select>
+
+    <select sql-case-id="select_from_msdb_managed_backup">
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <from start-index="14" stop-index="63">
+            <function-table start-index="14" stop-index="63">
+                <table-function function-name="msdb.managed_backup.fn_available_backups" text="msdb.managed_backup.fn_available_backups ('MyDB')">
+                    <parameter>
+                        <literal-expression value="MyDB" start-index="57" stop-index="62"/>
+                    </parameter>
+                </table-function>
+            </function-table>
+        </from>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -339,4 +339,5 @@
     <sql-case id="select_sqlserver_current_user" value="SELECT CURRENT_USER;" db-types="SQLServer"/>
     <sql-case id="select_parse_function" value="SELECT PARSE('Monday, 13 December 2010' AS datetime2 USING 'en-US') AS Result;" db-types="SQLServer"/>
     <sql-case id="select_try_parse_function" value="SELECT TRY_PARSE('Jabberwokkie' AS datetime2 USING 'en-US') AS Result;" db-types="SQLServer"/>
+    <sql-case id="select_from_msdb_managed_backup" value="SELECT * FROM msdb.managed_backup.fn_available_backups ('MyDB');" db-types="SQLServer"/>
 </sql-cases>


### PR DESCRIPTION
for https://github.com/apache/shardingsphere/issues/35908
official document:https://learn.microsoft.com/zh-cn/sql/relational-databases/system-functions/managed-backup-fn-available-backups-transact-sql?view=sql-server-ver17

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
