### PR TITLE
Remove useless sql federation config in e2e sql and refactor sql federation check logic

### DIFF
--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/compiler/SQLStatementCompilerEngine.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/compiler/SQLStatementCompilerEngine.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sqlfederation.compiler.compiler;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.sqlfederation.compiler.SQLFederationExecutionPlan;
 import org.apache.shardingsphere.sqlfederation.compiler.planner.cache.ExecutionPlanCacheBuilder;
@@ -32,8 +33,12 @@ public final class SQLStatementCompilerEngine {
     
     private final LoadingCache<ExecutionPlanCacheKey, SQLFederationExecutionPlan> executionPlanCache;
     
+    @Getter
+    private final SQLFederationCacheOption cacheOption;
+    
     public SQLStatementCompilerEngine(final SQLFederationCacheOption cacheOption) {
         executionPlanCache = ExecutionPlanCacheBuilder.build(cacheOption);
+        this.cacheOption = cacheOption;
     }
     
     /**
@@ -49,5 +54,14 @@ public final class SQLStatementCompilerEngine {
             log.debug("Execution plan cache {} for SQL: {}, useCache: {}.", cacheExists, cacheKey.getSql(), useCache);
         }
         return useCache ? executionPlanCache.get(cacheKey) : cacheKey.getSqlStatementCompiler().compile(cacheKey.getSqlStatement(), cacheKey.getSqlStatement().getDatabaseType().getType());
+    }
+    
+    /**
+     * Update cache option.
+     *
+     * @param cacheOption cache option
+     */
+    public void updateCacheOption(final SQLFederationCacheOption cacheOption) {
+        executionPlanCache.policy().eviction().ifPresent(optional -> optional.setMaximum(cacheOption.getMaximumSize()));
     }
 }

--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/compiler/SQLStatementCompilerEngineFactory.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/compiler/SQLStatementCompilerEngineFactory.java
@@ -45,7 +45,17 @@ public final class SQLStatementCompilerEngineFactory {
         SQLStatementCompilerEngine result = COMPILER_ENGINES.get(cacheKey);
         if (null == result) {
             result = COMPILER_ENGINES.computeIfAbsent(cacheKey, unused -> new SQLStatementCompilerEngine(cacheOption));
+        } else if (isOnlyModifyMaximumSizeConfig(cacheOption, result)) {
+            result.updateCacheOption(cacheOption);
+        } else if (!cacheOption.equals(result.getCacheOption())) {
+            result = new SQLStatementCompilerEngine(cacheOption);
+            COMPILER_ENGINES.put(cacheKey, result);
         }
         return result;
+    }
+    
+    private static boolean isOnlyModifyMaximumSizeConfig(final SQLFederationCacheOption cacheOption, final SQLStatementCompilerEngine compilerEngine) {
+        return cacheOption.getInitialCapacity() == compilerEngine.getCacheOption().getInitialCapacity()
+                && cacheOption.getMaximumSize() != compilerEngine.getCacheOption().getMaximumSize();
     }
 }

--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/exception/InvalidExecutionPlanCacheConfigException.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/exception/InvalidExecutionPlanCacheConfigException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sqlfederation.compiler.exception;
+
+import org.apache.shardingsphere.infra.exception.core.external.sql.sqlstate.XOpenSQLState;
+
+/**
+ * Invalid execution plan cache config exception.
+ */
+public final class InvalidExecutionPlanCacheConfigException extends SQLFederationSQLException {
+    
+    private static final long serialVersionUID = -8736329434228094859L;
+    
+    public InvalidExecutionPlanCacheConfigException(final Object configKey, final Object configValue) {
+        super(XOpenSQLState.GENERAL_ERROR, 8, "Invalid execution plan cache config: `%s`=`%s`, the value must be positive.", configKey, configValue);
+    }
+}

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/rule/SQLFederationRule.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/rule/SQLFederationRule.java
@@ -18,12 +18,15 @@
 package org.apache.shardingsphere.sqlfederation.rule;
 
 import lombok.Getter;
+import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.rule.scope.GlobalRule;
-import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
-import org.apache.shardingsphere.sqlfederation.constant.SQLFederationOrder;
 import org.apache.shardingsphere.sqlfederation.compiler.context.CompilerContext;
 import org.apache.shardingsphere.sqlfederation.compiler.context.CompilerContextFactory;
