### PR TITLE
fix:Support for OPTION clause in SELECT statements

### DIFF
--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
@@ -130,7 +130,7 @@ aggregationClause
     ;
 
 selectClause
-    : selectWithClause? SELECT duplicateSpecification? projections intoClause? onFileGroupClause? (fromClause withTempTable? withTableHint?)? whereClause? groupByClause? havingClause? orderByClause? forClause?
+    : selectWithClause? SELECT duplicateSpecification? projections intoClause? onFileGroupClause? (fromClause withTempTable? withTableHint?)? whereClause? groupByClause? havingClause? orderByClause? forClause? optionHint?
     ;
 
 duplicateSpecification

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -11453,4 +11453,34 @@
             </simple-table>
         </from>
     </select>
+
+    <select sql-case-id="select_option_clause">
+        <projections start-index="7" stop-index="25">
+            <column-projection name="ProductID" start-index="7" stop-index="15" />
+            <column-projection name="OrderQty" start-index="18" stop-index="25" />
+        </projections>
+        <from start-index="49" stop-index="53">
+            <simple-table name="SalesOrderDetail" start-index="32" stop-index="53">
+                <owner name="Sales" start-index="32" stop-index="36" />
+            </simple-table>
+        </from>
+        <where start-index="55" stop-index="76">
+            <expr>
+                <binary-operation-expression start-index="61" stop-index="76">
+                    <left>
+                        <column name="UnitPrice" start-index="61" stop-index="69" />
+                    </left>
+                    <right>
+                        <literal-expression value="5.00" start-index="73" stop-index="76" />
+                    </right>
+                    <operator>&lt;</operator>
+                </binary-operation-expression>
+            </expr>
+        </where>
+        <group-by start-index="98" stop-index="106">
+            <column-item name="ProductID" start-index="87" stop-index="95" />
+            <column-item name="OrderQty" start-index="98" stop-index="105" />
+        </group-by>
+        <option-hint start-index="107" stop-index="132" text="OPTION (HASH GROUP, LABEL = N'label1')" />
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -359,4 +359,5 @@
     <sql-case id="select_product_function" value="SELECT e.Name, PRODUCT(1 + edh.rateOfReturn) OVER (PARTITION BY e.DepartmentID ORDER BY edh.EffectiveDate) AS CompoundedReturn FROM HumanResources.Employee e JOIN HumanResources.EmployeePayHistory edh ON e.BusinessEntityID = edh.BusinessEntityID;" db-types="SQLServer"/>
     <sql-case id="select_for_system_time" value="SELECT DepartmentNumber, DepartmentName FROM DEPARTMENT FOR SYSTEM_TIME AS OF '2014-01-01' WHERE ManagerID = 5;" db-types="SQLServer"/>
     <sql-case id="select_from_tablesample" value="SELECT * FROM Sales.Customer TABLESAMPLE SYSTEM(10 PERCENT);" db-types="SQLServer"/>
+    <sql-case id="select_option_clause" value="SELECT ProductID, OrderQty FROM Sales.SalesOrderDetail WHERE UnitPrice &lt; 5.00 GROUP BY ProductID, OrderQty OPTION (HASH GROUP, LABEL = N'label1');" db-types="SQLServer"/>
 </sql-cases>


### PR DESCRIPTION
for https://github.com/apache/shardingsphere/issues/35908
official document:https://learn.microsoft.com/zh-cn/sql/t-sql/queries/option-clause-transact-sql?view=sql-server-ver17

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
