### PR TITLE
Recover pipeline E2E logger filter to reduce log

### DIFF
--- a/test/e2e/operation/pipeline/src/test/resources/logback-test.xml
+++ b/test/e2e/operation/pipeline/src/test/resources/logback-test.xml
@@ -18,6 +18,7 @@
 
 <configuration>
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="org.apache.shardingsphere.test.e2e.operation.pipeline.logger.PipelineLoggerFilter" />
         <encoder>
             <pattern>[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %logger{36} - %msg%n</pattern>
         </encoder>


### PR DESCRIPTION

Changes proposed in this pull request:
  - Recover pipeline E2E logger filter to reduce log

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
