### PR TITLE
Minor refactor for DataTypeConverter and LiteralExpressionConverter

### DIFF
--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/segment/expression/impl/LiteralExpressionConverter.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/segment/expression/impl/LiteralExpressionConverter.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sqlfederation.compiler.sql.ast.converter.segment.expression.impl;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.calcite.avatica.util.TimeUnit;
@@ -28,7 +29,6 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Optional;
 
 /**
@@ -37,9 +37,9 @@ import java.util.Optional;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class LiteralExpressionConverter {
     
-    private static final Collection<String> TRIM_FUNCTION_FLAGS = new HashSet<>(3, 1F);
+    private static final Collection<String> TRIM_FUNCTION_FLAGS = new CaseInsensitiveSet<>(3, 1F);
     
-    private static final Collection<String> TIME_UNIT_NAMES = new HashSet<>(7, 1F);
+    private static final Collection<String> TIME_UNIT_NAMES = new CaseInsensitiveSet<>(7, 1F);
     
     static {
         TRIM_FUNCTION_FLAGS.add("BOTH");
@@ -66,10 +66,10 @@ public final class LiteralExpressionConverter {
         }
         String literalValue = String.valueOf(segment.getLiterals());
         if (TRIM_FUNCTION_FLAGS.contains(literalValue)) {
-            return Optional.of(SqlLiteral.createSymbol(Flag.valueOf(literalValue), SqlParserPos.ZERO));
+            return Optional.of(SqlLiteral.createSymbol(Flag.valueOf(literalValue.toUpperCase()), SqlParserPos.ZERO));
         }
         if (TIME_UNIT_NAMES.contains(literalValue)) {
-            return Optional.of(new SqlIntervalQualifier(TimeUnit.valueOf(literalValue), null, SqlParserPos.ZERO));
+            return Optional.of(new SqlIntervalQualifier(TimeUnit.valueOf(literalValue.toUpperCase()), null, SqlParserPos.ZERO));
         }
         if (segment.getLiterals() instanceof Number) {
             return Optional.of(SqlLiteral.createExactNumeric(literalValue, SqlParserPos.ZERO));

--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/type/DataTypeConverter.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/type/DataTypeConverter.java
@@ -17,11 +17,11 @@
 
 package org.apache.shardingsphere.sqlfederation.compiler.sql.ast.converter.type;
 
+import com.cedarsoftware.util.CaseInsensitiveMap;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -30,7 +30,7 @@ import java.util.Map;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DataTypeConverter {
     
-    private static final Map<String, SqlTypeName> REGISTRY = new HashMap<>();
+    private static final Map<String, SqlTypeName> REGISTRY = new CaseInsensitiveMap<>();
     
     static {
         registerDataType();


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Minor refactor for DataTypeConverter and LiteralExpressionConverter

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
