### PR TITLE
Remove 'Single' in pipeline inventory calculator classes

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/result/RecordTableInventoryCheckCalculatedResult.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/result/RecordTableInventoryCheckCalculatedResult.java
@@ -29,11 +29,11 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Record single table inventory calculated result.
+ * Record table inventory calculated result.
  */
 @Getter
 @Slf4j
-public final class RecordSingleTableInventoryCalculatedResult implements SingleTableInventoryCalculatedResult {
+public final class RecordTableInventoryCheckCalculatedResult implements TableInventoryCheckCalculatedResult {
     
     private final Object maxUniqueKeyValue;
     
@@ -41,7 +41,7 @@ public final class RecordSingleTableInventoryCalculatedResult implements SingleT
     
     private final List<Map<String, Object>> records;
     
-    public RecordSingleTableInventoryCalculatedResult(final Object maxUniqueKeyValue, final List<Map<String, Object>> records) {
+    public RecordTableInventoryCheckCalculatedResult(final Object maxUniqueKeyValue, final List<Map<String, Object>> records) {
         this.maxUniqueKeyValue = maxUniqueKeyValue;
         recordsCount = records.size();
         this.records = records;
@@ -60,11 +60,11 @@ public final class RecordSingleTableInventoryCalculatedResult implements SingleT
         if (this == o) {
             return true;
         }
-        if (!(o instanceof RecordSingleTableInventoryCalculatedResult)) {
+        if (!(o instanceof RecordTableInventoryCheckCalculatedResult)) {
             log.warn("RecordSingleTableInventoryCalculatedResult type not match, o.className={}.", o.getClass().getName());
             return false;
         }
-        final RecordSingleTableInventoryCalculatedResult that = (RecordSingleTableInventoryCalculatedResult) o;
+        final RecordTableInventoryCheckCalculatedResult that = (RecordTableInventoryCheckCalculatedResult) o;
         EqualsBuilder equalsBuilder = new EqualsBuilder();
         if (recordsCount != that.recordsCount || !DataConsistencyCheckUtils.isMatched(equalsBuilder, maxUniqueKeyValue, that.maxUniqueKeyValue)) {
             log.warn("Record count or max unique key value not match, recordCount1={}, recordCount2={}, maxUniqueKeyValue1={}, maxUniqueKeyValue2={}, value1.class={}, value2.class={}.",

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/result/TableInventoryCheckCalculatedResult.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/result/TableInventoryCheckCalculatedResult.java
@@ -20,9 +20,9 @@ package org.apache.shardingsphere.data.pipeline.core.consistencycheck.result;
 import java.util.Optional;
 
 /**
- * Single table inventory calculated result.
+ * Table inventory check calculated result.
  */
-public interface SingleTableInventoryCalculatedResult {
+public interface TableInventoryCheckCalculatedResult {
     
     /**
      * Get max unique key value.

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/CRC32MatchTableDataConsistencyChecker.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/CRC32MatchTableDataConsistencyChecker.java
@@ -17,9 +17,9 @@
 
 package org.apache.shardingsphere.data.pipeline.core.consistencycheck.table;
 
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.SingleTableInventoryCalculatedResult;
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.CRC32SingleTableInventoryCheckCalculator;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.SingleTableInventoryCalculator;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableInventoryCheckCalculatedResult;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.CRC32TableInventoryCheckCalculator;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.TableInventoryCalculator;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.spi.annotation.SPIDescription;
@@ -64,8 +64,8 @@ public final class CRC32MatchTableDataConsistencyChecker implements TableDataCon
         }
         
         @Override
-        protected SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> buildSingleTableInventoryCalculator() {
-            return new CRC32SingleTableInventoryCheckCalculator();
+        protected TableInventoryCalculator<TableInventoryCheckCalculatedResult> buildSingleTableInventoryCalculator() {
+            return new CRC32TableInventoryCheckCalculator();
         }
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/DataMatchTableDataConsistencyChecker.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/DataMatchTableDataConsistencyChecker.java
@@ -18,13 +18,13 @@
 package org.apache.shardingsphere.data.pipeline.core.consistencycheck.table;
 
 import com.google.common.base.Strings;
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.SingleTableInventoryCalculatedResult;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableDataConsistencyCheckIgnoredType;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableDataConsistencyCheckResult;
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.RecordSingleTableInventoryCheckCalculator;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableInventoryCheckCalculatedResult;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator.RecordTableInventoryCheckCalculator;
 import org.apache.shardingsphere.data.pipeline.core.exception.param.PipelineInvalidParameterException;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.StreamingRangeType;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.SingleTableInventoryCalculator;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.TableInventoryCalculator;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.infra.spi.annotation.SPIDescription;
@@ -128,8 +128,8 @@ public final class DataMatchTableDataConsistencyChecker implements TableDataCons
         }
         
         @Override
-        protected SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> buildSingleTableInventoryCalculator() {
-            return new RecordSingleTableInventoryCheckCalculator(chunkSize, streamingRangeType);
+        protected TableInventoryCalculator<TableInventoryCheckCalculatedResult> buildSingleTableInventoryCalculator() {
+            return new RecordTableInventoryCheckCalculator(chunkSize, streamingRangeType);
         }
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/MatchingTableInventoryChecker.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/MatchingTableInventoryChecker.java
@@ -22,15 +22,15 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.position.TableCheckRangePosition;
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.SingleTableInventoryCalculatedResult;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableDataConsistencyCheckResult;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableInventoryCheckCalculatedResult;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.yaml.YamlTableDataConsistencyCheckResult;
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.yaml.YamlTableDataConsistencyCheckResultSwapper;
 import org.apache.shardingsphere.data.pipeline.core.constant.PipelineSQLOperationType;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.QueryRange;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.QueryType;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.SingleTableInventoryCalculateParameter;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.SingleTableInventoryCalculator;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.TableInventoryCalculateParameter;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.TableInventoryCalculator;
 import org.apache.shardingsphere.data.pipeline.core.job.progress.listener.PipelineJobUpdateProgress;
 import org.apache.shardingsphere.data.pipeline.core.task.PipelineTaskUtils;
 import org.apache.shardingsphere.infra.executor.kernel.thread.ExecutorThreadFactoryBuilder;
@@ -57,9 +57,9 @@ public abstract class MatchingTableInventoryChecker implements TableInventoryChe
     
     private final AtomicBoolean canceling = new AtomicBoolean(false);
     
-    private volatile SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> sourceCalculator;
+    private volatile TableInventoryCalculator<TableInventoryCheckCalculatedResult> sourceCalculator;
     
-    private volatile SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> targetCalculator;
+    private volatile TableInventoryCalculator<TableInventoryCheckCalculatedResult> targetCalculator;
     
     @Override
     public TableDataConsistencyCheckResult checkSingleTableInventoryData() {
@@ -74,22 +74,22 @@ public abstract class MatchingTableInventoryChecker implements TableInventoryChe
     }
     
     private TableDataConsistencyCheckResult checkSingleTableInventoryData(final TableInventoryCheckParameter param, final ThreadPoolExecutor executor) {
-        SingleTableInventoryCalculateParameter sourceParam = new SingleTableInventoryCalculateParameter(param.getSourceDataSource(), param.getSourceTable(),
+        TableInventoryCalculateParameter sourceParam = new TableInventoryCalculateParameter(param.getSourceDataSource(), param.getSourceTable(),
                 param.getColumnNames(), param.getUniqueKeys(), QueryType.RANGE_QUERY, param.getQueryCondition());
         TableCheckRangePosition checkRangePosition = param.getProgressContext().getTableCheckRangePositions().get(param.getSplittingItem());
         sourceParam.setQueryRange(new QueryRange(null != checkRangePosition.getSourcePosition() ? checkRangePosition.getSourcePosition() : checkRangePosition.getSourceRange().getBeginValue(),
                 true, checkRangePosition.getSourceRange().getEndValue()));
-        SingleTableInventoryCalculateParameter targetParam = new SingleTableInventoryCalculateParameter(param.getTargetDataSource(), param.getTargetTable(),
+        TableInventoryCalculateParameter targetParam = new TableInventoryCalculateParameter(param.getTargetDataSource(), param.getTargetTable(),
                 param.getColumnNames(), param.getUniqueKeys(), QueryType.RANGE_QUERY, param.getQueryCondition());
         targetParam.setQueryRange(new QueryRange(null != checkRangePosition.getTargetPosition() ? checkRangePosition.getTargetPosition() : checkRangePosition.getTargetRange().getBeginValue(),
                 true, checkRangePosition.getTargetRange().getEndValue()));
-        SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> sourceCalculator = buildSingleTableInventoryCalculator();
+        TableInventoryCalculator<TableInventoryCheckCalculatedResult> sourceCalculator = buildSingleTableInventoryCalculator();
         this.sourceCalculator = sourceCalculator;
-        SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> targetCalculator = buildSingleTableInventoryCalculator();
+        TableInventoryCalculator<TableInventoryCheckCalculatedResult> targetCalculator = buildSingleTableInventoryCalculator();
         this.targetCalculator = targetCalculator;
         try {
-            Iterator<SingleTableInventoryCalculatedResult> sourceCalculatedResults = PipelineTaskUtils.waitFuture(executor.submit(() -> sourceCalculator.calculate(sourceParam))).iterator();
-            Iterator<SingleTableInventoryCalculatedResult> targetCalculatedResults = PipelineTaskUtils.waitFuture(executor.submit(() -> targetCalculator.calculate(targetParam))).iterator();
+            Iterator<TableInventoryCheckCalculatedResult> sourceCalculatedResults = PipelineTaskUtils.waitFuture(executor.submit(() -> sourceCalculator.calculate(sourceParam))).iterator();
+            Iterator<TableInventoryCheckCalculatedResult> targetCalculatedResults = PipelineTaskUtils.waitFuture(executor.submit(() -> targetCalculator.calculate(targetParam))).iterator();
             return checkSingleTableInventoryData(sourceCalculatedResults, targetCalculatedResults, param, executor);
         } finally {
             QuietlyCloser.close(sourceParam.getCalculationContext());
@@ -99,16 +99,16 @@ public abstract class MatchingTableInventoryChecker implements TableInventoryChe
         }
     }
     
-    private TableDataConsistencyCheckResult checkSingleTableInventoryData(final Iterator<SingleTableInventoryCalculatedResult> sourceCalculatedResults,
-                                                                          final Iterator<SingleTableInventoryCalculatedResult> targetCalculatedResults,
+    private TableDataConsistencyCheckResult checkSingleTableInventoryData(final Iterator<TableInventoryCheckCalculatedResult> sourceCalculatedResults,
+                                                                          final Iterator<TableInventoryCheckCalculatedResult> targetCalculatedResults,
                                                                           final TableInventoryCheckParameter param, final ThreadPoolExecutor executor) {
         YamlTableDataConsistencyCheckResult checkResult = new YamlTableDataConsistencyCheckResult(true);
         while (sourceCalculatedResults.hasNext() && targetCalculatedResults.hasNext()) {
             if (null != param.getReadRateLimitAlgorithm()) {
                 param.getReadRateLimitAlgorithm().intercept(PipelineSQLOperationType.SELECT, 1);
             }
-            SingleTableInventoryCalculatedResult sourceCalculatedResult = PipelineTaskUtils.waitFuture(executor.submit(sourceCalculatedResults::next));
-            SingleTableInventoryCalculatedResult targetCalculatedResult = PipelineTaskUtils.waitFuture(executor.submit(targetCalculatedResults::next));
+            TableInventoryCheckCalculatedResult sourceCalculatedResult = PipelineTaskUtils.waitFuture(executor.submit(sourceCalculatedResults::next));
+            TableInventoryCheckCalculatedResult targetCalculatedResult = PipelineTaskUtils.waitFuture(executor.submit(targetCalculatedResults::next));
             if (!Objects.equals(sourceCalculatedResult, targetCalculatedResult)) {
                 checkResult.setMatched(false);
                 log.info("content matched false, jobId={}, sourceTable={}, targetTable={}, uniqueKeys={}", param.getJobId(), param.getSourceTable(), param.getTargetTable(), param.getUniqueKeys());
@@ -132,13 +132,13 @@ public abstract class MatchingTableInventoryChecker implements TableInventoryChe
         return new YamlTableDataConsistencyCheckResultSwapper().swapToObject(checkResult);
     }
     
-    protected abstract SingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> buildSingleTableInventoryCalculator();
+    protected abstract TableInventoryCalculator<TableInventoryCheckCalculatedResult> buildSingleTableInventoryCalculator();
     
     @Override
     public void cancel() {
         canceling.set(true);
-        Optional.ofNullable(sourceCalculator).ifPresent(SingleTableInventoryCalculator::cancel);
-        Optional.ofNullable(targetCalculator).ifPresent(SingleTableInventoryCalculator::cancel);
+        Optional.ofNullable(sourceCalculator).ifPresent(TableInventoryCalculator::cancel);
+        Optional.ofNullable(targetCalculator).ifPresent(TableInventoryCalculator::cancel);
     }
     
     @Override

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/CRC32TableInventoryCheckCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/CRC32TableInventoryCheckCalculator.java
@@ -20,10 +20,10 @@ package org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calc
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.SingleTableInventoryCalculatedResult;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableInventoryCheckCalculatedResult;
 import org.apache.shardingsphere.data.pipeline.core.exception.data.PipelineTableDataConsistencyCheckLoadingFailedException;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.AbstractSingleTableInventoryCalculator;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.SingleTableInventoryCalculateParameter;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.AbstractTableInventoryCalculator;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.TableInventoryCalculateParameter;
 import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql.PipelineDataConsistencyCalculateSQLBuilder;
 import org.apache.shardingsphere.infra.algorithm.core.exception.UnsupportedAlgorithmOnDatabaseTypeException;
 
@@ -38,19 +38,19 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * CRC32 single table inventory check calculator.
+ * CRC32 table inventory check calculator.
  */
 @Slf4j
-public final class CRC32SingleTableInventoryCheckCalculator extends AbstractSingleTableInventoryCalculator<SingleTableInventoryCalculatedResult> {
+public final class CRC32TableInventoryCheckCalculator extends AbstractTableInventoryCalculator<TableInventoryCheckCalculatedResult> {
     
     @Override
-    public Iterable<SingleTableInventoryCalculatedResult> calculate(final SingleTableInventoryCalculateParameter param) {
+    public Iterable<TableInventoryCheckCalculatedResult> calculate(final TableInventoryCalculateParameter param) {
         PipelineDataConsistencyCalculateSQLBuilder pipelineSQLBuilder = new PipelineDataConsistencyCalculateSQLBuilder(param.getDatabaseType());
         List<CalculatedItem> calculatedItems = param.getColumnNames().stream().map(each -> calculateCRC32(pipelineSQLBuilder, param, each)).collect(Collectors.toList());
         return Collections.singletonList(new CalculatedResult(calculatedItems.get(0).getRecordsCount(), calculatedItems.stream().map(CalculatedItem::getCrc32).collect(Collectors.toList())));
     }
     
-    private CalculatedItem calculateCRC32(final PipelineDataConsistencyCalculateSQLBuilder pipelineSQLBuilder, final SingleTableInventoryCalculateParameter param, final String columnName) {
+    private CalculatedItem calculateCRC32(final PipelineDataConsistencyCalculateSQLBuilder pipelineSQLBuilder, final TableInventoryCalculateParameter param, final String columnName) {
         String sql = pipelineSQLBuilder.buildCRC32SQL(param.getTable(), columnName)
                 .orElseThrow(() -> new UnsupportedAlgorithmOnDatabaseTypeException("DataConsistencyCalculate", "CRC32", param.getDatabaseType()));
         try (
@@ -79,7 +79,7 @@ public final class CRC32SingleTableInventoryCheckCalculator extends AbstractSing
     
     @RequiredArgsConstructor
     @Getter
-    private static final class CalculatedResult implements SingleTableInventoryCalculatedResult {
+    private static final class CalculatedResult implements TableInventoryCheckCalculatedResult {
         
         private final int recordsCount;
         

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordTableInventoryCheckCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/RecordTableInventoryCheckCalculator.java
@@ -18,11 +18,11 @@
 package org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator;
 
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.DataConsistencyCheckUtils;
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.RecordSingleTableInventoryCalculatedResult;
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.SingleTableInventoryCalculatedResult;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.RecordTableInventoryCheckCalculatedResult;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableInventoryCheckCalculatedResult;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.column.InventoryColumnValueReaderEngine;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.StreamingRangeType;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.AbstractRecordSingleTableInventoryCalculator;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.AbstractRecordTableInventoryCalculator;
 
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -32,15 +32,15 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Record single table inventory check calculator.
+ * Record table inventory check calculator.
  */
-public final class RecordSingleTableInventoryCheckCalculator extends AbstractRecordSingleTableInventoryCalculator<SingleTableInventoryCalculatedResult, Map<String, Object>> {
+public final class RecordTableInventoryCheckCalculator extends AbstractRecordTableInventoryCalculator<TableInventoryCheckCalculatedResult, Map<String, Object>> {
     
-    public RecordSingleTableInventoryCheckCalculator(final int chunkSize, final int streamingChunkCount, final StreamingRangeType streamingRangeType) {
+    public RecordTableInventoryCheckCalculator(final int chunkSize, final int streamingChunkCount, final StreamingRangeType streamingRangeType) {
         super(chunkSize, streamingChunkCount, streamingRangeType);
     }
     
-    public RecordSingleTableInventoryCheckCalculator(final int chunkSize, final StreamingRangeType streamingRangeType) {
+    public RecordTableInventoryCheckCalculator(final int chunkSize, final StreamingRangeType streamingRangeType) {
         super(chunkSize, streamingRangeType);
     }
     
@@ -59,7 +59,7 @@ public final class RecordSingleTableInventoryCheckCalculator extends AbstractRec
     }
     
     @Override
-    protected SingleTableInventoryCalculatedResult convertRecordsToResult(final List<Map<String, Object>> records, final Object maxUniqueKeyValue) {
-        return new RecordSingleTableInventoryCalculatedResult(maxUniqueKeyValue, records);
+    protected TableInventoryCheckCalculatedResult convertRecordsToResult(final List<Map<String, Object>> records, final Object maxUniqueKeyValue) {
+        return new RecordTableInventoryCheckCalculatedResult(maxUniqueKeyValue, records);
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumper.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumper.java
@@ -30,8 +30,8 @@ import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.posi
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.QueryRange;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.QueryType;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.StreamingRangeType;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.AbstractRecordSingleTableInventoryCalculator;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.SingleTableInventoryCalculateParameter;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.AbstractRecordTableInventoryCalculator;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.TableInventoryCalculateParameter;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.IngestPosition;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.type.finished.IngestFinishedPosition;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.type.pk.PrimaryKeyIngestPosition;
@@ -122,12 +122,12 @@ public final class InventoryDumper extends AbstractPipelineLifecycleRunnable imp
         IngestPosition initialPosition = dumperContext.getCommonContext().getPosition();
         log.info("Dump by calculator start, dataSource={}, table={}, initialPosition={}", dumperContext.getCommonContext().getDataSourceName(), table, initialPosition);
         List<String> columnNames = dumperContext.getQueryColumnNames();
-        SingleTableInventoryCalculateParameter calculateParam = new SingleTableInventoryCalculateParameter(dataSource, table,
+        TableInventoryCalculateParameter calculateParam = new TableInventoryCalculateParameter(dataSource, table,
                 columnNames, dumperContext.getUniqueKeyColumns(), QueryType.RANGE_QUERY, null);
         QueryRange queryRange = new QueryRange(((PrimaryKeyIngestPosition<?>) initialPosition).getBeginValue(), dumperContext.isFirstDump(),
                 ((PrimaryKeyIngestPosition<?>) initialPosition).getEndValue());
         calculateParam.setQueryRange(queryRange);
-        RecordSingleTableInventoryDumpCalculator dumpCalculator = new RecordSingleTableInventoryDumpCalculator(dumperContext.getBatchSize(), StreamingRangeType.SMALL);
+        RecordTableInventoryDumpCalculator dumpCalculator = new RecordTableInventoryDumpCalculator(dumperContext.getBatchSize(), StreamingRangeType.SMALL);
         long rowCount = 0L;
         try {
             String firstUniqueKey = calculateParam.getFirstUniqueKey().getName();
@@ -223,9 +223,9 @@ public final class InventoryDumper extends AbstractPipelineLifecycleRunnable imp
         Optional.ofNullable(runningStatement.get()).ifPresent(PipelineJdbcUtils::cancelStatement);
     }
     
-    private class RecordSingleTableInventoryDumpCalculator extends AbstractRecordSingleTableInventoryCalculator<List<DataRecord>, DataRecord> {
+    private class RecordTableInventoryDumpCalculator extends AbstractRecordTableInventoryCalculator<List<DataRecord>, DataRecord> {
         
-        RecordSingleTableInventoryDumpCalculator(final int chunkSize, final StreamingRangeType streamingRangeType) {
+        RecordTableInventoryDumpCalculator(final int chunkSize, final StreamingRangeType streamingRangeType) {
             super(chunkSize, streamingRangeType);
         }
         

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/calculator/AbstractStreamingTableInventoryCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/calculator/AbstractStreamingTableInventoryCalculator.java
@@ -27,15 +27,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Abstract streaming single table inventory calculator.
+ * Abstract streaming table inventory calculator.
  *
  * @param <S> the type of result
  */
 @Getter
-public abstract class AbstractStreamingSingleTableInventoryCalculator<S> extends AbstractSingleTableInventoryCalculator<S> {
+public abstract class AbstractStreamingTableInventoryCalculator<S> extends AbstractTableInventoryCalculator<S> {
     
     @Override
-    public final Iterable<S> calculate(final SingleTableInventoryCalculateParameter param) {
+    public final Iterable<S> calculate(final TableInventoryCalculateParameter param) {
         return new ResultIterable(param);
     }
     
@@ -45,7 +45,7 @@ public abstract class AbstractStreamingSingleTableInventoryCalculator<S> extends
      * @param param data consistency calculate parameter
      * @return optional calculated result, empty means there's no more result
      */
-    protected abstract Optional<S> calculateChunk(SingleTableInventoryCalculateParameter param);
+    protected abstract Optional<S> calculateChunk(TableInventoryCalculateParameter param);
     
     /**
      * It's not thread-safe, it should be executed in only one thread at the same time.
@@ -53,7 +53,7 @@ public abstract class AbstractStreamingSingleTableInventoryCalculator<S> extends
     @RequiredArgsConstructor
     private final class ResultIterable implements Iterable<S> {
         
-        private final SingleTableInventoryCalculateParameter param;
+        private final TableInventoryCalculateParameter param;
         
         @Override
         public Iterator<S> iterator() {
@@ -68,7 +68,7 @@ public abstract class AbstractStreamingSingleTableInventoryCalculator<S> extends
         
         private final AtomicReference<Optional<S>> nextResult = new AtomicReference<>();
         
-        private final SingleTableInventoryCalculateParameter param;
+        private final TableInventoryCalculateParameter param;
         
         @Override
         public boolean hasNext() {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/calculator/AbstractTableInventoryCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/calculator/AbstractTableInventoryCalculator.java
@@ -27,12 +27,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Abstract single table inventory calculator.
+ * Abstract table inventory calculator.
  *
  * @param <S> the type of result
  */
 @Slf4j
-public abstract class AbstractSingleTableInventoryCalculator<S> implements SingleTableInventoryCalculator<S> {
+public abstract class AbstractTableInventoryCalculator<S> implements TableInventoryCalculator<S> {
     
     private final AtomicBoolean canceling = new AtomicBoolean(false);
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/calculator/TableInventoryCalculateParameter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/calculator/TableInventoryCalculateParameter.java
@@ -34,11 +34,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 /**
- * Single table inventory calculate parameter.
+ * Table inventory calculate parameter.
  */
 @RequiredArgsConstructor
 @Getter
-public final class SingleTableInventoryCalculateParameter {
+public final class TableInventoryCalculateParameter {
     
     /**
      * Data source of source side or target side.

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/calculator/TableInventoryCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/calculator/TableInventoryCalculator.java
@@ -20,11 +20,11 @@ package org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.que
 import org.apache.shardingsphere.data.pipeline.core.consistencycheck.PipelineCancellable;
 
 /**
- * Single table inventory calculator.
+ * Table inventory calculator.
  *
  * @param <S> the type of result
  */
-public interface SingleTableInventoryCalculator<S> extends PipelineCancellable {
+public interface TableInventoryCalculator<S> extends PipelineCancellable {
     
     /**
      * Calculate for single table inventory data.
@@ -32,5 +32,5 @@ public interface SingleTableInventoryCalculator<S> extends PipelineCancellable {
      * @param param calculate parameter
      * @return calculated result
      */
-    Iterable<S> calculate(SingleTableInventoryCalculateParameter param);
+    Iterable<S> calculate(TableInventoryCalculateParameter param);
 }

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/result/RecordTableInventoryCheckCalculatedResultTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/result/RecordTableInventoryCheckCalculatedResultTest.java
@@ -31,43 +31,43 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-class RecordSingleTableInventoryCalculatedResultTest {
+class RecordTableInventoryCheckCalculatedResultTest {
     
     @Test
     void assertNotEqualsWithNull() {
-        assertFalse(new RecordSingleTableInventoryCalculatedResult(0, Collections.emptyList()).equals(null));
+        assertFalse(new RecordTableInventoryCheckCalculatedResult(0, Collections.emptyList()).equals(null));
     }
     
     @Test
     void assertEqualsWithSameObject() {
-        RecordSingleTableInventoryCalculatedResult calculatedResult = new RecordSingleTableInventoryCalculatedResult(0, Collections.emptyList());
+        RecordTableInventoryCheckCalculatedResult calculatedResult = new RecordTableInventoryCheckCalculatedResult(0, Collections.emptyList());
         assertThat(calculatedResult, is(calculatedResult));
     }
     
     @Test
     void assertNotEqualsWithDifferentClassType() {
-        RecordSingleTableInventoryCalculatedResult actual = new RecordSingleTableInventoryCalculatedResult(0, Collections.emptyList());
+        RecordTableInventoryCheckCalculatedResult actual = new RecordTableInventoryCheckCalculatedResult(0, Collections.emptyList());
         Object expected = new Object();
         assertThat(actual, not(expected));
     }
     
     @Test
     void assertEqualsWithEmptyRecords() {
-        RecordSingleTableInventoryCalculatedResult actual = new RecordSingleTableInventoryCalculatedResult(0, Collections.emptyList());
-        RecordSingleTableInventoryCalculatedResult expected = new RecordSingleTableInventoryCalculatedResult(0, Collections.emptyList());
+        RecordTableInventoryCheckCalculatedResult actual = new RecordTableInventoryCheckCalculatedResult(0, Collections.emptyList());
+        RecordTableInventoryCheckCalculatedResult expected = new RecordTableInventoryCheckCalculatedResult(0, Collections.emptyList());
         assertThat(actual, is(expected));
     }
     
     @Test
     void assertEqualsWithFullTypeRecords() {
-        RecordSingleTableInventoryCalculatedResult actual = new RecordSingleTableInventoryCalculatedResult(1000, Arrays.asList(buildFixedFullTypeRecord(), buildFixedFullTypeRecord()));
-        RecordSingleTableInventoryCalculatedResult expected = new RecordSingleTableInventoryCalculatedResult(1000, Arrays.asList(buildFixedFullTypeRecord(), buildFixedFullTypeRecord()));
+        RecordTableInventoryCheckCalculatedResult actual = new RecordTableInventoryCheckCalculatedResult(1000, Arrays.asList(buildFixedFullTypeRecord(), buildFixedFullTypeRecord()));
+        RecordTableInventoryCheckCalculatedResult expected = new RecordTableInventoryCheckCalculatedResult(1000, Arrays.asList(buildFixedFullTypeRecord(), buildFixedFullTypeRecord()));
         assertThat(actual, is(expected));
     }
     
     @Test
     void assertFullTypeRecordsEqualsWithDifferentDecimalScale() {
-        RecordSingleTableInventoryCalculatedResult expected = new RecordSingleTableInventoryCalculatedResult(1000, Collections.singletonList(buildFixedFullTypeRecord()));
+        RecordTableInventoryCheckCalculatedResult expected = new RecordTableInventoryCheckCalculatedResult(1000, Collections.singletonList(buildFixedFullTypeRecord()));
         Map<String, Object> recordMap = buildFixedFullTypeRecord();
         recordMap.forEach((key, value) -> {
             if (value instanceof BigDecimal) {
@@ -75,28 +75,28 @@ class RecordSingleTableInventoryCalculatedResultTest {
                 recordMap.put(key, decimal.setScale(decimal.scale() + 1, RoundingMode.CEILING));
             }
         });
-        RecordSingleTableInventoryCalculatedResult actual = new RecordSingleTableInventoryCalculatedResult(1000, Collections.singletonList(recordMap));
+        RecordTableInventoryCheckCalculatedResult actual = new RecordTableInventoryCheckCalculatedResult(1000, Collections.singletonList(recordMap));
         assertThat(actual, is(expected));
     }
     
     @Test
     void assertNotEqualsWithDifferentRecordsCount() {
-        assertThat(new RecordSingleTableInventoryCalculatedResult(1000, Collections.singletonList(buildFixedFullTypeRecord())),
-                not(new RecordSingleTableInventoryCalculatedResult(1000, Collections.emptyList())));
+        assertThat(new RecordTableInventoryCheckCalculatedResult(1000, Collections.singletonList(buildFixedFullTypeRecord())),
+                not(new RecordTableInventoryCheckCalculatedResult(1000, Collections.emptyList())));
     }
     
     @Test
     void assertNotEqualsWithDifferentMaxUniqueKeyValue() {
-        assertThat(new RecordSingleTableInventoryCalculatedResult(1000, Collections.singletonList(buildFixedFullTypeRecord())),
-                not(new RecordSingleTableInventoryCalculatedResult(1001, Collections.singletonList(buildFixedFullTypeRecord()))));
+        assertThat(new RecordTableInventoryCheckCalculatedResult(1000, Collections.singletonList(buildFixedFullTypeRecord())),
+                not(new RecordTableInventoryCheckCalculatedResult(1001, Collections.singletonList(buildFixedFullTypeRecord()))));
     }
     
     @Test
     void assertNotEqualsWithDifferentRandomColumnValue() {
         Map<String, Object> record = buildFixedFullTypeRecord();
-        RecordSingleTableInventoryCalculatedResult result1 = new RecordSingleTableInventoryCalculatedResult(1000, Collections.singletonList(record));
+        RecordTableInventoryCheckCalculatedResult result1 = new RecordTableInventoryCheckCalculatedResult(1000, Collections.singletonList(record));
         record.forEach((key, value) -> {
-            RecordSingleTableInventoryCalculatedResult result2 = new RecordSingleTableInventoryCalculatedResult(1000,
+            RecordTableInventoryCheckCalculatedResult result2 = new RecordTableInventoryCheckCalculatedResult(1000,
                     Collections.singletonList(modifyColumnValueRandomly(buildFixedFullTypeRecord(), key)));
             assertThat(result1, not(result2));
         });
@@ -112,7 +112,7 @@ class RecordSingleTableInventoryCalculatedResultTest {
     
     @Test
     void assertHashcode() {
-        assertThat(new RecordSingleTableInventoryCalculatedResult(1000, Collections.emptyList()).hashCode(),
-                is(new RecordSingleTableInventoryCalculatedResult(1000, Collections.emptyList()).hashCode()));
+        assertThat(new RecordTableInventoryCheckCalculatedResult(1000, Collections.emptyList()).hashCode(),
+                is(new RecordTableInventoryCheckCalculatedResult(1000, Collections.emptyList()).hashCode()));
     }
 }

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/CRC32TableInventoryCheckCalculatorTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/consistencycheck/table/calculator/CRC32TableInventoryCheckCalculatorTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.shardingsphere.data.pipeline.core.consistencycheck.table.calculator;
 
-import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.SingleTableInventoryCalculatedResult;
+import org.apache.shardingsphere.data.pipeline.core.consistencycheck.result.TableInventoryCheckCalculatedResult;
 import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSource;
 import org.apache.shardingsphere.data.pipeline.core.exception.data.PipelineTableDataConsistencyCheckLoadingFailedException;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.QueryType;
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.SingleTableInventoryCalculateParameter;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.calculator.TableInventoryCalculateParameter;
 import org.apache.shardingsphere.data.pipeline.core.metadata.model.PipelineColumnMetaData;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
@@ -53,9 +53,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class CRC32SingleTableInventoryCheckCalculatorTest {
+class CRC32TableInventoryCheckCalculatorTest {
     
-    private SingleTableInventoryCalculateParameter parameter;
+    private TableInventoryCalculateParameter parameter;
     
     @Mock
     private PipelineDataSource pipelineDataSource;
@@ -67,7 +67,7 @@ class CRC32SingleTableInventoryCheckCalculatorTest {
     void setUp() throws SQLException {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
         List<PipelineColumnMetaData> uniqueKeys = Collections.singletonList(new PipelineColumnMetaData(1, "id", Types.INTEGER, "integer", false, true, true));
-        parameter = new SingleTableInventoryCalculateParameter(pipelineDataSource, new QualifiedTable(null, "foo_tbl"),
+        parameter = new TableInventoryCalculateParameter(pipelineDataSource, new QualifiedTable(null, "foo_tbl"),
                 Arrays.asList("foo_col", "bar_col"), uniqueKeys, QueryType.RANGE_QUERY, null);
         when(pipelineDataSource.getDatabaseType()).thenReturn(databaseType);
         when(pipelineDataSource.getConnection()).thenReturn(connection);
@@ -79,7 +79,7 @@ class CRC32SingleTableInventoryCheckCalculatorTest {
         when(connection.prepareStatement("SELECT CRC32(foo_col) FROM foo_tbl")).thenReturn(preparedStatement0);
         PreparedStatement preparedStatement1 = mockPreparedStatement(456L, 10);
         when(connection.prepareStatement("SELECT CRC32(bar_col) FROM foo_tbl")).thenReturn(preparedStatement1);
-        Iterator<SingleTableInventoryCalculatedResult> actual = new CRC32SingleTableInventoryCheckCalculator().calculate(parameter).iterator();
+        Iterator<TableInventoryCheckCalculatedResult> actual = new CRC32TableInventoryCheckCalculator().calculate(parameter).iterator();
         assertThat(actual.next().getRecordsCount(), is(10));
         assertFalse(actual.hasNext());
     }
@@ -96,6 +96,6 @@ class CRC32SingleTableInventoryCheckCalculatorTest {
     @Test
     void assertCalculateFailed() throws SQLException {
         when(connection.prepareStatement(anyString())).thenThrow(new SQLException(""));
-        assertThrows(PipelineTableDataConsistencyCheckLoadingFailedException.class, () -> new CRC32SingleTableInventoryCheckCalculator().calculate(parameter));
+        assertThrows(PipelineTableDataConsistencyCheckLoadingFailedException.class, () -> new CRC32TableInventoryCheckCalculator().calculate(parameter));
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Rename SingleTableInventoryCalculator to TableInventoryCalculator, and sub-classes. Use the same style of 'TableInventoryChecker'.
  - Rename SingleTableInventoryCalculateParameter to TableInventoryCalculateParameter
  - Rename SingleTableInventoryCalculatedResult to TableInventoryCheckCalculatedResult, and sub-classes. 'Single' is removed. 'Check' is added to classify 'XxxCheckCalculator' and 'XxxDumpCalculator'.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
