### PR TITLE
Fixes CVE-2024-7254

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,7 @@
 ### CVE
 
 1. Fixes CVE-2025-48924 [#36085](https://github.com/apache/shardingsphere/pull/36085)
+1. Fixes CVE-2024-7254 [#36153](https://github.com/apache/shardingsphere/pull/36153)
 
 ### Metadata Storage Changes
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <vertx.version>4.5.1</vertx.version>
         
         <grpc.version>1.65.1</grpc.version>
-        <protobuf.version>3.21.12</protobuf.version>
+        <protobuf.version>3.25.8</protobuf.version>
         <okhttp.version>4.12.0</okhttp.version>
         
         <elasticjob.version>3.0.4</elasticjob.version>


### PR DESCRIPTION
Upgrade protobuf-java to 3.25.8 to fix https://www.cve.org/CVERecord?id=CVE-2024-7254