### PR TITLE
[Part 1] Add ParameterFilterable interface

### DIFF
--- a/infra/rewrite/core/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/ParameterFilterable.java
+++ b/infra/rewrite/core/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/ParameterFilterable.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo;
+
+import org.apache.shardingsphere.infra.route.context.RouteUnit;
+
+import java.util.Set;
+
+/**
+ * Parameter filterable.
+ * 
+ * <p>
+ * This interface allows SQL tokens to declare which parameters should be removed
+ * for specific route units during SQL rewriting. It provides a generic mechanism
+ * for parameter filtering that can be used by various features, though it is
+ * currently designed primarily for sharding IN predicate optimization.
+ * </p>
+ * 
+ * <p>
+ * Tokens implementing this interface can control parameter filtering on a per-route
+ * basis, enabling optimizations such as sending only relevant IN clause values to
+ * each shard.
+ * </p>
+ */
+public interface ParameterFilterable {
+    
+    /**
+     * Get removed parameter indices for the specified route unit.
+     *
+     * <p>
+     * Returns the set of parameter indices that should be removed from the
+     * parameter list when generating SQL for the given route unit. Parameter
+     * indices are zero-based and correspond to the positions in the original
+     * parameter list.
+     * </p>
+     *
+     * @param routeUnit route unit
+     * @return set of parameter indices to remove; empty set if no parameters should be removed
+     */
+    Set<Integer> getRemovedParameterIndices(RouteUnit routeUnit);
+    
+    /**
+     * Determine whether parameter filtering is enabled.
+     *
+     * <p>
+     * This default method allows implementations to conditionally enable or disable
+     * parameter filtering. By default, filtering is enabled for all implementations.
+     * </p>
+     *
+     * @return true if parameter filtering is enabled; false otherwise
+     */
+    default boolean isParameterFilterable() {
+        return true;
+    }
+}

--- a/infra/rewrite/core/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/ParameterFilterableTest.java
+++ b/infra/rewrite/core/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/ParameterFilterableTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo;
+
+import org.apache.shardingsphere.infra.route.context.RouteMapper;
+import org.apache.shardingsphere.infra.route.context.RouteUnit;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for {@link ParameterFilterable}.
+ *
+ * @author yinh
+ */
+class ParameterFilterableTest {
+    
+    @Test
+    void assertDefaultIsParameterFilterableReturnsTrue() {
+        ParameterFilterable filterable = new TestParameterFilterable();
+        assertTrue(filterable.isParameterFilterable());
+    }
+    
+    @Test
+    void assertGetRemovedParameterIndicesCanBeImplemented() {
+        RouteUnit routeUnit = createTestRouteUnit();
+        ParameterFilterable filterable = new TestParameterFilterable();
+        Set<Integer> removedIndices = filterable.getRemovedParameterIndices(routeUnit);
+        assertThat(removedIndices.size(), is(2));
+        assertTrue(removedIndices.contains(0));
+        assertTrue(removedIndices.contains(1));
+    }
+    
+    @Test
+    void assertDefaultMethodCanBeOverridden() {
+        ParameterFilterable filterable = new TestParameterFilterableWithOverride();
+        assertThat(filterable.isParameterFilterable(), is(false));
+    }
+    
+    private RouteUnit createTestRouteUnit() {
+        RouteMapper dataSourceMapper = new RouteMapper("ds_0", "ds_0");
+        RouteMapper tableMapper = new RouteMapper("t_order", "t_order_0");
+        return new RouteUnit(dataSourceMapper, Collections.singletonList(tableMapper));
+    }
+    
+    /**
+     * Test implementation of ParameterFilterable.
+     */
+    private static class TestParameterFilterable implements ParameterFilterable {
+        
+        @Override
+        public Set<Integer> getRemovedParameterIndices(final RouteUnit routeUnit) {
+            Set<Integer> result = new HashSet<>();
+            result.add(0);
+            result.add(1);
+            return result;
+        }
+    }
+    
+    /**
+     * Test implementation with overridden default method.
+     */
+    private static class TestParameterFilterableWithOverride implements ParameterFilterable {
+        
+        @Override
+        public Set<Integer> getRemovedParameterIndices(final RouteUnit routeUnit) {
+            return Collections.emptySet();
+        }
+        
+        @Override
+        public boolean isParameterFilterable() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Overview
This is the first PR for the IN predicate optimization feature, introducing the foundational interface for parameter filtering.
Changes

Add ParameterFilterable interface to define parameter filtering capability
Provide getRemovedParameterIndices(RouteUnit) method to declare parameter indices that should be removed
Provide isParameterFilterable() default method to allow conditional filtering enablement

Design Rationale

Interface is placed in infra.rewrite.core module as a generic extension point for the rewrite engine
Currently designed specifically for sharding IN optimization; may potentially support other parameter filtering scenarios in the future if such needs arise
Fully backward compatible - does not affect existing token generators

Related Issue
Part of #36454 (1)

Next Steps
The next PR will integrate parameter filtering logic into RouteSQLRewriteEngine.