### PR TITLE
Fix nativeTest failing under GraalVM Native Image due to class changes

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -46,19 +46,16 @@ jobs:
       max-parallel: 20
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest', 'windows-2025' ]
+        os: [ 'ubuntu-latest', 'windows-latest' ]
         java-version: [ '24.0.2' ]
     steps:
       - uses: actions/checkout@v4
+      - name: Free Disk Space on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: ./test/native/src/test/resources/test-native/sh/free-disk-space.sh
       - name: Setup Rancher Desktop without GUI on Windows Server
-        if: matrix.os == 'windows-2025'
+        if: matrix.os == 'windows-latest'
         run: |
-          iwr -Uri "https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1" -OutFile uninstall-docker-ce.ps1
-          .\uninstall-docker-ce.ps1 -Force
-          ri .\uninstall-docker-ce.ps1
-          winget install --id jazzdelightsme.WingetPathUpdater --source winget
-          winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
-          rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
           ./test/native/src/test/resources/test-native/ps1/wait-for-rancher-desktop-backend.ps1
           "PATH=$env:PATH" >> $env:GITHUB_ENV
       - uses: graalvm/setup-graalvm@v1
@@ -76,7 +73,7 @@ jobs:
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-
       # TODO Remove this workaround after. The graalvm native image built with windows server is missing some GRMs for testcontainers
       - name: Run test with GraalVM CE
