### PR TITLE
Refactor ShardingSphereColumn constructor to use this() chaining

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereColumn.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereColumn.java
@@ -47,13 +47,7 @@ public final class ShardingSphereColumn {
     private final boolean nullable;
     
     public ShardingSphereColumn(final ColumnMetaData columnMetaData) {
-        name = columnMetaData.getName();
-        dataType = columnMetaData.getDataType();
-        primaryKey = columnMetaData.isPrimaryKey();
-        generated = columnMetaData.isGenerated();
-        caseSensitive = columnMetaData.isCaseSensitive();
-        visible = columnMetaData.isVisible();
-        unsigned = columnMetaData.isUnsigned();
-        nullable = columnMetaData.isNullable();
+        this(columnMetaData.getName(), columnMetaData.getDataType(), columnMetaData.isPrimaryKey(), columnMetaData.isGenerated(),
+                columnMetaData.isCaseSensitive(), columnMetaData.isVisible(), columnMetaData.isUnsigned(), columnMetaData.isNullable());
     }
 }


### PR DESCRIPTION
Replace manual field assignments with constructor chaining to improve code maintainability and follow DRY principles.