### PR TITLE
Fix ExampleGeneratorMain null repository variable error

### DIFF
--- a/examples/shardingsphere-jdbc-example-generator/src/main/resources/template/pom.ftl
+++ b/examples/shardingsphere-jdbc-example-generator/src/main/resources/template/pom.ftl
@@ -38,7 +38,7 @@
             <version>${r'${project.version}'}</version>
         </dependency>
     </#if>
-    <#if mode?contains("standalone") && repository == "JDBC">
+    <#if mode?contains("standalone") && (repository?? && repository == "JDBC")>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-standalone-mode-repository-jdbc</artifactId>


### PR DESCRIPTION
Fixes #36965.

Changes proposed in this pull request:
  - Add null check for `repository` variable in `pom.ftl` template using FreeMarker's `??` operator
  - This prevents FreeMarker template error when `repository` property is not configured in `config.yaml`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)