### PR TITLE
Refactor SQLFederationResultSetMetaData and ColumnTypeConverter

### DIFF
--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/SQLFederationResultSetMetaData.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/SQLFederationResultSetMetaData.java
@@ -159,14 +159,13 @@ public final class SQLFederationResultSetMetaData extends WrapperAdapter impleme
         if (relDataType instanceof JavaType && BigInteger.class.isAssignableFrom(((JavaType) relDataType).getJavaClass())) {
             return SqlType.BIGINT.id;
         }
-        int jdbcType = relDataType.getSqlTypeName().getJdbcOrdinal();
-        return columnTypeConverter.convertColumnType(jdbcType);
+        return columnTypeConverter.convertColumnType(relDataType.getSqlTypeName());
     }
     
     @Override
     public String getColumnTypeName(final int column) {
         SqlTypeName originalSqlTypeName = resultColumnType.getFieldList().get(column - 1).getType().getSqlTypeName();
-        SqlTypeName convertSqlTypeName = SqlTypeName.getNameForJdbcType(columnTypeConverter.convertColumnType(originalSqlTypeName.getJdbcOrdinal()));
+        SqlTypeName convertSqlTypeName = SqlTypeName.getNameForJdbcType(columnTypeConverter.convertColumnType(originalSqlTypeName));
         return null == convertSqlTypeName ? originalSqlTypeName.getName() : convertSqlTypeName.getName();
     }
     

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/converter/SQLFederationColumnTypeConverter.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/converter/SQLFederationColumnTypeConverter.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sqlfederation.resultset.converter;
 
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPI;
 import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
 
@@ -39,10 +40,10 @@ public interface SQLFederationColumnTypeConverter extends DatabaseTypedSPI {
     /**
      * Convert column type.
      *
-     * @param columnType column type
+     * @param sqlTypeName column type
      * @return converted column type
      */
-    default int convertColumnType(int columnType) {
-        return columnType;
+    default int convertColumnType(SqlTypeName sqlTypeName) {
+        return sqlTypeName.getJdbcOrdinal();
     }
 }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/converter/impl/MySQLColumnTypeConverter.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/converter/impl/MySQLColumnTypeConverter.java
@@ -34,11 +34,12 @@ public final class MySQLColumnTypeConverter implements SQLFederationColumnTypeCo
     }
     
     @Override
-    public int convertColumnType(final int columnType) {
-        if (SqlTypeName.BOOLEAN.getJdbcOrdinal() == columnType || SqlTypeName.ANY.getJdbcOrdinal() == columnType) {
+    public int convertColumnType(final SqlTypeName sqlTypeName) {
+        int result = sqlTypeName.getJdbcOrdinal();
+        if (SqlTypeName.BOOLEAN.getJdbcOrdinal() == result || SqlTypeName.ANY.getJdbcOrdinal() == result) {
             return SqlTypeName.VARCHAR.getJdbcOrdinal();
         }
-        return columnType;
+        return result;
     }
     
     @Override


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Refactor SQLFederationResultSetMetaData and ColumnTypeConverter

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
