### PR TITLE
fix:Support for multiple keywords in the OUTPUT clause

### DIFF
--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
@@ -290,7 +290,7 @@ outputWithColumn
     ;
 
 outputWithAaterisk
-    : (INSERTED | DELETED) DOT_ASTERISK_
+    : ((INSERTED | DELETED) DOT_ASTERISK_ | expr) (COMMA_ ((INSERTED | DELETED) DOT_ASTERISK_ | expr))*
     ;
 
 outputTableName

--- a/test/it/parser/src/main/resources/case/dml/merge.xml
+++ b/test/it/parser/src/main/resources/case/dml/merge.xml
@@ -578,4 +578,71 @@
             </where>
         </delete>
     </merge>
+
+    <merge sql-case-id="merge_output_with_aaterisk">
+        <target>
+            <simple-table name="people_target" alias="pt" start-index="11" stop-index="26" />
+        </target>
+        <source>
+            <simple-table name="people_source" alias="ps" start-index="34" stop-index="49" />
+        </source>
+        <expr>
+            <binary-operation-expression start-index="55" stop-index="81">
+                <left>
+                    <column name="person_id" start-index="55" stop-index="66">
+                        <owner name="pt" start-index="55" stop-index="56" />
+                    </column>
+                </left>
+                <operator>=</operator>
+                <right>
+                    <column name="person_id" start-index="70" stop-index="81">
+                        <owner name="ps" start-index="70" stop-index="71" />
+                    </column>
+                </right>
+            </binary-operation-expression>
+        </expr>
+        <merge-items text="WHEN MATCHED THEN UPDATE SET first_name = ps.first_name, pt.last_name = ps.last_name, pt.title = ps.title" start-index="109" stop-index="188">
+            <update>
+                <set start-index="109" stop-index="188">
+                    <assignment start-index="109" stop-index="141">
+                        <column name="first_name" start-index="113" stop-index="122" />
+                        <assignment-value>
+                            <column name="first_name" start-index="126" stop-index="138">
+                                <owner name="ps" start-index="126" stop-index="127" />
+                            </column>
+                        </assignment-value>
+                    </assignment>
+                    <assignment start-index="142" stop-index="167">
+                        <column name="last_name" start-index="141" stop-index="152">
+                            <owner name="pt" start-index="141" stop-index="142" />
+                        </column>
+                        <assignment-value>
+                            <column name="last_name" start-index="156" stop-index="167">
+                                <owner name="ps" start-index="156" stop-index="157" />
+                            </column>
+                        </assignment-value>
+                    </assignment>
+                    <assignment start-index="170" stop-index="188">
+                        <column name="title" start-index="170" stop-index="177">
+                            <owner name="pt" start-index="170" stop-index="171" />
+                        </column>
+                        <assignment-value>
+                            <column name="title" start-index="181" stop-index="188">
+                                <owner name="ps" start-index="181" stop-index="182" />
+                            </column>
+                        </assignment-value>
+                    </assignment>
+                </set>
+            </update>
+        </merge-items>
+        <output start-index="190" stop-index="226">
+            <output-columns start-index="197" stop-index="222">
+                <expression-projection text="$action" start-index="545" stop-index="551">
+                    <expr>
+                        <common-expression text="$action" start-index="545" stop-index="551" />
+                    </expr>
+                </expression-projection>
+            </output-columns>
+        </output>
+    </merge>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/merge.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/merge.xml
@@ -35,4 +35,5 @@
                                                                 remark      = ?,
                                                                 status      = ?;"  db-types="Oracle" />
     <sql-case id="merge_into_select" value="MERGE INTO (SELECT * FROM bonuses WHERE department_id = 80) D USING (SELECT employee_id, salary, department_id FROM employees WHERE department_id = 80) S ON (D.employee_id = S.employee_id) WHEN MATCHED THEN UPDATE SET D.bonus = D.bonus + S.salary*.01 DELETE WHERE (S.salary > 8000)" db-types="Oracle" />
+    <sql-case id="merge_output_with_aaterisk" value="MERGE INTO people_target pt USING people_source ps ON (pt.person_id = ps.person_id) WHEN MATCHED THEN UPDATE SET first_name = ps.first_name, pt.last_name = ps.last_name, pt.title = ps.title OUTPUT deleted.*, $action, inserted.*" db-types="SQLServer" />
 </sql-cases>


### PR DESCRIPTION
for https://github.com/apache/shardingsphere/issues/35908
official document:

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
