### PR TITLE
Add test cases for HintManager.getDataSourceName()

### DIFF
--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/hint/HintManagerTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/hint/HintManagerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -206,5 +207,22 @@ class HintManagerTest {
         assertTrue(HintManager.isInstantiated());
         hintManager.close();
         assertFalse(HintManager.isInstantiated());
+    }
+    
+    @Test
+    void assertGetDataSourceNameWithValue() {
+        try (HintManager hintManager = HintManager.getInstance()) {
+            hintManager.setDataSourceName("foo_ds");
+            Optional<String> actual = HintManager.getDataSourceName();
+            assertTrue(actual.isPresent());
+            assertThat(actual.get(), is("foo_ds"));
+        }
+    }
+    
+    @Test
+    void assertGetDataSourceNameWithoutValue() {
+        try (HintManager ignored = HintManager.getInstance()) {
+            assertFalse(HintManager.getDataSourceName().isPresent());
+        }
     }
 }


### PR DESCRIPTION
- Add assertGetDataSourceNameWithValue() to test with data source name set
- Add assertGetDataSourceNameWithoutValue() to test without value
- Achieve 100% branch coverage for getDataSourceName() method
- Follow elegant test patterns: minimal methods, clean assertions, proper resource cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)