### PR TITLE
Fixes CVE-2025-55163, CVE-2025-58056, CVE-2025-58057

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,7 @@
 
 ### CVE
 
+1. Fix CVE-2025-55163, CVE-2025-58056, CVE-2025-58057 [#36758](https://github.com/apache/shardingsphere/pull/36758)
 1. Fix CVE-2025-48924 [#36085](https://github.com/apache/shardingsphere/pull/36085)
 1. Fix CVE-2024-7254 [#36153](https://github.com/apache/shardingsphere/pull/36153)
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <jetcd.version>0.7.7</jetcd.version>
         <vertx.version>4.5.1</vertx.version>
         
-        <grpc.version>1.65.1</grpc.version>
+        <grpc.version>1.75.0</grpc.version>
         <protobuf.version>3.25.8</protobuf.version>
         
         <elasticjob.version>3.0.4</elasticjob.version>
@@ -188,7 +188,7 @@
         <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
         <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
-        <dependency-check-maven.version>10.0.3</dependency-check-maven.version>
+        <dependency-check-maven.version>12.1.6</dependency-check-maven.version>
     </properties>
     
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         
         <jakarta.jakartaee-bom.version>8.0.0</jakarta.jakartaee-bom.version>
         
-        <netty.version>4.1.121.Final</netty.version>
+        <netty.version>4.1.126.Final</netty.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
         
         <curator.version>5.7.0</curator.version>


### PR DESCRIPTION
Upgrade netty to 4.1.126.Final to fix:
https://www.cve.org/CVERecord?id=CVE-2025-55163
https://www.cve.org/CVERecord?id=CVE-2025-58056
https://www.cve.org/CVERecord?id=CVE-2025-58057
