### PR TITLE
Fix failed unit tests for Seata AT integration related to Seata Server `2.5.0`

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           ./test/native/src/test/resources/test-native/ps1/uninstall-docker-engine-for-wcow.ps1
           winget install --id jazzdelightsme.WingetPathUpdater --source winget
-          winget install --id SUSE.RancherDesktop --source winget
+          winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
           rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
           ./test/native/src/test/resources/test-native/ps1/wait-for-rancher-desktop-backend.ps1
           "PATH=$env:PATH" >> $env:GITHUB_ENV

--- a/.github/workflows/nightly-ci-dynamic.yml
+++ b/.github/workflows/nightly-ci-dynamic.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           ./test/native/src/test/resources/test-native/ps1/uninstall-docker-engine-for-wcow.ps1
           winget install --id jazzdelightsme.WingetPathUpdater --source winget
-          winget install --id SUSE.RancherDesktop --source winget
+          winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
           rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
           ./test/native/src/test/resources/test-native/ps1/wait-for-rancher-desktop-backend.ps1
       - uses: graalvm/setup-graalvm@v1

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           ./test/native/src/test/resources/test-native/ps1/uninstall-docker-engine-for-wcow.ps1
           winget install --id jazzdelightsme.WingetPathUpdater --source winget
-          winget install --id SUSE.RancherDesktop --source winget
+          winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
           rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
           ./test/native/src/test/resources/test-native/ps1/wait-for-rancher-desktop-backend.ps1
           "PATH=$env:PATH" >> $env:GITHUB_ENV

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
@@ -261,8 +261,9 @@ class SolutionTest {
 ### 单元测试的已知问题
 
 受 https://github.com/apache/shardingsphere/issues/35052 影响，
-`org.apache.shardingsphere.test.natived.jdbc.modes.cluster.EtcdTest` 的单元测试无法在通过 Windows 11 Home 24H2 编译的 GraalVM Native Image 下运行。
+`org.apache.shardingsphere.test.natived.jdbc.modes.cluster.EtcdTest` 的单元测试无法在通过 `Windows 11 Home 24H2` 编译的 GraalVM Native Image 下运行。
 
+受 https://github.com/apache/incubator-seata/issues/7523 影响，
 `org.apache.shardingsphere.test.natived.proxy.transactions.base.SeataTest` 已被禁用，
 因为在 Github Actions Runner 执行此单元测试将导致其他单元测试出现 JDBC 连接泄露。
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
@@ -271,10 +271,11 @@ class SolutionTest {
 ### Known issues with unit testing
 
 Affected by https://github.com/apache/shardingsphere/issues/35052 , 
-the unit test of `org.apache.shardingsphere.test.natived.jdbc.modes.cluster.EtcdTest` cannot be run under GraalVM Native Image compiled by Windows 11 Home 24H2.
+the unit test of `org.apache.shardingsphere.test.natived.jdbc.modes.cluster.EtcdTest` cannot be run under GraalVM Native Image compiled by `Windows 11 Home 24H2`.
 
-`org.apache.shardingsphere.test.natived.proxy.transactions.base.SeataTest` has been disabled
-because executing this unit test in Github Actions Runner will cause JDBC connection leaks in other unit tests.
+Due to https://github.com/apache/incubator-seata/issues/7523 , 
+`org.apache.shardingsphere.test.natived.proxy.transactions.base.SeataTest` has been disabled.
+This is because executing this unit test in the Github Actions Runner will cause JDBC connection leaks in other unit tests.
 
 ### `CodeCachePoolMXBean` limitation
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.cn.md
@@ -9,7 +9,7 @@ Apache ShardingSphere 提供 BASE 事务，集成了 Seata 的实现。本文所
 
 ## 前提条件
 
-ShardingSphere 的 Seata 集成仅在 `apache/incubator-seata:v2.3.0` 或更高版本可用。
+ShardingSphere 的 Seata 集成仅在 `apache/incubator-seata:v2.5.0` 或更高版本可用。
 对于 `org.apache.seata:seata-all` Maven 模块对应的 Seata Client，此限制同时作用于 HotSpot VM 和 GraalVM Native Image。
 引入 Maven 依赖，并排除 `org.apache.seata:seata-all` 中过时的 `org.antlr:antlr4-runtime:4.8` 的 Maven 依赖。
 
@@ -29,7 +29,7 @@ ShardingSphere 的 Seata 集成仅在 `apache/incubator-seata:v2.3.0` 或更高�
       <dependency>
          <groupId>org.apache.seata</groupId>
          <artifactId>seata-all</artifactId>
-         <version>2.3.0</version>
+         <version>2.5.0</version>
          <exclusions>
             <exclusion>
                <groupId>org.antlr</groupId>
@@ -47,7 +47,7 @@ ShardingSphere 的 Seata 集成仅在 `apache/incubator-seata:v2.3.0` 或更高�
 ### `undo_log` 表限制
 
 在每一个 ShardingSphere 涉及的真实数据库实例中均需要创建 `undo_log` 表。
-每种数据库的 SQL 的内容以 https://github.com/apache/incubator-seata/tree/v2.3.0/script/client/at/db 内对应的数据库为准。
+每种数据库的 SQL 的内容以 https://github.com/apache/incubator-seata/tree/v2.5.0/script/client/at/db 内对应的数据库为准。
 
 ### 相关配置
 
@@ -61,7 +61,7 @@ transaction:
 ```
 
 在 classpath 的根目录中增加 `seata.conf` 文件，
-配置文件格式参考 `org.apache.seata.config.FileConfiguration` 的 [JavaDoc](https://github.com/apache/incubator-seata/blob/v2.3.0/config/seata-config-core/src/main/java/org/apache/seata/config/FileConfiguration.java)。
+配置文件格式参考 `org.apache.seata.config.FileConfiguration` 的 [JavaDoc](https://github.com/apache/incubator-seata/blob/v2.5.0/config/seata-config-core/src/main/java/org/apache/seata/config/FileConfiguration.java)。
 
 `seata.conf` 存在四个属性，
 
@@ -110,7 +110,7 @@ client.application.id = example
 ```yaml
 services:
    apache-seata-server:
-      image: apache/seata-server:2.3.0
+      image: apache/seata-server:2.5.0
       ports:
          - "8091:8091"
    mysql:
@@ -348,7 +348,7 @@ ShardingSphere 的 Seata 集成将获取到的 Seata 全局事务置入线程的
       <dependency>
          <groupId>org.apache.seata</groupId>
          <artifactId>seata-spring-boot-starter</artifactId>
-         <version>2.3.0</version>
+         <version>2.5.0</version>
          <exclusions>
             <exclusion>
                <groupId>org.antlr</groupId>
@@ -553,7 +553,7 @@ public class CustomWebMvcConfigurer implements WebMvcConfigurer {
 
 3. 微服务实例 `a-service` 和 `b-service` 均为 Spring Boot 微服务，但使用的 API 网关中间件阻断了所有包含 `TX_XID` 的 HTTP Header 的 HTTP 请求。
 用户需要考虑更改把 XID 通过服务调用传递到微服务实例 `a-service` 使用的 HTTP Header，或使用 RPC 框架把 XID 通过服务调用传递到微服务实例 `a-service`。
-参考 https://github.com/apache/incubator-seata/tree/v2.3.0/integration 。
+参考 https://github.com/apache/incubator-seata/tree/v2.5.0/integration 。
 
 4. 微服务实例 `a-service` 和 `b-service` 均为 Quarkus，Micronaut Framework 和 Helidon 等微服务。
 此情况下无法使用 Spring WebMVC HandlerInterceptor。

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.en.md
@@ -10,7 +10,7 @@ All references to Seata integration in this article refer to Seata AT mode.
 
 ## Prerequisites
 
-ShardingSphere's Seata integration is only available in `apache/incubator-seata:v2.3.0` or higher.
+ShardingSphere's Seata integration is only available in `apache/incubator-seata:v2.5.0` or higher.
 For Seata Client corresponding to the `org.apache.seata:seata-all` Maven module, this limitation applies to both HotSpot VM and GraalVM Native Image.
 Introduce Maven dependencies and exclude the outdated Maven dependency of `org.antlr:antlr4-runtime:4.8` in `org.apache.seata:seata-all`.
 
@@ -30,7 +30,7 @@ Introduce Maven dependencies and exclude the outdated Maven dependency of `org.a
       <dependency>
          <groupId>org.apache.seata</groupId>
          <artifactId>seata-all</artifactId>
-         <version>2.3.0</version>
+         <version>2.5.0</version>
          <exclusions>
             <exclusion>
                <groupId>org.antlr</groupId>
@@ -50,7 +50,7 @@ This type of database includes but is not limited to `mysql`, `gvenzl/oracle-fre
 ### `undo_log` table restrictions
 
 In each real database instance involved in ShardingSphere, an `undo_log` table needs to be created.
-The SQL content of each database is based on the corresponding database in https://github.com/apache/incubator-seata/tree/v2.3.0/script/client/at/db .
+The SQL content of each database is based on the corresponding database in https://github.com/apache/incubator-seata/tree/v2.5.0/script/client/at/db .
 
 ### Related configuration
 
@@ -66,7 +66,7 @@ transaction:
 ```
 
 Add the `seata.conf` file to the root directory of the classpath.
-For the configuration file format, refer to the [JavaDoc](https://github.com/apache/incubator-seata/blob/v2.3.0/config/seata-config-core/src/main/java/org/apache/seata/config/FileConfiguration.java) of `org.apache.seata.config.FileConfiguration`.
+For the configuration file format, refer to the [JavaDoc](https://github.com/apache/incubator-seata/blob/v2.5.0/config/seata-config-core/src/main/java/org/apache/seata/config/FileConfiguration.java) of `org.apache.seata.config.FileConfiguration`.
 
 `seata.conf` has four properties,
 
@@ -121,7 +121,7 @@ Write Docker Compose file to start Seata Server and MySQL Server.
 ```yaml
 services:
    apache-seata-server:
-      image: apache/seata-server:2.3.0
+      image: apache/seata-server:2.5.0
       ports:
          - "8091:8091"
    mysql:
@@ -363,7 +363,7 @@ A possible dependency relationship is as follows.
        <dependency>
           <groupId>org.apache.seata</groupId>
           <artifactId>seata-spring-boot-starter</artifactId>
-          <version>2.3.0</version>
+          <version>2.5.0</version>
           <exclusions>
              <exclusion>
                 <groupId>org.antlr</groupId>
@@ -583,7 +583,7 @@ the changes to the MySQL database instances `a-mysql` and `b-mysql` in the busin
 but the API gateway middleware used blocks all HTTP requests containing the HTTP Header of `TX_XID`.
 The user needs to consider changing the HTTP Header used to pass XID to the microservice instance `a-service` through service calls, 
 or use the RPC framework to pass XID to the microservice instance `a-service` through service calls.
-Refer to https://github.com/apache/incubator-seata/tree/v2.3.0/integration .
+Refer to https://github.com/apache/incubator-seata/tree/v2.5.0/integration .
 
 4. The microservice instances `a-service` and `b-service` are both microservices such as Quarkus, 
 Micronaut Framework and Helidon. In this case, Spring WebMVC HandlerInterceptor cannot be used.

--- a/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/seata-at/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/seata-at/_index.cn.md
@@ -19,7 +19,7 @@ ShardingSphere Proxy 或 GraalVM Native Image 形态的 ShardingSphere Proxy Nat
    传播事务到其他使用 Seata 集成的 ShardingSphere Proxy 实例或其他使用 Seata 集成的微服务。用户如果有这种需求，应考虑为 ShardingSphere 提交 PR
 5. ShardingSphere JDBC 对 Seata 的 TCC 模式建立的假设，在 ShardingSphere Proxy 上失效
 
-下文以使用 Seata Client 2.3.0 的 ShardingSphere Proxy 为例讨论。
+下文以使用 Seata Client 2.5.0 的 ShardingSphere Proxy 为例讨论。
 
 ## 操作步骤
 
@@ -33,21 +33,27 @@ ShardingSphere Proxy 或 GraalVM Native Image 形态的 ShardingSphere Proxy Nat
 
 ### 确认 Seata Client 的 JAR 和依赖列表
 
-对于已安装 `SDKMAN!` 的 Ubuntu 22.04.4，可以以如下命令确认 Seata Client 的所有 `compile` scope 的依赖，
+`OpenJDK` 和 `Maven` 可以通过 `sdkman/sdkman-cli` 或 `version-fox/vfox` 安装。
+对于已安装 `OpenJDK 23` 和 `Maven 3.9.11` 的 `Ubuntu 24.04.3` 或 `Windows 11 Home 24H2`，可以以如下命令确认 Seata Client 的所有 `compile` scope 的依赖，
+
+1. 如果使用 Bash，
 
 ```shell
-sdk install java 23-open
-sdk use java 23-open
-sdk install maven 3.9.11
-sdk use maven 3.9.11
-mvn dependency:get -Dartifact=org.apache.seata:seata-all:2.3.0
-mvn -f ~/.m2/repository/org/apache/seata/seata-all/2.3.0/seata-all-2.3.0.pom dependency:tree | grep -v ':provided' | grep -v ':runtime'
+mvn dependency:get "-Dartifact=org.apache.seata:seata-all:2.5.0"
+mvn -f "${HOME}/.m2/repository/org/apache/seata/seata-all/2.5.0/seata-all-2.5.0.pom" dependency:tree | grep -v ':provided' | grep -v ':runtime'
+```
+
+2. 如果使用 PowerShell 7，
+
+```shell
+mvn dependency:get "-Dartifact=org.apache.seata:seata-all:2.5.0"
+mvn -f "${HOME}/.m2/repository/org/apache/seata/seata-all/2.5.0/seata-all-2.5.0.pom" dependency:tree | Where-Object { $_ -notmatch ':provided' -and $_ -notmatch ':runtime' }
 ```
 
 与 `org.apache.shardingsphere:shardingsphere-proxy-distribution` 的 `pom.xml` 对比，不难发现有差异列表为，
 
 ```
-org.apache.seata:seata-all:jar:2.3.0
+org.apache.seata:seata-all:jar:2.5.0
 org.springframework:spring-context:jar:5.3.39
 org.springframework:spring-expression:jar:5.3.39
 org.springframework:spring-core:jar:5.3.39
@@ -104,9 +110,9 @@ services:
       volumes:
          - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
    apache-seata-server:
-      image: apache/seata-server:2.3.0
+      image: apache/seata-server:2.5.0
       healthcheck:
-         test: [ "CMD", "sh", "-c", "curl -s apache-seata-server:7091/health | grep -q '^ok$'" ]
+        test: [ "CMD", "sh", "-c", "curl -s apache-seata-server:8091/health | grep -q '\"ok\"'" ]
    shardingsphere-proxy-custom:
       image: example/shardingsphere-proxy-custom:latest
       pull_policy: build
@@ -115,7 +121,7 @@ services:
          dockerfile_inline: |
             FROM apache/shardingsphere-proxy:latest
             RUN wget https://repo1.maven.org/maven2/org/apache/shardingsphere/shardingsphere-transaction-base-seata-at/5.5.2/shardingsphere-transaction-base-seata-at-5.5.2.jar --directory-prefix=/opt/shardingsphere-proxy/ext-lib
-            RUN wget https://repo1.maven.org/maven2/org/apache/seata/seata-all/2.3.0/seata-all-2.3.0.jar --directory-prefix=/opt/shardingsphere-proxy/ext-lib
+            RUN wget https://repo1.maven.org/maven2/org/apache/seata/seata-all/2.5.0/seata-all-2.5.0.jar --directory-prefix=/opt/shardingsphere-proxy/ext-lib
             RUN wget https://repo1.maven.org/maven2/org/springframework/spring-context/5.3.39/spring-context-5.3.39.jar --directory-prefix=/opt/shardingsphere-proxy/ext-lib
             RUN wget https://repo1.maven.org/maven2/org/springframework/spring-expression/5.3.39/spring-expression-5.3.39.jar --directory-prefix=/opt/shardingsphere-proxy/ext-lib
             RUN wget https://repo1.maven.org/maven2/org/springframework/spring-core/5.3.39/spring-core-5.3.39.jar --directory-prefix=/opt/shardingsphere-proxy/ext-lib

--- a/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/seata-at/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/optional-plugins/seata-at/_index.en.md
@@ -19,7 +19,7 @@ but there are some differences,
 If users have such needs, they should consider submitting a PR for ShardingSphere
 5. The assumptions made by ShardingSphere JDBC on Seata's TCC mode are invalid on ShardingSphere Proxy
 
-The following discussion takes ShardingSphere Proxy using Seata Client 2.3.0 as an example.
+The following discussion takes ShardingSphere Proxy using Seata Client 2.5.0 as an example.
 
 ## Operation steps
 
@@ -33,23 +33,29 @@ The following discussion takes ShardingSphere Proxy using Seata Client 2.3.0 as 
 
 ### Confirm the JAR and dependency list of Seata Client
 
-For Ubuntu 22.04.4 with `SDKMAN!` installed, 
-you can confirm all `compile` scope dependencies of Seata Client with the following command:
+
+`OpenJDK` and `Maven` can be installed via `sdkman/sdkman-cli` or `version-fox/vfox`.
+For `Ubuntu 24.04.3` or `Windows 11 Home 24H2` with `OpenJDK 23` and `Maven 3.9.11` installed, user can confirm all `compile` scope dependencies of Seata Client with the following command,
+
+1. If using Bash,
 
 ```shell
-sdk install java 23-open
-sdk use java 23-open
-sdk install maven 3.9.11
-sdk use maven 3.9.11
-mvn dependency:get -Dartifact=org.apache.seata:seata-all:2.3.0
-mvn -f ~/.m2/repository/org/apache/seata/seata-all/2.3.0/seata-all-2.3.0.pom dependency:tree | grep -v ':provided' | grep -v ':runtime'
+mvn dependency:get "-Dartifact=org.apache.seata:seata-all:2.5.0"
+mvn -f "${HOME}/.m2/repository/org/apache/seata/seata-all/2.5.0/seata-all-2.5.0.pom" dependency:tree | grep -v ':provided' | grep -v ':runtime'
+```
+
+2. If using PowerShell 7,
+
+```shell
+mvn dependency:get "-Dartifact=org.apache.seata:seata-all:2.5.0"
+mvn -f "${HOME}/.m2/repository/org/apache/seata/seata-all/2.5.0/seata-all-2.5.0.pom" dependency:tree | Where-Object { $_ -notmatch ':provided' -and $_ -notmatch ':runtime' }
 ```
 
 Compared with the `pom.xml` of `org.apache.shardingsphere:shardingsphere-proxy-distribution`, 
 it is not difficult to find the differences listed as follows:
 
 ```
-org.apache.seata:seata-all:jar:2.3.0
+org.apache.seata:seata-all:jar:2.5.0
 org.springframework:spring-context:jar:5.3.39
 org.springframework:spring-expression:jar:5.3.39
 org.springframework:spring-core:jar:5.3.39
@@ -107,9 +113,9 @@ services:
       volumes:
          - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
    apache-seata-server:
-      image: apache/seata-server:2.3.0
+      image: apache/seata-server:2.5.0
       healthcheck:
-         test: [ "CMD", "sh", "-c", "curl -s apache-seata-server:7091/health | grep -q '^ok$'" ]
+         test: [ "CMD", "sh", "-c", "curl -s apache-seata-server:8091/health | grep -q '\"ok\"'" ]
    shardingsphere-proxy-custom:
       image: example/shardingsphere-proxy-custom:latest
       pull_policy: build
@@ -118,7 +124,7 @@ services:
          dockerfile_inline: |
             FROM apache/shardingsphere-proxy:latest
             RUN wget https://repo1.maven.org/maven2/org/apache/shardingsphere/shardingsphere-transaction-base-seata-at/5.5.2/shardingsphere-transaction-base-seata-at-5.5.2.jar --directory-prefix=/opt/shardingsphere-proxy/ext-lib
-            RUN wget https://repo1.maven.org/maven2/org/apache/seata/seata-all/2.3.0/seata-all-2.3.0.jar --directory-prefix=/opt/shardingsphere-proxy/ext-lib
+            RUN wget https://repo1.maven.org/maven2/org/apache/seata/seata-all/2.5.0/seata-all-2.5.0.jar --directory-prefix=/opt/shardingsphere-proxy/ext-lib
             RUN wget https://repo1.maven.org/maven2/org/springframework/spring-context/5.3.39/spring-context-5.3.39.jar --directory-prefix=/opt/shardingsphere-proxy/ext-lib
             RUN wget https://repo1.maven.org/maven2/org/springframework/spring-expression/5.3.39/spring-expression-5.3.39.jar --directory-prefix=/opt/shardingsphere-proxy/ext-lib
             RUN wget https://repo1.maven.org/maven2/org/springframework/spring-core/5.3.39/spring-core-5.3.39.jar --directory-prefix=/opt/shardingsphere-proxy/ext-lib

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.seata/seata-all/2.5.0/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.seata/seata-all/2.5.0/reachability-metadata.json
@@ -1473,6 +1473,25 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.seata.core.rpc.netty.ChannelEventHandler"
+      },
+      "type": "org.apache.seata.core.rpc.netty.ChannelEventHandler",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.seata.common.loader.EnhancedServiceLoader$InnerEnhancedServiceLoader"
+      },
+      "type": "org.apache.seata.rm.datasource.exec.oceanbase.OceanBaseInsertExecutor"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.seata.common.loader.EnhancedServiceLoader$InnerEnhancedServiceLoader"
+      },
+      "type": "org.apache.seata.rm.datasource.undo.parser.FuryUndoLogParser"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.seata.config.ConfigurationCache"
       },
       "type": {

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
@@ -1581,12 +1581,6 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.authority.rule.AuthorityRule"
       },
