### PR TITLE
Refactor: Use orElseGet() for lazy evaluation in ShardingSphereYamlRe…

### DIFF
--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/representer/ShardingSphereYamlRepresenter.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/representer/ShardingSphereYamlRepresenter.java
@@ -51,7 +51,7 @@ public final class ShardingSphereYamlRepresenter extends Representer {
     protected NodeTuple representJavaBeanProperty(final Object javaBean, final Property property, final Object propertyValue, final Tag customTag) {
         NodeTuple nodeTuple = super.representJavaBeanProperty(javaBean, property, propertyValue, customTag);
         return TypedSPILoader.findService(ShardingSphereYamlTupleProcessor.class, property.getName())
-                .map(optional -> optional.process(nodeTuple)).orElse(new DefaultYamlTupleProcessor().process(nodeTuple));
+                .map(processor -> processor.process(nodeTuple)).orElseGet(() -> new DefaultYamlTupleProcessor().process(nodeTuple));
     }
     
     @SuppressWarnings({"rawtypes", "unchecked"})


### PR DESCRIPTION
Fixes #37159

## What changes were proposed in this pull request?

Replace `orElse()` with `orElseGet()` in ShardingSphereYamlRepresenter to avoid eager evaluation of the default processor.

## Why are the changes needed?

- `orElse()` eagerly evaluates its argument, causing `DefaultYamlTupleProcessor` to be instantiated even when a suitable `ShardingSphereYamlTupleProcessor` is found
- `orElseGet()` uses lazy evaluation, only creating the default processor when needed
- This aligns with Java Optional best practices and improves code quality

## Does this PR introduce any user-facing change?

No, this is an internal refactoring with no user-facing changes.

## How was this patch tested?

- Existing unit tests pass
- Code change is minimal and follows Java Optional idiomatic usage