+import org.apache.shardingsphere.sqlfederation.compiler.exception.InvalidExecutionPlanCacheConfigException;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
+import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
+import org.apache.shardingsphere.sqlfederation.constant.SQLFederationOrder;
 
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicReference;
@@ -41,6 +44,13 @@ public final class SQLFederationRule implements GlobalRule {
     public SQLFederationRule(final SQLFederationRuleConfiguration ruleConfig, final Collection<ShardingSphereDatabase> databases) {
         configuration = ruleConfig;
         compilerContext = new AtomicReference<>(CompilerContextFactory.create(databases));
+        checkExecutionPlanCacheConfig(ruleConfig.getExecutionPlanCache());
+    }
+    
+    private void checkExecutionPlanCacheConfig(final SQLFederationCacheOption executionPlanCache) {
+        ShardingSpherePreconditions.checkState(executionPlanCache.getInitialCapacity() > 0,
+                () -> new InvalidExecutionPlanCacheConfigException("initialCapacity", executionPlanCache.getInitialCapacity()));
+        ShardingSpherePreconditions.checkState(executionPlanCache.getMaximumSize() > 0, () -> new InvalidExecutionPlanCacheConfigException("maximumSize", executionPlanCache.getMaximumSize()));
     }
     
     @Override

--- a/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/engine/SQLFederationEngineTest.java
+++ b/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/engine/SQLFederationEngineTest.java
@@ -61,7 +61,7 @@ class SQLFederationEngineTest {
     @Test
     void assertDecideWhenSelectStatementContainsSystemSchema() throws SQLException {
         Collection<ShardingSphereRule> globalRules = Collections.singleton(
-                new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
+                new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, new SQLFederationCacheOption(1, 1)), Collections.emptyList()));
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getSqlStatement().getDatabaseType()).thenReturn(databaseType);
         when(sqlStatementContext.getTablesContext().getDatabaseNames()).thenReturn(Collections.singletonList("information_schema"));
@@ -85,7 +85,7 @@ class SQLFederationEngineTest {
     void assertDecideWhenNotConfigSqlFederationEnabled() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
                 Collections
-                        .singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
+                        .singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(false, false, new SQLFederationCacheOption(1, 1)), Collections.emptyList()));
         SQLFederationEngine engine = createSQLFederationEngine(globalRules, Collections.emptyList());
         RuleMetaData globalRuleMetaData = new RuleMetaData(globalRules);
         assertFalse(engine.decide(mock(QueryContext.class), globalRuleMetaData));
@@ -95,7 +95,7 @@ class SQLFederationEngineTest {
     @Test
     void assertDecideWhenConfigAllQueryUseSQLFederation() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
-                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, true, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
+                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, true, new SQLFederationCacheOption(1, 1)), Collections.emptyList()));
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db",
                 databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(globalRules), Collections.emptyList());
         SelectStatementContext selectStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
@@ -113,7 +113,7 @@ class SQLFederationEngineTest {
     @Test
     void assertDecideWhenExecuteNotSelectStatement() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
-                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
+                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, new SQLFederationCacheOption(1, 1)), Collections.emptyList()));
         SQLFederationEngine engine = createSQLFederationEngine(globalRules, Collections.emptyList());
         RuleMetaData globalRuleMetaData = new RuleMetaData(globalRules);
         assertFalse(engine.decide(mock(QueryContext.class), globalRuleMetaData));
@@ -123,7 +123,7 @@ class SQLFederationEngineTest {
     @Test
     void assertDecideWhenConfigSingleMatchedRule() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
-                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
+                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, new SQLFederationCacheOption(1, 1)), Collections.emptyList()));
         Collection<ShardingSphereRule> databaseRules = Collections.singletonList(new SQLFederationDeciderRuleMatchFixture());
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db",
                 databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(globalRules), Collections.emptyList());
@@ -142,7 +142,7 @@ class SQLFederationEngineTest {
     @Test
     void assertDecideWhenConfigSingleNotMatchedRule() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
-                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
+                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, new SQLFederationCacheOption(1, 1)), Collections.emptyList()));
         Collection<ShardingSphereRule> databaseRules = Collections.singletonList(new SQLFederationDeciderRuleNotMatchFixture());
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db",
                 databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(databaseRules), Collections.emptyList());
@@ -160,7 +160,7 @@ class SQLFederationEngineTest {
     @Test
     void assertDecideWhenConfigMultiRule() throws SQLException {
         Collection<ShardingSphereRule> globalRules =
-                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, mock(SQLFederationCacheOption.class)), Collections.emptyList()));
+                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, false, new SQLFederationCacheOption(1, 1)), Collections.emptyList()));
         Collection<ShardingSphereRule> databaseRules = Arrays.asList(new SQLFederationDeciderRuleNotMatchFixture(),
                 new SQLFederationDeciderRuleMatchFixture());
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db",