-      "type": "org.apache.shardingsphere.authority.provider.database.DatabasePermittedPrivilegeProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.authority.rule.AuthorityRule"
-      },
       "type": "org.apache.shardingsphere.authority.provider.simple.AllPermittedPrivilegeProvider"
     },
     {
@@ -2611,54 +2605,6 @@
         "typeReached": "org.apache.shardingsphere.infra.spi.type.ordered.OrderedSPILoader"
       },
       "type": "org.apache.shardingsphere.encrypt.checker.config.EncryptRuleConfigurationChecker"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.executor.engine.DriverExecuteExecutor"
-      },
-      "type": "org.apache.shardingsphere.encrypt.checker.sql.EncryptSupportedSQLCheckersBuilder",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"
-      },
-      "type": "org.apache.shardingsphere.encrypt.checker.sql.EncryptSupportedSQLCheckersBuilder",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseConnector"
-      },
-      "type": "org.apache.shardingsphere.encrypt.checker.sql.EncryptSupportedSQLCheckersBuilder",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.encrypt.checker.sql.EncryptSupportedSQLCheckersBuilder"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.encrypt.checker.sql.EncryptSupportedSQLCheckersBuilder"
     },
     {
       "condition": {
@@ -8909,54 +8855,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.executor.engine.DriverExecuteExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.checker.sql.ShardingSupportedSQLCheckersBuilder",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"
-      },
-      "type": "org.apache.shardingsphere.sharding.checker.sql.ShardingSupportedSQLCheckersBuilder",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseConnector"
-      },
-      "type": "org.apache.shardingsphere.sharding.checker.sql.ShardingSupportedSQLCheckersBuilder",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.checker.sql.ShardingSupportedSQLCheckersBuilder"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.checker.sql.ShardingSupportedSQLCheckersBuilder"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.sqlfederation.engine.SQLFederationEngine"
       },
       "type": "org.apache.shardingsphere.sharding.decider.ShardingSQLFederationDecider"
