### PR TITLE
Support IN query batch split rewrite (#37297)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -50,6 +50,7 @@
 1. Proxy: Add authority check on SQL `SHOW CREATE DATABASE` for MySQL - [#36862](https://github.com/apache/shardingsphere/pull/36862)
 1. Sharding: Using cache to avoid memory overflow from inline expression parsing - [#22196](https://github.com/apache/shardingsphere/issues/22196)
 1. Sharding: Add digital suffix check with binding table names - [#35293](https://github.com/apache/shardingsphere/issues/35293)
+1. Sharding: Support IN query batch split rewrite - [#37297](https://github.com/apache/shardingsphere/issues/37297)
 1. Encrypt: Use EncryptDerivedColumnSuffix to enhance encrypt table subquery rewrite logic - [#34829](https://github.com/apache/shardingsphere/pull/34829)
 1. Encrypt: Add quotes to encrypt rewrite derived columns - [#34950](https://github.com/apache/shardingsphere/pull/34950)
 1. Encrypt: Support NOT LIKE operator in encryption feature - [#35984](https://github.com/apache/shardingsphere/pull/35984)

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/ShardingTokenGenerateBuilder.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/ShardingTokenGenerateBuilder.java
@@ -35,6 +35,7 @@ import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.ShardingD
 import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.ShardingFetchDirectionTokenGenerator;
 import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.ShardingIndexTokenGenerator;
 import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.ShardingInsertValuesTokenGenerator;
+import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.ShardingInValuesTokenGenerator;
 import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.ShardingOffsetTokenGenerator;
 import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.ShardingOrderByTokenGenerator;
 import org.apache.shardingsphere.sharding.rewrite.token.generator.impl.ShardingProjectionsTokenGenerator;
@@ -74,6 +75,7 @@ public final class ShardingTokenGenerateBuilder implements SQLTokenGeneratorBuil
         addSQLTokenGenerator(result, new GeneratedKeyForUseDefaultInsertColumnsTokenGenerator());
         addSQLTokenGenerator(result, new GeneratedKeyAssignmentTokenGenerator());
         addSQLTokenGenerator(result, new ShardingInsertValuesTokenGenerator());
+        addSQLTokenGenerator(result, new ShardingInValuesTokenGenerator());
         addSQLTokenGenerator(result, new GeneratedKeyInsertValuesTokenGenerator());
         addSQLTokenGenerator(result, new ShardingRemoveTokenGenerator());
         addSQLTokenGenerator(result, new ShardingCursorTokenGenerator(rule));

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/ShardingInValuesTokenGenerator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/ShardingInValuesTokenGenerator.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.rewrite.token.generator.impl;
+
+import lombok.Setter;
+import org.apache.shardingsphere.infra.binder.context.segment.select.invalues.InValueContext;
+import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
+import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
+import org.apache.shardingsphere.infra.datanode.DataNode;
+import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.CollectionSQLTokenGenerator;
+import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.aware.RouteContextAware;
+import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
+import org.apache.shardingsphere.infra.route.context.RouteContext;
+import org.apache.shardingsphere.sharding.rewrite.token.generator.IgnoreForSingleRoute;
+import org.apache.shardingsphere.sharding.rewrite.token.pojo.ShardingInValuesToken;
+import org.apache.shardingsphere.sharding.rewrite.token.pojo.ShardingInValueItem;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.InExpression;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Sharding IN values token generator.
+ */
+@Setter
+public final class ShardingInValuesTokenGenerator implements CollectionSQLTokenGenerator<SQLStatementContext>, RouteContextAware, IgnoreForSingleRoute {
+    
+    private RouteContext routeContext;
+    
+    @Override
+    public boolean isGenerateSQLToken(final SQLStatementContext sqlStatementContext) {
+        return sqlStatementContext instanceof SelectStatementContext && ((SelectStatementContext) sqlStatementContext).isNeedInValuesRewrite();
+    }
+    
+    @Override
+    public Collection<SQLToken> generateSQLTokens(final SQLStatementContext sqlStatementContext) {
+        SelectStatementContext selectCtx = (SelectStatementContext) sqlStatementContext;
+        InValueContext inValueContext = selectCtx.getInValueContext();
+        if (null == inValueContext) {
+            return Collections.emptyList();
+        }
+        ShardingInValuesToken token = createInValuesToken(inValueContext);
+        return token.getInValueItems().isEmpty() ? Collections.emptyList() : Collections.singleton(token);
+    }
+    
+    private ShardingInValuesToken createInValuesToken(final InValueContext inValueContext) {
+        InExpression inExpression = inValueContext.getInExpression();
+        ShardingInValuesToken result = new ShardingInValuesToken(
+                inExpression.getRight().getStartIndex(),
+                inExpression.getRight().getStopIndex());
+        List<ExpressionSegment> valueExpressions = inValueContext.getValueExpressions();
+        Iterator<Collection<DataNode>> dataNodesIterator = routeContext.getOriginalDataNodes().isEmpty()
+                ? Collections.emptyIterator()
+                : routeContext.getOriginalDataNodes().iterator();
+        for (ExpressionSegment each : valueExpressions) {
+            Collection<DataNode> dataNodes = dataNodesIterator.hasNext() ? dataNodesIterator.next() : Collections.emptyList();
+            result.getInValueItems().add(new ShardingInValueItem(each, dataNodes));
+        }
+        return result;
+    }
+}

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/ShardingInValueItem.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/ShardingInValueItem.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.rewrite.token.pojo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.datanode.DataNode;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.ParameterMarkerType;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+
+import java.util.Collection;
+
+/**
+ * Sharding IN value item.
+ * Similar to InsertValue, stores ExpressionSegment directly.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class ShardingInValueItem {
+    
+    private final ExpressionSegment valueExpression;
+    
+    private final Collection<DataNode> dataNodes;
+    
+    @Override
+    public String toString() {
+        if (valueExpression instanceof ParameterMarkerExpressionSegment) {
+            ParameterMarkerExpressionSegment segment = (ParameterMarkerExpressionSegment) valueExpression;
+            return ParameterMarkerType.QUESTION == segment.getParameterMarkerType() ? "?" : "$" + (segment.getParameterMarkerIndex() + 1);
+        }
+        if (valueExpression instanceof LiteralExpressionSegment) {
+            Object literals = ((LiteralExpressionSegment) valueExpression).getLiterals();
+            if (null == literals) {
+                return "NULL";
+            }
+            return literals instanceof String ? "'" + literals + "'" : String.valueOf(literals);
+        }
+        return valueExpression.getText();
+    }
+}

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/ShardingInValuesToken.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/ShardingInValuesToken.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.rewrite.token.pojo;
+
+import lombok.Getter;
+import org.apache.shardingsphere.infra.datanode.DataNode;
+import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.RouteUnitAware;
+import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
+import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.Substitutable;
+import org.apache.shardingsphere.infra.route.context.RouteUnit;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+/**
+ * Sharding IN values token for literal value IN queries.
+ */
+@Getter
+public final class ShardingInValuesToken extends SQLToken implements Substitutable, RouteUnitAware {
+    
+    private final int stopIndex;
+    
+    private final Collection<ShardingInValueItem> inValueItems = new LinkedList<>();
+    
+    public ShardingInValuesToken(final int startIndex, final int stopIndex) {
+        super(startIndex);
+        this.stopIndex = stopIndex;
+    }
+    
+    @Override
+    public String toString(final RouteUnit routeUnit) {
+        StringBuilder result = new StringBuilder();
+        appendInValues(routeUnit, result);
+        if (result.length() > 0) {
+            result.delete(result.length() - 2, result.length());
+            return "(" + result.toString() + ")";
+        }
+        return "(NULL)";
+    }
+    
+    @Override
+    public String toString() {
+        return toString(null);
+    }
+    
+    private void appendInValues(final RouteUnit routeUnit, final StringBuilder stringBuilder) {
+        for (ShardingInValueItem each : inValueItems) {
+            if (isAppend(routeUnit, each)) {
+                stringBuilder.append(each).append(", ");
+            }
+        }
+    }
+    
+    private boolean isAppend(final RouteUnit routeUnit, final ShardingInValueItem inValueItem) {
+        if (inValueItem.getDataNodes().isEmpty() || null == routeUnit) {
+            return true;
+        }
+        for (DataNode each : inValueItem.getDataNodes()) {
+            if (routeUnit.findTableMapper(each.getDataSourceName(), each.getTableName()).isPresent()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/ShardingInValuesTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/ShardingInValuesTokenGeneratorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.rewrite.token.generator.impl;
+
+import org.apache.shardingsphere.infra.binder.context.segment.select.invalues.InValueContext;
+import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
+import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
+import org.apache.shardingsphere.infra.datanode.DataNode;
+import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
+import org.apache.shardingsphere.infra.route.context.RouteContext;
+import org.apache.shardingsphere.sharding.rewrite.token.pojo.ShardingInValuesToken;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.InExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ListExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ShardingInValuesTokenGeneratorTest {
+    
+    private final ShardingInValuesTokenGenerator generator = new ShardingInValuesTokenGenerator();
+    
+    @Test
+    void assertIsNotGenerateSQLTokenWithNotSelectStatementContext() {
+        assertFalse(generator.isGenerateSQLToken(mock(SQLStatementContext.class)));
+    }
+    
+    @Test
+    void assertIsNotGenerateSQLTokenWhenNotNeedInValuesRewrite() {
+        SelectStatementContext selectStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
+        when(selectStatementContext.isNeedInValuesRewrite()).thenReturn(false);
+        assertFalse(generator.isGenerateSQLToken(selectStatementContext));
+    }
+    
+    @Test
+    void assertIsGenerateSQLToken() {
+        SelectStatementContext selectStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
+        when(selectStatementContext.isNeedInValuesRewrite()).thenReturn(true);
+        assertTrue(generator.isGenerateSQLToken(selectStatementContext));
+    }
+    
+    @Test
+    void assertGenerateSQLTokensWithEmptyDataNodes() {
+        generator.setRouteContext(new RouteContext());
+        SelectStatementContext selectStatementContext = mockSelectStatementContext();
+        Collection<SQLToken> tokens = generator.generateSQLTokens(selectStatementContext);
+        assertThat(tokens.size(), is(1));
+        ShardingInValuesToken token = (ShardingInValuesToken) tokens.iterator().next();
+        assertThat(token.getInValueItems().size(), is(2));
+    }
+    
+    @Test
+    void assertGenerateSQLTokensWithDataNodes() {
+        RouteContext routeContext = new RouteContext();
+        routeContext.getOriginalDataNodes().add(Collections.singleton(new DataNode("ds_0", (String) null, "t_user_0")));
+        routeContext.getOriginalDataNodes().add(Collections.singleton(new DataNode("ds_1", (String) null, "t_user_1")));
+        generator.setRouteContext(routeContext);
+        SelectStatementContext selectStatementContext = mockSelectStatementContext();
+        Collection<SQLToken> tokens = generator.generateSQLTokens(selectStatementContext);
+        assertThat(tokens.size(), is(1));
+        ShardingInValuesToken token = (ShardingInValuesToken) tokens.iterator().next();
+        assertThat(token.getInValueItems().size(), is(2));
+        assertThat(token.getInValueItems().iterator().next().getDataNodes().size(), is(1));
+    }
+    
+    @Test
+    void assertGenerateSQLTokensWithNullInValueContext() {
+        generator.setRouteContext(new RouteContext());
+        SelectStatementContext selectStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
+        when(selectStatementContext.getInValueContext()).thenReturn(null);
+        Collection<SQLToken> tokens = generator.generateSQLTokens(selectStatementContext);
+        assertTrue(tokens.isEmpty());
+    }
+    
+    @Test
+    void assertGenerateSQLTokensWithEmptyInValueItems() {
+        generator.setRouteContext(new RouteContext());
+        SelectStatementContext selectStatementContext = mockSelectStatementContextWithEmptyValues();
+        Collection<SQLToken> tokens = generator.generateSQLTokens(selectStatementContext);
+        assertTrue(tokens.isEmpty());
+    }
+    
+    private SelectStatementContext mockSelectStatementContext() {
+        SelectStatementContext result = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
+        ListExpression listExpression = new ListExpression(10, 20);
+        listExpression.getItems().add(new LiteralExpressionSegment(11, 13, 100));
+        listExpression.getItems().add(new LiteralExpressionSegment(15, 17, 101));
+        InExpression inExpression = mock(InExpression.class);
+        when(inExpression.getRight()).thenReturn(listExpression);
+        List<ExpressionSegment> valueExpressions = Arrays.asList(
+                new LiteralExpressionSegment(11, 13, 100),
+                new LiteralExpressionSegment(15, 17, 101));
+        InValueContext inValueContext = mock(InValueContext.class);
+        when(inValueContext.getInExpression()).thenReturn(inExpression);
+        when(inValueContext.getValueExpressions()).thenReturn(valueExpressions);
+        when(result.getInValueContext()).thenReturn(inValueContext);
+        return result;
+    }
+    
+    private SelectStatementContext mockSelectStatementContextWithEmptyValues() {
+        SelectStatementContext result = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
+        ListExpression listExpression = new ListExpression(10, 20);
+        InExpression inExpression = mock(InExpression.class);
+        when(inExpression.getRight()).thenReturn(listExpression);
+        InValueContext inValueContext = mock(InValueContext.class);
+        when(inValueContext.getInExpression()).thenReturn(inExpression);
+        when(inValueContext.getValueExpressions()).thenReturn(Collections.emptyList());
+        when(result.getInValueContext()).thenReturn(inValueContext);
+        return result;
+    }
+}

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/ShardingInValueItemTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/ShardingInValueItemTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.rewrite.token.pojo;
+
+import org.apache.shardingsphere.infra.datanode.DataNode;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.ParameterMarkerType;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ShardingInValueItemTest {
+    
+    @Test
+    void assertToStringWithParameterMarkerQuestion() {
+        ParameterMarkerExpressionSegment segment = new ParameterMarkerExpressionSegment(0, 1, 0, ParameterMarkerType.QUESTION);
+        ShardingInValueItem item = new ShardingInValueItem(segment, Collections.emptyList());
+        assertThat(item.toString(), is("?"));
+    }
+    
+    @Test
+    void assertToStringWithParameterMarkerDollar() {
+        ParameterMarkerExpressionSegment segment = new ParameterMarkerExpressionSegment(0, 1, 0, ParameterMarkerType.DOLLAR);
+        ShardingInValueItem item = new ShardingInValueItem(segment, Collections.emptyList());
+        assertThat(item.toString(), is("$1"));
+    }
+    
+    @Test
+    void assertToStringWithLiteralStringValue() {
+        LiteralExpressionSegment segment = new LiteralExpressionSegment(0, 5, "test");
+        ShardingInValueItem item = new ShardingInValueItem(segment, Collections.emptyList());
+        assertThat(item.toString(), is("'test'"));
+    }
+    
+    @Test
+    void assertToStringWithLiteralIntegerValue() {
+        LiteralExpressionSegment segment = new LiteralExpressionSegment(0, 3, 100);
+        ShardingInValueItem item = new ShardingInValueItem(segment, Collections.emptyList());
+        assertThat(item.toString(), is("100"));
+    }
+    
+    @Test
+    void assertToStringWithLiteralNullValue() {
+        LiteralExpressionSegment segment = new LiteralExpressionSegment(0, 3, null);
+        ShardingInValueItem item = new ShardingInValueItem(segment, Collections.emptyList());
+        assertThat(item.toString(), is("NULL"));
+    }
+    
+    @Test
+    void assertToStringWithOtherExpressionSegment() {
+        ExpressionSegment segment = mock(ExpressionSegment.class);
+        when(segment.getText()).thenReturn("col + 1");
+        ShardingInValueItem item = new ShardingInValueItem(segment, Collections.emptyList());
+        assertThat(item.toString(), is("col + 1"));
+    }
+    
+    @Test
+    void assertGetDataNodes() {
+        LiteralExpressionSegment segment = new LiteralExpressionSegment(0, 3, 100);
+        DataNode dataNode = new DataNode("ds_0", (String) null, "t_user_0");
+        ShardingInValueItem item = new ShardingInValueItem(segment, Collections.singleton(dataNode));
+        assertThat(item.getDataNodes().size(), is(1));
+        assertThat(item.getDataNodes().iterator().next(), is(dataNode));
+    }
+}

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/ShardingInValuesTokenTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/pojo/ShardingInValuesTokenTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.rewrite.token.pojo;
+
+import org.apache.shardingsphere.infra.datanode.DataNode;
+import org.apache.shardingsphere.infra.route.context.RouteMapper;
+import org.apache.shardingsphere.infra.route.context.RouteUnit;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ShardingInValuesTokenTest {
+    
+    @Test
+    void assertToStringWithRouteUnit() {
+        ShardingInValuesToken token = createInValuesToken();
+        RouteUnit routeUnit = createRouteUnit();
+        assertThat(token.toString(routeUnit), is("(100, 101)"));
+    }
+    
+    @Test
+    void assertToStringWithoutRouteUnit() {
+        ShardingInValuesToken token = createInValuesTokenWithEmptyDataNodes();
+        assertThat(token.toString(), is("(100, 101)"));
+    }
+    
+    @Test
+    void assertToStringWithNullRouteUnitAndNonEmptyDataNodes() {
+        ShardingInValuesToken token = createInValuesToken();
+        assertThat(token.toString(null), is("(100, 101)"));
+    }
+    
+    @Test
+    void assertToStringWithFilteredValues() {
+        ShardingInValuesToken token = new ShardingInValuesToken(0, 10);
+        DataNode dataNode1 = new DataNode("ds_0", (String) null, "t_user_0");
+        DataNode dataNode2 = new DataNode("ds_1", (String) null, "t_user_1");
+        token.getInValueItems().add(new ShardingInValueItem(new LiteralExpressionSegment(0, 3, 100), Collections.singleton(dataNode1)));
+        token.getInValueItems().add(new ShardingInValueItem(new LiteralExpressionSegment(5, 8, 101), Collections.singleton(dataNode2)));
+        RouteUnit routeUnit = createRouteUnit();
+        assertThat(token.toString(routeUnit), is("(100)"));
+    }
+    
+    @Test
+    void assertToStringWithEmptyInValueItems() {
+        ShardingInValuesToken token = new ShardingInValuesToken(0, 10);
+        assertThat(token.toString(), is("(NULL)"));
+    }
+    
+    @Test
+    void assertToStringWithAllValuesFiltered() {
+        ShardingInValuesToken token = new ShardingInValuesToken(0, 10);
+        DataNode dataNode = new DataNode("ds_other", (String) null, "t_other");
+        token.getInValueItems().add(new ShardingInValueItem(new LiteralExpressionSegment(0, 3, 100), Collections.singleton(dataNode)));
+        RouteUnit routeUnit = createRouteUnit();
+        assertThat(token.toString(routeUnit), is("(NULL)"));
+    }
+    
+    @Test
+    void assertGetStopIndex() {
+        ShardingInValuesToken token = new ShardingInValuesToken(5, 15);
+        assertThat(token.getStopIndex(), is(15));
+    }
+    
+    private ShardingInValuesToken createInValuesToken() {
+        ShardingInValuesToken result = new ShardingInValuesToken(0, 10);
+        DataNode dataNode = new DataNode("ds_0", (String) null, "t_user_0");
+        result.getInValueItems().add(new ShardingInValueItem(new LiteralExpressionSegment(0, 3, 100), Collections.singleton(dataNode)));
+        result.getInValueItems().add(new ShardingInValueItem(new LiteralExpressionSegment(5, 8, 101), Collections.singleton(dataNode)));
+        return result;
+    }
+    
+    private ShardingInValuesToken createInValuesTokenWithEmptyDataNodes() {
+        ShardingInValuesToken result = new ShardingInValuesToken(0, 10);
+        result.getInValueItems().add(new ShardingInValueItem(new LiteralExpressionSegment(0, 3, 100), Collections.emptyList()));
+        result.getInValueItems().add(new ShardingInValueItem(new LiteralExpressionSegment(5, 8, 101), Collections.emptyList()));
+        return result;
+    }
+    
+    private RouteUnit createRouteUnit() {
+        RouteMapper dataSourceMapper = new RouteMapper("ds_0", "ds_0");
+        RouteMapper tableMapper = new RouteMapper("t_user", "t_user_0");
+        return new RouteUnit(dataSourceMapper, Arrays.asList(tableMapper));
+    }
+}

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/invalues/InValueContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/invalues/InValueContext.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.context.segment.select.invalues;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.InExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ListExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.extractor.ExpressionExtractor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * IN value context.
+ * Stores structural information about IN expression, similar to InsertValueContext.
+ */
+@Getter
+@ToString
+public final class InValueContext {
+    
+    private final InExpression inExpression;
+    
+    private final int parameterCount;
+    
+    private final int parametersOffset;
+    
+    private final List<ExpressionSegment> valueExpressions;
+    
+    private final List<ParameterMarkerExpressionSegment> parameterMarkerExpressions;
+    
+    private final List<Object> parameters;
+    
+    /**
+     * Constructor for IN expression.
+     *
+     * @param inExpression IN expression segment
+     * @param params all parameters
+     * @param parametersOffset parameter offset
+     */
+    public InValueContext(final InExpression inExpression, final List<Object> params, final int parametersOffset) {
+        this.inExpression = inExpression;
+        this.parametersOffset = parametersOffset;
+        this.valueExpressions = getValueExpressions(inExpression);
+        this.parameterMarkerExpressions = ExpressionExtractor.getParameterMarkerExpressions(valueExpressions);
+        this.parameterCount = parameterMarkerExpressions.size();
+        this.parameters = getParameters(params, parametersOffset);
+    }
+    
+    private List<ExpressionSegment> getValueExpressions(final InExpression inExpression) {
+        ExpressionSegment right = inExpression.getRight();
+        if (right instanceof ListExpression) {
+            List<ExpressionSegment> result = new ArrayList<>(((ListExpression) right).getItems().size());
+            result.addAll(((ListExpression) right).getItems());
+            return result;
+        }
+        return Collections.emptyList();
+    }
+    
+    private List<Object> getParameters(final List<Object> params, final int parametersOffset) {
+        if (null == params || params.isEmpty() || 0 == parameterCount) {
+            return Collections.emptyList();
+        }
+        List<Object> result = new ArrayList<>(parameterCount);
+        result.addAll(params.subList(parametersOffset, parametersOffset + parameterCount));
+        return result;
+    }
+    
+    /**
+     * Get grouped parameters for IN query (each IN value is a group).
+     * Similar to InsertValueContext.getParameters().
+     * Only returns parameterized values, not literal values.
+     *
+     * @return grouped parameters, each inner list contains one IN value
+     */
+    public List<List<Object>> getGroupedParameters() {
+        List<List<Object>> result = new ArrayList<>(parameterCount);
+        int paramIndex = 0;
+        for (ExpressionSegment each : valueExpressions) {
+            if (each instanceof ParameterMarkerExpressionSegment) {
+                if (paramIndex < parameters.size()) {
+                    result.add(Collections.singletonList(parameters.get(paramIndex++)));
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementBindingContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementBindingContext.java
@@ -18,14 +18,25 @@
 package org.apache.shardingsphere.infra.binder.context.statement.type.dml;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.pagination.DialectPaginationOption;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
+import org.apache.shardingsphere.infra.binder.context.segment.select.invalues.InValueContext;
 import org.apache.shardingsphere.infra.binder.context.segment.select.pagination.PaginationContext;
 import org.apache.shardingsphere.infra.binder.context.segment.select.pagination.engine.PaginationContextEngine;
 import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.InExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ListExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -38,11 +49,136 @@ public final class SelectStatementBindingContext implements SQLStatementContext 
     @Getter
     private final PaginationContext paginationContext;
     
+    @Getter
+    private final InValueContext inValueContext;
+    
+    @Getter
+    @Setter
+    private boolean needInValuesRewrite;
+    
     public SelectStatementBindingContext(final List<Object> params, final SelectStatementBaseContext baseContext) {
         this.baseContext = baseContext;
         DialectPaginationOption paginationOption = new DatabaseTypeRegistry(baseContext.getSqlStatement().getDatabaseType()).getDialectDatabaseMetaData().getPaginationOption();
         paginationContext =
                 new PaginationContextEngine(paginationOption).createPaginationContext(baseContext.getSqlStatement(), baseContext.getProjectionsContext(), params, baseContext.getWhereSegments());
+        inValueContext = createInValueContext(baseContext.getSqlStatement(), params);
+    }
+    
+    private InExpression extractInExpression(final SelectStatement sqlStatement) {
+        if (!sqlStatement.getWhere().isPresent()) {
+            return null;
+        }
+        return findInExpression(sqlStatement.getWhere().get().getExpr());
+    }
+    
+    private InExpression findInExpression(final ExpressionSegment expression) {
+        Deque<ExpressionSegment> stack = new LinkedList<>();
+        stack.push(expression);
+        while (!stack.isEmpty()) {
+            ExpressionSegment current = stack.pop();
+            if (current instanceof InExpression) {
+                InExpression inExpr = (InExpression) current;
+                if (inExpr.getRight() instanceof ListExpression) {
+                    return inExpr;
+                }
+            }
+            if (current instanceof BinaryOperationExpression) {
+                BinaryOperationExpression binaryExpr = (BinaryOperationExpression) current;
+                stack.push(binaryExpr.getRight());
+                stack.push(binaryExpr.getLeft());
+            }
+        }
+        return null;
+    }
+    
+    private InValueContext createInValueContext(final SelectStatement sqlStatement, final List<Object> params) {
+        InExpression inExpression = extractInExpression(sqlStatement);
+        if (null == inExpression) {
+            return null;
+        }
+        int parametersOffset = calculateInParametersOffset(params, inExpression);
+        return new InValueContext(inExpression, params, parametersOffset);
+    }
+    
+    private int calculateInParametersOffset(final List<Object> params, final InExpression inExpression) {
+        if (null == params || params.isEmpty()) {
+            return 0;
+        }
+        ExpressionSegment right = inExpression.getRight();
+        if (!(right instanceof ListExpression)) {
+            return 0;
+        }
+        for (ExpressionSegment each : ((ListExpression) right).getItems()) {
+            if (each instanceof ParameterMarkerExpressionSegment) {
+                return ((ParameterMarkerExpressionSegment) each).getParameterIndex();
+            }
+        }
+        return 0;
+    }
+    
+    /**
+     * Check if has IN expression.
+     *
+     * @return true if has IN expression
+     */
+    public boolean hasInExpression() {
+        return null != inValueContext;
+    }
+    
+    /**
+     * Get grouped parameters for IN query.
+     *
+     * @return grouped parameters
+     */
+    public List<List<Object>> getGroupedParameters() {
+        if (null == inValueContext) {
+            return Collections.emptyList();
+        }
+        return inValueContext.getGroupedParameters();
+    }
+    
+    /**
+     * Get generic parameters before IN expression.
+     *
+     * @param params all parameters
+     * @return parameters before IN expression
+     */
+    public List<Object> getBeforeGenericParameters(final List<Object> params) {
+        if (null == inValueContext || null == params || params.isEmpty()) {
+            return Collections.emptyList();
+        }
+        int parametersOffset = inValueContext.getParametersOffset();
+        if (parametersOffset == 0) {
+            return Collections.emptyList();
+        }
+        List<Object> result = new ArrayList<>();
+        for (int i = 0; i < parametersOffset && i < params.size(); i++) {
+            result.add(params.get(i));
+        }
+        return result;
+    }
+    
+    /**
+     * Get generic parameters after IN expression.
+     *
+     * @param params all parameters
+     * @return parameters after IN expression
+     */
+    public List<Object> getAfterGenericParameters(final List<Object> params) {
+        if (null == inValueContext || null == params || params.isEmpty()) {
+            return Collections.emptyList();
+        }
+        int parametersOffset = inValueContext.getParametersOffset();
+        int parameterCount = inValueContext.getParameterCount();
+        int afterStart = parametersOffset + parameterCount;
+        if (afterStart >= params.size()) {
+            return Collections.emptyList();
+        }
+        List<Object> result = new ArrayList<>();
+        for (int i = afterStart; i < params.size(); i++) {
+            result.add(params.get(i));
+        }
+        return result;
     }
     
     @Override

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementContext.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.infra.binder.context.available.WhereContextAvai
 import org.apache.shardingsphere.infra.binder.context.aware.ParameterAware;
 import org.apache.shardingsphere.infra.binder.context.segment.select.groupby.GroupByContext;
 import org.apache.shardingsphere.infra.binder.context.segment.select.orderby.OrderByContext;
+import org.apache.shardingsphere.infra.binder.context.segment.select.invalues.InValueContext;
 import org.apache.shardingsphere.infra.binder.context.segment.select.pagination.PaginationContext;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.ProjectionsContext;
 import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
@@ -266,12 +267,77 @@ public final class SelectStatementContext implements SQLStatementContext, WhereC
     }
     
     /**
+     * Set need IN values rewrite.
+     *
+     * @param needInValuesRewrite need IN values rewrite
+     */
+    public void setNeedInValuesRewrite(final boolean needInValuesRewrite) {
+        bindingContext.setNeedInValuesRewrite(needInValuesRewrite);
+    }
+    
+    /**
+     * Judge whether need IN values rewrite or not.
+     *
+     * @return whether need IN values rewrite or not
+     */
+    public boolean isNeedInValuesRewrite() {
+        return bindingContext.isNeedInValuesRewrite();
+    }
+    
+    /**
      * Get pagination context.
      *
      * @return pagination context
      */
     public PaginationContext getPaginationContext() {
         return bindingContext.getPaginationContext();
+    }
+    
+    /**
+     * Check if this SELECT has IN expression.
+     *
+     * @return true if has IN expression
+     */
+    public boolean hasInExpression() {
+        return bindingContext.hasInExpression();
+    }
+    
+    /**
+     * Get IN value context.
+     *
+     * @return IN value context
+     */
+    public InValueContext getInValueContext() {
+        return bindingContext.getInValueContext();
+    }
+    
+    /**
+     * Get grouped parameters for IN query.
+     *
+     * @return grouped parameters
+     */
+    public List<List<Object>> getGroupedParameters() {
+        return bindingContext.getGroupedParameters();
+    }
+    
+    /**
+     * Get generic parameters before IN expression.
+     *
+     * @param params all parameters
+     * @return parameters before IN expression
+     */
+    public List<Object> getBeforeGenericParameters(final List<Object> params) {
+        return bindingContext.getBeforeGenericParameters(params);
+    }
+    
+    /**
+     * Get generic parameters after IN expression.
+     *
+     * @param params all parameters
+     * @return parameters after IN expression
+     */
+    public List<Object> getAfterGenericParameters(final List<Object> params) {
+        return bindingContext.getAfterGenericParameters(params);
     }
     
     @Override

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/invalues/InValueContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/invalues/InValueContextTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.context.segment.select.invalues;
+
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.InExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ListExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InValueContextTest {
+    
+    @Test
+    void assertConstructorWithParameterMarkers() {
+        InExpression inExpression = createInExpressionWithParameterMarkers(3);
+        List<Object> params = Arrays.asList(100, 101, 102);
+        InValueContext context = new InValueContext(inExpression, params, 0);
+        assertThat(context.getParameterCount(), is(3));
+        assertThat(context.getParametersOffset(), is(0));
+        assertThat(context.getParameters(), is(params));
+        assertThat(context.getValueExpressions().size(), is(3));
+    }
+    
+    @Test
+    void assertConstructorWithParameterOffset() {
+        InExpression inExpression = createInExpressionWithParameterMarkers(2);
+        List<Object> params = Arrays.asList("before", 100, 101, "after");
+        InValueContext context = new InValueContext(inExpression, params, 1);
+        assertThat(context.getParameterCount(), is(2));
+        assertThat(context.getParametersOffset(), is(1));
+        assertThat(context.getParameters(), is(Arrays.asList(100, 101)));
+    }
+    
+    @Test
+    void assertConstructorWithLiteralValues() {
+        InExpression inExpression = createInExpressionWithLiterals(100, 101, 102);
+        InValueContext context = new InValueContext(inExpression, Collections.emptyList(), 0);
+        assertThat(context.getParameterCount(), is(0));
+        assertThat(context.getValueExpressions().size(), is(3));
+        assertTrue(context.getParameters().isEmpty());
+    }
+    
+    @Test
+    void assertConstructorWithEmptyParams() {
+        InExpression inExpression = createInExpressionWithParameterMarkers(2);
+        InValueContext context = new InValueContext(inExpression, Collections.emptyList(), 0);
+        assertThat(context.getParameterCount(), is(2));
+        assertTrue(context.getParameters().isEmpty());
+        assertTrue(context.getGroupedParameters().isEmpty());
+    }
+    
+    @Test
+    void assertConstructorWithNullParams() {
+        InExpression inExpression = createInExpressionWithParameterMarkers(2);
+        InValueContext context = new InValueContext(inExpression, null, 0);
+        assertThat(context.getParameterCount(), is(2));
+        assertTrue(context.getParameters().isEmpty());
+    }
+    
+    @Test
+    void assertGetGroupedParametersWithParameterMarkers() {
+        InExpression inExpression = createInExpressionWithParameterMarkers(3);
+        List<Object> params = Arrays.asList(100, 101, 102);
+        InValueContext context = new InValueContext(inExpression, params, 0);
+        List<List<Object>> grouped = context.getGroupedParameters();
+        assertThat(grouped.size(), is(3));
+        assertThat(grouped.get(0), is(Collections.singletonList(100)));
+        assertThat(grouped.get(1), is(Collections.singletonList(101)));
+        assertThat(grouped.get(2), is(Collections.singletonList(102)));
+    }
+    
+    @Test
+    void assertGetGroupedParametersWithLiteralValues() {
+        InExpression inExpression = createInExpressionWithLiterals(100, 101, 102);
+        InValueContext context = new InValueContext(inExpression, Collections.emptyList(), 0);
+        List<List<Object>> grouped = context.getGroupedParameters();
+        assertTrue(grouped.isEmpty());
+    }
+    
+    @Test
+    void assertGetGroupedParametersWithMixedValues() {
+        ListExpression listExpression = new ListExpression(0, 50);
+        listExpression.getItems().add(new ParameterMarkerExpressionSegment(0, 1, 0));
+        listExpression.getItems().add(new LiteralExpressionSegment(5, 8, 200));
+        listExpression.getItems().add(new ParameterMarkerExpressionSegment(10, 11, 1));
+        InExpression inExpression = new InExpression(0, 50,
+                new ColumnSegment(0, 10, new IdentifierValue("user_id")), listExpression, false);
+        List<Object> params = Arrays.asList(100, 300);
+        InValueContext context = new InValueContext(inExpression, params, 0);
+        List<List<Object>> grouped = context.getGroupedParameters();
+        assertThat(grouped.size(), is(2));
+        assertThat(grouped.get(0), is(Collections.singletonList(100)));
+        assertThat(grouped.get(1), is(Collections.singletonList(300)));
+    }
+    
+    @Test
+    void assertGetGroupedParametersWithEmptyResult() {
+        InExpression inExpression = createInExpressionWithNonListRight();
+        InValueContext context = new InValueContext(inExpression, Collections.emptyList(), 0);
+        assertTrue(context.getGroupedParameters().isEmpty());
+    }
+    
+    @Test
+    void assertGetParametersWithZeroParameterCount() {
+        InExpression inExpression = createInExpressionWithLiterals(100, 101);
+        List<Object> params = Arrays.asList("some", "params");
+        InValueContext context = new InValueContext(inExpression, params, 0);
+        assertTrue(context.getParameters().isEmpty());
+    }
+    
+    @Test
+    void assertGetGroupedParametersWithOtherExpressionType() {
+        ListExpression listExpression = new ListExpression(0, 50);
+        listExpression.getItems().add(new ParameterMarkerExpressionSegment(0, 1, 0));
+        listExpression.getItems().add(new ColumnSegment(5, 15, new IdentifierValue("col")));
+        InExpression inExpression = new InExpression(0, 50,
+                new ColumnSegment(0, 10, new IdentifierValue("user_id")), listExpression, false);
+        List<Object> params = Collections.singletonList(100);
+        InValueContext context = new InValueContext(inExpression, params, 0);
+        List<List<Object>> grouped = context.getGroupedParameters();
+        assertThat(grouped.size(), is(1));
+        assertThat(grouped.get(0), is(Collections.singletonList(100)));
+    }
+    
+    private InExpression createInExpressionWithParameterMarkers(final int count) {
+        ListExpression listExpression = new ListExpression(0, 50);
+        for (int i = 0; i < count; i++) {
+            listExpression.getItems().add(new ParameterMarkerExpressionSegment(i * 3, i * 3 + 1, i));
+        }
+        return new InExpression(0, 50, new ColumnSegment(0, 10, new IdentifierValue("user_id")), listExpression, false);
+    }
+    
+    private InExpression createInExpressionWithLiterals(final Object... values) {
+        ListExpression listExpression = new ListExpression(0, 50);
+        int pos = 0;
+        for (Object value : values) {
+            listExpression.getItems().add(new LiteralExpressionSegment(pos, pos + 3, value));
+            pos += 5;
+        }
+        return new InExpression(0, 50, new ColumnSegment(0, 10, new IdentifierValue("user_id")), listExpression, false);
+    }
+    
+    private InExpression createInExpressionWithNonListRight() {
+        return new InExpression(0, 50,
+                new ColumnSegment(0, 10, new IdentifierValue("user_id")),
+                new ColumnSegment(20, 30, new IdentifierValue("other_col")), false);
+    }
+}

--- a/test/it/rewriter/src/test/resources/scenario/sharding/case/dml/select.xml
+++ b/test/it/rewriter/src/test/resources/scenario/sharding/case/dml/select.xml
@@ -279,26 +279,26 @@
     
     <rewrite-assertion id="select_limit_with_multiple_route_for_parameters_for_mysql" db-types="MySQL">
         <input sql="SELECT * FROM t_account WHERE account_id IN (100, 101) LIMIT ?, ?" parameters="100, 10" />
-        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) LIMIT ?, ?" parameters="0, 110" />
-        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) LIMIT ?, ?" parameters="0, 110" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100) LIMIT ?, ?" parameters="0, 110" />
+        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (101) LIMIT ?, ?" parameters="0, 110" />
     </rewrite-assertion>
-    
+
     <rewrite-assertion id="select_limit_with_multiple_route_for_literals_for_mysql" db-types="MySQL">
         <input sql="SELECT * FROM t_account WHERE account_id IN (100, 101) LIMIT 100, 10" />
-        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) LIMIT 0, 110" />
-        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) LIMIT 0, 110" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100) LIMIT 0, 110" />
+        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (101) LIMIT 0, 110" />
     </rewrite-assertion>
-    
+
     <rewrite-assertion id="select_limit_with_multiple_route_with_memory_group_by_for_parameters_for_mysql" db-types="MySQL">
         <input sql="SELECT * FROM t_account WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ?, ?" parameters="100, 10" />
-        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ?, ?" parameters="0, 2147483647" />
-        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ?, ?" parameters="0, 2147483647" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100) GROUP BY account_id ORDER BY account_id DESC LIMIT ?, ?" parameters="0, 2147483647" />
+        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (101) GROUP BY account_id ORDER BY account_id DESC LIMIT ?, ?" parameters="0, 2147483647" />
     </rewrite-assertion>
-    
+
     <rewrite-assertion id="select_limit_with_multiple_route_with_memory_group_by_for_literals_for_mysql" db-types="MySQL">
         <input sql="SELECT * FROM t_account WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 100, 10" />
-        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 0, 2147483647" />
-        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 0, 2147483647" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100) GROUP BY account_id ORDER BY account_id DESC LIMIT 0, 2147483647" />
+        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (101) GROUP BY account_id ORDER BY account_id DESC LIMIT 0, 2147483647" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_limit_with_single_route_for_parameters_for_postgresql" db-types="PostgreSQL,openGauss">
@@ -313,26 +313,26 @@
     
     <rewrite-assertion id="select_limit_with_multiple_route_for_parameters_for_postgresql" db-types="PostgreSQL,openGauss">
         <input sql="SELECT * FROM t_account WHERE account_id IN (100, 101) LIMIT ? OFFSET ?" parameters="10, 100" />
-        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) LIMIT ? OFFSET ?" parameters="110, 0" />
-        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) LIMIT ? OFFSET ?" parameters="110, 0" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100) LIMIT ? OFFSET ?" parameters="110, 0" />
+        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (101) LIMIT ? OFFSET ?" parameters="110, 0" />
     </rewrite-assertion>
-    
+
     <rewrite-assertion id="select_limit_with_multiple_route_for_literals_for_postgresql" db-types="PostgreSQL,openGauss">
         <input sql="SELECT * FROM t_account WHERE account_id IN (100, 101) LIMIT 10 OFFSET 100" />
-        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) LIMIT 110 OFFSET 0" />
-        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) LIMIT 110 OFFSET 0" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100) LIMIT 110 OFFSET 0" />
+        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (101) LIMIT 110 OFFSET 0" />
     </rewrite-assertion>
-    
+
     <rewrite-assertion id="select_limit_with_multiple_route_with_memory_group_by_for_parameters_for_postgresql" db-types="PostgreSQL,openGauss">
         <input sql="SELECT * FROM t_account WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ? OFFSET ?" parameters="10, 100" />
-        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ? OFFSET ?" parameters="2147483647, 0" />
-        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT ? OFFSET ?" parameters="2147483647, 0" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100) GROUP BY account_id ORDER BY account_id DESC LIMIT ? OFFSET ?" parameters="2147483647, 0" />
+        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (101) GROUP BY account_id ORDER BY account_id DESC LIMIT ? OFFSET ?" parameters="2147483647, 0" />
     </rewrite-assertion>
-    
+
     <rewrite-assertion id="select_limit_with_multiple_route_with_memory_group_by_for_literals_for_postgresql" db-types="PostgreSQL,openGauss">
         <input sql="SELECT * FROM t_account WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 10 OFFSET 100" />
-        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 2147483647 OFFSET 0" />
-        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC LIMIT 2147483647 OFFSET 0" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id IN (100) GROUP BY account_id ORDER BY account_id DESC LIMIT 2147483647 OFFSET 0" />
+        <output sql="SELECT * FROM t_account_1 WHERE account_id IN (101) GROUP BY account_id ORDER BY account_id DESC LIMIT 2147483647 OFFSET 0" />
     </rewrite-assertion>
     
     <!-- FIXME -->
@@ -444,7 +444,7 @@
         <output sql="SELECT * FROM (SELECT TOP(?) row_number() OVER (ORDER BY o.account_id) AS rownum_, o.account_id FROM t_account_0 o WHERE o.account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC) AS row_ WHERE row_.rownum_ &gt; ?" parameters="110, 0" />
         <output sql="SELECT * FROM (SELECT TOP(?) row_number() OVER (ORDER BY o.account_id) AS rownum_, o.account_id FROM t_account_1 o WHERE o.account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC) AS row_ WHERE row_.rownum_ &gt; ?" parameters="110, 0" />
     </rewrite-assertion>
-    
+
     <rewrite-assertion id="select_top_with_multiple_route_with_memory_group_by_for_literals_for_sqlserver" db-types="SQLServer">
         <input sql="SELECT * FROM (SELECT TOP(110) row_number() OVER (ORDER BY o.account_id) AS rownum_, o.account_id FROM t_account o WHERE o.account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC) AS row_ WHERE row_.rownum_ &gt; 100" />
         <output sql="SELECT * FROM (SELECT TOP(110) row_number() OVER (ORDER BY o.account_id) AS rownum_, o.account_id FROM t_account_0 o WHERE o.account_id IN (100, 101) GROUP BY account_id ORDER BY account_id DESC) AS row_ WHERE row_.rownum_ &gt; 0" />


### PR DESCRIPTION
 Fixes #37297.

  Changes proposed in this pull request:
    - Add `InValueContext` to store IN expression structural information (aligned with `InsertValueContext`)
    - Add `ShardingInValuesToken` and `ShardingInValueItem` for IN values rewriting based on route unit
    - Add `ShardingInValuesTokenGenerator` to generate tokens for IN expressions in WHERE clause
    - Update `ShardingStandardRouteEngine` to split IN query conditions and route each value individually
    - Update `SelectStatementContext` to support IN expression context, grouped parameter building, and `needInValuesRewrite` flag
    - Update `SQLRewriteContext` to use `GroupedParameterBuilder` for IN queries (aligned with INSERT VALUES pattern)

  ## Summary

  This PR implements IN query batch split rewrite fully aligned with the existing INSERT VALUES pattern. When a SELECT query contains IN expression on a sharding key, each value is routed individually and       
  the SQL is rewritten per shard to only include values that route to that specific shard.

  **Architecture Design:**
  | Phase | Responsibility | Storage |
  |-------|----------------|---------|
  | Binder | Extract IN parameter structure | `SelectStatementContext.inValueContext` (static) |
  | Router | Decide if rewrite needed | `SelectStatementContext.needInValuesRewrite` (dynamic) |
  | Rewriter | Combine both for rewriting | From StatementContext + RouteContext |

  **Before:** All shards receive `SELECT * FROM t_order WHERE user_id IN (100, 101, 102, 103)`

  **After:**
  - ds_0: `SELECT * FROM t_order_0 WHERE user_id IN (100, 102)`
  - ds_1: `SELECT * FROM t_order_1 WHERE user_id IN (101, 103)`

  ## Technical Decisions

  ### Why use `needInValuesRewrite` flag?

  **Problem**: Unlike INSERT VALUES, IN column may **not** be a sharding key.

  **Solution**: Use `needInValuesRewrite` flag to distinguish:
  - **Set to true**: IN column is sharding key → need IN values rewrite
  - **Set to false**: IN column is not sharding key → all shards execute same SQL

  ### Why reuse `originalDataNodes`?

  **Advantage**: Fully aligned with INSERT VALUES pattern - both use `RouteContext.originalDataNodes` to store per-value routing information, enabling unified `GroupedParameterBuilder` processing in rewrite     
  phase.

  | Scenario | originalDataNodes | needInValuesRewrite | Behavior |
  |----------|------------------|-------------------|----------|
  | IN sharding key | Fine-grained `[[ds_0], [ds_1], ...]` | `true` | Generate token, filter params ✅ |
  | IN non-sharding key | Coarse-grained `[[ds_0, ds_1, ds_2]]` | `false` | No token, all shards same SQL ✅ |

  **Limitation**: Since `originalDataNodes` is a single-dimensional list, this implementation currently supports only **single IN expression**. Multiple IN expressions (e.g., `WHERE col1 IN (...) AND col2 IN    
   (...)`) would require multi-dimensional routing storage, which is not supported in current design.

  ### Why rebuild InValueContext in bindParameters()?

  **Problem**: PreparedStatement uses empty parameters when creating StatementContext, actual parameters provided via callback.

  **Solution**: Rebuild `InValueContext` with actual parameters in `bindParameters()` callback, aligned with `InsertStatementContext` pattern.

  ## Key Benefits

  - Zero infra module API changes (uses existing `ParameterAware` callback)
  - Fully aligned with INSERT VALUES design pattern
  - Clear separation of concerns between Binder/Router/Rewriter
  - Supports both Statement and PreparedStatement modes

 ## Limitations

  This implementation has the following design constraints:

  1. **Single IN Expression Only**: Multiple IN expressions (e.g., `WHERE col1 IN (...) AND col2 IN (...)`) are not supported. The `originalDataNodes` storage is a single-dimensional list that maps each IN      
  value to its routing target sequentially.

  2. **SELECT Statements Only**: IN query batch split is only supported for SELECT statements. UPDATE/DELETE statements with IN expressions will use standard routing.

  3. **Simple Column Reference**: The IN expression's left side must be a simple column reference (e.g., `user_id IN (...)`). Expression-based IN conditions (e.g., `LOWER(col) IN (...)`) are not supported.      

  4. **Homogeneous Value Types**: All IN values must be either all literals OR all parameter markers. Mixed modes (e.g., `IN (?, 100, ?)`) are not supported.

  5. **Single Sharding Column**: Only single-column sharding strategies are supported. Composite sharding keys are not eligible for IN query batch split.

  6. **Single Sharding Condition**: Only queries with exactly one sharding condition targeting the IN expression column are supported.

  These limitations are by design to ensure predictable routing behavior and may be extended in future versions.

  ---

  Before committing this PR, I'm sure that I have checked the following options:
  - [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
  - [x] I have self-reviewed the commit code.
  - [x] I have (or in comment I request) added corresponding labels for the pull request.
  - [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
  - [ ] I have made corresponding changes to the documentation.
  - [x] I have added corresponding unit tests for my changes.
  - [x] I have updated the Release Notes of the current development version.
