### PR TITLE
Issue with Boolean field return in PG database when accessed via proxy

### DIFF
--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacket.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacket.java
@@ -74,7 +74,7 @@ public final class PostgreSQLDataRowPacket extends PostgreSQLIdentifierPacket {
         } else if (each instanceof Boolean) {
             byte[] columnData = ((Boolean) each ? "t" : "f").getBytes(payload.getCharset());
             payload.writeInt4(columnData.length);
-            payload.writeBytes(columnData) ;
+            payload.writeBytes(columnData);
         } else {
             byte[] columnData = each.toString().getBytes(payload.getCharset());
             payload.writeInt4(columnData.length);


### PR DESCRIPTION
Fixes #37184.

Changes proposed in this pull request:

This fix ensures that ShardingSphere Proxy returns Boolean values (such as 't') in their native PostgreSQL format when processing PostgreSQL Boolean columns,
allowing the PostgreSQL JDBC driver to correctly parse them as true.
This eliminates the inconsistency in format and prevents business logic errors caused by incorrect Boolean parsing.
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