@@ -9922,54 +9820,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.executor.engine.DriverExecuteExecutor"
-      },
-      "type": "org.apache.shardingsphere.single.checker.sql.SingleSupportedSQLCheckersBuilder",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"
-      },
-      "type": "org.apache.shardingsphere.single.checker.sql.SingleSupportedSQLCheckersBuilder",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseConnector"
-      },
-      "type": "org.apache.shardingsphere.single.checker.sql.SingleSupportedSQLCheckersBuilder",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.single.checker.sql.SingleSupportedSQLCheckersBuilder"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.single.checker.sql.SingleSupportedSQLCheckersBuilder"
     },
     {
       "condition": {
@@ -11630,12 +11480,6 @@
         "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
       },
       "type": "org.apache.shardingsphere.sqltranslator.distsql.parser.facade.SQLTranslatorDistSQLParserFacade"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqltranslator.rule.SQLTranslatorRule"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.natived.NativeSQLTranslator"
     },
     {
       "condition": {

--- a/kernel/transaction/type/base/seata-at/pom.xml
+++ b/kernel/transaction/type/base/seata-at/pom.xml
@@ -27,7 +27,7 @@
     <name>${project.artifactId}</name>
     
     <properties>
-        <seata.version>2.3.0</seata.version>
+        <seata.version>2.5.0</seata.version>
         <commons-lang.version>2.6</commons-lang.version>
         <httpcore5.version>5.3.4</httpcore5.version>
     </properties>

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/transactions/base/SeataTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/transactions/base/SeataTest.java
@@ -55,9 +55,9 @@ import static org.hamcrest.Matchers.nullValue;
 class SeataTest {
     
     @Container
-    private final GenericContainer<?> container = new GenericContainer<>("apache/seata-server:2.3.0")
-            .withExposedPorts(7091, 8091)
-            .waitingFor(Wait.forHttp("/health").forPort(7091).forStatusCode(HttpStatus.SC_OK).forResponsePredicate("ok"::equals));
+    private final GenericContainer<?> container = new GenericContainer<>("apache/seata-server:2.5.0")
+            .withExposedPorts(8091)
+            .waitingFor(Wait.forHttp("/health").forPort(8091).forStatusCode(HttpStatus.SC_OK).forResponsePredicate("\"ok\""::equals));
     
     @Container
     private final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:17.5-bookworm")
@@ -89,7 +89,7 @@ class SeataTest {
     }
     
     /**
-     * TODO Apparently there is a real connection leak on Seata Client 2.3.0.
+     * TODO Apparently there is a real connection leak on Seata Client 2.5.0.
      */
     @AfterEach
     void afterEach() {


### PR DESCRIPTION
For #29052 .

Changes proposed in this pull request:
  - Fix failed unit tests for Seata AT integration related to Seata Server `2.5.0`. This is related to https://github.com/apache/incubator-seata/pull/7346. The related PR removed port `7091` on Seata Server, which is related to the fact that Seata Server no longer includes the web UI of Seata Console.
  - Add Windows 11 configuration documentation for Seata integration of ShardingSphere Proxy. 
  - Document the aftereffects of https://github.com/apache/incubator-seata/issues/7523 .
  - It looks like updating WSL on Windows Server 2025 will break Rancher Desktop starting with 2025.08.16. The `--skip-dependencies` winget parameter has been added back, but it's not clear what the August Windows patch did. See https://github.com/apache/shardingsphere/actions/runs/17003670205/job/48211134883 .
```shell
Installer failed with exit code: 1603
Installer log is available at: C:\Users\runneradmin\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\DiagOutputDir\WinGet-Microsoft.WSL.2.5.10-2025-08-16-04-04-14.549.log
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
