### PR TITLE
Extract PipelineInventoryCalculateSQLBuilder from PipelineDataConsistencyCalculateSQLBuilder

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/calculator/AbstractRecordTableInventoryCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/calculator/AbstractRecordTableInventoryCalculator.java
@@ -28,7 +28,7 @@ import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.quer
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.QueryType;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.StreamingRangeType;
 import org.apache.shardingsphere.data.pipeline.core.query.JDBCStreamQueryBuilder;
-import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql.PipelineDataConsistencyCalculateSQLBuilder;
+import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql.PipelineInventoryCalculateSQLBuilder;
 import org.apache.shardingsphere.infra.annotation.HighFrequencyInvocation;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.exception.external.sql.type.kernel.category.PipelineSQLException;
@@ -262,7 +262,7 @@ public abstract class AbstractRecordTableInventoryCalculator<S, C> extends Abstr
     private String getQuerySQL(final TableInventoryCalculateParameter param) {
         ShardingSpherePreconditions.checkState(null != param.getUniqueKeys() && !param.getUniqueKeys().isEmpty() && null != param.getFirstUniqueKey(),
                 () -> new UnsupportedOperationException("Record inventory calculator does not support table without unique key and primary key now."));
-        PipelineDataConsistencyCalculateSQLBuilder pipelineSQLBuilder = new PipelineDataConsistencyCalculateSQLBuilder(param.getDatabaseType());
+        PipelineInventoryCalculateSQLBuilder pipelineSQLBuilder = new PipelineInventoryCalculateSQLBuilder(param.getDatabaseType());
         Collection<String> columnNames = param.getColumnNames().isEmpty() ? Collections.singleton("*") : param.getColumnNames();
         switch (param.getQueryType()) {
             case RANGE_QUERY:

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineDataConsistencyCalculateSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineDataConsistencyCalculateSQLBuilder.java
@@ -17,18 +17,13 @@
 
 package org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql;
 
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.QueryRange;
 import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.dialect.DialectPipelineSQLBuilder;
 import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.segment.PipelineSQLSegmentBuilder;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Pipeline data consistency calculate SQL builder.
@@ -42,79 +37,6 @@ public final class PipelineDataConsistencyCalculateSQLBuilder {
     public PipelineDataConsistencyCalculateSQLBuilder(final DatabaseType databaseType) {
         dialectSQLBuilder = DatabaseTypedSPILoader.getService(DialectPipelineSQLBuilder.class, databaseType);
         sqlSegmentBuilder = new PipelineSQLSegmentBuilder(databaseType);
-    }
-    
-    /**
-     * Build query range ordering SQL.
-     *
-     * @param qualifiedTable qualified table
-     * @param columnNames column names
-     * @param uniqueKeys unique keys, it may be primary key, not null
-     * @param queryRange query range
-     * @param pageQuery whether it is page query
-     * @param shardingColumnsNames sharding columns names
-     * @return built SQL
-     */
-    public String buildQueryRangeOrderingSQL(final QualifiedTable qualifiedTable, final Collection<String> columnNames, final List<String> uniqueKeys, final QueryRange queryRange,
-                                             final boolean pageQuery, final List<String> shardingColumnsNames) {
-        String result = buildQueryRangeOrderingSQL0(qualifiedTable, columnNames, uniqueKeys, queryRange, shardingColumnsNames);
-        return pageQuery ? dialectSQLBuilder.wrapWithPageQuery(result) : result;
-    }
-    
-    private String buildQueryRangeOrderingSQL0(final QualifiedTable qualifiedTable, final Collection<String> columnNames, final List<String> uniqueKeys, final QueryRange queryRange,
-                                               final List<String> shardingColumnsNames) {
-        String qualifiedTableName = sqlSegmentBuilder.getQualifiedTableName(qualifiedTable);
-        String queryColumns = columnNames.stream().map(sqlSegmentBuilder::getEscapedIdentifier).collect(Collectors.joining(","));
-        String firstUniqueKey = uniqueKeys.get(0);
-        String orderByColumns = joinColumns(uniqueKeys, shardingColumnsNames).stream().map(each -> sqlSegmentBuilder.getEscapedIdentifier(each) + " ASC").collect(Collectors.joining(", "));
-        if (null != queryRange.getLower() && null != queryRange.getUpper()) {
-            return String.format("SELECT %s FROM %s WHERE %s AND %s ORDER BY %s", queryColumns, qualifiedTableName,
-                    buildLowerQueryRangeCondition(queryRange.isLowerInclusive(), firstUniqueKey),
-                    buildUpperQueryRangeCondition(firstUniqueKey), orderByColumns);
-        } else if (null != queryRange.getLower()) {
-            return String.format("SELECT %s FROM %s WHERE %s ORDER BY %s", queryColumns, qualifiedTableName,
-                    buildLowerQueryRangeCondition(queryRange.isLowerInclusive(), firstUniqueKey), orderByColumns);
-        } else if (null != queryRange.getUpper()) {
-            return String.format("SELECT %s FROM %s WHERE %s ORDER BY %s", queryColumns, qualifiedTableName,
-                    buildUpperQueryRangeCondition(firstUniqueKey), orderByColumns);
-        } else {
-            return String.format("SELECT %s FROM %s ORDER BY %s", queryColumns, qualifiedTableName, orderByColumns);
-        }
-    }
-    
-    private String buildLowerQueryRangeCondition(final boolean inclusive, final String firstUniqueKey) {
-        String delimiter = inclusive ? ">=?" : ">?";
-        return sqlSegmentBuilder.getEscapedIdentifier(firstUniqueKey) + delimiter;
-    }
-    
-    private String buildUpperQueryRangeCondition(final String firstUniqueKey) {
-        return sqlSegmentBuilder.getEscapedIdentifier(firstUniqueKey) + "<=?";
-    }
-    
-    /**
-     * Build point query SQL.
-     *
-     * @param qualifiedTable qualified table
-     * @param columnNames column names
-     * @param uniqueKeys unique keys, it may be primary key, not null
-     * @param shardingColumnsNames sharding columns names, nullable
-     * @return built SQL
-     */
-    public String buildPointQuerySQL(final QualifiedTable qualifiedTable, final Collection<String> columnNames, final List<String> uniqueKeys, final List<String> shardingColumnsNames) {
-        String qualifiedTableName = sqlSegmentBuilder.getQualifiedTableName(qualifiedTable);
-        String queryColumns = columnNames.stream().map(sqlSegmentBuilder::getEscapedIdentifier).collect(Collectors.joining(","));
-        String equalsConditions = joinColumns(uniqueKeys, shardingColumnsNames).stream().map(each -> sqlSegmentBuilder.getEscapedIdentifier(each) + "=?").collect(Collectors.joining(" AND "));
-        return String.format("SELECT %s FROM %s WHERE %s", queryColumns, qualifiedTableName, equalsConditions);
-    }
-    
-    private List<String> joinColumns(final List<String> uniqueKeys, final List<String> shardingColumnsNames) {
-        if (shardingColumnsNames.isEmpty()) {
-            return uniqueKeys;
-        }
-        List<String> result = new ArrayList<>(uniqueKeys.size() + shardingColumnsNames.size());
-        result.addAll(uniqueKeys);
-        result.addAll(shardingColumnsNames);
-        return result;
     }
     
     /**

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineInventoryCalculateSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineInventoryCalculateSQLBuilder.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql;
+
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.QueryRange;
+import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.dialect.DialectPipelineSQLBuilder;
+import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.segment.PipelineSQLSegmentBuilder;
+import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Pipeline inventory calculate SQL builder.
+ */
+public final class PipelineInventoryCalculateSQLBuilder {
+    
+    private final DialectPipelineSQLBuilder dialectSQLBuilder;
+    
+    private final PipelineSQLSegmentBuilder sqlSegmentBuilder;
+    
+    public PipelineInventoryCalculateSQLBuilder(final DatabaseType databaseType) {
+        dialectSQLBuilder = DatabaseTypedSPILoader.getService(DialectPipelineSQLBuilder.class, databaseType);
+        sqlSegmentBuilder = new PipelineSQLSegmentBuilder(databaseType);
+    }
+    
+    /**
+     * Build query range ordering SQL.
+     *
+     * @param qualifiedTable qualified table
+     * @param columnNames column names
+     * @param uniqueKeys unique keys, it may be primary key, not null
+     * @param queryRange query range
+     * @param pageQuery whether it is page query
+     * @param shardingColumnsNames sharding columns names
+     * @return built SQL
+     */
+    public String buildQueryRangeOrderingSQL(final QualifiedTable qualifiedTable, final Collection<String> columnNames, final List<String> uniqueKeys, final QueryRange queryRange,
+                                             final boolean pageQuery, final List<String> shardingColumnsNames) {
+        String result = buildQueryRangeOrderingSQL0(qualifiedTable, columnNames, uniqueKeys, queryRange, shardingColumnsNames);
+        return pageQuery ? dialectSQLBuilder.wrapWithPageQuery(result) : result;
+    }
+    
+    private String buildQueryRangeOrderingSQL0(final QualifiedTable qualifiedTable, final Collection<String> columnNames, final List<String> uniqueKeys, final QueryRange queryRange,
+                                               final List<String> shardingColumnsNames) {
+        String qualifiedTableName = sqlSegmentBuilder.getQualifiedTableName(qualifiedTable);
+        String queryColumns = columnNames.stream().map(sqlSegmentBuilder::getEscapedIdentifier).collect(Collectors.joining(","));
+        String firstUniqueKey = uniqueKeys.get(0);
+        String orderByColumns = joinColumns(uniqueKeys, shardingColumnsNames).stream().map(each -> sqlSegmentBuilder.getEscapedIdentifier(each) + " ASC").collect(Collectors.joining(", "));
+        if (null != queryRange.getLower() && null != queryRange.getUpper()) {
+            return String.format("SELECT %s FROM %s WHERE %s AND %s ORDER BY %s", queryColumns, qualifiedTableName,
+                    buildLowerQueryRangeCondition(queryRange.isLowerInclusive(), firstUniqueKey),
+                    buildUpperQueryRangeCondition(firstUniqueKey), orderByColumns);
+        } else if (null != queryRange.getLower()) {
+            return String.format("SELECT %s FROM %s WHERE %s ORDER BY %s", queryColumns, qualifiedTableName,
+                    buildLowerQueryRangeCondition(queryRange.isLowerInclusive(), firstUniqueKey), orderByColumns);
+        } else if (null != queryRange.getUpper()) {
+            return String.format("SELECT %s FROM %s WHERE %s ORDER BY %s", queryColumns, qualifiedTableName,
+                    buildUpperQueryRangeCondition(firstUniqueKey), orderByColumns);
+        } else {
+            return String.format("SELECT %s FROM %s ORDER BY %s", queryColumns, qualifiedTableName, orderByColumns);
+        }
+    }
+    
+    private String buildLowerQueryRangeCondition(final boolean inclusive, final String firstUniqueKey) {
+        String delimiter = inclusive ? ">=?" : ">?";
+        return sqlSegmentBuilder.getEscapedIdentifier(firstUniqueKey) + delimiter;
+    }
+    
+    private String buildUpperQueryRangeCondition(final String firstUniqueKey) {
+        return sqlSegmentBuilder.getEscapedIdentifier(firstUniqueKey) + "<=?";
+    }
+    
+    /**
+     * Build point query SQL.
+     *
+     * @param qualifiedTable qualified table
+     * @param columnNames column names
+     * @param uniqueKeys unique keys, it may be primary key, not null
+     * @param shardingColumnsNames sharding columns names, nullable
+     * @return built SQL
+     */
+    public String buildPointQuerySQL(final QualifiedTable qualifiedTable, final Collection<String> columnNames, final List<String> uniqueKeys, final List<String> shardingColumnsNames) {
+        String qualifiedTableName = sqlSegmentBuilder.getQualifiedTableName(qualifiedTable);
+        String queryColumns = columnNames.stream().map(sqlSegmentBuilder::getEscapedIdentifier).collect(Collectors.joining(","));
+        String equalsConditions = joinColumns(uniqueKeys, shardingColumnsNames).stream().map(each -> sqlSegmentBuilder.getEscapedIdentifier(each) + "=?").collect(Collectors.joining(" AND "));
+        return String.format("SELECT %s FROM %s WHERE %s", queryColumns, qualifiedTableName, equalsConditions);
+    }
+    
+    private List<String> joinColumns(final List<String> uniqueKeys, final List<String> shardingColumnsNames) {
+        if (shardingColumnsNames.isEmpty()) {
+            return uniqueKeys;
+        }
+        List<String> result = new ArrayList<>(uniqueKeys.size() + shardingColumnsNames.size());
+        result.addAll(uniqueKeys);
+        result.addAll(shardingColumnsNames);
+        return result;
+    }
+}

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineDataConsistencyCalculateSQLBuilderTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineDataConsistencyCalculateSQLBuilderTest.java
@@ -17,16 +17,11 @@
 
 package org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql;
 
-import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.QueryRange;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -34,61 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 class PipelineDataConsistencyCalculateSQLBuilderTest {
     
-    private static final Collection<String> COLUMN_NAMES = Arrays.asList("order_id", "user_id", "status");
-    
-    private static final List<String> UNIQUE_KEYS = Arrays.asList("order_id", "status");
-    
-    private static final List<String> SHARDING_COLUMNS_NAMES = Collections.singletonList("user_id");
-    
     private final PipelineDataConsistencyCalculateSQLBuilder sqlBuilder = new PipelineDataConsistencyCalculateSQLBuilder(TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
-    
-    @Test
-    void assertBuildQueryRangeOrderingSQLPageQuery() {
-        String actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(1, true, 5), true, SHARDING_COLUMNS_NAMES);
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? AND order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
-        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(1, false, 5), true, SHARDING_COLUMNS_NAMES);
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? AND order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
-        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(1, false, null), true, SHARDING_COLUMNS_NAMES);
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
-        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(null, false, 5), true, SHARDING_COLUMNS_NAMES);
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
-        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(null, false, null), true, SHARDING_COLUMNS_NAMES);
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
-    }
-    
-    @Test
-    void assertBuildQueryRangeOrderingSQLNotPageQuery() {
-        String actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(1, true, 5), false, SHARDING_COLUMNS_NAMES);
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? AND order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC"));
-        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(1, false, 5), false, SHARDING_COLUMNS_NAMES);
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? AND order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC"));
-        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(1, false, null), false, SHARDING_COLUMNS_NAMES);
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? ORDER BY order_id ASC, status ASC, user_id ASC"));
-        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(null, false, 5), false, SHARDING_COLUMNS_NAMES);
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC"));
-        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
-                new QueryRange(null, false, null), false, SHARDING_COLUMNS_NAMES);
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order ORDER BY order_id ASC, status ASC, user_id ASC"));
-    }
-    
-    @Test
-    void assertBuildPointQuerySQLWithoutQueryCondition() {
-        String actual = sqlBuilder.buildPointQuerySQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS, Collections.emptyList());
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id=? AND status=?"));
-        actual = sqlBuilder.buildPointQuerySQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS, Collections.emptyList());
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id=? AND status=?"));
-        actual = sqlBuilder.buildPointQuerySQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS, Collections.singletonList("user_id"));
-        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id=? AND status=? AND user_id=?"));
-    }
     
     @Test
     void assertBuildCRC32SQL() {

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineInventoryCalculateSQLBuilderTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/sql/PipelineInventoryCalculateSQLBuilderTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql;
+
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.QueryRange;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class PipelineInventoryCalculateSQLBuilderTest {
+    
+    private static final Collection<String> COLUMN_NAMES = Arrays.asList("order_id", "user_id", "status");
+    
+    private static final List<String> UNIQUE_KEYS = Arrays.asList("order_id", "status");
+    
+    private static final List<String> SHARDING_COLUMNS_NAMES = Collections.singletonList("user_id");
+    
+    private final PipelineInventoryCalculateSQLBuilder sqlBuilder = new PipelineInventoryCalculateSQLBuilder(TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+    
+    @Test
+    void assertBuildQueryRangeOrderingSQLPageQuery() {
+        String actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(1, true, 5), true, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? AND order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
+        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(1, false, 5), true, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? AND order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
+        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(1, false, null), true, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
+        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(null, false, 5), true, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
+        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(null, false, null), true, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order ORDER BY order_id ASC, status ASC, user_id ASC LIMIT ?"));
+    }
+    
+    @Test
+    void assertBuildQueryRangeOrderingSQLNotPageQuery() {
+        String actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(1, true, 5), false, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>=? AND order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC"));
+        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(1, false, 5), false, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? AND order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC"));
+        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(1, false, null), false, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id>? ORDER BY order_id ASC, status ASC, user_id ASC"));
+        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(null, false, 5), false, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id<=? ORDER BY order_id ASC, status ASC, user_id ASC"));
+        actual = sqlBuilder.buildQueryRangeOrderingSQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS,
+                new QueryRange(null, false, null), false, SHARDING_COLUMNS_NAMES);
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order ORDER BY order_id ASC, status ASC, user_id ASC"));
+    }
+    
+    @Test
+    void assertBuildPointQuerySQLWithoutQueryCondition() {
+        String actual = sqlBuilder.buildPointQuerySQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS, Collections.emptyList());
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id=? AND status=?"));
+        actual = sqlBuilder.buildPointQuerySQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS, Collections.emptyList());
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id=? AND status=?"));
+        actual = sqlBuilder.buildPointQuerySQL(new QualifiedTable(null, "t_order"), COLUMN_NAMES, UNIQUE_KEYS, Collections.singletonList("user_id"));
+        assertThat(actual, is("SELECT order_id,user_id,status FROM t_order WHERE order_id=? AND status=? AND user_id=?"));
+    }
+}


### PR DESCRIPTION

Changes proposed in this pull request:
  - Extract PipelineInventoryCalculateSQLBuilder from PipelineDataConsistencyCalculateSQLBuilder

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
