### PR TITLE
fix:Support for the rowSetFunction in DELETE statements

### DIFF
--- a/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
+++ b/parser/sql/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
@@ -110,7 +110,7 @@ optionHint
     ;
 
 singleTableClause
-    : FROM? LP_? tableName RP_? (AS? alias)?
+    : FROM? LP_? (tableName | rowSetFunction) RP_? (AS? alias)?
     ;
 
 multipleTablesClause

--- a/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
+++ b/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
@@ -1764,11 +1764,21 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
     
     @Override
     public ASTNode visitSingleTableClause(final SingleTableClauseContext ctx) {
-        SimpleTableSegment result = (SimpleTableSegment) visit(ctx.tableName());
-        if (null != ctx.alias()) {
-            result.setAlias((AliasSegment) visit(ctx.alias()));
+        if (null != ctx.tableName()) {
+            SimpleTableSegment result = (SimpleTableSegment) visit(ctx.tableName());
+            if (null != ctx.alias()) {
+                result.setAlias((AliasSegment) visit(ctx.alias()));
+            }
+            return result;
+        } else if (null != ctx.rowSetFunction()) {
+            FunctionSegment functionSegment = (FunctionSegment) visit(ctx.rowSetFunction());
+            FunctionTableSegment result = new FunctionTableSegment(functionSegment.getStartIndex(), functionSegment.getStopIndex(), functionSegment);
+            if (null != ctx.alias()) {
+                result.setAlias((AliasSegment) visit(ctx.alias()));
+            }
+            return result;
         }
-        return result;
+        return null;
     }
     
     @Override

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dml/standard/type/DeleteStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dml/standard/type/DeleteStatementAssert.java
@@ -35,6 +35,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.out
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.table.TableAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.where.WhereClauseAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.with.WithClauseAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedTable;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dml.standard.DeleteStatementTestCase;
 
 import java.util.LinkedList;
@@ -89,6 +90,11 @@ public final class DeleteStatementAssert {
                 actualTableSegments.addAll(deleteMultiTableSegment.getActualDeleteTables());
             }
             TableAssert.assertIs(assertContext, actualTableSegments, expected.getTables());
+        } else if (null != expected.getFunctionTable()) {
+            assertNotNull(actual.getTable(), assertContext.getText("Actual function table segment should exist."));
+            ExpectedTable expectedTable = new ExpectedTable();
+            expectedTable.setFunctionTable(expected.getFunctionTable());
+            TableAssert.assertIs(assertContext, actual.getTable(), expectedTable);
         } else if (null != expected.getSubqueryTable()) {
             assertNotNull(actual.getTable(), assertContext.getText("Actual subquery table segment should exist."));
             TableAssert.assertIs(assertContext, (SubqueryTableSegment) actual.getTable(), expected.getSubqueryTable());

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dml/standard/DeleteStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dml/standard/DeleteStatementTestCase.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.S
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.limit.ExpectedLimitClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.orderby.ExpectedOrderByClause;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.output.ExpectedOutputClause;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedFunctionTable;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedSimpleTable;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedSubqueryTable;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.where.ExpectedWhereClause;
@@ -59,4 +60,7 @@ public final class DeleteStatementTestCase extends SQLParserTestCase {
     
     @XmlElement(name = "subquery-table")
     private ExpectedSubqueryTable subqueryTable;
+    
+    @XmlElement(name = "function-table")
+    private ExpectedFunctionTable functionTable;
 }

--- a/test/it/parser/src/main/resources/case/dml/delete.xml
+++ b/test/it/parser/src/main/resources/case/dml/delete.xml
@@ -823,4 +823,30 @@
             </expr>
         </where>
     </delete>
+
+    <delete sql-case-id="delete_rowset_function">
+        <function-table start-index="12" stop-index="144">
+            <table-function function-name="OPENDATASOURCE" text="OPENDATASOURCE('SQLNCLI', 'Data Source= &lt;server_name&gt;; Integrated Security=SSPI').AdventureWorks2022.HumanResources.Department">
+                <parameter>
+                    <literal-expression value="SQLNCLI" start-index="26" stop-index="34" />
+                </parameter>
+                <parameter>
+                    <literal-expression value="Data Source= &lt;server_name&gt;; Integrated Security=SSPI" start-index="37" stop-index="93" />
+                </parameter>
+            </table-function>
+        </function-table>
+        <where start-index="139" stop-index="161">
+            <expr>
+                <binary-operation-expression start-index="145" stop-index="161">
+                    <left>
+                        <column name="DepartmentID" start-index="145" stop-index="156" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="17" start-index="160" stop-index="161" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </delete>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/delete.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/delete.xml
@@ -47,4 +47,5 @@
     <sql-case id="delete_with_output_clause_with_compress_function" value="DELETE FROM player OUTPUT deleted.id,deleted.name, deleted.surname,deleted.datemodifier,COMPRESS(deleted.info) INTO dbo.inactivePlayers WHERE datemodified &lt; @startOfYear" db-types="SQLServer" />
     <sql-case id="delete_returning_expressions" value="DELETE FROM t2 WHERE id = 2 RETURNING id,t&amp;t" db-types="MySQL,Firebird" />
     <sql-case id="delete_with_table_hint" value="DELETE TOP(1) dbo.DatabaseLog WITH (READPAST) OUTPUT DELETED.* WHERE DatabaseLogID = 7;" db-types="SQLServer"/>
+    <sql-case id="delete_rowset_function" value="DELETE FROM OPENDATASOURCE('SQLNCLI', 'Data Source= &lt;server_name&gt;; Integrated Security=SSPI').AdventureWorks2022.HumanResources.Department WHERE DepartmentID = 17;" db-types="SQLServer" />
 </sql-cases>


### PR DESCRIPTION
for https://github.com/apache/shardingsphere/issues/35908
official document:https://learn.microsoft.com/zh-cn/sql/t-sql/statements/delete-transact-sql?view=sql-server-ver17

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