-        if: matrix.os == 'windows-2025'
+        if: matrix.os == 'windows-latest'
         run: ./mvnw -PgenerateMetadata -e -T 1C clean verify
       - name: Run nativeTest with GraalVM CE for ${{ matrix.java-version }}
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -110,18 +110,15 @@ jobs:
       max-parallel: 20
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-2025 ]
+        os: [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
+      - name: Free Disk Space on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: ./test/native/src/test/resources/test-native/sh/free-disk-space.sh
       - name: Setup Rancher Desktop without GUI on Windows Server
-        if: matrix.os == 'windows-2025'
+        if: matrix.os == 'windows-latest'
         run: |
-          iwr -Uri "https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1" -OutFile uninstall-docker-ce.ps1
-          .\uninstall-docker-ce.ps1 -Force
-          ri .\uninstall-docker-ce.ps1
-          winget install --id jazzdelightsme.WingetPathUpdater --source winget
-          winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
-          rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
           ./test/native/src/test/resources/test-native/ps1/wait-for-rancher-desktop-backend.ps1
           "PATH=$env:PATH" >> $env:GITHUB_ENV
       - uses: graalvm/setup-graalvm@v1
@@ -139,7 +136,7 @@ jobs:
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-
       # TODO Remove this workaround after. The graalvm native image built with windows server is missing some GRMs for testcontainers
       - name: Run test with GraalVM CE
-        if: matrix.os == 'windows-2025'
+        if: matrix.os == 'windows-latest'
         run: ./mvnw -PgenerateMetadata -e -T 1C clean verify
       - name: Run nativeTest with GraalVM CE
         if: matrix.os == 'ubuntu-latest'

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
@@ -81,7 +81,7 @@ newgrp docker
 可在 Powershell 7 通过如下命令利用 `version-fox/vfox` 安装 GraalVM CE。
 
 ```shell
-winget install version-fox.vfox
+winget install --id version-fox.vfox --source winget --exact
 if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
 # 此时需要打开新的 Powershell 7 终端
 vfox add java
@@ -95,7 +95,7 @@ vfox use --global java@24.0.2-graalce
 可在 Powershell 7 通过如下命令安装编译 GraalVM Native Image 所需要的本地工具链。**特定情况下，开发者可能需要为 Visual Studio 的使用购买许可证。**
 
 ```shell
-winget install --id Microsoft.VisualStudio.2022.Community
+winget install --id Microsoft.VisualStudio.2022.Community --source winget --exact
 ```
 
 打开 `Visual Studio Installer` 以修改 `Visual Studio Community 2022` 的 `工作负荷`，勾选 `桌面应用与移动应用` 的 `使用 C++ 的桌面开发` 后点击`修改`。
@@ -106,7 +106,15 @@ winget install --id Microsoft.VisualStudio.2022.Community
 wsl --install
 ```
 
-完成 WSL2 的启用后，在 https://rancherdesktop.io/ 下载和安装 `rancher-sandbox/rancher-desktop`，并设置使用 `dockerd(moby)` 的 `Container Engine`。
+完成 WSL2 的启用后，通过如下的 PowerShell 7 命令下载和安装 `rancher-sandbox/rancher-desktop`，
+并设置使用 `dockerd(moby)` 的 `Container Engine`。
+
+```shell
+winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
+# 打开新的 PowerShell 7 终端
+rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
+```
+
 本文不讨论更改 Linux 发行版 `rancher-desktop` 的 `/etc/docker/daemon.json` 的默认 logging driver。
 
 ### Windows Server
@@ -119,12 +127,13 @@ wsl --install
 可在 PowerShell 7 执行如下命令，
 
 ```shell
-iwr -Uri "https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1" -OutFile uninstall-docker-ce.ps1
-.\uninstall-docker-ce.ps1 -Force
-ri .\uninstall-docker-ce.ps1
+iex "& { $(irm https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1) } -Force"
+winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
+# 打开新的 PowerShell 7 终端
+rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
 ```
 
-这类操作常见于 `windows-2025` 的 GitHub Actions Runner 中。
+这类操作常见于 `windows-latest` 的 GitHub Actions Runner 中。
 
 ## 处理单元测试
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
@@ -84,7 +84,7 @@ It is assumed that the developer is on a fresh Windows 11 Home 24H2 instance wit
 GraalVM CE can be installed using `version-fox/vfox` in Powershell 7 using the following command.
 
 ```shell
-winget install version-fox.vfox
+winget install --id version-fox.vfox --source winget --exact
 if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
 # At this time, developer need to open a new Powershell 7 terminal
 vfox add java
@@ -100,7 +100,7 @@ Developer can install the local toolchain required to compile GraalVM Native Ima
 **In certain cases, developer may need to purchase a license for the use of Visual Studio.**
 
 ```shell
-winget install --id Microsoft.VisualStudio.2022.Community
+winget install --id Microsoft.VisualStudio.2022.Community --source winget --exact
 ```
 
 Open `Visual Studio Installer` to modify `Workloads` of `Visual Studio Community 2022`, 
@@ -112,9 +112,16 @@ Developer can enable WSL2 and set `Ubuntu WSL` as the default Linux distribution
 wsl --install
 ```
 
-After enabling WSL2, 
-download and install `rancher-sandbox/rancher-desktop` from https://rancherdesktop.io/ and set up `Container Engine` using `dockerd(moby)`.
-This article does not discuss changing the default logging driver in `/etc/docker/daemon.json` of the Linux distribution `rancher-desktop`.
+After enabling WSL2, download and install `rancher-sandbox/rancher-desktop` using the following PowerShell 7 command,
+and configure it to use the `dockerd(moby)` `Container Engine`.
+
+```shell
+winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
+# Open a new PowerShell 7 terminal
+rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
+```
+
+This article does not discuss changing the default logging driver in `/etc/docker/daemon.json` of the Linux distribution's `rancher-desktop`.
 
 ### Windows Server
 
@@ -126,12 +133,13 @@ they will need to uninstall Docker Engine using the script provided by Microsoft
 You can execute the following command in PowerShell 7:
 
 ```shell
-iwr -Uri "https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1" -OutFile uninstall-docker-ce.ps1
-.\uninstall-docker-ce.ps1 -Force
-ri .\uninstall-docker-ce.ps1
+iex "& { $(irm https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1) } -Force"
+winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
+# Open a new PowerShell 7 terminal
+rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
 ```
 
-This type of operation is commonly found in the GitHub Actions Runner for `windows-2025`.
+This type of operation is commonly found in the GitHub Actions Runner for `windows-latest`.
 
 ## Handling unit tests
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -167,7 +167,7 @@ newgrp docker
 可在 Powershell 7 通过如下命令利用 `version-fox/vfox` 安装 OpenJDK 21。
 
 ```shell
-winget install version-fox.vfox
+winget install --id version-fox.vfox --source winget --exact
 if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
 # 此时需要打开新的 Powershell 7 终端
 vfox add java

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -171,7 +171,7 @@ Assuming the contributor is on a fresh Windows 11 Home 24H2 instance with `git-f
 OpenJDK 21 can be installed using `version-fox/vfox` in Powershell 7 using the following command.
 
 ```shell
-winget install version-fox.vfox
+winget install --id version-fox.vfox --source winget --exact
 if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
 # At this time, you need to open a new Powershell 7 terminal
 vfox add java

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
@@ -32,12 +32,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.io.Closeable"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.io.Closeable"
@@ -116,19 +110,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.io.Serializable"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-      },
-      "type": "java.io.Serializable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.io.Serializable"
     },
@@ -146,12 +128,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.AutoCloseable"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.lang.AutoCloseable"
@@ -161,13 +137,6 @@
         "typeReached": "org.apache.shardingsphere.mode.repository.cluster.etcd.EtcdRepository"
       },
       "type": "java.lang.BaseVirtualThread"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.Boolean",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -237,12 +206,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.Comparable"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.lang.Comparable"
@@ -261,12 +224,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.Enum"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.lang.Enum"
@@ -276,13 +233,6 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.lang.Float"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.Integer",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -304,13 +254,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.Long",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.lang.Long"
@@ -320,13 +263,6 @@
         "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.impl.MySQLNotFunction"
       },
       "type": "java.lang.Math"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.Number",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -383,18 +319,6 @@
       },
       "type": "java.lang.Object",
       "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabaseFactory"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "type": "java.lang.Object"
     },
     {
       "condition": {
@@ -512,7 +436,8 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
-      "type": "java.lang.Object"
+      "type": "java.lang.Object",
+      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -560,7 +485,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.CreateDatabaseProxyBackendHandler"
+        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
       },
       "type": "java.lang.Object"
     },
@@ -635,20 +560,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.SecurityManager",
-      "methods": [
-        {
-          "name": "checkPermission",
-          "parameterTypes": [
-            "java.security.Permission"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.lang.Short"
@@ -676,18 +587,6 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.lang.StringBuilder"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.System",
-      "methods": [
-        {
-          "name": "getSecurityManager",
-          "parameterTypes": []
-        }
-      ]
     },
     {
       "condition": {
@@ -770,21 +669,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.constant.Constable"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.lang.constant.Constable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.constant.ConstantDesc"
     },
     {
       "condition": {
@@ -848,21 +735,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.net.Socket",
-      "methods": [
-        {
-          "name": "setOption",
-          "parameterTypes": [
-            "java.net.SocketOption",
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.net.Socket"
@@ -883,6 +755,23 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.repository.cluster.etcd.EtcdRepository"
       },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.repository.cluster.etcd.EtcdRepository"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.repository.cluster.etcd.EtcdRepository"
+      },
       "type": "java.nio.ByteBuffer"
     },
     {
@@ -890,6 +779,12 @@
         "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.impl.MySQLNotFunction"
       },
       "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.repository.cluster.etcd.EtcdRepository"
+      },
+      "type": "java.nio.DirectByteBuffer"
     },
     {
       "condition": {
@@ -908,20 +803,6 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.nio.charset.Charset"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.security.AccessController",
-      "methods": [
-        {
-          "name": "doPrivileged",
-          "parameterTypes": [
-            "java.security.PrivilegedExceptionAction"
-          ]
-        }
-      ]
     },
     {
       "condition": {
@@ -969,6 +850,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.repository.cluster.etcd.EtcdRepository"
+      },
+      "type": "java.time.Instant"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.util.AbstractCollection"
@@ -978,12 +865,6 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.util.AbstractMap"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.util.ArrayList"
     },
     {
       "condition": {
@@ -1041,12 +922,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.util.HashMap"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.util.Iterator"
@@ -1056,12 +931,6 @@
         "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.impl.MySQLNotFunction"
       },
       "type": "java.util.Iterator"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.util.LinkedHashMap"
     },
     {
       "condition": {
@@ -1529,7 +1398,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.authority.distsql.parser.core.AuthorityDistSQLLexer"
     },
@@ -1561,7 +1430,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.authority.distsql.parser.core.AuthorityDistSQLParser"
     },
@@ -1573,7 +1442,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.authority.distsql.parser.facade.AuthorityDistSQLParserFacade"
     },
@@ -1802,7 +1671,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLLexer"
     },
@@ -1834,7 +1703,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLParser"
     },
@@ -1864,7 +1733,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLStatementVisitor"
     },
@@ -1876,7 +1745,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.broadcast.distsql.parser.facade.BroadcastDistSQLParserFacade"
     },
@@ -2045,7 +1914,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.data.pipeline.cdc.distsql.parser.core.CDCDistSQLLexer"
     },
@@ -2077,7 +1946,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.data.pipeline.cdc.distsql.parser.core.CDCDistSQLParser"
     },
@@ -2089,7 +1958,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.data.pipeline.cdc.distsql.parser.facade.CDCDistSQLParserFacade"
     },
@@ -2199,7 +2068,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.data.pipeline.scenario.migration.distsql.parser.core.MigrationDistSQLLexer"
     },
@@ -2231,7 +2100,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.data.pipeline.scenario.migration.distsql.parser.core.MigrationDistSQLParser"
     },
@@ -2243,7 +2112,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.data.pipeline.scenario.migration.distsql.parser.facade.MigrationDistSQLParserFacade"
     },
@@ -2258,6 +2127,12 @@
         "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.clickhouse.type.ClickHouseDatabaseType"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.database.connector.core.metadata.data.loader.MetaDataLoader"
+      },
+      "type": "org.apache.shardingsphere.database.connector.firebird.metadata.data.loader.FirebirdMetaDataLoader"
     },
     {
       "condition": {
@@ -2315,6 +2190,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.database.DatabaseTypeEngine"
+      },
+      "type": "org.apache.shardingsphere.database.connector.hive.jdbcurl.HiveJdbcUrlFetcher"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.database.connector.core.metadata.data.loader.MetaDataLoader"
       },
       "type": "org.apache.shardingsphere.database.connector.hive.metadata.data.loader.HiveMetaDataLoader"
@@ -2336,12 +2217,6 @@
         "typeReached": "org.apache.shardingsphere.transaction.xa.XAShardingSphereTransactionManager"
       },
       "type": "org.apache.shardingsphere.database.connector.mysql.checker.MySQLDatabasePrivilegeChecker"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"
-      },
-      "type": "org.apache.shardingsphere.database.connector.mysql.keygen.MySQLGeneratedKeyColumnProvider"
     },
     {
       "condition": {
@@ -2501,33 +2376,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.database.protocol.constant.DatabaseProtocolServerInfo"
-      },
-      "type": "org.apache.shardingsphere.database.protocol.firebird.constant.FirebirdProtocolDefaultVersionProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.database.protocol.constant.DatabaseProtocolServerInfo"
-      },
-      "type": "org.apache.shardingsphere.database.protocol.mysql.constant.MySQLProtocolDefaultVersionProvider"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.MySQLFrontendEngine"
       },
       "type": "org.apache.shardingsphere.database.protocol.mysql.netty.MySQLSequenceIdInboundHandler"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.database.protocol.constant.DatabaseProtocolServerInfo"
-      },
-      "type": "org.apache.shardingsphere.database.protocol.opengauss.constant.OpenGaussProtocolDefaultVersionProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.database.protocol.constant.DatabaseProtocolServerInfo"
-      },
-      "type": "org.apache.shardingsphere.database.protocol.postgresql.constant.PostgreSQLProtocolDefaultVersionProvider"
     },
     {
       "condition": {
@@ -2569,7 +2420,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLLexer"
     },
@@ -2601,7 +2452,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLParser"
     },
@@ -2638,12 +2489,6 @@
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.handler.validate.DistSQLDataSourcePoolPropertiesValidator"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
     },
@@ -2860,7 +2705,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.encrypt.distsql.parser.facade.EncryptDistSQLParserFacade"
     },
@@ -3088,7 +2933,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.globalclock.distsql.parser.core.GlobalClockDistSQLLexer"
     },
@@ -3120,7 +2965,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.globalclock.distsql.parser.core.GlobalClockDistSQLParser"
     },
@@ -3132,7 +2977,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.globalclock.distsql.parser.facade.GlobalClockDistSQLParserFacade"
     },
@@ -4153,13 +3998,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.PostgreSQLAdminExecutorCreator"
+        "typeReached": "org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.factory.PostgreSQLSelectAdminExecutorFactory"
       },
       "type": "org.apache.shardingsphere.infra.metadata.statistics.collector.opengauss.OpenGaussStatisticsCollector"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.PostgreSQLAdminExecutorCreator"
+        "typeReached": "org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.factory.PostgreSQLSelectAdminExecutorFactory"
       },
       "type": "org.apache.shardingsphere.infra.metadata.statistics.collector.postgresql.PostgreSQLStatisticsCollector"
     },
@@ -4174,12 +4019,6 @@
         "typeReached": "org.apache.shardingsphere.infra.metadata.statistics.collector.postgresql.PostgreSQLStatisticsCollector"
       },
       "type": "org.apache.shardingsphere.infra.metadata.statistics.collector.postgresql.table.PostgreSQLPgNamespaceTableStatisticsCollector"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.PostgreSQLAdminExecutorCreator"
-      },
-      "type": "org.apache.shardingsphere.infra.metadata.statistics.collector.shardingsphere.ShardingSphereStatisticsCollector"
     },
     {
       "condition": {
@@ -4210,12 +4049,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.eventbus.EventBusContext"
       },
       "type": "org.apache.shardingsphere.infra.spi.ShardingSphereSPI"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.driver.ShardingSphereURLLoadEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
     },
     {
       "condition": {
@@ -4421,7 +4254,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.CreateDatabaseProxyBackendHandler"
+        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
       },
       "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
     },
@@ -4459,26 +4292,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabaseFactory"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn",
-      "methods": [
-        {
-          "name": "setNullable",
-          "parameterTypes": [
-            "boolean"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.builder.SystemSchemaBuilder"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn",
@@ -4542,6 +4355,7 @@
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn",
+      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -4613,58 +4427,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumnBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumnCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabaseFactory"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
-      "methods": [
-        {
-          "name": "setColumns",
-          "parameterTypes": [
-            "java.util.Collection"
-          ]
-        },
-        {
-          "name": "setUnique",
-          "parameterTypes": [
-            "boolean"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.builder.SystemSchemaBuilder"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
@@ -4692,6 +4454,7 @@
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
+      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -4724,64 +4487,6 @@
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
       "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndexBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndexBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndexCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndexCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabaseFactory"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
-      "methods": [
-        {
-          "name": "setType",
-          "parameterTypes": [
-            "org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType"
-          ]
-        }
-      ]
     },
     {
       "condition": {
@@ -4817,7 +4522,15 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
       },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable"
+      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
+      "methods": [
+        {
+          "name": "setType",
+          "parameterTypes": [
+            "org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType"
+          ]
+        }
+      ]
     },
     {
       "condition": {
@@ -4837,6 +4550,7 @@
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
+      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -4878,12 +4592,6 @@
           "name": "setName",
           "parameterTypes": [
             "java.lang.String"
-          ]
-        },
-        {
-          "name": "setType",
-          "parameterTypes": [
-            "org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType"
           ]
         }
       ]
@@ -4927,25 +4635,6 @@
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
       "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTableBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTableCustomizer"
     },
     {
       "condition": {
@@ -5165,7 +4854,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.mask.distsql.parser.facade.MaskDistSQLParserFacade"
     },
@@ -5432,6 +5121,24 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.federation.FederationMetaDataRefreshEngine"
+      },
+      "type": "org.apache.shardingsphere.mode.metadata.refresher.federation.type.AlterViewFederationMetaDataRefresher"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.federation.FederationMetaDataRefreshEngine"
+      },
+      "type": "org.apache.shardingsphere.mode.metadata.refresher.federation.type.CreateViewFederationMetaDataRefresher"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.federation.FederationMetaDataRefreshEngine"
+      },
+      "type": "org.apache.shardingsphere.mode.metadata.refresher.federation.type.DropViewFederationMetaDataRefresher"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.PushDownMetaDataRefreshEngine"
       },
       "type": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.type.index.AlterIndexPushDownMetaDataRefresher"
@@ -5619,6 +5326,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
@@ -5738,7 +5451,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.CreateDatabaseProxyBackendHandler"
+        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
@@ -6079,6 +5792,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
@@ -6210,6 +5929,12 @@
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
     },
@@ -6417,7 +6142,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.CreateDatabaseProxyBackendHandler"
+        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
     },
@@ -6570,7 +6295,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.CreateDatabaseProxyBackendHandler"
+        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
     },
@@ -6688,7 +6413,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.CreateDatabaseProxyBackendHandler"
+        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
     },
@@ -6800,7 +6525,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.CreateDatabaseProxyBackendHandler"
+        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
     },
@@ -7181,7 +6906,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.parser.distsql.parser.core.SQLParserDistSQLLexer"
     },
@@ -7213,7 +6938,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.parser.distsql.parser.core.SQLParserDistSQLParser"
     },
@@ -7225,7 +6950,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.parser.distsql.parser.facade.SQLParserDistSQLParserFacade"
     },
@@ -7459,13 +7184,7 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetSetExecutor"
       },
-      "type": "org.apache.shardingsphere.proxy.backend.firebird.handler.admin.executor.variable.charset.FirebirdSetCharsetExecutor"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
-      },
-      "type": "org.apache.shardingsphere.proxy.backend.firebird.handler.transaction.FirebirdTransactionalErrorAllowedSQLStatementHandler"
+      "type": "org.apache.shardingsphere.proxy.backend.firebird.handler.admin.executor.variable.charset.FirebirdCharsetVariableProvider"
     },
     {
       "condition": {
@@ -7555,7 +7274,7 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetSetExecutor"
       },
-      "type": "org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.charset.MySQLSetCharsetExecutor"
+      "type": "org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.variable.charset.MySQLCharsetVariableProvider"
     },
     {
       "condition": {
@@ -7589,12 +7308,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
-      },
-      "type": "org.apache.shardingsphere.proxy.backend.opengauss.handler.transaction.OpenGaussTransactionalErrorAllowedSQLStatementHandler"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilderEngine"
       },
       "type": "org.apache.shardingsphere.proxy.backend.opengauss.response.header.query.OpenGaussQueryHeaderBuilder"
@@ -7615,19 +7328,25 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetSetExecutor"
       },
-      "type": "org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.executor.variable.charset.PostgreSQLSetCharsetExecutor"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
-      },
-      "type": "org.apache.shardingsphere.proxy.backend.postgresql.handler.transaction.PostgreSQLTransactionalErrorAllowedSQLStatementHandler"
+      "type": "org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.executor.variable.charset.PostgreSQLCharsetVariableProvider"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilderEngine"
       },
       "type": "org.apache.shardingsphere.proxy.backend.postgresql.response.header.query.PostgreSQLQueryHeaderBuilder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+      },
+      "type": "org.apache.shardingsphere.proxy.backend.state.type.ReadOnlyProxyStateChecker"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+      },
+      "type": "org.apache.shardingsphere.proxy.backend.state.type.UnavailableProxyStateChecker"
     },
     {
       "condition": {
@@ -7769,7 +7488,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.readwritesplitting.distsql.parser.facade.ReadwriteSplittingDistSQLParserFacade"
     },
@@ -8037,7 +7756,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.shadow.distsql.parser.facade.ShadowDistSQLParserFacade"
     },
@@ -8611,7 +8330,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLLexer"
     },
@@ -8643,7 +8362,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLParser"
     },
@@ -8673,7 +8392,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLStatementVisitor"
     },
@@ -8685,7 +8404,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sharding.distsql.parser.facade.ShardingDistSQLParserFacade"
     },
@@ -9537,7 +9256,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.single.distsql.parser.core.SingleDistSQLLexer"
     },
@@ -9569,7 +9288,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.single.distsql.parser.core.SingleDistSQLParser"
     },
@@ -9581,7 +9300,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.single.distsql.parser.facade.SingleDistSQLParserFacade"
     },
@@ -9803,7 +9522,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.mysql.parser.MySQLLexer",
       "methods": [
@@ -9831,7 +9550,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.mysql.parser.MySQLParser",
       "methods": [
@@ -9845,7 +9564,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.mysql.visitor.statement.type.MySQLDALStatementVisitor",
       "methods": [
@@ -9873,7 +9592,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.mysql.visitor.statement.type.MySQLDDLStatementVisitor",
       "methods": [
@@ -9901,7 +9620,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.mysql.visitor.statement.type.MySQLDMLStatementVisitor",
       "methods": [
@@ -9915,7 +9634,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.mysql.visitor.statement.type.MySQLTCLStatementVisitor",
       "methods": [
@@ -10013,6 +9732,20 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
+      },
+      "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.parser.PostgreSQLLexer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.antlr.v4.runtime.CharStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.parser.PostgreSQLParser",
@@ -10035,6 +9768,34 @@
           "name": "<init>",
           "parameterTypes": [
             "org.antlr.v4.runtime.TokenStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
+      },
+      "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.parser.PostgreSQLParser",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.antlr.v4.runtime.TokenStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
+      },
+      "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.visitor.statement.type.PostgreSQLDALStatementVisitor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.apache.shardingsphere.database.connector.core.type.DatabaseType"
           ]
         }
       ]
@@ -10072,6 +9833,20 @@
         "typeReached": "org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.visitor.statement.type.PostgreSQLDMLStatementVisitor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.apache.shardingsphere.database.connector.core.type.DatabaseType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
+      },
+      "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.visitor.statement.type.PostgreSQLTCLStatementVisitor",
       "methods": [
         {
           "name": "<init>",
@@ -10178,48 +9953,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.impl.OpenGaussConnectionConfigBuilder"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.impl.OracleConnectionConfigBuilder"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.impl.PostgreSQLConnectionConfigBuilder"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.impl.SQL92ConnectionConfigBuilder"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.impl.SQLServerConnectionConfigBuilder"
     },
     {
       "condition": {
@@ -10408,6 +10141,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.schema.CalciteSchemaBuilder"
+      },
+      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.postgresql.impl.PostgreSQLSystemFunction"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.sqlfederation.opengauss.OpenGaussSQLFederationFunctionRegister"
       },
       "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.postgresql.impl.PostgreSQLSystemFunction"
@@ -10440,7 +10179,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sqlfederation.distsql.parser.core.SQLFederationDistSQLLexer"
     },
@@ -10472,7 +10211,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sqlfederation.distsql.parser.core.SQLFederationDistSQLParser"
     },
@@ -10484,9 +10223,33 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sqlfederation.distsql.parser.facade.SQLFederationDistSQLParserFacade"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
+      },
+      "type": "org.apache.shardingsphere.sqlfederation.mysql.MySQLSQLFederationConnectionConfigBuilder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
+      },
+      "type": "org.apache.shardingsphere.sqlfederation.opengauss.OpenGaussSQLFederationConnectionConfigBuilder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
+      },
+      "type": "org.apache.shardingsphere.sqlfederation.oracle.OracleSQLFederationConnectionConfigBuilder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
+      },
+      "type": "org.apache.shardingsphere.sqlfederation.postgresql.PostgreSQLSQLFederationConnectionConfigBuilder"
     },
     {
       "condition": {
@@ -10499,6 +10262,12 @@
         "typeReached": "org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"
       },
       "type": "org.apache.shardingsphere.sqlfederation.rule.builder.SQLFederationRuleBuilder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
+      },
+      "type": "org.apache.shardingsphere.sqlfederation.sqlserver.SQLServerSQLFederationConnectionConfigBuilder"
     },
     {
       "condition": {
@@ -10635,7 +10404,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sqltranslator.distsql.parser.core.SQLTranslatorDistSQLLexer"
     },
@@ -10667,7 +10436,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sqltranslator.distsql.parser.core.SQLTranslatorDistSQLParser"
     },
@@ -10679,7 +10448,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sqltranslator.distsql.parser.facade.SQLTranslatorDistSQLParserFacade"
     },
@@ -11088,7 +10857,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.transaction.distsql.parser.core.TransactionDistSQLLexer"
     },
@@ -11120,7 +10889,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.transaction.distsql.parser.core.TransactionDistSQLParser"
     },
@@ -11132,7 +10901,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.transaction.distsql.parser.facade.TransactionDistSQLParserFacade"
     },
@@ -11213,54 +10982,6 @@
         "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
       },
       "type": "org.apache.shardingsphere.transaction.xa.jta.connection.dialect.PostgreSQLXAConnectionWrapper"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.xa.jta.datasource.properties.dialect.FirebirdXADataSourceDefinition"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.xa.jta.datasource.properties.dialect.H2XADataSourceDefinition"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.xa.jta.datasource.properties.dialect.MariaDBXADataSourceDefinition"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.xa.jta.datasource.properties.dialect.MySQLXADataSourceDefinition"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.xa.jta.datasource.properties.dialect.OpenGaussXADataSourceDefinition"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.xa.jta.datasource.properties.dialect.OracleXADataSourceDefinition"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.xa.jta.datasource.properties.dialect.PostgreSQLXADataSourceDefinition"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.xa.jta.datasource.properties.dialect.SQLServerXADataSourceDefinition"
     },
     {
       "condition": {
@@ -11411,16 +11132,6 @@
         "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": {
-        "proxy": [
-          "java.sql.Connection"
-        ]
-      }
     }
   ],
   "resources": [
@@ -11576,30 +11287,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "META-INF/services/com.clickhouse.client.ClickHouseClient"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "META-INF/services/com.clickhouse.client.ClickHouseRequestManager"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "META-INF/services/com.clickhouse.data.ClickHouseDataStreamFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "META-INF/services/com.clickhouse.jdbc.JdbcTypeMapping"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.repository.cluster.etcd.EtcdRepository"
       },
       "glob": "META-INF/services/io.grpc.LoadBalancerProvider"
@@ -11660,7 +11347,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCharacterSet"
+        "typeReached": "org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCharacterSets"
       },
       "glob": "META-INF/services/java.nio.charset.spi.CharsetProvider"
     },
@@ -11669,12 +11356,6 @@
         "typeReached": "org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.executor.variable.charset.PostgreSQLCharacterSets"
       },
       "glob": "META-INF/services/java.nio.charset.spi.CharsetProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
     },
     {
       "condition": {
@@ -11774,15 +11455,15 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.database.connector.core.jdbcurl.judger.DatabaseInstanceJudgeEngine"
+        "typeReached": "org.apache.shardingsphere.infra.database.DatabaseTypeEngine"
       },
-      "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.jdbcurl.judger.DialectDatabaseInstanceJudger"
+      "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.jdbcurl.DialectJdbcUrlFetcher"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.jdbcurl.judger.DatabaseInstanceJudgeEngine"
       },
-      "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.keygen.GeneratedKeyColumnProvider"
+      "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.jdbcurl.judger.DialectDatabaseInstanceJudger"
     },
     {
       "condition": {
@@ -11810,12 +11491,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.database.protocol.constant.DatabaseProtocolServerInfo"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.database.protocol.constant.DatabaseProtocolDefaultVersionProvider"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.distsql.handler.engine.update.AdvancedDistSQLUpdateExecutor"
@@ -11834,7 +11509,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.distsql.parser.engine.spi.DistSQLParserFacade"
     },
@@ -11906,7 +11581,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.PostgreSQLAdminExecutorCreator"
+        "typeReached": "org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.factory.PostgreSQLSelectAdminExecutorFactory"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.infra.metadata.statistics.collector.DialectDatabaseStatisticsCollector"
     },
@@ -11915,12 +11590,6 @@
         "typeReached": "org.apache.shardingsphere.infra.metadata.statistics.collector.postgresql.PostgreSQLStatisticsCollector"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.infra.metadata.statistics.collector.postgresql.PostgreSQLTableStatisticsCollector"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.statistics.collector.shardingsphere.ShardingSphereStatisticsCollector"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.infra.metadata.statistics.collector.shardingsphere.ShardingSphereTableStatisticsCollector"
     },
     {
       "condition": {
@@ -11966,12 +11635,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.driver.ShardingSphereURLLoadEngine"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.infra.url.spi.ShardingSphereURLLoader"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.constructor.ShardingSphereYamlConstructor"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.infra.util.yaml.constructor.ShardingSphereYamlConstruct"
@@ -11999,6 +11662,12 @@
         "typeReached": "org.apache.shardingsphere.mode.manager.listener.ContextManagerLifecycleListenerFactory"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.mode.manager.listener.ContextManagerLifecycleListener"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.federation.FederationMetaDataRefreshEngine"
+      },
+      "glob": "META-INF/services/org.apache.shardingsphere.mode.metadata.refresher.federation.FederationMetaDataRefresher"
     },
     {
       "condition": {
@@ -12056,12 +11725,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.proxy.backend.handler.tcl.TransactionalErrorAllowedSQLStatementHandler"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilderEngine"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilder"
@@ -12071,6 +11734,12 @@
         "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.proxy.backend.state.DialectProxyStateSupportedSQLProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+      },
+      "glob": "META-INF/services/org.apache.shardingsphere.proxy.backend.state.ProxyClusterStateChecker"
     },
     {
       "condition": {
@@ -12110,12 +11779,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.transaction.xa.jta.datasource.properties.XADataSourceDefinition"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.transaction.xa.XAShardingSphereTransactionManager"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.transaction.xa.spi.XATransactionManagerProvider"
@@ -12128,7 +11791,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "glob": "META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider"
     },
@@ -12136,31 +11799,7 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
-      "glob": "META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
       "glob": "META-INF/services/org.testcontainers.core.CreateContainerCmdModifier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
-      },
-      "glob": "META-INF/services/org.testcontainers.core.CreateContainerCmdModifier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "META-INF/services/org.testcontainers.dockerclient.DockerClientProviderStrategy"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "META-INF/services/org.testcontainers.utility.ImageNameSubstitutor"
     },
     {
       "condition": {
@@ -12182,33 +11821,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "com/clickhouse/client/internal/jpountz/util/win32/amd64/liblz4-java.so"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "com/github/dockerjava/zerodep/shaded/org/apache/hc/client5/version.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "container-license-acceptance.txt"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.autogen.version.ShardingSphereVersion"
+        "typeReached": "org.apache.shardingsphere.infra.version.ShardingSphereVersion"
       },
       "glob": "current-git-commit.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "docker-java.properties"
     },
     {
       "condition": {
@@ -12227,24 +11842,6 @@
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "glob": "lib/sqlparser/druid.jar"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "mozilla/public-suffix-list.txt"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "org/h2/util/data.zip"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "org/postgresql/driverconfig.properties"
     },
     {
       "condition": {
@@ -12272,3037 +11869,1225 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/common/shardingsphere/cluster_information.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/administrable_role_authorizations.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/applicable_roles.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/character_sets.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/check_constraints.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/collation_character_set_applicability.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/collations.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/column_privileges.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/column_statistics.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/columns.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/columns_extensions.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/enabled_roles.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/engines.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/events.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/files.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/global_status.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/global_variables.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_buffer_page.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_buffer_page_lru.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_buffer_pool_stats.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_cached_indexes.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_cmp.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_cmp_per_index.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_cmp_per_index_reset.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_cmp_reset.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_cmpmem.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_cmpmem_reset.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_columns.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_datafiles.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_fields.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_foreign.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_foreign_cols.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_ft_being_deleted.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_ft_config.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_ft_default_stopword.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_ft_deleted.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_ft_index_cache.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_ft_index_table.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_indexes.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_lock_waits.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_locks.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_metrics.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_session_temp_tablespaces.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_sys_columns.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_sys_datafiles.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_sys_fields.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_sys_foreign.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_sys_foreign_cols.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_sys_indexes.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_sys_tables.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_sys_tablespaces.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_sys_tablestats.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_sys_virtual.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_tables.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_tablespaces.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_tablespaces_brief.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_tablestats.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_temp_table_info.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_trx.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/innodb_virtual.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/key_column_usage.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/keywords.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/optimizer_trace.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/parameters.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/partitions.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/plugins.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/processlist.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/profiling.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/referential_constraints.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/resource_groups.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/role_column_grants.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/role_routine_grants.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/role_table_grants.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/routines.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/schema_privileges.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/schemata.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/schemata_extensions.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/session_status.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/session_variables.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/st_geometry_columns.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/st_spatial_reference_systems.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/st_units_of_measure.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/statistics.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/table_constraints.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/table_constraints_extensions.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/table_privileges.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/tables.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/tables_extensions.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/tablespaces.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/tablespaces_extensions.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/triggers.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/user_attributes.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/user_privileges.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/view_routine_usage.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/view_table_usage.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/information_schema/views.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/columns_priv.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/component.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/db.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/default_roles.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/engine_cost.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/event.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/func.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/general_log.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/global_grants.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/gtid_executed.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/help_category.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/help_keyword.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/help_relation.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/help_topic.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/innodb_index_stats.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/innodb_table_stats.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/ndb_binlog_index.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/password_history.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/plugin.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/proc.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/procs_priv.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/proxies_priv.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/replication_asynchronous_connection_failover.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/replication_asynchronous_connection_failover_managed.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/replication_group_configuration_version.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/replication_group_member_actions.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/role_edges.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/server_cost.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/servers.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/slave_master_info.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/slave_relay_log_info.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/slave_worker_info.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/slow_log.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/tables_priv.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/time_zone.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/time_zone_leap_second.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/time_zone_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/time_zone_transition.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/time_zone_transition_type.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/mysql/user.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/accounts.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/binary_log_transaction_compression_stats.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/cond_instances.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/data_lock_waits.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/data_locks.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/error_log.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_errors_summary_by_account_by_error.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_errors_summary_by_host_by_error.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_errors_summary_by_thread_by_error.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_errors_summary_by_user_by_error.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_errors_summary_global_by_error.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_stages_current.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_stages_history.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_stages_history_long.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_stages_summary_by_account_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_stages_summary_by_host_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_stages_summary_by_thread_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_stages_summary_by_user_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_stages_summary_global_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_statements_current.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_statements_histogram_by_digest.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_statements_histogram_global.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_statements_history.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_statements_history_long.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_statements_summary_by_account_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_statements_summary_by_digest.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_statements_summary_by_host_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_statements_summary_by_program.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_statements_summary_by_thread_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_statements_summary_by_user_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_statements_summary_global_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_transactions_current.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_transactions_history.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_transactions_history_long.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_transactions_summary_by_account_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_transactions_summary_by_host_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_transactions_summary_by_thread_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_transactions_summary_by_user_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_transactions_summary_global_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_waits_current.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_waits_history.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_waits_history_long.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_waits_summary_by_account_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_waits_summary_by_host_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_waits_summary_by_instance.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_waits_summary_by_thread_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_waits_summary_by_user_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/events_waits_summary_global_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/file_instances.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/file_summary_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/file_summary_by_instance.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/global_status.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/global_variables.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/host_cache.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/hosts.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/innodb_redo_log_files.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/keyring_component_status.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/keyring_keys.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/log_status.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/memory_summary_by_account_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/memory_summary_by_host_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/memory_summary_by_thread_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/memory_summary_by_user_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/memory_summary_global_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/metadata_locks.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/mutex_instances.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/objects_summary_global_by_type.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/performance_timers.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/persisted_variables.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/prepared_statements_instances.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/processlist.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/replication_applier_configuration.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/replication_applier_filters.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/replication_applier_global_filters.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/replication_applier_status.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/replication_applier_status_by_coordinator.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/replication_applier_status_by_worker.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/replication_asynchronous_connection_failover.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/replication_asynchronous_connection_failover_managed.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/replication_connection_configuration.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/replication_connection_status.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/replication_group_member_stats.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/replication_group_members.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/rwlock_instances.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/session_account_connect_attrs.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/session_connect_attrs.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/session_status.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/session_variables.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/setup_actors.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/setup_consumers.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/setup_instruments.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/setup_meters.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/setup_metrics.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/setup_objects.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/setup_threads.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/setup_timers.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/socket_instances.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/socket_summary_by_event_name.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/socket_summary_by_instance.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/status_by_account.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/status_by_host.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/status_by_thread.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/status_by_user.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/table_handles.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/table_io_waits_summary_by_index_usage.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/table_io_waits_summary_by_table.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/table_lock_waits_summary_by_table.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/threads.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/tls_channel_status.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/user_defined_functions.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/user_variables_by_thread.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/users.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/variables_by_thread.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/performance_schema/variables_info.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/host_summary.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/host_summary_by_file_io.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/host_summary_by_file_io_type.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/host_summary_by_stages.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/host_summary_by_statement_latency.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/host_summary_by_statement_type.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/innodb_buffer_stats_by_schema.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/innodb_buffer_stats_by_table.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/innodb_lock_waits.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/io_by_thread_by_latency.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/io_global_by_file_by_bytes.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/io_global_by_file_by_latency.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/io_global_by_wait_by_bytes.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/io_global_by_wait_by_latency.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/latest_file_io.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/memory_by_host_by_current_bytes.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/memory_by_thread_by_current_bytes.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/memory_by_user_by_current_bytes.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/memory_global_by_current_bytes.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/memory_global_total.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/metrics.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/processlist.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/ps_check_lost_instrumentation.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/schema_auto_increment_columns.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/schema_index_statistics.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/schema_object_overview.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/schema_redundant_indexes.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/schema_table_lock_waits.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/schema_table_statistics.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/schema_table_statistics_with_buffer.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/schema_tables_with_full_table_scans.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/schema_unused_indexes.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/session.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/session_ssl_status.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/statement_analysis.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/statements_with_errors_or_warnings.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/statements_with_full_table_scans.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/statements_with_runtimes_in_95th_percentile.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/statements_with_sorting.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/statements_with_temp_tables.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/sys_config.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/user_summary.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/user_summary_by_file_io.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/user_summary_by_file_io_type.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/user_summary_by_stages.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/user_summary_by_statement_latency.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/user_summary_by_statement_type.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/version.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/wait_classes_global_by_avg_latency.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/wait_classes_global_by_latency.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/waits_by_host_by_latency.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/waits_by_user_by_latency.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
-      },
-      "glob": "schema/mysql/sys/waits_global_by_latency.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/_pg_foreign_data_wrappers.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/_pg_foreign_servers.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/_pg_foreign_table_columns.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/_pg_foreign_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/_pg_user_mappings.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/administrable_role_authorizations.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/applicable_roles.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/attributes.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/character_sets.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/check_constraint_routine_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/check_constraints.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/collation_character_set_applicability.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/collations.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/column_column_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/column_domain_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/column_options.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/column_privileges.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/column_udt_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/columns.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/constraint_column_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/constraint_table_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/data_type_privileges.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/domain_constraints.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/domain_udt_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/domains.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/element_types.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/enabled_roles.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/foreign_data_wrapper_options.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/foreign_data_wrappers.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/foreign_server_options.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/foreign_servers.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/foreign_table_options.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/foreign_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/information_schema_catalog_name.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/key_column_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/parameters.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/referential_constraints.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/role_column_grants.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/role_routine_grants.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/role_table_grants.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/role_udt_grants.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/role_usage_grants.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/routine_column_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/routine_privileges.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/routine_routine_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/routine_sequence_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/routine_table_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/routines.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/schemata.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/sequences.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/sql_features.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/sql_implementation_info.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/sql_parts.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/sql_sizing.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/table_constraints.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/table_privileges.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/transforms.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/triggered_update_columns.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/triggers.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/udt_privileges.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/usage_privileges.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/user_defined_types.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/user_mapping_options.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/user_mappings.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/view_column_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/view_routine_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/view_table_usage.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/information_schema/views.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_aggregate.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_am.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_amop.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_amproc.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_attrdef.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_attribute.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_auth_members.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_authid.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_available_extension_versions.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_available_extensions.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_backend_memory_contexts.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_cast.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_class.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_collation.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_config.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_constraint.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_conversion.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_cursors.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_database.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_db_role_setting.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_default_acl.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_depend.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_description.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_enum.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_event_trigger.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_extension.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_file_settings.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_foreign_data_wrapper.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_foreign_server.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_foreign_table.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_group.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_hba_file_rules.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_index.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_indexes.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_inherits.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_init_privs.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_language.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_largeobject.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_largeobject_metadata.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_locks.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_matviews.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_namespace.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_opclass.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_operator.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_opfamily.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_partitioned_table.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_policies.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_policy.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_prepared_statements.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_prepared_xacts.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_proc.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_publication.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_publication_rel.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_publication_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_range.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_replication_origin.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_replication_origin_status.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_replication_slots.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_rewrite.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_roles.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_rules.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_seclabel.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_seclabels.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_sequence.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_sequences.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_settings.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_shadow.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_shdepend.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_shdescription.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_shmem_allocations.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_shseclabel.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_activity.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_all_indexes.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_all_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_archiver.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_bgwriter.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_database.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_database_conflicts.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_gssapi.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_progress_analyze.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_progress_basebackup.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_progress_cluster.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_progress_copy.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_progress_create_index.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_progress_vacuum.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_replication.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_replication_slots.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_slru.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_ssl.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_subscription.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_sys_indexes.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_sys_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_user_functions.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_user_indexes.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_user_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_wal.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_wal_receiver.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_xact_all_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_xact_sys_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_xact_user_functions.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stat_xact_user_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_statio_all_indexes.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_statio_all_sequences.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_statio_all_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_statio_sys_indexes.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_statio_sys_sequences.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_statio_sys_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_statio_user_indexes.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_statio_user_sequences.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_statio_user_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_statistic.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_statistic_ext.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_statistic_ext_data.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stats.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stats_ext.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_stats_ext_exprs.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_subscription.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_subscription_rel.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_tables.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_tablespace.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_timezone_abbrevs.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_timezone_names.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_transform.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_trigger.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_ts_config.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_ts_config_map.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_ts_dict.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_ts_parser.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_ts_template.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_type.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_user.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_user_mapping.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_user_mappings.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.DialectSystemSchemaManager"
       },
       "glob": "schema/postgresql/pg_catalog/pg_views.yaml"
     },
@@ -15317,6 +13102,12 @@
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "glob": "seata.conf"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.version.ShardingSphereVersion"
+      },
+      "glob": "shardingsphere-version.properties"
     },
     {
       "condition": {
@@ -15344,159 +13135,141 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "test-native/sql/clickhouse-init.sql"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "test-native/sql/seata-script-client-at-postgresql.sql"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "glob": "test-native/sql/seata-script-client-at-postgresql.sql"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/databases/clickhouse.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/databases/doris.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/databases/firebird.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/databases/hive/acid.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/databases/hive/iceberg.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/databases/hive/system-schemas.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/databases/hive/zsd.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/databases/mysql.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/databases/opengauss.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/databases/postgresql.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/databases/presto.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/databases/sqlserver.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/features/encrypt.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/features/mask.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/features/readwrite-splitting.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/features/shadow.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/features/sharding.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/modes/cluster/etcd.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/modes/cluster/zookeeper.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/transactions/base/seata.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/transactions/xa/atomikos.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/jdbc/transactions/xa/narayana.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "testcontainers.properties"
     },
     {
       "condition": {
@@ -15517,12 +13290,5 @@
       "glob": "vertx-default-jul-logging.properties"
     }
   ],
-  "bundles": [
-    {
-      "name": "com.microsoft.sqlserver.jdbc.SQLServerResource",
-      "locales": [
-        "zh-CN"
-      ]
-    }
-  ]
+  "bundles": []
 }

--- a/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native-test-metadata/reachability-metadata.json
+++ b/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native-test-metadata/reachability-metadata.json
@@ -278,37 +278,37 @@
   "resources": [
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/properties/**/*.properties"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/sh/**/*.sh"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/yaml/**/*.yaml"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "test-native/sql/**/*.sql"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "*.conf"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathURLLoader"
+        "typeReached": "org.apache.shardingsphere.infra.url.classpath.ClassPathLocalFileURLLoader"
       },
       "glob": "container-license-acceptance.txt"
     },

--- a/test/native/src/test/resources/test-native/ps1/wait-for-rancher-desktop-backend.ps1
+++ b/test/native/src/test/resources/test-native/ps1/wait-for-rancher-desktop-backend.ps1
@@ -18,6 +18,11 @@
 #
 
 # This file is only used in the PowerShell 7 of ShardingSphere in GitHub Actions environment and should not be executed manually in a development environment.
+# Background information can be found at https://github.com/apache/shardingsphere/pull/35905 .
+iex "& { $(irm https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1) } -Force"
+winget install --id jazzdelightsme.WingetPathUpdater --source winget
+winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
+rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
 $deadline = (Get-Date).AddMinutes(10)
 $state = "UNKNOWN"
 while ((Get-Date) -lt $deadline)

--- a/test/native/src/test/resources/test-native/sh/free-disk-space.sh
+++ b/test/native/src/test/resources/test-native/sh/free-disk-space.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file is only used in the Bash of ShardingSphere in GitHub Actions environment and should not be executed manually in a development environment.
+# Background information can be found at https://github.com/apache/shardingsphere/pull/37333 .
+set -e
+RMZ_VERSION="3.1.1"
+arch="$(uname -m)"
+case "${arch}" in
+    x86_64|amd64) ASSET="x86_64-unknown-linux-gnu-rmz" ;;
+    aarch64|arm64) ASSET="aarch64-unknown-linux-gnu-rmz" ;;
+    *) echo "Unsupported arch: ${arch}"; exit 0 ;;
+esac
+RMZ_RELEASE_URL="https://github.com/SUPERCILEX/fuc/releases/download/${RMZ_VERSION}/${ASSET}"
+tmpfile=$(mktemp)
+if ! curl -fsSL -o "${tmpfile}" "${RMZ_RELEASE_URL}"; then
+    rm -f "${tmpfile}"
+    exit 0
+fi
+sudo install -m 0755 "${tmpfile}" /usr/local/bin/rmz
+rm -f "${tmpfile}"
+COMMAND_RMZ=$(command -v rmz || true)
+if ! [[ -x "${COMMAND_RMZ}" ]]; then
+    exit 0
+fi
+sudo rmz -f /usr/local/lib/android || true
+sudo rmz -f /opt/android || true
+sudo rmz -f /usr/local/android-sdk || true
+sudo rmz -f /home/runner/Android || true
+ANDROID_PACKAGES=$(dpkg -l | grep -E "^ii.*(android|adb)" | awk '{print $2}' | tr '\n' ' ' || true)
+if [[ -n "${ANDROID_PACKAGES}" ]]; then
+    sudo apt-get remove -y "${ANDROID_PACKAGES}" --fix-missing > /dev/null 2>&1 || true
+    sudo apt-get autoremove -y > /dev/null 2>&1 || true
+    sudo apt-get clean > /dev/null 2>&1 || true
+fi
+sudo rmz -f /usr/share/dotnet || true
+sudo rmz -f /usr/share/doc/dotnet-* || true
+DOTNET_PACKAGES=$(dpkg -l | grep -E "^ii.*dotnet" | awk '{print $2}' | tr '\n' ' ' || true)
+if [[ -n "${DOTNET_PACKAGES}" ]]; then
+    sudo apt-get remove -y "${DOTNET_PACKAGES}" --fix-missing > /dev/null 2>&1 || true
+    sudo apt-get autoremove -y > /dev/null 2>&1 || true
+    sudo apt-get clean > /dev/null 2>&1 || true
+fi
+sudo rmz -f /opt/ghc || true
+sudo rmz -f /usr/local/.ghcup || true
+sudo rmz -f /opt/cabal || true
+sudo rmz -f /home/runner/.ghcup || true
+sudo rmz -f /home/runner/.cabal || true
+HASKELL_PACKAGES=$(dpkg -l | grep -E "^ii.*(ghc|haskell|cabal)" | awk '{print $2}' | tr '\n' ' ' || true)
+if [[ -n "${HASKELL_PACKAGES}" ]]; then
+    sudo apt-get remove -y "${HASKELL_PACKAGES}" --fix-missing > /dev/null 2>&1 || true
+    sudo apt-get autoremove -y > /dev/null 2>&1 || true
+    sudo apt-get clean > /dev/null 2>&1 || true
+fi


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/actions/runs/20064786314/job/57550395345 .

Changes proposed in this pull request:
  - Fix nativeTest failing under GraalVM Native Image due to class changes. Before investigating https://github.com/apache/shardingsphere/issues/36672, we need to resolve the issues on the master branch.
  - Due to the changes in https://github.com/actions/runner-images/issues/12677, `windows-latest` is used to point to the Windows Server 2025 instance that contains `winget`.
  - Because issue https://github.com/actions/runner-images/issues/13291 remains unresolved, we are actually using `Visual Studio Enterprise 2022 17.14.36717.8` in Github Actions. It is necessary to prevent developers from using `Visual Studio 2026` to execute ShardingSphere's native tests until this is resolved at https://github.com/oracle/graal/issues/12529 .
  - Due to limitations outlined in https://github.com/PowerShell/PowerShell/issues/23836 and https://github.com/microsoft/winget-cli/issues/549 , the PowerShell commands have been slightly modified.
  - `rmz` is a significant improvement over CI. It only takes 29 seconds to download the `rmz` binary and delete useless files using the `curl` command, while `rm` takes 60 seconds to delete the same useless files. See https://github.com/apache/shardingsphere/pull/37333#pullrequestreview-3563427699 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
