### PR TITLE
Prevent MS SQL Server JDBC Driver from implicitly passing JAXB dependencies in unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         
         <postgresql.version>42.7.5</postgresql.version>
         <mysql-connector-java.version>8.3.0</mysql-connector-java.version>
-        <mssql.version>6.1.7.jre8-preview</mssql.version>
+        <mssql.version>12.10.1.jre8</mssql.version>
         <h2.version>2.2.224</h2.version>
         <opengauss.version>3.1.0-og</opengauss.version>
         <mariadb-java-client.version>2.4.2</mariadb-java-client.version>


### PR DESCRIPTION
For #26041 .

Changes proposed in this pull request:
  - Prevent MS SQL Server JDBC Driver from implicitly passing JAXB dependencies in unit tests.
  - This is a follow-up to https://github.com/apache/shardingsphere/pull/36230. Due to changes in the related PR, JAXB is no longer a global dependency. Instead, `com.microsoft.sqlserver:mssql-jdbc:6.1.7.jre8-preview` is implicitly passing a JAXB dependency. This causes `org.apache.shardingsphere.test.natived.jdbc.databases.SQLServerTest` to fail in https://github.com/apache/shardingsphere/actions/runs/16881168066/job/47817474910.
```shell
Error:  Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 76.12 s <<< FAILURE! -- in org.apache.shardingsphere.test.natived.jdbc.databases.SQLServerTest
Error:  org.apache.shardingsphere.test.natived.jdbc.databases.SQLServerTest.assertShardingInLocalTransactions -- Time elapsed: 76.11 s <<< ERROR!
java.lang.NoClassDefFoundError: javax/xml/bind/DatatypeConverter
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.sendLogon(SQLServerConnection.java:3984)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.logon(SQLServerConnection.java:3097)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.access$100(SQLServerConnection.java:82)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection$LogonCommand.doExecute(SQLServerConnection.java:3061)
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
