### PR TITLE
Move "new EqualsBuilder()" into method for pipeline

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordSingleTableInventoryCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordSingleTableInventoryCalculator.java
@@ -63,8 +63,6 @@ public final class RecordSingleTableInventoryCalculator extends AbstractStreamin
     
     private final StreamingRangeType streamingRangeType;
     
-    private final EqualsBuilder equalsBuilder = new EqualsBuilder();
-    
     public RecordSingleTableInventoryCalculator(final int chunkSize, final StreamingRangeType streamingRangeType) {
         this(chunkSize, DEFAULT_STREAMING_CHUNK_COUNT, streamingRangeType);
     }
@@ -179,6 +177,7 @@ public final class RecordSingleTableInventoryCalculator extends AbstractStreamin
         if (null != previousRecord) {
             duplicateRecords.add(previousRecord);
         }
+        EqualsBuilder equalsBuilder = new EqualsBuilder();
         while (resultSet.next()) {
             ShardingSpherePreconditions.checkState(!isCanceling(), () -> new PipelineJobCancelingException("Calculate chunk canceled, qualified table: %s", param.getTable()));
             Map<String, Object> record = readRecord(columnValueReaderEngine, resultSet, resultSetMetaData);


### PR DESCRIPTION

Changes proposed in this pull request:
  - Move "new EqualsBuilder()" into method for pipeline

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
