### PR TITLE
Updated write method for PostgreSQLBoolArrayBinaryProtocolValue

### DIFF
--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolArrayBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBoolArrayBinaryProtocolValue.java
@@ -20,6 +20,11 @@ package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.ex
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
 
+import java.util.List;
+import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
+
+
 /**
  * Binary protocol value for boolean array for PostgreSQL.
  */
@@ -41,6 +46,24 @@ public final class PostgreSQLBoolArrayBinaryProtocolValue implements PostgreSQLB
     
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
-        throw new UnsupportedSQLOperationException("PostgreSQLBoolArrayBinaryProtocolValue.write()");
+        StringBuilder result = new StringBuilder("{");
+        List<String> boolStrings = new ArrayList<>();
+
+        if (value instanceof boolean[]) {
+            for (boolean b : (boolean[]) value) {
+                boolStrings.add(b ? "t" : "f");
+            }
+        } else if (value instanceof Boolean[]) {
+            for (Boolean b : (Boolean[]) value) {
+                boolStrings.add(Boolean.TRUE.equals(b) ? "t" : "f");
+            }
+        } else {
+            throw new UnsupportedSQLOperationException("Unsupported type for PostgreSQLBoolArrayBinaryProtocolValue.write()");
+        }
+
+        result.append(String.join(",", boolStrings)).append("}");
+        byte[] bytes = result.toString().getBytes(StandardCharsets.UTF_8);
+        payload.getByteBuf().writeInt(bytes.length);
+        payload.getByteBuf().writeBytes(bytes);
     }
 }

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBinaryProtocolValueFactoryTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBinaryProtocolValueFactoryTest.java
@@ -93,6 +93,12 @@ class PostgreSQLBinaryProtocolValueFactoryTest {
     }
     
     @Test
+    void assertGetBoolArrayBinaryProtocolValue() {
+        PostgreSQLBinaryProtocolValue binaryProtocolValue = PostgreSQLBinaryProtocolValueFactory.getBinaryProtocolValue(PostgreSQLColumnType.BOOL_ARRAY);
+        assertThat(binaryProtocolValue, instanceOf(PostgreSQLBoolArrayBinaryProtocolValue.class));
+    }
+    
+    @Test
     void assertGetBinaryProtocolValueExThrown() {
         assertThrows(IllegalArgumentException.class, () -> PostgreSQLBinaryProtocolValueFactory.getBinaryProtocolValue(PostgreSQLColumnType.XML));
     }


### PR DESCRIPTION
Fixes #35830

Changes proposed in this pull request:
  -Updated write method for PostgreSQLBoolArrayBinaryProtocolValue

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
