### PR TITLE
Fix migration might skip some records on big table after job restarting

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumper.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumper.java
@@ -124,8 +124,7 @@ public final class InventoryDumper extends AbstractPipelineLifecycleRunnable imp
         List<String> columnNames = dumperContext.getQueryColumnNames();
         TableInventoryCalculateParameter calculateParam = new TableInventoryCalculateParameter(dataSource, table,
                 columnNames, dumperContext.getUniqueKeyColumns(), QueryType.RANGE_QUERY, null);
-        QueryRange queryRange = new QueryRange(((PrimaryKeyIngestPosition<?>) initialPosition).getBeginValue(), dumperContext.isFirstDump(),
-                ((PrimaryKeyIngestPosition<?>) initialPosition).getEndValue());
+        QueryRange queryRange = new QueryRange(((PrimaryKeyIngestPosition<?>) initialPosition).getBeginValue(), true, ((PrimaryKeyIngestPosition<?>) initialPosition).getEndValue());
         calculateParam.setQueryRange(queryRange);
         RecordTableInventoryDumpCalculator dumpCalculator = new RecordTableInventoryDumpCalculator(dumperContext.getBatchSize(), StreamingRangeType.SMALL);
         long rowCount = 0L;

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumperContext.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/InventoryDumperContext.java
@@ -56,8 +56,6 @@ public final class InventoryDumperContext {
     
     private JobRateLimitAlgorithm rateLimitAlgorithm;
     
-    private boolean firstDump = true;
-    
     public InventoryDumperContext(final DumperCommonContext commonContext) {
         this.commonContext = new DumperCommonContext(
                 commonContext.getDataSourceName(), commonContext.getDataSourceConfig(), commonContext.getTableNameMapper(), commonContext.getTableAndSchemaNameMapper());

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/splitter/InventoryDumperContextSplitter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/splitter/InventoryDumperContextSplitter.java
@@ -94,7 +94,7 @@ public final class InventoryDumperContextSplitter {
         JobRateLimitAlgorithm rateLimitAlgorithm = jobProcessContext.getReadRateLimitAlgorithm();
         int i = 0;
         for (IngestPosition each : getInventoryPositions(dumperContext, jobItemContext)) {
-            result.add(createPrimaryKeySplitDumperContext(dumperContext, each, i++, batchSize, rateLimitAlgorithm, jobItemContext));
+            result.add(createPrimaryKeySplitDumperContext(dumperContext, each, i++, batchSize, rateLimitAlgorithm));
         }
         return result;
     }
@@ -151,8 +151,7 @@ public final class InventoryDumperContextSplitter {
     }
     
     private InventoryDumperContext createPrimaryKeySplitDumperContext(final InventoryDumperContext dumperContext, final IngestPosition position,
-                                                                      final int shardingItem, final int batchSize, final JobRateLimitAlgorithm rateLimitAlgorithm,
-                                                                      final TransmissionJobItemContext jobItemContext) {
+                                                                      final int shardingItem, final int batchSize, final JobRateLimitAlgorithm rateLimitAlgorithm) {
         InventoryDumperContext result = new InventoryDumperContext(dumperContext.getCommonContext());
         result.getCommonContext().setPosition(position);
         result.setShardingItem(shardingItem);
@@ -162,11 +161,6 @@ public final class InventoryDumperContextSplitter {
         result.setInsertColumnNames(dumperContext.getInsertColumnNames());
         result.setBatchSize(batchSize);
         result.setRateLimitAlgorithm(rateLimitAlgorithm);
-        result.setFirstDump(isFirstDump(jobItemContext));
         return result;
-    }
-    
-    private boolean isFirstDump(final TransmissionJobItemContext jobItemContext) {
-        return null == jobItemContext.getInitProgress() && jobItemContext.getProcessedRecordsCount() == 0;
     }
 }


### PR DESCRIPTION
Related to #33996.

Changes proposed in this pull request:
  - Remove InventoryDumperContext.firstDump

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