--- a/kernel/sql-federation/distsql/handler/src/main/java/org/apache/shardingsphere/sqlfederation/distsql/handler/update/AlterSQLFederationRuleExecutor.java
+++ b/kernel/sql-federation/distsql/handler/src/main/java/org/apache/shardingsphere/sqlfederation/distsql/handler/update/AlterSQLFederationRuleExecutor.java
@@ -19,6 +19,8 @@ package org.apache.shardingsphere.sqlfederation.distsql.handler.update;
 
 import lombok.Setter;
 import org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.global.GlobalRuleDefinitionExecutor;
+import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
+import org.apache.shardingsphere.sqlfederation.compiler.exception.InvalidExecutionPlanCacheConfigException;
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationCacheOption;
 import org.apache.shardingsphere.sqlfederation.config.SQLFederationRuleConfiguration;
 import org.apache.shardingsphere.sqlfederation.distsql.segment.CacheOptionSegment;
@@ -46,7 +48,15 @@ public final class AlterSQLFederationRuleExecutor implements GlobalRuleDefinitio
     private SQLFederationCacheOption createCacheOption(final SQLFederationCacheOption cacheOption, final CacheOptionSegment segment) {
         int initialCapacity = null == segment.getInitialCapacity() ? cacheOption.getInitialCapacity() : segment.getInitialCapacity();
         long maximumSize = null == segment.getMaximumSize() ? cacheOption.getMaximumSize() : segment.getMaximumSize();
-        return new SQLFederationCacheOption(initialCapacity, maximumSize);
+        SQLFederationCacheOption result = new SQLFederationCacheOption(initialCapacity, maximumSize);
+        checkExecutionPlanCacheConfig(result);
+        return result;
+    }
+    
+    private void checkExecutionPlanCacheConfig(final SQLFederationCacheOption executionPlanCache) {
+        ShardingSpherePreconditions.checkState(executionPlanCache.getInitialCapacity() > 0,
+                () -> new InvalidExecutionPlanCacheConfigException("initialCapacity", executionPlanCache.getInitialCapacity()));
+        ShardingSpherePreconditions.checkState(executionPlanCache.getMaximumSize() > 0, () -> new InvalidExecutionPlanCacheConfigException("maximumSize", executionPlanCache.getMaximumSize()));
     }
     
     @Override

--- a/test/e2e/sql/src/test/resources/env/scenario/db/proxy/mode/cluster/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/db/proxy/mode/cluster/global.yaml
@@ -42,12 +42,6 @@ sqlParser:
   parseTreeCache:
     initialCapacity: 128
     maximumSize: 1024
-    
-sqlFederation:
-  sqlFederationEnabled: false
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
 
 props:
   max-connections-size-per-query: 1

--- a/test/e2e/sql/src/test/resources/env/scenario/db/proxy/mode/standalone/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/db/proxy/mode/standalone/global.yaml
@@ -31,12 +31,6 @@ sqlParser:
     initialCapacity: 128
     maximumSize: 1024
 
-sqlFederation:
-  sqlFederationEnabled: false
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
-
 props:
   max-connections-size-per-query: 1
   kernel-executor-size: 16  # Infinite by default.

--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting/proxy/mode/cluster/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting/proxy/mode/cluster/global.yaml
@@ -42,12 +42,6 @@ sqlParser:
   parseTreeCache:
     initialCapacity: 128
     maximumSize: 1024
-    
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
 
 props:
   max-connections-size-per-query: 1

--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting/proxy/mode/standalone/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting/proxy/mode/standalone/global.yaml
@@ -31,12 +31,6 @@ sqlParser:
     initialCapacity: 128
     maximumSize: 1024
 
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
-
 props:
   max-connections-size-per-query: 1
   kernel-executor-size: 16  # Infinite by default.

--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting/rules.yaml
@@ -135,12 +135,6 @@ rules:
   loadBalancers:
     roundRobin:
       type: ROUND_ROBIN
-
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
     
 props:
   sql-show: true

--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/proxy/mode/cluster/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/proxy/mode/cluster/global.yaml
@@ -42,12 +42,6 @@ sqlParser:
   parseTreeCache:
     initialCapacity: 128
     maximumSize: 1024
-    
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
 
 props:
   max-connections-size-per-query: 1

--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/proxy/mode/standalone/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/proxy/mode/standalone/global.yaml
@@ -31,12 +31,6 @@ sqlParser:
     initialCapacity: 128
     maximumSize: 1024
 
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
-
 props:
   max-connections-size-per-query: 1
   kernel-executor-size: 16  # Infinite by default.

--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/rules.yaml
@@ -188,12 +188,6 @@ rules:
           cipher:
             name: number_new_cipher
             encryptorName: aes_encryptor
-
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
     
 props:
   sql-show: true

--- a/test/e2e/sql/src/test/resources/env/scenario/empty_rules/proxy/mode/cluster/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/empty_rules/proxy/mode/cluster/global.yaml
@@ -42,12 +42,6 @@ sqlParser:
   parseTreeCache:
     initialCapacity: 128
     maximumSize: 1024
