### PR TITLE
Refactor constructor chaining for ShardingSphereConstraint and ShardingSphereIndex

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereConstraint.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereConstraint.java
@@ -35,7 +35,6 @@ public final class ShardingSphereConstraint {
     private final String referencedTableName;
     
     public ShardingSphereConstraint(final ConstraintMetaData constraintMetaData) {
-        name = constraintMetaData.getName();
-        referencedTableName = constraintMetaData.getReferencedTableName();
+        this(constraintMetaData.getName(), constraintMetaData.getReferencedTableName());
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereIndex.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereIndex.java
@@ -39,8 +39,6 @@ public final class ShardingSphereIndex {
     private final boolean unique;
     
     public ShardingSphereIndex(final IndexMetaData indexMetaData) {
-        name = indexMetaData.getName();
-        columns = indexMetaData.getColumns();
-        unique = indexMetaData.isUnique();
+        this(indexMetaData.getName(), indexMetaData.getColumns(), indexMetaData.isUnique());
     }
 }


### PR DESCRIPTION
Replace manual field assignments with constructor chaining in ShardingSphereConstraint and ShardingSphereIndex to improve code maintainability and follow DRY principles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)