### PR TITLE
feat(pg-metadata): add column typeName propagation across metadata, YAML, and binder layers

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/ColumnMetaDataLoader.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/ColumnMetaDataLoader.java
@@ -52,6 +52,8 @@ public final class ColumnMetaDataLoader {
     
     private static final String IS_NULLABLE = "IS_NULLABLE";
     
+    private static final String TYPE_NAME = "TYPE_NAME";
+    
     /**
      * Load column meta data list.
      *
@@ -66,6 +68,7 @@ public final class ColumnMetaDataLoader {
         Collection<String> primaryKeys = loadPrimaryKeys(connection, tableNamePattern);
         List<String> columnNames = new ArrayList<>();
         List<Integer> columnTypes = new ArrayList<>();
+        List<String> columnTypeNames = new ArrayList<>();
         List<Boolean> primaryKeyFlags = new ArrayList<>();
         List<Boolean> caseSensitiveFlags = new ArrayList<>();
         List<Boolean> nullableFlags = new ArrayList<>();
@@ -75,6 +78,7 @@ public final class ColumnMetaDataLoader {
                 if (Objects.equals(tableNamePattern, tableName)) {
                     String columnName = resultSet.getString(COLUMN_NAME);
                     columnTypes.add(resultSet.getInt(DATA_TYPE));
+                    columnTypeNames.add(resultSet.getString(TYPE_NAME));
                     primaryKeyFlags.add(primaryKeys.contains(columnName));
                     nullableFlags.add("YES".equals(resultSet.getString(IS_NULLABLE)));
                     columnNames.add(columnName);
@@ -87,8 +91,10 @@ public final class ColumnMetaDataLoader {
                 ResultSet resultSet = statement.executeQuery(emptyResultSQL)) {
             for (int i = 0; i < columnNames.size(); i++) {
                 boolean generated = resultSet.getMetaData().isAutoIncrement(i + 1);
+                
                 caseSensitiveFlags.add(resultSet.getMetaData().isCaseSensitive(resultSet.findColumn(columnNames.get(i))));
-                result.add(new ColumnMetaData(columnNames.get(i), columnTypes.get(i), primaryKeyFlags.get(i), generated, caseSensitiveFlags.get(i), true, false, nullableFlags.get(i)));
+                result.add(new ColumnMetaData(columnNames.get(i), columnTypes.get(i), primaryKeyFlags.get(i), generated, columnTypeNames.get(i), caseSensitiveFlags.get(i), true, false,
+                        nullableFlags.get(i)));
             }
         } catch (final SQLException ex) {
             log.error("Error occurred while loading column meta data, SQL: {}", emptyResultSQL, ex);

--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/data/model/ColumnMetaData.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/data/model/ColumnMetaData.java
@@ -37,6 +37,8 @@ public final class ColumnMetaData {
     
     private final boolean generated;
     
+    private final String typeName;
+    
     private final boolean caseSensitive;
     
     private final boolean visible;

--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/datatype/DataTypeLoader.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/datatype/DataTypeLoader.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.database.connector.core.metadata.database.datatype;
 
 import com.cedarsoftware.util.CaseInsensitiveMap;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.datatype.DialectDataTypeOption;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 
@@ -41,7 +42,10 @@ public final class DataTypeLoader {
      */
     public Map<String, Integer> load(final DatabaseMetaData databaseMetaData, final DatabaseType databaseType) throws SQLException {
         Map<String, Integer> result = loadStandardDataTypes(databaseMetaData);
-        result.putAll(new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getDataTypeOption().getExtraDataTypes());
+        DialectDataTypeOption dataTypeOption = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getDataTypeOption();
+        result.putAll(dataTypeOption.getExtraDataTypes());
+        result.putAll(dataTypeOption.loadUDTTypes(databaseMetaData.getConnection()));
+        
         return result;
     }
     

--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/option/datatype/DefaultDataTypeOption.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/option/datatype/DefaultDataTypeOption.java
@@ -17,8 +17,11 @@
 
 package org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.datatype;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -75,5 +78,10 @@ public final class DefaultDataTypeOption implements DialectDataTypeOption {
             default:
                 return false;
         }
+    }
+    
+    @Override
+    public Map<String, Integer> loadUDTTypes(Connection connection) throws SQLException {
+        return new HashMap<>();
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereColumn.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereColumn.java
@@ -38,6 +38,8 @@ public final class ShardingSphereColumn {
     
     private final boolean generated;
     
+    private final String typeName;
+    
     private final boolean caseSensitive;
     
     private final boolean visible;
@@ -47,7 +49,7 @@ public final class ShardingSphereColumn {
     private final boolean nullable;
     
     public ShardingSphereColumn(final ColumnMetaData columnMetaData) {
-        this(columnMetaData.getName(), columnMetaData.getDataType(), columnMetaData.isPrimaryKey(), columnMetaData.isGenerated(),
+        this(columnMetaData.getName(), columnMetaData.getDataType(), columnMetaData.isPrimaryKey(), columnMetaData.isGenerated(), columnMetaData.getTypeName(),
                 columnMetaData.isCaseSensitive(), columnMetaData.isVisible(), columnMetaData.isUnsigned(), columnMetaData.isNullable());
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/column/ColumnReviseEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/column/ColumnReviseEngine.java
@@ -56,7 +56,8 @@ public final class ColumnReviseEngine<T extends ShardingSphereRule> {
             }
             String name = nameReviser.isPresent() ? nameReviser.get().revise(each.getName()) : each.getName();
             boolean generated = generatedReviser.map(optional -> optional.revise(each)).orElseGet(each::isGenerated);
-            result.add(new ColumnMetaData(name, each.getDataType(), each.isPrimaryKey(), generated, each.isCaseSensitive(), each.isVisible(), each.isUnsigned(), each.isNullable()));
+            result.add(
+                    new ColumnMetaData(name, each.getDataType(), each.isPrimaryKey(), generated, each.getTypeName(), each.isCaseSensitive(), each.isVisible(), each.isUnsigned(), each.isNullable()));
         }
         return result;
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/schema/pojo/YamlShardingSphereColumn.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/schema/pojo/YamlShardingSphereColumn.java
@@ -36,6 +36,8 @@ public final class YamlShardingSphereColumn implements YamlConfiguration {
     
     private boolean generated;
     
+    private String typeName;
+    
     private boolean caseSensitive;
     
     private boolean visible;

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/schema/swapper/YamlColumnSwapper.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/schema/swapper/YamlColumnSwapper.java
@@ -33,6 +33,7 @@ public final class YamlColumnSwapper implements YamlConfigurationSwapper<YamlSha
         result.setDataType(data.getDataType());
         result.setPrimaryKey(data.isPrimaryKey());
         result.setGenerated(data.isGenerated());
+        result.setTypeName(data.getTypeName());
         result.setCaseSensitive(data.isCaseSensitive());
         result.setVisible(data.isVisible());
         result.setUnsigned(data.isUnsigned());
@@ -43,6 +44,6 @@ public final class YamlColumnSwapper implements YamlConfigurationSwapper<YamlSha
     @Override
     public ShardingSphereColumn swapToObject(final YamlShardingSphereColumn yamlConfig) {
         return new ShardingSphereColumn(yamlConfig.getName(), yamlConfig.getDataType(),
-                yamlConfig.isPrimaryKey(), yamlConfig.isGenerated(), yamlConfig.isCaseSensitive(), yamlConfig.isVisible(), yamlConfig.isUnsigned(), yamlConfig.isNullable());
+                yamlConfig.isPrimaryKey(), yamlConfig.isGenerated(), yamlConfig.getTypeName(), yamlConfig.isCaseSensitive(), yamlConfig.isVisible(), yamlConfig.isUnsigned(), yamlConfig.isNullable());
     }
 }


### PR DESCRIPTION
Fixes #36978.

Changes proposed in this pull request:
  - Add PostgreSQL column typeName propagation across metadata pipeline.
  - Extend ColumnMetaData, ShardingSphereColumn, and YAML schema to include typeName.
  - Update ColumnReviseEngine for typeName population and revision.
  - Adjust CreateTableStatementBinder and PrepareStatementBinder to handle typeName.
  - Extract metadata/binder/YAML changes from the original parent PR (#37216).

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the code of conduct of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version.
