### PR TITLE
Add generic type RESULT for SingleTableInventoryCalculator

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/CRC32MatchTableDataConsistencyChecker.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/CRC32MatchTableDataConsistencyChecker.java
@@ -17,8 +17,9 @@
 
 package org.apache.shardingsphere.data.pipeline.core.consistencycheck.table;
 
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.CRC32SingleTableInventoryCalculator;
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.SingleTableInventoryCalculator;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.SingleTableInventoryCalculatedResult;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.CRC32SingleTableInventoryCheckCalculator;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.SingleTableInventoryCalculator;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.spi.annotation.SPIDescription;
@@ -63,8 +64,8 @@ public final class CRC32MatchTableDataConsistencyChecker implements TableDataCon
         }
         
         @Override
-        protected SingleTableInventoryCalculator buildSingleTableInventoryCalculator() {
-            return new CRC32SingleTableInventoryCalculator();
+        protected SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> buildSingleTableInventoryCalculator() {
+            return new CRC32SingleTableInventoryCheckCalculator();
         }
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/DataMatchTableDataConsistencyChecker.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/DataMatchTableDataConsistencyChecker.java
@@ -18,10 +18,11 @@
 package org.apache.shardingsphere.data.pipeline.core.consistencycheck.table;
 
 import com.google.common.base.Strings;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.SingleTableInventoryCalculatedResult;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableDataConsistencyCheckIgnoredType;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableDataConsistencyCheckResult;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.RecordSingleTableInventoryCalculator;
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.SingleTableInventoryCalculator;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.SingleTableInventoryCalculator;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.StreamingRangeType;
 import org.apache.shardingsphere.data.pipeline.core.exception.param.PipelineInvalidParameterException;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
@@ -127,7 +128,7 @@ public final class DataMatchTableDataConsistencyChecker implements TableDataCons
         }
         
         @Override
-        protected SingleTableInventoryCalculator buildSingleTableInventoryCalculator() {
+        protected SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> buildSingleTableInventoryCalculator() {
             return new RecordSingleTableInventoryCalculator(chunkSize, streamingRangeType);
         }
     }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/MatchingTableInventoryChecker.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/MatchingTableInventoryChecker.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.Tabl
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.yaml.YamlTableDataConsistencyCheckResult;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.yaml.YamlTableDataConsistencyCheckResultSwapper;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.SingleTableInventoryCalculateParameter;
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.SingleTableInventoryCalculator;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.SingleTableInventoryCalculator;
 import org.apache.shardingsphere.data.pipeline.core.constant.PipelineSQLOperationType;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.QueryType;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.range.QueryRange;
@@ -57,9 +57,9 @@ public abstract class MatchingTableInventoryChecker implements TableInventoryChe
     
     private final AtomicBoolean canceling = new AtomicBoolean(false);
     
-    private volatile SingleTableInventoryCalculator sourceCalculator;
+    private volatile SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> sourceCalculator;
     
-    private volatile SingleTableInventoryCalculator targetCalculator;
+    private volatile SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> targetCalculator;
     
     @Override
     public TableDataConsistencyCheckResult checkSingleTableInventoryData() {
@@ -83,9 +83,9 @@ public abstract class MatchingTableInventoryChecker implements TableInventoryChe
                 param.getColumnNames(), param.getUniqueKeys(), QueryType.RANGE_QUERY, param.getQueryCondition());
         targetParam.setQueryRange(new QueryRange(null != checkRangePosition.getTargetPosition() ? checkRangePosition.getTargetPosition() : checkRangePosition.getTargetRange().getBeginValue(),
                 true, checkRangePosition.getTargetRange().getEndValue()));
-        SingleTableInventoryCalculator sourceCalculator = buildSingleTableInventoryCalculator();
+        SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> sourceCalculator = buildSingleTableInventoryCalculator();
         this.sourceCalculator = sourceCalculator;
-        SingleTableInventoryCalculator targetCalculator = buildSingleTableInventoryCalculator();
+        SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> targetCalculator = buildSingleTableInventoryCalculator();
         this.targetCalculator = targetCalculator;
         try {
             Iterator<SingleTableInventoryCalculatedResult> sourceCalculatedResults = PipelineTaskUtils.waitFuture(executor.submit(() -> sourceCalculator.calculate(sourceParam))).iterator();
@@ -132,7 +132,7 @@ public abstract class MatchingTableInventoryChecker implements TableInventoryChe
         return new YamlTableDataConsistencyCheckResultSwapper().swapToObject(checkResult);
     }
     
