### PR TITLE
Fix the bug that `StandardJdbcUrlParser` cannot parse the jdbcUrl of `ContainerDatabaseDriver`

### DIFF
--- a/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/connector/url/StandardJdbcUrlParser.java
+++ b/infra/database/core/src/main/java/org/apache/shardingsphere/infra/database/core/connector/url/StandardJdbcUrlParser.java
@@ -69,6 +69,9 @@ public final class StandardJdbcUrlParser {
         ShardingSpherePreconditions.checkState(matcher.matches(), () -> new UnrecognizedDatabaseURLException(jdbcUrl, CONNECTION_URL_PATTERN.pattern().replaceAll("%", "%%")));
         String authority = matcher.group(AUTHORITY_GROUP_KEY);
         ShardingSpherePreconditions.checkNotNull(authority, () -> new UnrecognizedDatabaseURLException(jdbcUrl, CONNECTION_URL_PATTERN.pattern().replaceAll("%", "%%")));
+        if (authority.isEmpty()) {
+            return new JdbcUrl("", -1, matcher.group(PATH_GROUP_KEY), parseQueryProperties(matcher.group(QUERY_GROUP_KEY)));
+        }
         Matcher hostMatcher = HOST_PORT_PATTERN_PATTERN.matcher(authority);
         ShardingSpherePreconditions.checkState(hostMatcher.find(), () -> new UnrecognizedDatabaseURLException(jdbcUrl, CONNECTION_URL_PATTERN.pattern().replaceAll("%", "%%")));
         return new JdbcUrl(parseHostname(hostMatcher), parsePort(hostMatcher), matcher.group(PATH_GROUP_KEY), parseQueryProperties(matcher.group(QUERY_GROUP_KEY)));

--- a/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/connector/url/StandardJdbcUrlParserTest.java
+++ b/infra/database/core/src/test/java/org/apache/shardingsphere/infra/database/core/connector/url/StandardJdbcUrlParserTest.java
@@ -64,8 +64,24 @@ class StandardJdbcUrlParserTest {
                     Arguments.arguments("MySQL_with_replication", "jdbc:mysql:replication://master-ip:3306,slave-1-ip:3306,slave-2-ip:3306/foo_ds?useUnicode=true", "master-ip", 3306, "foo_ds",
                             PropertiesBuilder.build(new Property("useUnicode", Boolean.TRUE.toString()))),
                     Arguments.arguments("PostgreSQL_v4", "jdbc:postgresql://127.0.0.1:5432/foo_ds?prepareThreshold=1&preferQueryMode=extendedForPrepared", "127.0.0.1", 5432, "foo_ds",
-                            PropertiesBuilder.build(new Property("prepareThreshold", "1"), new Property("preferQueryMode", "extendedForPrepared"))));
-            
+                            PropertiesBuilder.build(new Property("prepareThreshold", "1"), new Property("preferQueryMode", "extendedForPrepared"))),
+                    Arguments.arguments("testcontainers_MySQL", "jdbc:tc:mysql:5.7.34:///demo_ds", "", -1, "demo_ds", new Properties()),
+                    Arguments.arguments("testcontainers_Postgres", "jdbc:tc:postgresql:9.6.8:///demo_ds", "", -1, "demo_ds", new Properties()),
+                    Arguments.arguments("testcontainers_PostGIS", "jdbc:tc:postgis:9.6-2.5:///demo_ds", "", -1, "demo_ds", new Properties()),
+                    Arguments.arguments("testcontainers_TimescaleDB", "jdbc:tc:timescaledb:2.1.0-pg13:///demo_ds", "", -1, "demo_ds", new Properties()),
+                    Arguments.arguments("testcontainers_Trino", "jdbc:tc:trino:352://localhost/memory/default", "localhost", -1, "memory/default", new Properties()),
+                    Arguments.arguments("testcontainers_CockroachDB", "jdbc:tc:cockroach:v21.2.3:///demo_ds", "", -1, "demo_ds", new Properties()),
+                    Arguments.arguments("testcontainers_TiDB", "jdbc:tc:tidb:v6.1.0:///demo_ds", "", -1, "demo_ds", new Properties()),
+                    Arguments.arguments("testcontainers_INITSCRIPT_CLASSPATH", "jdbc:tc:mysql:5.7.34:///demo_ds?TC_INITSCRIPT=somepath/init_mysql.sql", "", -1, "demo_ds",
+                            PropertiesBuilder.build(new Property("TC_INITSCRIPT", "somepath/init_mysql.sql"))),
+                    Arguments.arguments("testcontainers_INITSCRIPT", "jdbc:tc:mysql:5.7.34:///demo_ds?TC_INITSCRIPT=file:src/main/resources/init_mysql.sql", "", -1, "demo_ds",
+                            PropertiesBuilder.build(new Property("TC_INITSCRIPT", "file:src/main/resources/init_mysql.sql"))),
+                    Arguments.arguments("testcontainers_INITFUNCTION", "jdbc:tc:mysql:5.7.34:///demo_ds?TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction", "", -1, "demo_ds",
+                            PropertiesBuilder.build(new Property("TC_INITFUNCTION", "org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction"))),
+                    Arguments.arguments("testcontainers_DAEMON", "jdbc:tc:mysql:5.7.34:///demo_ds?TC_DAEMON=true", "", -1, "demo_ds",
+                            PropertiesBuilder.build(new Property("TC_DAEMON", Boolean.TRUE.toString()))),
+                    Arguments.arguments("testcontainers_TMPFS", "jdbc:tc:postgresql:9.6.8:///demo_ds?TC_TMPFS=/testtmpfs:rw", "", -1, "demo_ds",
+                            PropertiesBuilder.build(new Property("TC_TMPFS", "/testtmpfs:rw"))));
         }
     }
 }


### PR DESCRIPTION
For #35524 .

Changes proposed in this pull request:
  - Fix the bug that `org.apache.shardingsphere.infra.database.core.connector.url.StandardJdbcUrlParser` cannot parse the jdbcUrl of `org.testcontainers.jdbc.ContainerDatabaseDriver`. #35524 missed a corner case.
  - This PR aims to fix integration tests using `org.testcontainers.jdbc.ContainerDatabaseDriver`, such as `org.apache.shardingsphere.test.natived.jdbc.databases.ClickHouseTest`, under HotSpot VM. See https://github.com/apache/shardingsphere/actions/runs/16881168066/job/47817474910 .
```shell
Error:  2025-08-11 13:30:15.744 [main] com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Exception during pool initialization.
org.apache.shardingsphere.infra.database.core.exception.UnrecognizedDatabaseURLException: The URL `jdbc:tc:clickhouse:25.6.5.41:///demo_ds_2?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql` is not recognized, please refer to the pattern `(?<schema>[\w-.+:%%]+)\s*(?://(?<authority>[^/?#]*))?\s*(?:/(?!\s*/)(?<path>[^?#]*))?(?:\?(?!\s*\?)(?<query>[^#]*))?`.
	at org.apache.shardingsphere.infra.database.core.connector.url.StandardJdbcUrlParser.lambda$parse$2(StandardJdbcUrlParser.java:73)
	at org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions.checkState(ShardingSpherePreconditions.java:44)
	at org.apache.shardingsphere.infra.database.core.connector.url.StandardJdbcUrlParser.parse(StandardJdbcUrlParser.java:73)
	at org.apache.shardingsphere.infra.database.clickhouse.connector.ClickHouseConnectionPropertiesParser.parse(ClickHouseConnectionPropertiesParser.java:37)
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
