### PR TITLE
Unify maxPoolSize and minPoolSize in dbtbl_with_readwrite_splitting

### DIFF
--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting/proxy/conf/mysql/database-dbtbl-with-readwrite-splitting.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting/proxy/conf/mysql/database-dbtbl-with-readwrite-splitting.yaml
@@ -25,8 +25,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_1:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_1?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -34,8 +34,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_2:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_2?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -43,8 +43,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_3:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_3?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -52,8 +52,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_4:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_4?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -61,8 +61,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_5:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_5?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -70,8 +70,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_6:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_6?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -79,8 +79,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_7:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_7?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -88,8 +88,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_8:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_8?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -97,8 +97,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_9:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_9?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -106,8 +106,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_0:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_0?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -115,8 +115,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_1:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_1?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -124,8 +124,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_2:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_2?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -133,8 +133,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_3:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_3?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -142,8 +142,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_4:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_4?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -151,8 +151,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_5:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_5?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -160,8 +160,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_6:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_6?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -169,8 +169,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_7:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_7?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -178,8 +178,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_8:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_8?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -187,8 +187,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_9:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_9?useSSL=false&characterEncoding=utf-8
     username: test_user
@@ -196,8 +196,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
 
 rules:
 - !SINGLE

--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting/proxy/conf/opengauss/database-dbtbl-with-readwrite-splitting.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting/proxy/conf/opengauss/database-dbtbl-with-readwrite-splitting.yaml
@@ -25,8 +25,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_1:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/write_ds_1
     username: test_user
@@ -34,8 +34,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_2:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/write_ds_2
     username: test_user
@@ -43,8 +43,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_3:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/write_ds_3
     username: test_user
@@ -52,8 +52,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_4:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/write_ds_4
     username: test_user
@@ -61,8 +61,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_5:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/write_ds_5
     username: test_user
@@ -70,8 +70,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_6:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/write_ds_6
     username: test_user
@@ -79,8 +79,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_7:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/write_ds_7
     username: test_user
@@ -88,8 +88,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_8:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/write_ds_8
     username: test_user
@@ -97,8 +97,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_9:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/write_ds_9
     username: test_user
@@ -106,8 +106,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_0:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/read_ds_0
     username: test_user
@@ -115,8 +115,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_1:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/read_ds_1
     username: test_user
@@ -124,8 +124,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_2:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/read_ds_2
     username: test_user
@@ -133,8 +133,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_3:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/read_ds_3
     username: test_user
@@ -142,8 +142,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_4:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/read_ds_4
     username: test_user
@@ -151,8 +151,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_5:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/read_ds_5
     username: test_user
@@ -160,8 +160,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_6:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/read_ds_6
     username: test_user
@@ -169,8 +169,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_7:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/read_ds_7
     username: test_user
@@ -178,8 +178,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_8:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/read_ds_8
     username: test_user
@@ -187,8 +187,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_9:
     url: jdbc:opengauss://opengauss.dbtbl_with_readwrite_splitting.host:5432/read_ds_9
     username: test_user
@@ -196,8 +196,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 20
-    minPoolSize: 10
+    maxPoolSize: 5
+    minPoolSize: 2
 
 rules:
 - !SINGLE

--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting/proxy/conf/postgresql/database-dbtbl-with-readwrite-splitting.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting/proxy/conf/postgresql/database-dbtbl-with-readwrite-splitting.yaml
@@ -25,8 +25,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_1:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_1
     username: test_user
@@ -34,8 +34,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_2:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_2
     username: test_user
@@ -43,8 +43,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_3:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_3
     username: test_user
@@ -52,8 +52,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_4:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_4
     username: test_user
@@ -61,8 +61,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_5:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_5
     username: test_user
@@ -70,8 +70,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_6:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_6
     username: test_user
@@ -79,8 +79,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_7:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_7
     username: test_user
@@ -88,8 +88,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_8:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_8
     username: test_user
@@ -97,8 +97,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   write_ds_9:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_9
     username: test_user
@@ -106,8 +106,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_0:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_0
     username: test_user
@@ -115,8 +115,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_1:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_1
     username: test_user
@@ -124,8 +124,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_2:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_2
     username: test_user
@@ -133,8 +133,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_3:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_3
     username: test_user
@@ -142,8 +142,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_4:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_4
     username: test_user
@@ -151,8 +151,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_5:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_5
     username: test_user
@@ -160,8 +160,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_6:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_6
     username: test_user
@@ -169,8 +169,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_7:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_7
     username: test_user
@@ -178,8 +178,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_8:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_8
     username: test_user
@@ -187,8 +187,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
   read_ds_9:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_9
     username: test_user
@@ -196,8 +196,8 @@ dataSources:
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     maxLifetimeMilliseconds: 1800000
-    maxPoolSize: 10
-    minPoolSize: 5
+    maxPoolSize: 5
+    minPoolSize: 2
 
 rules:
 - !SINGLE


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Unify maxPoolSize and minPoolSize in dbtbl_with_readwrite_splitting

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
