### PR TITLE
Remove useless parameter in SQLFederationRelConverter

### DIFF
--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/rel/converter/SQLFederationRelConverter.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/rel/converter/SQLFederationRelConverter.java
@@ -60,12 +60,12 @@ public final class SQLFederationRelConverter {
         RelDataTypeFactory typeFactory = SQLFederationDataTypeFactory.getInstance();
         CalciteConnectionConfig connectionConfig = compilerContext.getConnectionConfig();
         CalciteCatalogReader catalogReader = new SQLFederationCatalogReader(compilerContext.getCalciteSchema(), schemaPath, typeFactory, connectionConfig);
-        SqlValidator validator = createSqlValidator(catalogReader, typeFactory, databaseType, connectionConfig, compilerContext.getOperatorTables());
+        SqlValidator validator = createSqlValidator(catalogReader, typeFactory, connectionConfig, compilerContext.getOperatorTables());
         RelOptCluster relOptCluster = createRelOptCluster(typeFactory, convention);
         sqlToRelConverter = createSqlToRelConverter(catalogReader, validator, relOptCluster, compilerContext.getSqlParserRule(), databaseType, true);
     }
     
-    private SqlValidator createSqlValidator(final CalciteCatalogReader catalogReader, final RelDataTypeFactory typeFactory, final DatabaseType databaseType,
+    private SqlValidator createSqlValidator(final CalciteCatalogReader catalogReader, final RelDataTypeFactory typeFactory,
                                             final CalciteConnectionConfig connectionConfig, final Collection<SqlOperatorTable> operatorTables) {
         SqlValidator.Config validatorConfig = SqlValidator.Config.DEFAULT.withLenientOperatorLookup(connectionConfig.lenientOperatorLookup()).withConformance(connectionConfig.conformance())
                 .withDefaultNullCollation(connectionConfig.defaultNullCollation()).withIdentifierExpansion(true);

--- a/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/compiler/it/SQLStatementCompilerIT.java
+++ b/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/compiler/it/SQLStatementCompilerIT.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.io.IOException;
 import java.sql.Types;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -93,7 +92,7 @@ class SQLStatementCompilerIT {
     private Collection<SqlOperatorTable> getOperatorTables() {
         SqlOperatorTable operatorTable =
                 SqlLibraryOperatorTableFactory.INSTANCE.getOperatorTable(Arrays.asList(SqlLibrary.STANDARD, SqlLibrary.MYSQL));
-        return new ArrayList<>(Arrays.asList(new MySQLOperatorTable(), operatorTable));
+        return Arrays.asList(new MySQLOperatorTable(), operatorTable);
     }
     
     private ShardingSphereTable createOrderFederationTableMetaData() {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove useless parameter in SQLFederationRelConverter

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
