### PR TITLE
Fix column bind exception caused by oracle XMLELEMENT function first parameter without quote

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -60,6 +60,7 @@
 1. SQL Parser: Fix SQL parser error when SQL contains subquery with alias for Oracle - [#35239](https://github.com/apache/shardingsphere/pull/35239)
 1. SQL Binder: Fix unable to find the outer table in the NotExpressionBinder - [36135](https://github.com/apache/shardingsphere/pull/36135)
 1. SQL Binder: Fix unable to find the outer table in the ExistsSubqueryExpressionBinder - [#36068](https://github.com/apache/shardingsphere/pull/36068)
+1. SQL Binder: Fix column bind exception caused by oracle XMLELEMENT function first parameter without quote - [#36963](https://github.com/apache/shardingsphere/pull/36963)
 1. Transaction: Fix conflicting dependencies of BASE transaction integration module - [#35142](https://github.com/apache/shardingsphere/pull/35142)
 1. Transaction: Alleviate connection leaks caused by SEATA client throwing exceptions - [#34463](https://github.com/apache/shardingsphere/pull/34463)
 1. SQL Federation: Fix Operation not allowed after ResultSet closed exception when use SQL federation - [#35206](https://github.com/apache/shardingsphere/pull/35206)

--- a/test/it/binder/src/test/resources/cases/dml/select-function.xml
+++ b/test/it/binder/src/test/resources/cases/dml/select-function.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <select sql-case-id="select_with_xml_function">
+        <projections start-index="7" stop-index="144">
+            <expression-projection text="to_char(XMLAGGG(XMLELEMENT(E, ( SELECT i.item_id FROM t_order_item i WHERE i.item_id = 1 ) OR ',')).EXTRACT('//text()').getclobval())" alias="n" start-index="7" stop-index="144">
+                <expr>
+                    <function function-name="to_char" text="to_char(XMLAGGG(XMLELEMENT(E, ( SELECT i.item_id FROM t_order_item i WHERE i.item_id = 1 ) OR ',')).EXTRACT('//text()').getclobval())" start-index="7" stop-index="139">
+                        <parameter>
+                            <binary-operation-expression start-index="15" stop-index="138">
+                                <left>
+                                    <binary-operation-expression start-index="15" stop-index="125">
+                                        <left>
+                                            <function function-name="XMLAGGG" text="XMLAGGG(XMLELEMENT(E, ( SELECT i.item_id FROM t_order_item i WHERE i.item_id = 1 ) OR ','))" start-index="15" stop-index="105">
+                                                <parameter>
+                                                    <function function-name="XMLELEMENT" text="XMLELEMENT(E, ( SELECT i.item_id FROM t_order_item i WHERE i.item_id = 1 ) OR ',')" start-index="23" stop-index="104">
+                                                        <parameter>
+                                                            <column name="E" start-index="34" stop-index="34" />
+                                                        </parameter>
+                                                        <parameter>
+                                                            <binary-operation-expression start-index="37" stop-index="103">
+                                                                <left>
+                                                                    <subquery start-index="37" stop-index="96">
+                                                                        <select>
+                                                                            <projections start-index="46" stop-index="54">
+                                                                                <column-projection name="item_id" start-index="46" stop-index="54">
+                                                                                    <owner name="i" start-index="46" stop-index="46" />
+                                                                                    <column-bound>
+                                                                                        <original-database name="foo_db_1" />
+                                                                                        <original-schema name="foo_db_1" />
+                                                                                        <original-table name="t_order_item" />
+                                                                                        <original-column name="item_id" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                                                                        <table-source-type name="PHYSICAL_TABLE"/>
+                                                                                    </column-bound>
+                                                                                </column-projection>
+                                                                            </projections>
+                                                                            <from>
+                                                                                <simple-table name="t_order_item" alias="i" start-index="61" stop-index="74">
+                                                                                    <table-bound>
+                                                                                        <original-database name="foo_db_1" />
+                                                                                        <original-schema name="foo_db_1" />
+                                                                                    </table-bound>
+                                                                                </simple-table>
+                                                                            </from>
+                                                                            <where start-index="76" stop-index="94">
+                                                                                <expr>
+                                                                                    <binary-operation-expression start-index="82" stop-index="94">
+                                                                                        <left>
+                                                                                            <column name="item_id" start-index="82" stop-index="90" >
+                                                                                                <owner name="i" start-index="82" stop-index="82" />
+                                                                                                <column-bound>
+                                                                                                    <original-database name="foo_db_1" />
+                                                                                                    <original-schema name="foo_db_1" />
+                                                                                                    <original-table name="t_order_item" />
+                                                                                                    <original-column name="item_id" start-delimiter="&quot;" end-delimiter="&quot;" />
+                                                                                                    <table-source-type name="PHYSICAL_TABLE"/>
+                                                                                                </column-bound>
+                                                                                            </column>
+                                                                                        </left>
+                                                                                        <operator>=</operator>
+                                                                                        <right>
+                                                                                            <literal-expression value="1" start-index="94" stop-index="94" />
+                                                                                        </right>
+                                                                                    </binary-operation-expression>
+                                                                                </expr>
+                                                                            </where>
+                                                                        </select>
+                                                                    </subquery>
+                                                                </left>
+                                                                <operator>OR</operator>
+                                                                <right>
+                                                                    <literal-expression value="," start-index="101" stop-index="103" />
+                                                                </right>
+                                                            </binary-operation-expression>
+                                                        </parameter>
+                                                    </function>
+                                                </parameter>
+                                            </function>
+                                        </left>
+                                        <operator>.</operator>
+                                        <right>
+                                            <function function-name="EXTRACT" text="EXTRACT('//text()')" start-index="107" stop-index="125">
+                                                <parameter>
+                                                    <literal-expression value="//text()" start-index="115" stop-index="124" />
+                                                </parameter>
+                                            </function>
+                                        </right>
+                                    </binary-operation-expression>
+                                </left>
+                                <operator>.</operator>
+                                <right>
+                                    <function function-name="getclobval" text="getclobval()" start-index="127" stop-index="138" />
+                                </right>
+                            </binary-operation-expression>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table name="DUAL" start-index="151" stop-index="154">
+                <table-bound>
+                    <original-database name="foo_db_1" />
+                    <original-schema name="foo_db_1" />
+                </table-bound>
+            </simple-table>
+        </from>
+    </select>
+</sql-parser-test-cases>

--- a/test/it/binder/src/test/resources/sqls/dml/select-function.xml
+++ b/test/it/binder/src/test/resources/sqls/dml/select-function.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="select_with_xml_function" value="SELECT to_char(XMLAGGG(XMLELEMENT(E, ( SELECT i.item_id FROM t_order_item i WHERE i.item_id = 1 ) OR ',')).EXTRACT('//text()').getclobval()) AS n FROM DUAL" db-types="Oracle"/>
+</sql-cases>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix column bind exception caused by oracle XMLELEMENT function first parameter without quote

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
