### PR TITLE
Fix maven-gpg-plugin blocking issue by upgrading Apache parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>29</version>
+        <version>35</version>
     </parent>
     <groupId>org.apache.shardingsphere</groupId>
     <artifactId>shardingsphere</artifactId>


### PR DESCRIPTION
Upgrade Apache parent POM from version 29 to 35 to resolve maven-gpg-plugin compatibility issues. This upgrade changes the maven-gpg-plugin from problematic version 3.0.1 to stable version 3.2.7, fixing GPG signing functionality that was blocked in certain environments.

Resolves issue #26770 where maven-gpg-plugin:3.0.1 had known blocking issues (Apache JIRA MGPG-90). The upgrade ensures GPG signing works properly for Apache releases while maintaining full backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #26770.