### PR TITLE
Simplify InventoryDumper usage of PipelineTableMetaData

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumperContext.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumperContext.java
@@ -23,10 +23,12 @@ import lombok.ToString;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.DumperCommonContext;
 import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineColumnMetaData;
 import org.apache.shardingsphere.data.pipeline.core.ratelimit.JobRateLimitAlgorithm;
+import org.apache.shardingsphere.infra.metadata.identifier.ShardingSphereIdentifier;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Inventory dumper context.
@@ -43,6 +45,8 @@ public final class InventoryDumperContext {
     private String logicTableName;
     
     private List<PipelineColumnMetaData> uniqueKeyColumns;
+    
+    private List<ShardingSphereIdentifier> targetUniqueKeysNames;
     
     private List<String> insertColumnNames;
     
@@ -63,6 +67,18 @@ public final class InventoryDumperContext {
     public InventoryDumperContext(final DumperCommonContext commonContext) {
         this.commonContext = new DumperCommonContext(
                 commonContext.getDataSourceName(), commonContext.getDataSourceConfig(), commonContext.getTableNameMapper(), commonContext.getTableAndSchemaNameMapper());
+    }
+    
+    /**
+     * Set unique key columns.
+     *
+     * @param uniqueKeyColumns unique key columns
+     */
+    public void setUniqueKeyColumns(final List<PipelineColumnMetaData> uniqueKeyColumns) {
+        this.uniqueKeyColumns = uniqueKeyColumns;
+        targetUniqueKeysNames = hasUniqueKey()
+                ? uniqueKeyColumns.stream().map(each -> new ShardingSphereIdentifier(each.getName())).collect(Collectors.toList())
+                : Collections.emptyList();
     }
     
     /**


### PR DESCRIPTION

Changes proposed in this pull request:
  - Simplify InventoryDumper usage of PipelineTableMetaData

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
