### PR TITLE
Fix readwrite_splitting rql e2e test case

### DIFF
--- a/test/e2e/sql/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting/show_readwrite_splitting_rules.xml
+++ b/test/e2e/sql/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting/show_readwrite_splitting_rules.xml
@@ -24,14 +24,14 @@
         <column name="load_balancer_type" />
         <column name="load_balancer_props" />
     </metadata>
-    <row values="readwrite_ds_0| write_ds_0| read_ds_0| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_1| write_ds_1| read_ds_1| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_2| write_ds_2| read_ds_2| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_3| write_ds_3| read_ds_3| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_4| write_ds_4| read_ds_4| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_5| write_ds_5| read_ds_5| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_6| write_ds_6| read_ds_6| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_7| write_ds_7| read_ds_7| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_8| write_ds_8| read_ds_8| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_9| write_ds_9| read_ds_9| DYNAMIC| ROUND_ROBIN| " />
+    <row values="readwrite_ds_0| write_ds_0| read_ds_0| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_1| write_ds_1| read_ds_1| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_2| write_ds_2| read_ds_2| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_3| write_ds_3| read_ds_3| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_4| write_ds_4| read_ds_4| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_5| write_ds_5| read_ds_5| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_6| write_ds_6| read_ds_6| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_7| write_ds_7| read_ds_7| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_8| write_ds_8| read_ds_8| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_9| write_ds_9| read_ds_9| PRIMARY| ROUND_ROBIN| " />
 </dataset>

--- a/test/e2e/sql/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting_and_encrypt/show_readwrite_splitting_rules.xml
+++ b/test/e2e/sql/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting_and_encrypt/show_readwrite_splitting_rules.xml
@@ -24,14 +24,14 @@
         <column name="load_balancer_type" />
         <column name="load_balancer_props" />
     </metadata>
-    <row values="readwrite_ds_0| encrypt_write_ds_0| encrypt_read_ds_0| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_1| encrypt_write_ds_1| encrypt_read_ds_1| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_2| encrypt_write_ds_2| encrypt_read_ds_2| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_3| encrypt_write_ds_3| encrypt_read_ds_3| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_4| encrypt_write_ds_4| encrypt_read_ds_4| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_5| encrypt_write_ds_5| encrypt_read_ds_5| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_6| encrypt_write_ds_6| encrypt_read_ds_6| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_7| encrypt_write_ds_7| encrypt_read_ds_7| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_8| encrypt_write_ds_8| encrypt_read_ds_8| DYNAMIC| ROUND_ROBIN| " />
-    <row values="readwrite_ds_9| encrypt_write_ds_9| encrypt_read_ds_9| DYNAMIC| ROUND_ROBIN| " />
+    <row values="readwrite_ds_0| encrypt_write_ds_0| encrypt_read_ds_0| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_1| encrypt_write_ds_1| encrypt_read_ds_1| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_2| encrypt_write_ds_2| encrypt_read_ds_2| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_3| encrypt_write_ds_3| encrypt_read_ds_3| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_4| encrypt_write_ds_4| encrypt_read_ds_4| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_5| encrypt_write_ds_5| encrypt_read_ds_5| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_6| encrypt_write_ds_6| encrypt_read_ds_6| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_7| encrypt_write_ds_7| encrypt_read_ds_7| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_8| encrypt_write_ds_8| encrypt_read_ds_8| PRIMARY| ROUND_ROBIN| " />
+    <row values="readwrite_ds_9| encrypt_write_ds_9| encrypt_read_ds_9| PRIMARY| ROUND_ROBIN| " />
 </dataset>

--- a/test/e2e/sql/src/test/resources/cases/rql/dataset/encrypt_and_readwrite_splitting/show_readwrite_splitting_rules.xml
+++ b/test/e2e/sql/src/test/resources/cases/rql/dataset/encrypt_and_readwrite_splitting/show_readwrite_splitting_rules.xml
@@ -24,5 +24,5 @@
         <column name="load_balancer_type" />
         <column name="load_balancer_props" />
     </metadata>
-    <row values="readwrite_ds| encrypt_write_ds| encrypt_read_ds| DYNAMIC| ROUND_ROBIN| " />
+    <row values="readwrite_ds| encrypt_write_ds| encrypt_read_ds| PRIMARY| ROUND_ROBIN| " />
 </dataset>

--- a/test/e2e/sql/src/test/resources/cases/rql/dataset/readwrite_splitting/show_readwrite_splitting_rules.xml
+++ b/test/e2e/sql/src/test/resources/cases/rql/dataset/readwrite_splitting/show_readwrite_splitting_rules.xml
@@ -24,5 +24,5 @@
         <column name="load_balancer_type" />
         <column name="load_balancer_props" />
     </metadata>
-    <row values="write-read-ds| write_ds| read_0,read_1| DYNAMIC| | " />
+    <row values="write-read-ds| write_ds| read_0,read_1| PRIMARY| | " />
 </dataset>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix readwrite_splitting rql e2e test case

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
