### PR TITLE
Compatible with COMPLEX_INLINE allow-range-query-with-inline-sharding for pipeline

### DIFF
--- a/kernel/data-pipeline/feature/sharding/src/main/java/org/apache/shardingsphere/data/pipeline/sharding/ShardingPipelineYamlRuleConfigurationReviser.java
+++ b/kernel/data-pipeline/feature/sharding/src/main/java/org/apache/shardingsphere/data/pipeline/sharding/ShardingPipelineYamlRuleConfigurationReviser.java
@@ -35,7 +35,7 @@ public final class ShardingPipelineYamlRuleConfigurationReviser implements Pipel
     
     private void enableRangeQueryForInline(final YamlShardingRuleConfiguration yamlRuleConfig) {
         for (YamlAlgorithmConfiguration each : yamlRuleConfig.getShardingAlgorithms().values()) {
-            if ("INLINE".equalsIgnoreCase(each.getType())) {
+            if ("INLINE".equalsIgnoreCase(each.getType()) || "COMPLEX_INLINE".equalsIgnoreCase(each.getType())) {
                 each.getProps().put("allow-range-query-with-inline-sharding", Boolean.TRUE.toString());
             }
         }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Compatible with COMPLEX_INLINE allow-range-query-with-inline-sharding for pipeline

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
