### PR TITLE
Remove java stream api usage in encrypt

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/insert/EncryptInsertOnUpdateTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/insert/EncryptInsertOnUpdateTokenGenerator.java
@@ -86,9 +86,10 @@ public final class EncryptInsertOnUpdateTokenGenerator implements CollectionSQLT
         for (ColumnAssignmentSegment each : onDuplicateKeyColumnsSegments) {
             boolean leftColumnIsEncrypt = encryptTable.isEncryptColumn(each.getColumns().get(0).getIdentifier().getValue());
             if (each.getValue() instanceof FunctionSegment && "VALUES".equalsIgnoreCase(((FunctionSegment) each.getValue()).getFunctionName())) {
-                Optional<ExpressionSegment> rightColumnSegment = ((FunctionSegment) each.getValue()).getParameters().stream().findFirst();
-                Preconditions.checkState(rightColumnSegment.isPresent());
-                boolean rightColumnIsEncrypt = encryptTable.isEncryptColumn(((ColumnSegment) rightColumnSegment.get()).getIdentifier().getValue());
+                FunctionSegment functionSegment = (FunctionSegment) each.getValue();
+                ExpressionSegment rightColumnSegment = functionSegment.getParameters().isEmpty() ? null : functionSegment.getParameters().iterator().next();
+                ShardingSpherePreconditions.checkNotNull(rightColumnSegment, () -> new IllegalArgumentException("right column segment can not be null"));
+                boolean rightColumnIsEncrypt = encryptTable.isEncryptColumn(((ColumnSegment) rightColumnSegment).getIdentifier().getValue());
                 if (!leftColumnIsEncrypt && !rightColumnIsEncrypt) {
                     continue;
                 }
@@ -139,9 +140,9 @@ public final class EncryptInsertOnUpdateTokenGenerator implements CollectionSQLT
                                                           final QuoteCharacter quoteCharacter) {
         ColumnSegment columnSegment = assignmentSegment.getColumns().get(0);
         String column = columnSegment.getIdentifier().getValue();
-        Optional<ExpressionSegment> valueColumnSegment = functionSegment.getParameters().stream().findFirst();
-        Preconditions.checkState(valueColumnSegment.isPresent());
-        String valueColumn = ((ColumnSegment) valueColumnSegment.get()).getIdentifier().getValue();
+        ExpressionSegment valueColumnSegment = functionSegment.getParameters().isEmpty() ? null : functionSegment.getParameters().iterator().next();
+        ShardingSpherePreconditions.checkNotNull(valueColumnSegment, () -> new IllegalArgumentException("value column segment can not be null"));
+        String valueColumn = ((ColumnSegment) valueColumnSegment).getIdentifier().getValue();
         EncryptFunctionAssignmentToken result =
                 new EncryptFunctionAssignmentToken(columnSegment.getStartIndex(), assignmentSegment.getStopIndex(), quoteCharacter);
         boolean isEncryptColumn = encryptTable.isEncryptColumn(column);

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptProjectionTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/projection/EncryptProjectionTokenGenerator.java
@@ -83,7 +83,7 @@ public final class EncryptProjectionTokenGenerator {
      */
     public Collection<SQLToken> generateSQLTokens(final SelectStatementContext selectStatementContext) {
         Collection<SQLToken> result = new LinkedList<>();
-        selectStatementContext.getSubqueryContexts().values().stream().map(this::generateSQLTokens).forEach(result::addAll);
+        selectStatementContext.getSubqueryContexts().values().forEach(each -> result.addAll(generateSQLTokens(each)));
         result.addAll(generateSelectSQLTokens(selectStatementContext));
         return result;
     }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/pojo/EncryptLiteralAssignmentToken.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/pojo/EncryptLiteralAssignmentToken.java
@@ -17,12 +17,12 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.token.pojo;
 
+import com.google.common.base.Joiner;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
 
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.stream.Collectors;
 
 /**
  * Literal assignment token for encrypt.
@@ -47,7 +47,7 @@ public final class EncryptLiteralAssignmentToken extends EncryptAssignmentToken 
     
     @Override
     public String toString() {
-        return assignments.stream().map(LiteralAssignment::toString).collect(Collectors.joining(", "));
+        return Joiner.on(", ").join(assignments);
     }
     
     @RequiredArgsConstructor


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove java stream api usage in encrypt

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
