### PR TITLE
fix:Support for the WITH table hint in DELETE statements

### DIFF
--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
@@ -102,7 +102,7 @@ assignmentValue
     ;
 
 delete
-    : withClause? DELETE top? (singleTableClause | multipleTablesClause) outputClause? whereClause? optionHint?
+    : withClause? DELETE top? (singleTableClause | multipleTablesClause) withTableHint? outputClause? whereClause? optionHint?
     ;
 
 optionHint

--- a/test/it/parser/src/main/resources/case/dml/delete.xml
+++ b/test/it/parser/src/main/resources/case/dml/delete.xml
@@ -803,4 +803,24 @@
             </projections>
         </returning>
     </delete>
+
+    <delete sql-case-id="delete_with_table_hint">
+        <table name="DatabaseLog" start-index="14" stop-index="28">
+            <owner name="dbo" start-index="14" stop-index="16" />
+        </table>
+        <output start-index="46" stop-index="61" />
+        <where start-index="63" stop-index="85">
+            <expr>
+                <binary-operation-expression start-index="69" stop-index="85">
+                    <left>
+                        <column name="DatabaseLogID" start-index="69" stop-index="81" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="7" start-index="85" stop-index="85" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </delete>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/delete.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/delete.xml
@@ -46,4 +46,5 @@
     <sql-case id="delete_with_simple_condition" value="DELETE FROM Q1_2000_sales WHERE amount_sold &lt; 0" db-types="Oracle" />
     <sql-case id="delete_with_output_clause_with_compress_function" value="DELETE FROM player OUTPUT deleted.id,deleted.name, deleted.surname,deleted.datemodifier,COMPRESS(deleted.info) INTO dbo.inactivePlayers WHERE datemodified &lt; @startOfYear" db-types="SQLServer" />
     <sql-case id="delete_returning_expressions" value="DELETE FROM t2 WHERE id = 2 RETURNING id,t&amp;t" db-types="MySQL,Firebird" />
+    <sql-case id="delete_with_table_hint" value="DELETE TOP(1) dbo.DatabaseLog WITH (READPAST) OUTPUT DELETED.* WHERE DatabaseLogID = 7;" db-types="SQLServer"/>
 </sql-cases>


### PR DESCRIPTION
for https://github.com/apache/shardingsphere/issues/35908
official document:https://learn.microsoft.com/zh-cn/sql/t-sql/statements/delete-transact-sql?view=sql-server-ver17

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