-    
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
 
 props:
   max-connections-size-per-query: 1

--- a/test/e2e/sql/src/test/resources/env/scenario/empty_rules/proxy/mode/standalone/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/empty_rules/proxy/mode/standalone/global.yaml
@@ -31,12 +31,6 @@ sqlParser:
     initialCapacity: 128
     maximumSize: 1024
 
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
-
 props:
   max-connections-size-per-query: 1
   kernel-executor-size: 16  # Infinite by default.

--- a/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/cluster/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/cluster/global.yaml
@@ -42,12 +42,6 @@ sqlParser:
   parseTreeCache:
     initialCapacity: 128
     maximumSize: 1024
-    
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
 
 props:
   max-connections-size-per-query: 1

--- a/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/cluster/mysql/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/cluster/mysql/global.yaml
@@ -42,12 +42,6 @@ sqlParser:
   parseTreeCache:
     initialCapacity: 128
     maximumSize: 1024
-    
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
 
 props:
   max-connections-size-per-query: 1

--- a/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/cluster/opengauss/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/cluster/opengauss/global.yaml
@@ -42,12 +42,6 @@ sqlParser:
   parseTreeCache:
     initialCapacity: 128
     maximumSize: 1024
-    
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
 
 props:
   max-connections-size-per-query: 1

--- a/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/cluster/postgresql/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/cluster/postgresql/global.yaml
@@ -42,12 +42,6 @@ sqlParser:
   parseTreeCache:
     initialCapacity: 128
     maximumSize: 1024
-    
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
 
 props:
   max-connections-size-per-query: 1

--- a/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/standalone/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/standalone/global.yaml
@@ -31,12 +31,6 @@ sqlParser:
     initialCapacity: 128
     maximumSize: 1024
 
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
-
 props:
   max-connections-size-per-query: 1
   kernel-executor-size: 16  # Infinite by default.

--- a/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/standalone/mysql/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/standalone/mysql/global.yaml
@@ -31,12 +31,6 @@ sqlParser:
     initialCapacity: 128
     maximumSize: 1024
 
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
-
 props:
   max-connections-size-per-query: 1
   kernel-executor-size: 16  # Infinite by default.

--- a/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/standalone/opengauss/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/standalone/opengauss/global.yaml
@@ -31,12 +31,6 @@ sqlParser:
     initialCapacity: 128
     maximumSize: 1024
 
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
-
 props:
   max-connections-size-per-query: 1
   kernel-executor-size: 16  # Infinite by default.

--- a/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/standalone/postgresql/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/empty_storage_units/proxy/mode/standalone/postgresql/global.yaml
@@ -31,12 +31,6 @@ sqlParser:
     initialCapacity: 128
     maximumSize: 1024
 
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
-
 props:
   max-connections-size-per-query: 1
   kernel-executor-size: 16  # Infinite by default.

--- a/test/e2e/sql/src/test/resources/env/scenario/sharding_and_encrypt/proxy/mode/cluster/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/sharding_and_encrypt/proxy/mode/cluster/global.yaml
@@ -35,12 +35,6 @@ authority:
   privilege:
     type: ALL_PERMITTED
 
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
-
 props:
   max-connections-size-per-query: 1
   kernel-executor-size: 16  # Infinite by default.

--- a/test/e2e/sql/src/test/resources/env/scenario/sharding_and_encrypt/proxy/mode/standalone/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/sharding_and_encrypt/proxy/mode/standalone/global.yaml
@@ -23,12 +23,6 @@ authority:
   privilege:
     type: ALL_PERMITTED
 
-sqlFederation:
-  sqlFederationEnabled: true
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
-
 props:
   max-connections-size-per-query: 1
   kernel-executor-size: 16  # Infinite by default.

--- a/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/mode/cluster/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/mode/cluster/global.yaml
@@ -42,12 +42,6 @@ sqlParser:
   parseTreeCache:
     initialCapacity: 128
     maximumSize: 1024
-    
-sqlFederation:
-  sqlFederationEnabled: false
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
 
 props:
   max-connections-size-per-query: 1

--- a/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/mode/standalone/global.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/mode/standalone/global.yaml
@@ -31,12 +31,6 @@ sqlParser:
     initialCapacity: 128
     maximumSize: 1024
 
-sqlFederation:
-  sqlFederationEnabled: false
-  executionPlanCache:
-    initialCapacity: 2000
-    maximumSize: 65535
-
 props:
   max-connections-size-per-query: 1
   kernel-executor-size: 16  # Infinite by default.


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove useless sql federation config in e2e sql and refactor sql federation check logic

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
