### PR TITLE
Updated write method for PostgreSQLInt8ArrayBinaryProtocolValue

### DIFF
--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt8ArrayBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt8ArrayBinaryProtocolValue.java
@@ -26,6 +26,10 @@ import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperation
 public final class PostgreSQLInt8ArrayBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
     
     private static final PostgreSQLArrayParameterDecoder ARRAY_PARAMETER_DECODER = new PostgreSQLArrayParameterDecoder();
+    private static final int DIMENSIONS = 1;
+    private static final int FLAGS_NO_NULLS = 0;
+    private static final int LOWER_BOUND = 1;
+    private static final int INT8_LENGTH = 8;
     
     @Override
     public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
@@ -41,6 +45,29 @@ public final class PostgreSQLInt8ArrayBinaryProtocolValue implements PostgreSQLB
     
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
-        throw new UnsupportedSQLOperationException("PostgreSQLInt8ArrayBinaryProtocolValue.write()");
+        if (!(value instanceof Object[])) {
+            throw new IllegalArgumentException("Expected Object[] for int8 array, but got: " + value.getClass().getSimpleName());
+        }
+        Object[] elements = (Object[]) value;
+        final int DIMENSIONS = 1;
+        final int FLAGS_NO_NULLS = 0;
+        final int INT8_OID = 20;
+        final int LOWER_BOUND = 1;
+        final int INT8_LENGTH = 8;
+        payload.writeInt4(DIMENSIONS);
+        payload.writeInt4(FLAGS_NO_NULLS);
+        payload.writeInt4(INT8_OID);
+        payload.writeInt4(elements.length);
+        payload.writeInt4(LOWER_BOUND);
+        for (Object element : elements) {
+            if (element == null) {
+                payload.writeInt4(-1);
+            } else if (element instanceof Number) {
+                payload.writeInt4(INT8_LENGTH);
+                payload.writeInt8(((Number) element).longValue());
+            } else {
+                throw new IllegalArgumentException("Invalid element type in int8 array: " + element);
+            }
+        }
     }
 }

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt8ArrayBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLInt8ArrayBinaryProtocolValueTest.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.db.protocol.postgresql.packet.ByteBufTestUtils;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
 import org.junit.jupiter.api.Test;
+import io.netty.buffer.Unpooled;
 
 import java.nio.charset.StandardCharsets;
 
@@ -52,6 +53,19 @@ class PostgreSQLInt8ArrayBinaryProtocolValueTest {
     
     @Test
     void assertWrite() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLInt8ArrayBinaryProtocolValue().write(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
+        Object[] input = new Object[]{11L, 12L};
+        ByteBuf byteBuf = Unpooled.buffer();
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
+        new PostgreSQLInt8ArrayBinaryProtocolValue().write(payload, input);
+        byteBuf.readerIndex(0);
+        assertThat(byteBuf.readInt(), is(1));
+        assertThat(byteBuf.readInt(), is(0));
+        assertThat(byteBuf.readInt(), is(20));
+        assertThat(byteBuf.readInt(), is(2));
+        assertThat(byteBuf.readInt(), is(1));
+        assertThat(byteBuf.readInt(), is(8));
+        assertThat(byteBuf.readLong(), is(11L));
+        assertThat(byteBuf.readInt(), is(8));
+        assertThat(byteBuf.readLong(), is(12L));
     }
 }


### PR DESCRIPTION
Fixes #35830 

Changes proposed in this pull request:
  - Updated write method for PostgreSQLInt8ArrayBinaryProtocolValue

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
