### PR TITLE
Fix MySQL JDBC query properties extension when SSL is required on server

### DIFF
--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtension.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtension.java
@@ -36,7 +36,6 @@ public final class MySQLJdbcQueryPropertiesExtension implements JdbcQueryPropert
     private final Properties completeIfMissedQueryProps = new Properties();
     
     public MySQLJdbcQueryPropertiesExtension() {
-        toBeOverrideQueryProps.setProperty("useSSL", Boolean.FALSE.toString());
         toBeOverrideQueryProps.setProperty("useServerPrepStmts", Boolean.FALSE.toString());
         toBeOverrideQueryProps.setProperty("rewriteBatchedStatements", Boolean.TRUE.toString());
         toBeOverrideQueryProps.setProperty("yearIsDateType", Boolean.FALSE.toString());

--- a/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtensionTest.java
+++ b/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtensionTest.java
@@ -53,8 +53,7 @@ class MySQLJdbcQueryPropertiesExtensionTest {
     }
     
     private void assertQueryProperties(final Properties actual, final String expectedNetTimeoutForStreamingResults) {
-        assertThat(actual.size(), is(8));
-        assertThat(actual.getProperty("useSSL"), is(Boolean.FALSE.toString()));
+        assertThat(actual.size(), is(7));
         assertThat(actual.getProperty("useServerPrepStmts"), is(Boolean.FALSE.toString()));
         assertThat(actual.getProperty("rewriteBatchedStatements"), is(Boolean.TRUE.toString()));
         assertThat(actual.getProperty("yearIsDateType"), is(Boolean.FALSE.toString()));


### PR DESCRIPTION

Changes proposed in this pull request:
  - Fix MySQL JDBC query properties extension when SSL is required on server

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