-    protected abstract SingleTableInventoryCalculator buildSingleTableInventoryCalculator();
+    protected abstract SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> buildSingleTableInventoryCalculator();
     
     @Override
     public void cancel() {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/AbstractSingleTableInventoryCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/AbstractSingleTableInventoryCalculator.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calc
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.SingleTableInventoryCalculator;
 
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
@@ -28,9 +29,11 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Abstract single table inventory calculator.
+ *
+ * @param <S> the type of result
  */
 @Slf4j
-public abstract class AbstractSingleTableInventoryCalculator implements SingleTableInventoryCalculator {
+public abstract class AbstractSingleTableInventoryCalculator<S> implements SingleTableInventoryCalculator<S> {
     
     private final AtomicBoolean canceling = new AtomicBoolean(false);
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/CRC32SingleTableInventoryCheckCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/CRC32SingleTableInventoryCheckCalculator.java
@@ -36,10 +36,10 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * CRC32 single table inventory calculator.
+ * CRC32 single table inventory check calculator.
  */
 @Slf4j
-public final class CRC32SingleTableInventoryCalculator extends AbstractSingleTableInventoryCalculator {
+public final class CRC32SingleTableInventoryCheckCalculator extends AbstractSingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> {
     
     @Override
     public Iterable<SingleTableInventoryCalculatedResult> calculate(final SingleTableInventoryCalculateParameter param) {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordSingleTableInventoryCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordSingleTableInventoryCalculator.java
@@ -53,7 +53,7 @@ import java.util.Optional;
  */
 @HighFrequencyInvocation
 @RequiredArgsConstructor
-public final class RecordSingleTableInventoryCalculator extends AbstractStreamingSingleTableInventoryCalculator {
+public final class RecordSingleTableInventoryCalculator extends AbstractStreamingSingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> {
     
     private static final int DEFAULT_STREAMING_CHUNK_COUNT = 100;
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/calculator/SingleTableInventoryCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/calculator/SingleTableInventoryCalculator.java
@@ -15,15 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator;
+package org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator;
 
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.PipelineCancellable;
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.SingleTableInventoryCalculatedResult;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.SingleTableInventoryCalculateParameter;
 
 /**
  * Single table inventory calculator.
+ *
+ * @param <S> the type of result
  */
-public interface SingleTableInventoryCalculator extends PipelineCancellable {
+public interface SingleTableInventoryCalculator<S> extends PipelineCancellable {
     
     /**
      * Calculate for single table inventory data.
@@ -31,5 +33,5 @@ public interface SingleTableInventoryCalculator extends PipelineCancellable {
      * @param param calculate parameter
      * @return calculated result
      */
-    Iterable<SingleTableInventoryCalculatedResult> calculate(SingleTableInventoryCalculateParameter param);
+    Iterable<S> calculate(SingleTableInventoryCalculateParameter param);
 }

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/CRC32SingleTableInventoryCheckCalculatorTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/CRC32SingleTableInventoryCheckCalculatorTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class CRC32SingleTableInventoryCalculatorTest {
+class CRC32SingleTableInventoryCheckCalculatorTest {
     
     private SingleTableInventoryCalculateParameter parameter;
     
@@ -78,7 +78,7 @@ class CRC32SingleTableInventoryCalculatorTest {
         when(connection.prepareStatement("SELECT CRC32(foo_col) FROM foo_tbl")).thenReturn(preparedStatement0);
         PreparedStatement preparedStatement1 = mockPreparedStatement(456L, 10);
         when(connection.prepareStatement("SELECT CRC32(bar_col) FROM foo_tbl")).thenReturn(preparedStatement1);
-        Iterator<SingleTableInventoryCalculatedResult> actual = new CRC32SingleTableInventoryCalculator().calculate(parameter).iterator();
+        Iterator<SingleTableInventoryCalculatedResult> actual = new CRC32SingleTableInventoryCheckCalculator().calculate(parameter).iterator();
         assertThat(actual.next().getRecordsCount(), is(10));
         assertFalse(actual.hasNext());
     }
@@ -95,6 +95,6 @@ class CRC32SingleTableInventoryCalculatorTest {
     @Test
     void assertCalculateFailed() throws SQLException {
         when(connection.prepareStatement(anyString())).thenThrow(new SQLException(""));
-        assertThrows(PipelineTableDataConsistencyCheckLoadingFailedException.class, () -> new CRC32SingleTableInventoryCalculator().calculate(parameter));
+        assertThrows(PipelineTableDataConsistencyCheckLoadingFailedException.class, () -> new CRC32SingleTableInventoryCheckCalculator().calculate(parameter));
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Add generic type RESULT for SingleTableInventoryCalculator

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
