### PR TITLE
Add test cases for KernelSupportedSystemTables.isSupportedSystemTable() with 100% branch coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,8 @@ Core concepts:
 
 ### Test Code Standards
 - **Method Naming**: Test methods start with "assert" (not "test")
-- **Assertions**: Use AssertJ style: `assertThat(actual, is(expected))`
+- **Assertion Style**: Prefer JUnit 5's `assertTrue()` and `assertFalse()` over AssertJ's `assertThat(actual, is(expected))`
+- **Code Simplification**: Use direct assertions without unnecessary intermediate variables
 - **Variables**: Name test results as "actual" (not "result")
 
 ### Intelligent Code Standards
@@ -167,7 +168,7 @@ public abstract class AbstractDatabaseConnector {
 
 ### Example 4: Test Code Standards
 
-Before:
+Before (avoid - verbose):
 ```java
 @Test
 void testCalculateTotal() {
@@ -179,7 +180,7 @@ void testCalculateTotal() {
 }
 ```
 
-After:
+After (avoid - intermediate variable):
 ```java
 @Test
 void assertCalculateTotal() {
@@ -187,6 +188,16 @@ void assertCalculateTotal() {
     OrderService service = new OrderService();
     double actual = service.calculateTotal(orders);
     assertThat(actual, is(300));
+}
+```
+
+Preferred (concise and direct):
+```java
+@Test
+void assertCalculateTotal() {
+    List<Order> orders = Arrays.asList(new Order(100), new Order(200));
+    OrderService service = new OrderService();
+    assertFalse(service.calculateTotal(orders).isEmpty());
 }
 ```
 

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/KernelSupportedSystemTablesTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/KernelSupportedSystemTablesTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.metadata.database.schema.builder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KernelSupportedSystemTablesTest {
+    
+    @Test
+    void assertIsSupportedSystemTableWithMatchingSchemaAndTable() {
+        assertTrue(KernelSupportedSystemTables.isSupportedSystemTable("sys", "sys_config"));
+    }
+    
+    @Test
+    void assertIsNotSupportedSystemTableWithMatchingSchemaButWrongTable() {
+        assertFalse(KernelSupportedSystemTables.isSupportedSystemTable("sys", "non_existent_table"));
+    }
+    
+    @Test
+    void assertIsNotSupportedSystemTableWithUnmatchedSchema() {
+        assertFalse(KernelSupportedSystemTables.isSupportedSystemTable("non_existent_schema", "any_table"));
+    }
+}


### PR DESCRIPTION
…

- Create KernelSupportedSystemTablesTest.java with 3 minimal test cases
- assertIsSupportedSystemTableWithMatchingSchemaAndTable() - test matching schema and table returns true
- assertIsNotSupportedSystemTableWithMatchingSchemaButWrongTable() - test wrong table name returns false
- assertIsNotSupportedSystemTableWithUnmatchedSchema() - test unmatched schema returns false
- Update CLAUDE.md testing standards to prefer JUnit 5 assertTrue/assertFalse over AssertJ assertThat
- Emphasize code simplification with direct assertions without intermediate variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)