### PR TITLE
Fixes CVE-2025-48924

### DIFF
--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -228,7 +228,6 @@ The text of each license is the standard Apache 2.0 license.
     commons-dbcp2 2.11.0: https://commons.apache.org/proper/commons-dbcp, Apache 2.0
     commons-exec 1.3: https://github.com/apache/commons-exec, Apache 2.0
     commons-io 2.11.0: https://github.com/apache/commons-io, Apache 2.0
-    commons-lang 2.4: https://github.com/apache/commons-lang, Apache 2.0
     commons-lang3 3.18.0: https://github.com/apache/commons-lang, Apache 2.0
     commons-math3 3.6.1: https://commons.apache.org/proper/commons-math, Apache 2.0
     commons-pool2 2.12.0: https://commons.apache.org/proper/commons-pool, Apache 2.0

--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -216,7 +216,7 @@ The following components are provided under the Apache License. See project link
 The text of each license is the standard Apache 2.0 license.
 
     accessors-smart 2.4.9: https://www.minidev.net/, Apache 2.0
-    aggdesigner-algorithm 6.0: Apache 2.0
+    aggdesigner-algorithm 6.1: Apache 2.0
     apiguardian-api 1.1.2: https://github.com/apiguardian-team/apiguardian, Apache 2.0
     audience-annotations 0.12.0: https://github.com/apache/yetus, Apache 2.0
     avatica-core 1.26.0: https://calcite.apache.org/avatica, Apache 2.0

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.cn.md
@@ -41,9 +41,6 @@ ShardingSphere 的 Seata 集成仅在 `apache/incubator-seata:v2.3.0` 或更高�
 </project>
 ```
 
-受 Calcite 的影响，ShardingSphere JDBC 使用的 `commons-lang:commons-lang` 与 Seata Client 存在依赖冲突，
-需用户根据实际情景考虑是否需要解决依赖冲突。如果不解决依赖冲突，Maven 等构建工具会在 classpath 随机使用一个冲突依赖的版本。
-
 使用 ShardingSphere 的 Seata 集成模块时，ShardingSphere 连接的数据库实例应同时实现 ShardingSphere 的方言解析支持与 Seata AT 模式的方言解析支持。
 这类数据库包括但不限于 `mysql`，`gvenzl/oracle-free`，`gvenzl/oracle-xe`，`postgres`，`mcr.microsoft.com/mssql/server` 等 Docker Image。
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.en.md
@@ -42,10 +42,6 @@ Introduce Maven dependencies and exclude the outdated Maven dependency of `org.a
 </project>
 ```
 
-Affected by Calcite, `commons-lang:commons-lang` used by ShardingSphere JDBC has a dependency conflict with Seata Client.
-Users need to consider whether to resolve the dependency conflict based on the actual situation. 
-If the dependency conflict is not resolved, Maven and other build tools will randomly use a version of the conflicting dependency in the classpath.
-
 When using ShardingSphere's Seata integration module, 
 the database instance connected to ShardingSphere should implement both ShardingSphere's dialect parsing support and Seata AT mode's dialect parsing support.
 This type of database includes but is not limited to `mysql`, `gvenzl/oracle-free`, `gvenzl/oracle-xe`, `postgres`, 

--- a/kernel/transaction/type/base/seata-at/pom.xml
+++ b/kernel/transaction/type/base/seata-at/pom.xml
@@ -66,5 +66,11 @@
             <artifactId>seata-all</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>${commons-lang.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <j2objc-annotations.version>1.3</j2objc-annotations.version>
         <calcite.version>1.40.0</calcite.version>
         
+        <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-codec.version>1.16.0</commons-codec.version>
         <commons-math3.version>3.6.1</commons-math3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <commons-codec.version>1.16.0</commons-codec.version>
         <commons-math3.version>3.6.1</commons-math3.version>
         <commons-pool2.version>2.12.0</commons-pool2.version>
+        <aggdesigner-algorithm.version>6.1</aggdesigner-algorithm.version>
         <caffeine.version>2.9.3</caffeine.version>
         <transmittable-thread-local.version>2.14.2</transmittable-thread-local.version>
         <java-util.version>2.4.0</java-util.version>
@@ -244,6 +245,11 @@
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>${commons-codec.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.hydromatic</groupId>
+                <artifactId>aggdesigner-algorithm</artifactId>
+                <version>${aggdesigner-algorithm.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>

--- a/test/native/pom.xml
+++ b/test/native/pom.xml
@@ -96,6 +96,12 @@
         </dependency>
         
         <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>${commons-lang.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-grpc</artifactId>
             <version>${vertx.version}</version>


### PR DESCRIPTION
Upgrade aggdesigner-algorithm to 6.1 and refactor usage of commons-lang to fix https://www.cve.org/CVERecord?id=CVE-2025-48924

For #36085