### PR TITLE
fix:Support for the FROM clause in DELETE statements

### DIFF
--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
@@ -322,7 +322,7 @@ outputWithAaterisk
     ;
 
 outputTableName
-    : tableName | variableName
+    : tableName
     ;
 
 queryHint

--- a/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
+++ b/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
@@ -262,7 +262,6 @@ import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.Rol
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.GroupingSetsClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.GroupingExprListContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.ExpressionListContext;
-import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.VariableNameContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.PredictFunctionContext;
 
 import java.util.Collection;
@@ -1592,11 +1591,6 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
         if (null != ctx.outputTableName()) {
             if (null != ctx.outputTableName().tableName()) {
                 result.setTable((SimpleTableSegment) visit(ctx.outputTableName().tableName()));
-            } else if (null != ctx.outputTableName().variableName()) {
-                VariableNameContext variableNameCtx = ctx.outputTableName().variableName();
-                SimpleTableSegment tableSegment =
-                        new SimpleTableSegment(new TableNameSegment(variableNameCtx.start.getStartIndex(), variableNameCtx.stop.getStopIndex(), new IdentifierValue(variableNameCtx.getText())));
-                result.setTable(tableSegment);
             }
             if (null != ctx.columnNames()) {
                 ColumnNamesContext columnNames = ctx.columnNames();

--- a/test/it/parser/src/main/resources/case/dml/delete.xml
+++ b/test/it/parser/src/main/resources/case/dml/delete.xml
@@ -849,4 +849,17 @@
             </expr>
         </where>
     </delete>
+
+    <delete sql-case-id="delete_from_clause">
+        <table name="ProductProductPhoto" start-index="7" stop-index="36">
+            <owner name="Production" start-index="7" stop-index="16" />
+        </table>
+        <output start-index="38" stop-index="102">
+            <output-columns start-index="45" stop-index="85">
+                <column-projection name="ProductID" start-index="45" stop-index="61" />
+                <column-projection name="ProductPhotoID" start-index="64" stop-index="85" />
+            </output-columns>
+            <output-table name="@MyTableVar" start-index="92" stop-index="102" />
+        </output>
+    </delete>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/delete.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/delete.xml
@@ -48,4 +48,5 @@
     <sql-case id="delete_returning_expressions" value="DELETE FROM t2 WHERE id = 2 RETURNING id,t&amp;t" db-types="MySQL,Firebird" />
     <sql-case id="delete_with_table_hint" value="DELETE TOP(1) dbo.DatabaseLog WITH (READPAST) OUTPUT DELETED.* WHERE DatabaseLogID = 7;" db-types="SQLServer"/>
     <sql-case id="delete_rowset_function" value="DELETE FROM OPENDATASOURCE('SQLNCLI', 'Data Source= &lt;server_name&gt;; Integrated Security=SSPI').AdventureWorks2022.HumanResources.Department WHERE DepartmentID = 17;" db-types="SQLServer" />
+    <sql-case id="delete_from_clause" value="DELETE Production.ProductProductPhoto OUTPUT DELETED.ProductID, DELETED.ProductPhotoID INTO @MyTableVar FROM Production.ProductProductPhoto AS ph;" db-types="SQLServer" />
 </sql-cases>


### PR DESCRIPTION
for https://github.com/apache/shardingsphere/issues/35908
official document:https://learn.microsoft.com/zh-cn/sql/t-sql/statements/delete-transact-sql?view=sql-server-ver17

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
