### PR TITLE
Support ALTER TABLE RENAME TO for sharding and broadcast tables

### DIFF
--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/persist/service/MetaDataManagerPersistService.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/persist/service/MetaDataManagerPersistService.java
@@ -91,6 +91,15 @@ public interface MetaDataManagerPersistService {
     void dropTables(ShardingSphereDatabase database, String schemaName, Collection<String> tableNames);
     
     /**
+     * Rename tables.
+     *
+     * @param database database
+     * @param schemaName schema name
+     * @param renameTableMap rename table map, key is old table name, value is new table name
+     */
+    void renameTables(ShardingSphereDatabase database, String schemaName, Map<String, String> renameTableMap);
+    
+    /**
      * Alter tables.
      *
      * @param database database

--- a/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistService.java
+++ b/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistService.java
@@ -127,6 +127,22 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
     }
     
     @Override
+    public void renameTables(final ShardingSphereDatabase database, final String schemaName, final Map<String, String> renameTableMap) {
+        boolean isNeedRefresh = TableRefreshUtils.isNeedRefresh(database.getRuleMetaData(), schemaName, renameTableMap.keySet());
+        // Drop old tables from metadata
+        renameTableMap.keySet().forEach(each -> {
+            metaDataPersistFacade.getDatabaseMetaDataFacade().getTable().drop(database.getName(), schemaName, each);
+            metaDataContextManager.getDatabaseMetaDataManager().dropTable(database.getName(), schemaName, each);
+        });
+        // Add new tables to metadata (new tables should be auto-discovered after physical rename)
+        // For single tables, update rule configuration
+        if (isNeedRefresh && renameTableMap.keySet().stream().anyMatch(each -> TableRefreshUtils.isSingleTable(each, database))) {
+            alterSingleRuleConfiguration(database, database.getRuleMetaData());
+        }
+        // Note: For sharding and broadcast tables, rules need to be updated through separate DistSQL commands or manual configuration updates
+    }
+    
+    @Override
     public void alterTables(final ShardingSphereDatabase database, final String schemaName, final Collection<ShardingSphereTable> alteredTables) {
         metaDataPersistFacade.getDatabaseMetaDataFacade().getTable().persist(database.getName(), schemaName, alteredTables);
         alteredTables.forEach(each -> metaDataContextManager.getDatabaseMetaDataManager().alterTable(database.getName(), schemaName, each));


### PR DESCRIPTION
## Problem

Currently, `ALTER TABLE ... RENAME TO ...` and `RENAME TABLE` statements are blocked for sharding and broadcast tables, even though the underlying physical rename operation would succeed. This limitation exists because the original implementation (PR #10462) only addressed single tables, leaving sharding and broadcast tables unsupported.

Users managing sharded databases cannot rename their tables through standard SQL, forcing them to manually drop and recreate tables with new names - a disruptive operation that requires data migration.

## Solution

Instead of blocking rename operations entirely, this change allows the physical table rename to proceed while validating that the new table name doesn't conflict with existing sharding rules or schema tables.

The validation logic now focuses on preventing naming conflicts rather than blocking the operation outright:
- Ensures the new table name isn't already defined as a sharding table
- Ensures the new table name doesn't already exist in the current schema

For single tables, metadata rules are automatically refreshed after rename. For sharding and broadcast tables, the physical rename succeeds and users can update their rules via DistSQL commands - consistent with existing DROP/CREATE TABLE behavior.

## Impact

**Breaking change in validation behavior**: Previously, any rename operation involving sharding tables would fail immediately. Now, validation focuses on the target table name conflicts, allowing legitimate rename operations to proceed.

**Supported modes**: Works in both Standalone and Cluster modes. In Standalone mode with in-memory repository, changes are volatile; with JDBC repository, changes persist across restarts.

**User workflow for sharding/broadcast tables**:
1. Execute `ALTER TABLE ... RENAME TO ...` or `RENAME TABLE` - physical tables are renamed
2. Update sharding/broadcast rules manually via DistSQL to reflect new table names

Closes #10476

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
