### PR TITLE
Support building Proxy Native via GraalVM CE for JDK 25

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest' ]
-        java-version: [ '24.0.2' ]
+        java-version: [ '25.0.1' ]
     steps:
       - uses: actions/checkout@v4
       - name: Free Disk Space on Ubuntu
@@ -72,9 +72,9 @@ jobs:
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-cache-
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-
       # TODO Remove this workaround after. The graalvm native image built with windows server is missing some GRMs for testcontainers
-      - name: Run test with GraalVM CE
+      - name: Run test with GraalVM CE for ${{ matrix.java-version }}
         if: matrix.os == 'windows-latest'
         run: ./mvnw -PgenerateMetadata -e -T 1C clean verify
       - name: Run nativeTest with GraalVM CE for ${{ matrix.java-version }}
         if: matrix.os == 'ubuntu-latest'
-        run: ./mvnw -PnativeTestInShardingSphere -e "-DjvmArgs=-XX:MaxRAMPercentage=85.0" clean verify
+        run: ./mvnw -PnativeTestInShardingSphere -e clean verify

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -123,7 +123,7 @@ jobs:
           "PATH=$env:PATH" >> $env:GITHUB_ENV
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24.0.2'
+          java-version: '25.0.1'
           distribution: 'graalvm-community'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
@@ -135,9 +135,9 @@ jobs:
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-cache-
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-
       # TODO Remove this workaround after. The graalvm native image built with windows server is missing some GRMs for testcontainers
-      - name: Run test with GraalVM CE
+      - name: Run test with GraalVM CE for ${{ matrix.java-version }}
         if: matrix.os == 'windows-latest'
         run: ./mvnw -PgenerateMetadata -e -T 1C clean verify
-      - name: Run nativeTest with GraalVM CE
+      - name: Run nativeTest with GraalVM CE for ${{ matrix.java-version }}
         if: matrix.os == 'ubuntu-latest'
-        run: ./mvnw -PnativeTestInShardingSphere -e "-DjvmArgs=-XX:MaxRAMPercentage=85.0" clean verify
+        run: ./mvnw -PnativeTestInShardingSphere -e clean verify

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -66,6 +66,7 @@
 1. Pipeline: Improve "alter transmission rule": verify STREAM_CHANNEL TYPE NAME - [#36864](https://github.com/apache/shardingsphere/pull/36864)
 1. Pipeline: InventoryDumperContextSplitter supports multi-columns unique key first integer column splitting - [#36935](https://github.com/apache/shardingsphere/pull/36935)
 1. Encrypt: Support handling show create view result decoration in encrypt - [#37299](https://github.com/apache/shardingsphere/pull/37299)
+1. Proxy Native: Support building Proxy Native via GraalVM CE for JDK 25 - [#37357](https://github.com/apache/shardingsphere/pull/37357)
 
 ### Bug Fixes
 

--- a/distribution/proxy-native/Dockerfile-linux-dynamic
+++ b/distribution/proxy-native/Dockerfile-linux-dynamic
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM ghcr.io/graalvm/native-image-community:24.0.2 AS nativebuild
+FROM ghcr.io/graalvm/native-image-community:25.0.1 AS nativebuild
 WORKDIR /build
 COPY ./ .
 RUN --mount=type=cache,target=/root/.m2 ./mvnw -am -pl distribution/proxy-native -T1C -DskipTests "-Prelease.native" clean package

--- a/distribution/proxy-native/Dockerfile-linux-mostly
+++ b/distribution/proxy-native/Dockerfile-linux-mostly
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM ghcr.io/graalvm/native-image-community:24.0.2 AS nativebuild
+FROM ghcr.io/graalvm/native-image-community:25.0.1 AS nativebuild
 ENV NATIVE_IMAGE_OPTIONS="--static-nolibc"
 WORKDIR /build
 COPY ./ .

--- a/distribution/proxy-native/Dockerfile-linux-static
+++ b/distribution/proxy-native/Dockerfile-linux-static
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM ghcr.io/graalvm/native-image-community:24.0.2-muslib AS nativebuild
+FROM ghcr.io/graalvm/native-image-community:25.0.1-muslib AS nativebuild
 ENV NATIVE_IMAGE_OPTIONS="--static,--libc=musl"
 WORKDIR /build
 COPY ./ .

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.cn.md
@@ -15,7 +15,7 @@ CE 的 `native-image` 命令行工具的长篇大论的 shell 命令。
 ShardingSphere JDBC 要求在如下或更高版本的 `GraalVM CE` 完成构建 GraalVM Native Image。使用者可通过 SDKMAN! 快速切换 JDK。这同理
 适用于 https://sdkman.io/jdks#graal ， https://sdkman.io/jdks#nik 和 https://sdkman.io/jdks#mandrel 等 `GraalVM CE` 的下游发行版。
 
-- GraalVM CE For JDK 24.0.2，对应于 SDKMAN! 的 `24.0.2-graalce`
+- GraalVM CE For JDK 25.0.1，对应于 SDKMAN! 的 `25.0.1-graalce`
 
 用户依然可以使用 SDKMAN! 上的 `21.0.8-graal` 等旧版本的 Oracle GraalVM 来构建 ShardingSphere 的 GraalVM Native Image 产物。
 但这将导致集成部分第三方依赖时，构建 GraalVM Native Image 失败。
@@ -52,7 +52,7 @@ java.beans.Introspector was unintentionally initialized at build time. To see wh
             <plugin>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
-                <version>0.11.0</version>
+                <version>0.11.3</version>
                 <extensions>true</extensions>
                 <configuration>
                     <buildArgs>
@@ -92,12 +92,12 @@ java.beans.Introspector was unintentionally initialized at build time. To see wh
 
 ```groovy
 plugins {
-   id 'org.graalvm.buildtools.native' version '0.11.0'
+   id 'org.graalvm.buildtools.native' version '0.11.3'
 }
 
 dependencies {
    implementation 'org.apache.shardingsphere:shardingsphere-jdbc:${shardingsphere.version}'
-   implementation(group: 'org.graalvm.buildtools', name: 'graalvm-reachability-metadata', version: '0.11.0', classifier: 'repository', ext: 'zip')
+   implementation(group: 'org.graalvm.buildtools', name: 'graalvm-reachability-metadata', version: '0.11.3', classifier: 'repository', ext: 'zip')
 }
 
 graalvmNative {

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/_index.en.md
@@ -16,7 +16,7 @@ ShardingSphere JDBC requires GraalVM Native Image to be built with GraalVM CE as
 JDK through `SDKMAN!`. Same reason applicable to downstream distributions of `GraalVM CE` such as https://sdkman.io/jdks#graal ,
 https://sdkman.io/jdks#nik and https://sdkman.io/jdks#mandrel .
 
-- GraalVM CE For JDK 24.0.2, corresponding to `24.0.2-graalce` of SDKMAN!
+- GraalVM CE For JDK 25.0.1, corresponding to `25.0.1-graalce` of SDKMAN!
 
 Users can still use old versions of Oracle GraalVM such as `21.0.8-graal` on SDKMAN! to build ShardingSphere's GraalVM Native Image product.
 But this will cause the failure of building GraalVM Native Image when integrating some third-party dependencies.
@@ -53,7 +53,7 @@ and the documentation of GraalVM Native Build Tools shall prevail.
              <plugin>
                  <groupId>org.graalvm.buildtools</groupId>
                  <artifactId>native-maven-plugin</artifactId>
-                 <version>0.11.0</version>
+                 <version>0.11.3</version>
                  <extensions>true</extensions>
                  <configuration>
                     <buildArgs>
@@ -95,12 +95,12 @@ Reference https://github.com/graalvm/native-build-tools/issues/572 .
 
 ```groovy
 plugins {
-   id 'org.graalvm.buildtools.native' version '0.11.0'
+   id 'org.graalvm.buildtools.native' version '0.11.3'
 }
 
 dependencies {
    implementation 'org.apache.shardingsphere:shardingsphere-jdbc:${shardingsphere.version}'
-   implementation(group: 'org.graalvm.buildtools', name: 'graalvm-reachability-metadata', version: '0.11.0', classifier: 'repository', ext: 'zip')
+   implementation(group: 'org.graalvm.buildtools', name: 'graalvm-reachability-metadata', version: '0.11.3', classifier: 'repository', ext: 'zip')
 }
 
 graalvmNative {

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
@@ -25,7 +25,7 @@ ShardingSphere 定义了，
 
 贡献者必须在设备安装，
 
-1. GraalVM CE 24.0.2，或与 GraalVM CE 24.0.2 兼容的 GraalVM 下游发行版。以 [GraalVM Native Image](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image) 为准。
+1. GraalVM CE 25.0.1，或与 GraalVM CE 25.0.1 兼容的 GraalVM 下游发行版。以 [GraalVM Native Image](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image) 为准。
 2. 编译 GraalVM Native Image 所需要的本地工具链。以 https://www.graalvm.org/latest/reference-manual/native-image/#prerequisites 为准。
 3. 可运行 Linux Containers 的 Docker Engine，或与 testcontainers-java 兼容的 Container Runtime。以 https://java.testcontainers.org/supported_docker_environment/ 为准。
 
@@ -41,8 +41,8 @@ ShardingSphere 定义了，
 sudo apt install unzip zip -y
 curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"
-sdk install java 24.0.2-graalce
-sdk use java 24.0.2-graalce
+sdk install java 25.0.1-graalce
+sdk use java 25.0.1-graalce
 ```
 
 可在 bash 通过如下命令安装编译 GraalVM Native Image 所需要的本地工具链。
@@ -85,11 +85,11 @@ winget install --id version-fox.vfox --source winget --exact
 if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
 # 此时需要打开新的 Powershell 7 终端
 vfox add java
-vfox install java@24.0.2-graalce
-vfox use --global java@24.0.2-graalce
+vfox install java@25.0.1-graalce
+vfox use --global java@25.0.1-graalce
 ```
 
-当 Windows 弹出窗口，要求允许类似 `C:\users\shard\.version-fox\cache\java\v-24.0.2-graalce\java-24.0.2-graalce\bin\java.exe` 路径的应用通过 Windows 防火墙时，应当批准。
+当 Windows 弹出窗口，要求允许类似 `C:\users\shard\.version-fox\cache\java\v-25.0.1-graalce\java-25.0.1-graalce\bin\java.exe` 路径的应用通过 Windows 防火墙时，应当批准。
 背景参考 https://support.microsoft.com/en-us/windows/risks-of-allowing-apps-through-windows-firewall-654559af-3f54-3dcf-349f-71ccd90bcc5c 。
 
 可在 Powershell 7 通过如下命令安装编译 GraalVM Native Image 所需要的本地工具链。**特定情况下，开发者可能需要为 Visual Studio 的使用购买许可证。**
@@ -286,34 +286,38 @@ class SolutionTest {
 当前执行 `./mvnw -PnativeTestInShardingSphere -e -T 1C clean verify` 将涉及到针对 `com.oracle.svm.core.code.CodeCachePoolMXBean` 的警告日志，
 
 ```shell
-org.graalvm.nativeimage.MissingReflectionRegistrationError: The program tried to reflectively access
+org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the 'com.oracle.svm.core.code.CodeCachePoolMXBean$CodeAndDataPool'. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
 
-   com.oracle.svm.core.code.CodeCachePoolMXBean$CodeAndDataPool.getConstructors()
+  {
+    "type": "com.oracle.svm.core.code.CodeCachePoolMXBean$CodeAndDataPool"
+  }
 
-without it being registered for runtime reflection. Add com.oracle.svm.core.code.CodeCachePoolMXBean$CodeAndDataPool.getConstructors() to the reflection metadata to solve this problem. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection for help.
-  java.base@24.0.2/java.lang.Class.getConstructors(DynamicHub.java:1128)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.findConstructors(MBeanIntrospector.java:459)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.getClassMBeanInfo(MBeanIntrospector.java:430)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.getMBeanInfo(MBeanIntrospector.java:389)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanSupport.<init>(MBeanSupport.java:137)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MXBeanSupport.<init>(MXBeanSupport.java:66)
-  java.management@24.0.2/javax.management.StandardMBean.construct(StandardMBean.java:174)
-  java.management@24.0.2/javax.management.StandardMBean.<init>(StandardMBean.java:268)
-org.graalvm.nativeimage.MissingReflectionRegistrationError: The program tried to reflectively access
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
+  java.base@25.0.1/java.lang.Class.getConstructors(DynamicHub.java:1277)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanIntrospector.findConstructors(MBeanIntrospector.java:459)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanIntrospector.getClassMBeanInfo(MBeanIntrospector.java:430)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanIntrospector.getMBeanInfo(MBeanIntrospector.java:389)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanSupport.<init>(MBeanSupport.java:137)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MXBeanSupport.<init>(MXBeanSupport.java:66)
+  java.management@25.0.1/javax.management.StandardMBean.construct(StandardMBean.java:174)
+  java.management@25.0.1/javax.management.StandardMBean.<init>(StandardMBean.java:268)
+org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the 'com.oracle.svm.core.code.CodeCachePoolMXBean$NativeMetadataPool'. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
 
-   com.oracle.svm.core.code.CodeCachePoolMXBean$NativeMetadataPool.getConstructors()
+  {
+    "type": "com.oracle.svm.core.code.CodeCachePoolMXBean$NativeMetadataPool"
+  }
 
-without it being registered for runtime reflection. Add com.oracle.svm.core.code.CodeCachePoolMXBean$NativeMetadataPool.getConstructors() to the reflection metadata to solve this problem. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection for help.
-  java.base@24.0.2/java.lang.Class.getConstructors(DynamicHub.java:1128)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.findConstructors(MBeanIntrospector.java:459)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.getClassMBeanInfo(MBeanIntrospector.java:430)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.getMBeanInfo(MBeanIntrospector.java:389)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanSupport.<init>(MBeanSupport.java:137)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MXBeanSupport.<init>(MXBeanSupport.java:66)
-  java.management@24.0.2/javax.management.StandardMBean.construct(StandardMBean.java:174)
-  java.management@24.0.2/javax.management.StandardMBean.<init>(StandardMBean.java:268)
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
+  java.base@25.0.1/java.lang.Class.getConstructors(DynamicHub.java:1277)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanIntrospector.findConstructors(MBeanIntrospector.java:459)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanIntrospector.getClassMBeanInfo(MBeanIntrospector.java:430)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanIntrospector.getMBeanInfo(MBeanIntrospector.java:389)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanSupport.<init>(MBeanSupport.java:137)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MXBeanSupport.<init>(MXBeanSupport.java:66)
+  java.management@25.0.1/javax.management.StandardMBean.construct(StandardMBean.java:174)
+  java.management@25.0.1/javax.management.StandardMBean.<init>(StandardMBean.java:268)
 ```
 
-相关警告在 `GraalVM CE For JDK 24.0.2` 上无法避免。
+相关警告在 `GraalVM CE For JDK 25.0.1` 上无法避免。
 因为 `com.oracle.svm.core.code.CodeCachePoolMXBean` 的无参构造函数通过 Java 类 `org.graalvm.nativeimage.Platform.HOSTED_ONLY` 被标记为无论实际的 Platform 是什么，
 仅在 Native Image 生成期间可见，且无法在 Runtime 使用的元素。

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
@@ -27,7 +27,7 @@ ShardingSphere defines,
 
 Developer must have installed on their devices,
 
-1. GraalVM CE 24.0.2, or a GraalVM downstream distribution compatible with GraalVM CE 24.0.2. Refer to [GraalVM Native Image](/en/user-manual/shardingsphere-jdbc/graalvm-native-image).
+1. GraalVM CE 25.0.1, or a GraalVM downstream distribution compatible with GraalVM CE 25.0.1. Refer to [GraalVM Native Image](/en/user-manual/shardingsphere-jdbc/graalvm-native-image).
 2. The native toolchain required to compile the GraalVM Native Image. Refer to https://www.graalvm.org/latest/reference-manual/native-image/#prerequisites .
 3. Docker Engine that can run Linux Containers, or a Container Runtime compatible with testcontainers-java. Refer to https://java.testcontainers.org/supported_docker_environment/ .
 
@@ -43,8 +43,8 @@ GraalVM CE can be installed using `SDKMAN!` in bash using the following command.
 sudo apt install unzip zip -y
 curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"
-sdk install java 24.0.2-graalce
-sdk use java 24.0.2-graalce
+sdk install java 25.0.1-graalce
+sdk use java 25.0.1-graalce
 ```
 
 Developer can use the following command in bash to install the local toolchain required to compile GraalVM Native Image.
@@ -88,11 +88,11 @@ winget install --id version-fox.vfox --source winget --exact
 if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
 # At this time, developer need to open a new Powershell 7 terminal
 vfox add java
-vfox install java@24.0.2-graalce
-vfox use --global java@24.0.2-graalce
+vfox install java@25.0.1-graalce
+vfox use --global java@25.0.1-graalce
 ```
 
-When Windows pops up a window asking developer to allow an application with a path like `C:\users\shard\.version-fox\cache\java\v-24.0.2-graalce\java-24.0.2-graalce\bin\java.exe` to pass through Windows Firewall,
+When Windows pops up a window asking developer to allow an application with a path like `C:\users\shard\.version-fox\cache\java\v-25.0.1-graalce\java-25.0.1-graalce\bin\java.exe` to pass through Windows Firewall,
 developer should approve it.
 Background reference https://support.microsoft.com/en-us/windows/risks-of-allowing-apps-through-windows-firewall-654559af-3f54-3dcf-349f-71ccd90bcc5c .
 
@@ -295,35 +295,39 @@ This is because executing this unit test in the Github Actions Runner will cause
 Currently executing `./mvnw -PnativeTestInShardingSphere -e -T 1C clean verify` will involve warning logs for `com.oracle.svm.core.code.CodeCachePoolMXBean`.
 
 ```shell
-org.graalvm.nativeimage.MissingReflectionRegistrationError: The program tried to reflectively access
+org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the 'com.oracle.svm.core.code.CodeCachePoolMXBean$CodeAndDataPool'. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
 
-   com.oracle.svm.core.code.CodeCachePoolMXBean$CodeAndDataPool.getConstructors()
+  {
+    "type": "com.oracle.svm.core.code.CodeCachePoolMXBean$CodeAndDataPool"
+  }
 
-without it being registered for runtime reflection. Add com.oracle.svm.core.code.CodeCachePoolMXBean$CodeAndDataPool.getConstructors() to the reflection metadata to solve this problem. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection for help.
-  java.base@24.0.2/java.lang.Class.getConstructors(DynamicHub.java:1128)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.findConstructors(MBeanIntrospector.java:459)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.getClassMBeanInfo(MBeanIntrospector.java:430)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.getMBeanInfo(MBeanIntrospector.java:389)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanSupport.<init>(MBeanSupport.java:137)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MXBeanSupport.<init>(MXBeanSupport.java:66)
-  java.management@24.0.2/javax.management.StandardMBean.construct(StandardMBean.java:174)
-  java.management@24.0.2/javax.management.StandardMBean.<init>(StandardMBean.java:268)
-org.graalvm.nativeimage.MissingReflectionRegistrationError: The program tried to reflectively access
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
+  java.base@25.0.1/java.lang.Class.getConstructors(DynamicHub.java:1277)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanIntrospector.findConstructors(MBeanIntrospector.java:459)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanIntrospector.getClassMBeanInfo(MBeanIntrospector.java:430)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanIntrospector.getMBeanInfo(MBeanIntrospector.java:389)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanSupport.<init>(MBeanSupport.java:137)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MXBeanSupport.<init>(MXBeanSupport.java:66)
+  java.management@25.0.1/javax.management.StandardMBean.construct(StandardMBean.java:174)
+  java.management@25.0.1/javax.management.StandardMBean.<init>(StandardMBean.java:268)
+org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the 'com.oracle.svm.core.code.CodeCachePoolMXBean$NativeMetadataPool'. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
 
-   com.oracle.svm.core.code.CodeCachePoolMXBean$NativeMetadataPool.getConstructors()
+  {
+    "type": "com.oracle.svm.core.code.CodeCachePoolMXBean$NativeMetadataPool"
+  }
 
-without it being registered for runtime reflection. Add com.oracle.svm.core.code.CodeCachePoolMXBean$NativeMetadataPool.getConstructors() to the reflection metadata to solve this problem. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection for help.
-  java.base@24.0.2/java.lang.Class.getConstructors(DynamicHub.java:1128)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.findConstructors(MBeanIntrospector.java:459)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.getClassMBeanInfo(MBeanIntrospector.java:430)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanIntrospector.getMBeanInfo(MBeanIntrospector.java:389)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MBeanSupport.<init>(MBeanSupport.java:137)
-  java.management@24.0.2/com.sun.jmx.mbeanserver.MXBeanSupport.<init>(MXBeanSupport.java:66)
-  java.management@24.0.2/javax.management.StandardMBean.construct(StandardMBean.java:174)
-  java.management@24.0.2/javax.management.StandardMBean.<init>(StandardMBean.java:268)
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
+  java.base@25.0.1/java.lang.Class.getConstructors(DynamicHub.java:1277)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanIntrospector.findConstructors(MBeanIntrospector.java:459)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanIntrospector.getClassMBeanInfo(MBeanIntrospector.java:430)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanIntrospector.getMBeanInfo(MBeanIntrospector.java:389)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MBeanSupport.<init>(MBeanSupport.java:137)
+  java.management@25.0.1/com.sun.jmx.mbeanserver.MXBeanSupport.<init>(MXBeanSupport.java:66)
+  java.management@25.0.1/javax.management.StandardMBean.construct(StandardMBean.java:174)
+  java.management@25.0.1/javax.management.StandardMBean.<init>(StandardMBean.java:268)
 ```
 
-The relevant warning cannot be avoided on `GraalVM CE For JDK 24.0.2`.
+The relevant warning cannot be avoided on `GraalVM CE For JDK 25.0.1`.
 Because the no-argument constructor of `com.oracle.svm.core.code.CodeCachePoolMXBean` is marked as an element that is only visible during Native Image generation and cannot be used at Runtime, 
 regardless of the actual Platform,
 through the Java class `org.graalvm.nativeimage.Platform.HOSTED_ONLY`.

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.cn.md
@@ -118,7 +118,7 @@ services:
       environment:
          MYSQL_ROOT_PASSWORD: example
       volumes:
-         - ./mysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+         - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
       ports:
          - "3306:3306"
 ```

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/transaction/seata.en.md
@@ -129,7 +129,7 @@ services:
       environment:
          MYSQL_ROOT_PASSWORD: example
       volumes:
-         - ./mysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+         - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
       ports:
          - "3306:3306"
 ```

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -260,7 +260,7 @@ services:
 
 贡献者必须在设备安装，
 
-1. GraalVM CE 24.0.2，或与 GraalVM CE 24.0.2 兼容的 GraalVM 下游发行版。以 [GraalVM Native Image](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image) 为准。
+1. GraalVM CE 25.0.1，或与 GraalVM CE 25.0.1 兼容的 GraalVM 下游发行版。以 [GraalVM Native Image](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image) 为准。
 2. 编译 GraalVM Native Image 所需要的本地工具链。以 https://www.graalvm.org/latest/reference-manual/native-image/#prerequisites 为准。
 
 在 Ubuntu 与 Windows 下可能的所需操作与[开发和测试](/cn/user-manual/shardingsphere-jdbc/graalvm-native-image/development)一致。

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -264,7 +264,7 @@ services:
 
 Contributors must have installed on their devices,
 
-1. GraalVM CE 24.0.2, or a GraalVM downstream distribution compatible with GraalVM CE 24.0.2. Refer to [GraalVM Native Image](/en/user-manual/shardingsphere-jdbc/graalvm-native-image).
+1. GraalVM CE 25.0.1, or a GraalVM downstream distribution compatible with GraalVM CE 25.0.1. Refer to [GraalVM Native Image](/en/user-manual/shardingsphere-jdbc/graalvm-native-image).
 2. The native toolchain required to compile GraalVM Native Image. Refer to https://www.graalvm.org/latest/reference-manual/native-image/#prerequisites .
 
 The possible required operations under Ubuntu and Windows are consistent with [Development and test](/en/user-manual/shardingsphere-jdbc/graalvm-native-image/development).

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
@@ -148,15 +148,7 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.impl.MySQLNotFunction"
       },
-      "type": "java.lang.Boolean",
-      "fields": [
-        {
-          "name": "FALSE"
-        },
-        {
-          "name": "TRUE"
-        }
-      ]
+      "type": "java.lang.Boolean"
     },
     {
       "condition": {
@@ -278,37 +270,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.algorithm.core.processor.AlgorithmChangedProcessor"
       },
       "type": "java.lang.Object"
@@ -317,8 +278,7 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
+      "type": "java.lang.Object"
     },
     {
       "condition": {
@@ -336,8 +296,7 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
+      "type": "java.lang.Object"
     },
     {
       "condition": {
@@ -349,33 +308,11 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
       },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
-      },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
+      "type": "java.lang.Object"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
-      },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterMetaDataManagerPersistService"
-      },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
       },
       "type": "java.lang.Object"
     },
@@ -387,58 +324,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.MetaDataContexts"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManager"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.config.global.GlobalRulePersistService"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
+      "type": "java.lang.Object"
     },
     {
       "condition": {
@@ -448,66 +336,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.statistics.StatisticsPersistService"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.PushDownMetaDataRefreshEngine"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.type.table.CreateTablePushDownMetaDataRefresher"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.node.rule.tuple.YamlRuleNodeTupleSwapperEngine"
       },
       "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseProxyConnector"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -596,6 +427,15 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.lang.StringBuilder"
+    },
+    {
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
+      },
+      "type": "java.lang.String[]"
     },
     {
       "condition": {
@@ -828,6 +668,42 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.database.DatabaseTypeEngine"
+      },
+      "type": "java.sql.Statement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"
+      },
+      "type": "java.sql.Statement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilder"
+      },
+      "type": "java.sql.Statement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"
+      },
+      "type": "java.sql.Statement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.jdbc.datasource.JDBCBackendDataSource"
+      },
+      "type": "java.sql.Statement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
+      },
+      "type": "java.sql.Statement[]"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "java.sql.Timestamp"
@@ -924,54 +800,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.util.List"
@@ -1044,24 +872,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.algorithm.core.processor.AlgorithmChangedProcessor"
       },
       "type": "java.util.Properties",
@@ -1083,36 +893,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "java.util.Properties"
     },
     {
       "condition": {
@@ -1346,24 +1126,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.authority.distsql.parser.core.AuthorityDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.authority.distsql.parser.core.AuthorityDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.authority.distsql.parser.core.AuthorityDistSQLLexer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.authority.distsql.parser.core.AuthorityDistSQLParser",
@@ -1375,24 +1137,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.authority.distsql.parser.core.AuthorityDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.authority.distsql.parser.core.AuthorityDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.authority.distsql.parser.core.AuthorityDistSQLParser"
     },
     {
       "condition": {
@@ -1420,17 +1164,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -1458,43 +1194,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.config.global.GlobalRulePersistService"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.node.rule.tuple.YamlRuleNodeTupleSwapperEngine"
       },
       "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration",
@@ -1516,13 +1215,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -1553,7 +1245,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.authority.yaml.config.YamlUserConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -1619,24 +1310,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLLexer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLParser",
@@ -1651,24 +1324,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLParser"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLStatementVisitor",
@@ -1678,24 +1333,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLStatementVisitor"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLStatementVisitor"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.broadcast.distsql.parser.core.BroadcastDistSQLStatementVisitor"
     },
     {
       "condition": {
@@ -1729,35 +1366,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -1779,48 +1390,31 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
       },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"
+      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
+      "fields": [
+        {
+          "name": "tables"
+        }
+      ]
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
       },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"
+      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
+      "fields": [
+        {
+          "name": "tables"
+        }
+      ]
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.node.rule.node.DatabaseRuleNodeGenerator"
       },
       "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -1862,24 +1456,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.data.pipeline.cdc.distsql.parser.core.CDCDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.data.pipeline.cdc.distsql.parser.core.CDCDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.data.pipeline.cdc.distsql.parser.core.CDCDistSQLLexer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.data.pipeline.cdc.distsql.parser.core.CDCDistSQLParser",
@@ -1891,24 +1467,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.data.pipeline.cdc.distsql.parser.core.CDCDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.data.pipeline.cdc.distsql.parser.core.CDCDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.data.pipeline.cdc.distsql.parser.core.CDCDistSQLParser"
     },
     {
       "condition": {
@@ -2016,24 +1574,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.data.pipeline.scenario.migration.distsql.parser.core.MigrationDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.data.pipeline.scenario.migration.distsql.parser.core.MigrationDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.data.pipeline.scenario.migration.distsql.parser.core.MigrationDistSQLLexer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.data.pipeline.scenario.migration.distsql.parser.core.MigrationDistSQLParser",
@@ -2045,24 +1585,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.data.pipeline.scenario.migration.distsql.parser.core.MigrationDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.data.pipeline.scenario.migration.distsql.parser.core.MigrationDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.data.pipeline.scenario.migration.distsql.parser.core.MigrationDistSQLParser"
     },
     {
       "condition": {
@@ -2368,24 +1890,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLLexer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLStatementParserEngine"
       },
       "type": "org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLParser",
@@ -2397,54 +1901,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.distsql.parser.core.kernel.KernelDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.validate.DistSQLDataSourcePoolPropertiesValidator"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
     },
     {
       "condition": {
@@ -2466,43 +1922,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"
       },
       "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
+        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.jdbc.datasource.JDBCBackendDataSource"
       },
       "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
     },
@@ -2517,7 +1943,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.driver.yaml.YamlJDBCConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -2599,12 +2024,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.encrypt.rule.builder.EncryptRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.encrypt.algorithm.assisted.MD5AssistedEncryptAlgorithm"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.encrypt.checker.config.EncryptRuleConfigurationChecker"
       },
       "type": "org.apache.shardingsphere.encrypt.algorithm.standard.AESEncryptAlgorithm",
@@ -2626,12 +2045,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.encrypt.rule.builder.EncryptRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.encrypt.algorithm.standard.AESEncryptAlgorithm"
     },
     {
       "condition": {
@@ -2698,14 +2111,20 @@
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration",
-      "allDeclaredFields": true
+      "fields": [
+        {
+          "name": "encryptors"
+        },
+        {
+          "name": "tables"
+        }
+      ]
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -2748,7 +2167,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -2785,7 +2203,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -2822,7 +2239,6 @@
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "getColumns",
@@ -2839,7 +2255,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -2881,24 +2296,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.globalclock.distsql.parser.core.GlobalClockDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.globalclock.distsql.parser.core.GlobalClockDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.globalclock.distsql.parser.core.GlobalClockDistSQLLexer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.globalclock.distsql.parser.core.GlobalClockDistSQLParser",
@@ -2910,24 +2307,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.globalclock.distsql.parser.core.GlobalClockDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.globalclock.distsql.parser.core.GlobalClockDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.globalclock.distsql.parser.core.GlobalClockDistSQLParser"
     },
     {
       "condition": {
@@ -2955,51 +2334,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.config.global.GlobalRulePersistService"
       },
       "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfiguration"
     },
@@ -3029,14 +2364,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationBeanInfo"
     },
@@ -3044,56 +2372,7 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
       },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
       "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -3124,7 +2403,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -3146,31 +2424,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.node.rule.tuple.YamlRuleNodeTupleSwapperEngine"
       },
       "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
@@ -3184,26 +2437,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -3231,48 +2464,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.encrypt.checker.config.EncryptRuleConfigurationChecker"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.cryptographic.aes.AESCryptographicAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.encrypt.rule.EncryptRule"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.cryptographic.aes.AESCryptographicAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.encrypt.rule.builder.EncryptRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.cryptographic.aes.AESCryptographicAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.encrypt.algorithm.standard.AESEncryptAlgorithm"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.cryptographic.aes.props.DefaultAESPropertiesProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.encrypt.checker.config.EncryptRuleConfigurationChecker"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.cryptographic.aes.props.DefaultAESPropertiesProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.encrypt.rule.EncryptRule"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.cryptographic.aes.props.DefaultAESPropertiesProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.encrypt.rule.builder.EncryptRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.cryptographic.aes.props.DefaultAESPropertiesProvider"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.algorithm.cryptographic.aes.AESCryptographicAlgorithm"
       },
       "type": "org.apache.shardingsphere.infra.algorithm.cryptographic.aes.props.DefaultAESPropertiesProvider",
@@ -3285,66 +2476,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.sharding.checker.config.ShardingRuleConfigurationChecker"
       },
       "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm",
@@ -3381,72 +2512,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.builder.ShardingRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.sharding.checker.config.ShardingRuleConfigurationChecker"
       },
       "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm",
@@ -3480,12 +2545,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.builder.ShardingRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
     },
     {
       "condition": {
@@ -3501,12 +2560,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.rule.builder.ReadwriteSplittingRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.loadbalancer.random.RandomLoadBalanceAlgorithm"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.readwritesplitting.rule.ReadwriteSplittingRule"
       },
       "type": "org.apache.shardingsphere.infra.algorithm.loadbalancer.round.robin.RoundRobinLoadBalanceAlgorithm",
@@ -3519,12 +2572,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.rule.builder.ReadwriteSplittingRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.loadbalancer.round.robin.RoundRobinLoadBalanceAlgorithm"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.readwritesplitting.rule.ReadwriteSplittingRule"
       },
       "type": "org.apache.shardingsphere.infra.algorithm.loadbalancer.weight.WeightLoadBalanceAlgorithm",
@@ -3534,12 +2581,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.rule.builder.ReadwriteSplittingRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.loadbalancer.weight.WeightLoadBalanceAlgorithm"
     },
     {
       "condition": {
@@ -3597,18 +2638,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.entry.InlineExpressionParserFactory"
       },
       "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser",
@@ -3618,90 +2647,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.checker.ReadwriteSplittingDataSourceRuleConfigurationChecker"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.checker.ReadwriteSplittingRuleConfigurationChecker"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.rule.ReadwriteSplittingRule"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.rule.builder.ReadwriteSplittingRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.distsql.handler.checker.ShardingTableRuleStatementChecker"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.distsql.handler.converter.ShardingTableRuleStatementConverter"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.distsql.handler.update.CreateShardingTableRuleExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.ShardingRule"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.ShardingTable"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
     },
     {
       "condition": {
@@ -3717,90 +2662,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.checker.ReadwriteSplittingDataSourceRuleConfigurationChecker"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.checker.ReadwriteSplittingRuleConfigurationChecker"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.rule.ReadwriteSplittingRule"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.rule.builder.ReadwriteSplittingRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.distsql.handler.checker.ShardingTableRuleStatementChecker"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.distsql.handler.converter.ShardingTableRuleStatementConverter"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.distsql.handler.update.CreateShardingTableRuleExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.ShardingRule"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.ShardingTable"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.interval.IntervalInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.entry.InlineExpressionParserFactory"
       },
       "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser",
@@ -3813,82 +2674,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.checker.ReadwriteSplittingDataSourceRuleConfigurationChecker"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.checker.ReadwriteSplittingRuleConfigurationChecker"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.rule.ReadwriteSplittingRule"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.readwritesplitting.rule.builder.ReadwriteSplittingRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.distsql.handler.checker.ShardingTableRuleStatementChecker"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.distsql.handler.converter.ShardingTableRuleStatementConverter"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.distsql.handler.update.CreateShardingTableRuleExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.ShardingRule"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.ShardingTable"
-      },
-      "type": "org.apache.shardingsphere.infra.expr.literal.LiteralInlineExpressionParser"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
       },
       "type": "org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeData",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -3970,18 +2758,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.parser.sql.SQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.parser.sql.SQLStatementParserEngineFactory"
-      },
-      "type": "org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.generic.RemoveTokenGenerator"
       },
       "type": "org.apache.shardingsphere.infra.rewrite.mysql.MySQLToBeRemovedSegmentsProvider"
@@ -4000,6 +2776,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "org.apache.shardingsphere.infra.util.yaml.YamlConfiguration"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.infra.util.yaml.YamlConfiguration"
@@ -4015,7 +2797,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -4052,7 +2833,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlPersistRepositoryConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -4092,69 +2872,15 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
+        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.MetaDataContexts"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManager"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
+      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration"
     },
     {
       "condition": {
@@ -4187,38 +2913,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.statistics.StatisticsPersistService"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -4288,17 +2982,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -4374,17 +3060,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -4439,7 +3117,6 @@
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "setType",
@@ -4451,23 +3128,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -4512,38 +3175,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.PushDownMetaDataRefreshEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.type.table.CreateTablePushDownMetaDataRefresher"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseProxyConnector"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -4796,14 +3427,20 @@
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfiguration",
-      "allDeclaredFields": true
+      "fields": [
+        {
+          "name": "maskAlgorithms"
+        },
+        {
+          "name": "tables"
+        }
+      ]
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -4846,7 +3483,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskColumnRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -4877,7 +3513,6 @@
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "getColumns",
@@ -4894,7 +3529,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -5126,77 +3760,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.type.DatabaseMetaDataChangedListener"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
@@ -5204,39 +3774,11 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.changed.RuleItemChangedNodePathBuilder"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
@@ -5244,44 +3786,17 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.config.database.DataSourceUnitPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.config.database.DatabaseRulePersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.DatabaseMetaDataPersistFacade"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
@@ -5289,55 +3804,23 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.DatabaseMetaDataPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.SchemaMetaDataPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.ViewMetaDataPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.PushDownMetaDataRefreshEngine"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.type.table.CreateTablePushDownMetaDataRefresher"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.ViewMetaDataPersistService"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
@@ -5345,122 +3828,17 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.node.path.engine.searcher.NodePathSearcher"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.repository.cluster.zookeeper.ZookeeperRepository"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseProxyConnector"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.type.DatabaseMetaDataChangedListener"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageNodeNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "storageNodeName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.repository.cluster.zookeeper.ZookeeperRepository"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageNodeNodePath"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.type.DatabaseMetaDataChangedListener"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "storageUnitName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath"
     },
@@ -5468,232 +3846,41 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.config.database.DataSourceUnitPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "storageUnitName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.repository.cluster.zookeeper.ZookeeperRepository"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.type.DatabaseMetaDataChangedListener"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "databaseRuleItem"
-        },
-        {
-          "name": "ruleType"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "databaseRuleItem"
-        },
-        {
-          "name": "ruleType"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.changed.RuleItemChangedNodePathBuilder"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "databaseRuleItem"
-        },
-        {
-          "name": "ruleType"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "databaseRuleItem"
-        },
-        {
-          "name": "ruleType"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.config.database.DatabaseRulePersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "databaseRuleItem"
-        },
-        {
-          "name": "ruleType"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.repository.cluster.zookeeper.ZookeeperRepository"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.type.DatabaseMetaDataChangedListener"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "schemaName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.DatabaseMetaDataPersistFacade"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
     },
@@ -5701,53 +3888,17 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.SchemaMetaDataPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "schemaName"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "schemaName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.ViewMetaDataPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "schemaName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.PushDownMetaDataRefreshEngine"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.type.table.CreateTablePushDownMetaDataRefresher"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.ViewMetaDataPersistService"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
     },
@@ -5755,87 +3906,11 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.node.path.engine.searcher.NodePathSearcher"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "schemaName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.repository.cluster.zookeeper.ZookeeperRepository"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseProxyConnector"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.type.DatabaseMetaDataChangedListener"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath",
-      "fields": [
-        {
-          "name": "schema"
-        },
-        {
-          "name": "tableName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.DatabaseMetaDataPersistFacade"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
     },
@@ -5843,39 +3918,11 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.SchemaMetaDataPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath",
-      "fields": [
-        {
-          "name": "schema"
-        },
-        {
-          "name": "tableName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath",
-      "fields": [
-        {
-          "name": "schema"
-        },
-        {
-          "name": "tableName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.PushDownMetaDataRefreshEngine"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.type.table.CreateTablePushDownMetaDataRefresher"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
     },
@@ -5883,63 +3930,11 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.node.path.engine.searcher.NodePathSearcher"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath",
-      "fields": [
-        {
-          "name": "schema"
-        },
-        {
-          "name": "tableName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.repository.cluster.zookeeper.ZookeeperRepository"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseProxyConnector"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.type.DatabaseMetaDataChangedListener"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.ViewMetaDataNodePath",
-      "fields": [
-        {
-          "name": "schema"
-        },
-        {
-          "name": "viewName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.ViewMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.SchemaMetaDataPersistService"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.ViewMetaDataNodePath"
     },
@@ -5947,230 +3942,29 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.ViewMetaDataPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.ViewMetaDataNodePath",
-      "fields": [
-        {
-          "name": "schema"
-        },
-        {
-          "name": "viewName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.repository.cluster.zookeeper.ZookeeperRepository"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.ViewMetaDataNodePath"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.MetaDataContexts"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath",
-      "fields": [
-        {
-          "name": "table"
-        },
-        {
-          "name": "uniqueKey"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.statistics.StatisticsPersistService"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.MetaDataContexts"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.MetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.statistics.StatisticsPersistService"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
     },
@@ -6178,111 +3972,11 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.statistics.StatisticsPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.MetaDataContexts"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
     },
@@ -6290,210 +3984,17 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "schemaName"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.statistics.StatisticsPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "schemaName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.MetaDataContexts"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath",
-      "fields": [
-        {
-          "name": "schema"
-        },
-        {
-          "name": "tableName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.statistics.StatisticsPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath",
-      "fields": [
-        {
-          "name": "schema"
-        },
-        {
-          "name": "tableName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.config.GlobalRuleNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.config.GlobalRuleNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.config.GlobalRuleNodePath",
-      "fields": [
-        {
-          "name": "ruleType"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.config.GlobalRuleNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.config.GlobalRuleNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.config.GlobalRuleNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.global.config.GlobalRuleNodePath"
     },
@@ -6501,135 +4002,65 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.config.global.GlobalRulePersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.config.GlobalRuleNodePath",
-      "fields": [
-        {
-          "name": "ruleType"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
       "type": "org.apache.shardingsphere.mode.node.path.type.global.config.GlobalRuleNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.label.LabelNodePath",
-      "fields": [
-        {
-          "name": "instanceId"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.label.LabelNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.label.LabelNodePath",
-      "fields": [
-        {
-          "name": "instanceId"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.label.LabelNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.process.KillProcessTriggerNodePath",
-      "fields": [
-        {
-          "name": "instanceProcess"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.process.KillProcessTriggerNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.process.ShowProcessListTriggerNodePath",
-      "fields": [
-        {
-          "name": "instanceProcess"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.process.ShowProcessListTriggerNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.OnlineNodePath",
-      "fields": [
-        {
-          "name": "instanceType"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.OnlineNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.OnlineNodePath",
-      "fields": [
-        {
-          "name": "instanceId"
-        },
-        {
-          "name": "instanceType"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.OnlineNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.StatusNodePath",
-      "fields": [
-        {
-          "name": "instanceId"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.StatusNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.StatusNodePath",
-      "fields": [
-        {
-          "name": "instanceId"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.StatusNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.workerid.ComputeNodeWorkerIDNodePath",
-      "fields": [
-        {
-          "name": "instanceId"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.workerid.ComputeNodeWorkerIDNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.workerid.ComputeNodeWorkerIDNodePath",
-      "fields": [
-        {
-          "name": "instanceId"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.workerid.ClusterWorkerIdGenerator"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.workerid.ComputeNodeWorkerIDNodePath"
     },
@@ -6637,56 +4068,31 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.storage.QualifiedDataSourceNodePath",
-      "fields": [
-        {
-          "name": "qualifiedDataSource"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.storage.QualifiedDataSourceNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.node.QualifiedDataSourceStatePersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.storage.QualifiedDataSourceNodePath",
-      "fields": [
-        {
-          "name": "qualifiedDataSource"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.storage.QualifiedDataSourceNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.workerid.ReservationPersistService"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.reservation.WorkerIDReservationNodePath",
-      "fields": [
-        {
-          "name": "preselectedWorkerId"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.reservation.WorkerIDReservationNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.state.DatabaseListenerCoordinatorNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.state.DatabaseListenerCoordinatorNodePath"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.global.state.coordinator.TableCoordinatorNodePath",
-      "fields": [
-        {
-          "name": "qualifiedTableName"
-        }
-      ]
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.state.coordinator.TableCoordinatorNodePath"
     },
     {
       "condition": {
@@ -6714,12 +4120,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository",
@@ -6732,28 +4132,44 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.repository.standalone.jdbc.sql.JDBCRepositorySQLLoader"
       },
       "type": "org.apache.shardingsphere.mode.repository.standalone.jdbc.sql.JDBCRepositorySQL",
-      "allDeclaredFields": true,
+      "fields": [
+        {
+          "name": "createTableSQL"
+        },
+        {
+          "name": "deleteSQL"
+        },
+        {
+          "name": "driverClassName"
+        },
+        {
+          "name": "insertSQL"
+        },
+        {
+          "name": "isDefault"
+        },
+        {
+          "name": "selectByKeySQL"
+        },
+        {
+          "name": "selectByParentKeySQL"
+        },
+        {
+          "name": "type"
+        },
+        {
+          "name": "updateSQL"
+        }
+      ],
       "methods": [
         {
           "name": "<init>",
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.mode.repository.standalone.memory.MemoryRepository"
     },
     {
       "condition": {
@@ -6766,12 +4182,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.mode.repository.standalone.memory.MemoryRepository"
     },
     {
       "condition": {
@@ -6789,24 +4199,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.parser.distsql.parser.core.SQLParserDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.parser.distsql.parser.core.SQLParserDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.parser.distsql.parser.core.SQLParserDistSQLLexer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.parser.distsql.parser.core.SQLParserDistSQLParser",
@@ -6818,24 +4210,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.parser.distsql.parser.core.SQLParserDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.parser.distsql.parser.core.SQLParserDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.parser.distsql.parser.core.SQLParserDistSQLParser"
     },
     {
       "condition": {
@@ -6860,7 +4234,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserCacheOptionRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -6882,17 +4255,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -6920,43 +4285,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.config.global.GlobalRulePersistService"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.node.rule.tuple.YamlRuleNodeTupleSwapperEngine"
       },
       "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration",
@@ -6973,44 +4301,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationCustomizer"
     },
@@ -7019,7 +4316,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -7416,14 +4712,20 @@
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfiguration",
-      "allDeclaredFields": true
+      "fields": [
+        {
+          "name": "dataSourceGroups"
+        },
+        {
+          "name": "loadBalancers"
+        }
+      ]
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -7460,7 +4762,6 @@
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "getLoadBalancerName",
@@ -7485,7 +4786,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -7690,14 +4990,26 @@
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfiguration",
-      "allDeclaredFields": true
+      "fields": [
+        {
+          "name": "dataSources"
+        },
+        {
+          "name": "defaultShadowAlgorithmName"
+        },
+        {
+          "name": "shadowAlgorithms"
+        },
+        {
+          "name": "tables"
+        }
+      ]
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -7752,7 +5064,6 @@
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "getProductionDataSourceName",
@@ -7769,7 +5080,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -7806,7 +5116,6 @@
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "getDataSourceNames",
@@ -7823,7 +5132,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -8213,24 +5521,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLLexer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLParser",
@@ -8245,24 +5535,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLParser"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLStatementVisitor",
@@ -8272,24 +5544,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLStatementVisitor"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLStatementVisitor"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLStatementVisitor"
     },
     {
       "condition": {
@@ -8395,35 +5649,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -8469,48 +5697,97 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
       },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"
+      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
+      "fields": [
+        {
+          "name": "auditors"
+        },
+        {
+          "name": "autoTables"
+        },
+        {
+          "name": "bindingTables"
+        },
+        {
+          "name": "defaultAuditStrategy"
+        },
+        {
+          "name": "defaultDatabaseStrategy"
+        },
+        {
+          "name": "defaultKeyGenerateStrategy"
+        },
+        {
+          "name": "defaultShardingColumn"
+        },
+        {
+          "name": "defaultTableStrategy"
+        },
+        {
+          "name": "keyGenerators"
+        },
+        {
+          "name": "shardingAlgorithms"
+        },
+        {
+          "name": "shardingCache"
+        },
+        {
+          "name": "tables"
+        }
+      ]
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
       },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"
+      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
+      "fields": [
+        {
+          "name": "auditors"
+        },
+        {
+          "name": "autoTables"
+        },
+        {
+          "name": "bindingTables"
+        },
+        {
+          "name": "defaultAuditStrategy"
+        },
+        {
+          "name": "defaultDatabaseStrategy"
+        },
+        {
+          "name": "defaultKeyGenerateStrategy"
+        },
+        {
+          "name": "defaultShardingColumn"
+        },
+        {
+          "name": "defaultTableStrategy"
+        },
+        {
+          "name": "keyGenerators"
+        },
+        {
+          "name": "shardingAlgorithms"
+        },
+        {
+          "name": "shardingCache"
+        },
+        {
+          "name": "tables"
+        }
+      ]
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.node.rule.node.DatabaseRuleNodeGenerator"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -8526,35 +5803,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -8573,31 +5824,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"
     },
     {
       "condition": {
@@ -8630,26 +5856,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -8707,28 +5913,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -8747,38 +5934,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -8824,28 +5979,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -8864,7 +6000,6 @@
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "getComplex",
@@ -8907,32 +6042,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -8978,28 +6087,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -9018,38 +6108,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -9139,24 +6197,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.single.distsql.parser.core.SingleDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.single.distsql.parser.core.SingleDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.single.distsql.parser.core.SingleDistSQLLexer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.single.distsql.parser.core.SingleDistSQLParser",
@@ -9168,24 +6208,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.single.distsql.parser.core.SingleDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.single.distsql.parser.core.SingleDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.single.distsql.parser.core.SingleDistSQLParser"
     },
     {
       "condition": {
@@ -9225,71 +6247,37 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
       },
       "type": "org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
       },
-      "type": "org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration"
+      "type": "org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration",
+      "fields": [
+        {
+          "name": "defaultDataSource"
+        },
+        {
+          "name": "tables"
+        }
+      ]
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
       },
-      "type": "org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheBuilder"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.core.database.cache.ParseTreeCacheLoader"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.core.database.cache.ParseTreeCacheLoader"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.parser.sql.SQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.core.database.cache.ParseTreeCacheLoader"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.parser.sql.SQLStatementParserEngineFactory"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.core.database.cache.ParseTreeCacheLoader"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.parser.sql.SQLStatementParserExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.core.database.cache.ParseTreeCacheLoader"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sql.parser.engine.api.SQLParserEngine"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.core.database.cache.ParseTreeCacheLoader"
+      "type": "org.apache.shardingsphere.single.yaml.config.YamlSingleRuleConfiguration",
+      "fields": [
+        {
+          "name": "defaultDataSource"
+        },
+        {
+          "name": "tables"
+        }
+      ]
     },
     {
       "condition": {
@@ -9845,164 +6833,17 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable",
-      "allPublicFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable",
-      "allPublicFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.MetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManager"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable",
-      "allPublicFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable",
-      "allPublicFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable",
-      "allPublicFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.CompilerContextFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
       },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.rule.SQLFederationRule"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.rule.builder.SQLFederationRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.schema.CalciteSchemaBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.impl.MySQLBinFunction"
+      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable",
+      "fields": [
+        {
+          "name": "BIT_COUNT"
+        },
+        {
+          "name": "NOT"
+        }
+      ]
     },
     {
       "condition": {
@@ -10030,18 +6871,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.schema.CalciteSchemaBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.postgresql.impl.PostgreSQLSystemFunction"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sqlfederation.opengauss.OpenGaussSQLFederationFunctionRegister"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.postgresql.impl.PostgreSQLSystemFunction"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.sqlfederation.postgresql.PostgreSQLSQLFederationFunctionRegister"
       },
       "type": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.postgresql.impl.PostgreSQLSystemFunction"
@@ -10062,24 +6891,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.distsql.parser.core.SQLFederationDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.distsql.parser.core.SQLFederationDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.distsql.parser.core.SQLFederationDistSQLLexer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.sqlfederation.distsql.parser.core.SQLFederationDistSQLParser",
@@ -10091,24 +6902,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.distsql.parser.core.SQLFederationDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.distsql.parser.core.SQLFederationDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.distsql.parser.core.SQLFederationDistSQLParser"
     },
     {
       "condition": {
@@ -10160,51 +6953,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.config.global.GlobalRulePersistService"
       },
       "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration"
     },
@@ -10230,44 +6979,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationCustomizer"
     },
@@ -10287,24 +7005,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.distsql.parser.core.SQLTranslatorDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.distsql.parser.core.SQLTranslatorDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.distsql.parser.core.SQLTranslatorDistSQLLexer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.sqltranslator.distsql.parser.core.SQLTranslatorDistSQLParser",
@@ -10316,24 +7016,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.distsql.parser.core.SQLTranslatorDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.distsql.parser.core.SQLTranslatorDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.distsql.parser.core.SQLTranslatorDistSQLParser"
     },
     {
       "condition": {
@@ -10355,51 +7037,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.config.global.GlobalRulePersistService"
       },
       "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfiguration"
     },
@@ -10425,44 +7063,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationCustomizer"
     },
@@ -10480,120 +7087,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.MetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.timeservice.core.rule.TimestampServiceRule"
       },
       "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService",
@@ -10603,12 +7096,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.timeservice.core.rule.builder.TimestampServiceRuleBuilder"
-      },
-      "type": "org.apache.shardingsphere.timeservice.type.system.SystemTimestampService"
     },
     {
       "condition": {
@@ -10624,66 +7111,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.executor.engine.DriverExecuteQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.executor.engine.facade.DriverExecutorFacade"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.executor.engine.pushdown.jdbc.DriverJDBCPushDownExecuteExecutor"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.executor.engine.pushdown.jdbc.DriverJDBCPushDownExecuteQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.executor.engine.pushdown.jdbc.DriverJDBCPushDownExecuteUpdateExecutor"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.executor.kernel.ExecutorEngine"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutor"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutorCallback"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.executor.sql.hook.SPISQLExecutionHook"
       },
       "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook",
@@ -10693,36 +7120,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.ProxySQLExecutor"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseProxyConnector"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.jdbc.executor.ProxyJDBCExecutor"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook"
     },
     {
       "condition": {
@@ -10740,24 +7137,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.transaction.distsql.parser.core.TransactionDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.transaction.distsql.parser.core.TransactionDistSQLLexer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.transaction.distsql.parser.core.TransactionDistSQLLexer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.parser.core.featured.DistSQLParserEngine"
       },
       "type": "org.apache.shardingsphere.transaction.distsql.parser.core.TransactionDistSQLParser",
@@ -10769,24 +7148,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.parser.engine.api.DistSQLStatementParserEngine"
-      },
-      "type": "org.apache.shardingsphere.transaction.distsql.parser.core.TransactionDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.transaction.distsql.parser.core.TransactionDistSQLParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.transaction.distsql.parser.core.TransactionDistSQLParser"
     },
     {
       "condition": {
@@ -10886,17 +7247,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration",
-      "allDeclaredFields": true,
       "methods": [
         {
           "name": "<init>",
@@ -10924,43 +7277,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.config.global.GlobalRulePersistService"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.node.rule.tuple.YamlRuleNodeTupleSwapperEngine"
       },
       "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration",
@@ -10981,44 +7297,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationCustomizer"
     }
@@ -13136,6 +9421,5 @@
       },
       "glob": "transactions.properties"
     }
-  ],
-  "bundles": []
+  ]
 }

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reachability-metadata.json
@@ -263,6 +263,18 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex"
+      },
+      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndexBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex"
+      },
+      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndexCustomizer"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.builder.SystemSchemaBuilder"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
@@ -523,6 +535,160 @@
           "parameterTypes": []
         }
       ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.DatabaseMetaDataPersistService"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.statistics.StatisticsPersistService"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDatabaseNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.workerid.ComputeNodeWorkerIDNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.version.VersionNodePath"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.config.GlobalRuleNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.workerid.ReservationPersistService"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.reservation.WorkerIDReservationNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.version.VersionNodePath"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageUnitNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.version.VersionNodePath"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.rule.DatabaseRuleNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.version.VersionNodePath"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.generator.NodePathSegment"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsDataNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsTableNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.QualifiedDataSourceStatePersistService"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.storage.QualifiedDataSourceNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.generator.NodePathSegment"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.statistics.StatisticsSchemaNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.OnlineNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.StatusNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.label.LabelNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.state.DatabaseListenerCoordinatorNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.state.coordinator.TableCoordinatorNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.process.ShowProcessListTriggerNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.process.KillProcessTriggerNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.version.VersionNodePath"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.ViewMetaDataNodePath",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.version.VersionNodePath"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.datasource.StorageNodeNodePath",
+      "allDeclaredFields": true
     },
     {
       "condition": {

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
         <os-detector-maven-plugin.version>0.3.1</os-detector-maven-plugin.version>
-        <native-maven-plugin.version>0.11.0</native-maven-plugin.version>
+        <native-maven-plugin.version>0.11.3</native-maven-plugin.version>
         
         <!-- Compile plugin versions -->
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
@@ -1176,14 +1176,6 @@
                                         <goal>merge-agent-files</goal>
                                     </goals>
                                     <phase>integration-test</phase>
-                                </execution>
-                                <!--TODO See https://github.com/graalvm/native-build-tools/pull/748 -->
-                                <execution>
-                                    <id>metadata-copy-manually</id>
-                                    <goals>
-                                        <goal>metadata-copy</goal>
-                                    </goals>
-                                    <phase>deploy</phase>
                                 </execution>
                             </executions>
                         </plugin>

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/util/ProxyTestingServer.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/util/ProxyTestingServer.java
@@ -24,7 +24,6 @@ import org.awaitility.Awaitility;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -61,10 +60,8 @@ public final class ProxyTestingServer {
     /**
      * Force close ShardingSphere Proxy.
      *
-     * @param logicDataBaseNameList List of logical database names created by Proxy.
      */
-    public void close(final List<String> logicDataBaseNameList) {
-        ResourceUtils.closeProxyDataSource(logicDataBaseNameList);
+    public void close() {
         completableFuture.cancel(false);
         Awaitility.await().atMost(1L, TimeUnit.MINUTES).until(completableFuture::isDone);
     }

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/util/ResourceUtils.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/util/ResourceUtils.java
@@ -21,19 +21,16 @@ import org.apache.shardingsphere.database.connector.core.DefaultDatabase;
 import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
 import org.apache.shardingsphere.mode.manager.ContextManager;
-import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.List;
 
 /**
- * When creating {@link com.zaxxer.hikari.HikariDataSource} through {@link org.apache.shardingsphere.driver.ShardingSphereDriver}
- * or starting ShardingSphere Proxy through {@link org.apache.shardingsphere.proxy.Bootstrap},
+ * When creating {@link com.zaxxer.hikari.HikariDataSource} through {@link org.apache.shardingsphere.driver.ShardingSphereDriver},
  * the internal real data source will not be closed directly.
  * This causes the hooks for closing the data source of third-party dependencies such as Seata Client to not take effect.
- * Refer to the changes in <a href="https://github.com/apache/incubator-seata/pull/7044">apache/incubator-seata#7044</a>.
+ * Refer to the changes in <a href="https://github.com/apache/incubator-seata/issues/7523">apache/incubator-seata#7523</a>.
  *
  * @see org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource#close()
  */
@@ -67,21 +64,6 @@ public class ResourceUtils {
             contextManager.getStorageUnits(logicDataBaseName).values().stream().map(StorageUnit::getDataSource).forEach(ResourceUtils::close);
             contextManager.close();
         }
-    }
-    
-    /**
-     * Close Proxy dataSource.
-     *
-     * @param logicDataBaseNameList List of logical database names created by Proxy.
-     */
-    public static void closeProxyDataSource(final List<String> logicDataBaseNameList) {
-        ContextManager contextManager = ProxyContext.getInstance().getContextManager();
-        logicDataBaseNameList.forEach(logicDataBaseName -> contextManager.getStorageUnits(logicDataBaseName)
-                .values()
-                .stream()
-                .map(StorageUnit::getDataSource)
-                .forEach(ResourceUtils::close));
-        contextManager.close();
     }
     
     private static void close(final DataSource dataSource) {

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/SQLServerTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/SQLServerTest.java
@@ -22,12 +22,15 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.apache.shardingsphere.test.natived.commons.TestShardingService;
 import org.apache.shardingsphere.test.natived.commons.util.ResourceUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledInNativeImage;
 import org.testcontainers.jdbc.ContainerDatabaseDriver;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @EnabledInNativeImage
 class SQLServerTest {
@@ -35,6 +38,15 @@ class SQLServerTest {
     private DataSource logicDataSource;
     
     private TestShardingService testShardingService;
+    
+    /**
+     * Related to <a href="https://github.com/testcontainers/testcontainers-java/issues/3079">testcontainers/testcontainers-java#3079</a>
+     * and {@link com.microsoft.sqlserver.jdbc.SQLServerConnection}.
+     */
+    @BeforeEach
+    void beforeEach() {
+        Logger.getLogger("com.microsoft.sqlserver.jdbc.internals.SQLServerConnection").setLevel(Level.SEVERE);
+    }
     
     @AfterEach
     void afterEach() throws SQLException {

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/databases/MySQLTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/databases/MySQLTest.java
@@ -38,8 +38,8 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings({"SqlNoDataSourceInspection", "SameParameterValue", "resource"})
 @EnabledInNativeImage
@@ -71,15 +71,14 @@ class MySQLTest {
         }
         String absolutePath = Paths.get("src/test/resources/test-native/yaml/proxy/databases/mysql").toAbsolutePath().toString();
         proxyTestingServer = new ProxyTestingServer(absolutePath);
-        Awaitility.await().atMost(Duration.ofSeconds(30L)).ignoreExceptionsMatching(CommunicationsException.class::isInstance).until(() -> {
-            openConnection("root", "root", "jdbc:mysql://127.0.0.1:" + proxyTestingServer.getProxyPort()).close();
-            return true;
-        });
+        // TODO lingh remove
+        Awaitility.await().timeout(5L, TimeUnit.MINUTES).pollDelay(30L, TimeUnit.SECONDS).until(() -> true);
+        openConnection("root", "root", "jdbc:mysql://127.0.0.1:" + proxyTestingServer.getProxyPort()).close();
     }
     
     @AfterEach
     void afterEach() {
-        proxyTestingServer.close(Collections.singletonList("sharding_db"));
+        proxyTestingServer.close();
     }
     
     /**

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/databases/PostgresTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/databases/PostgresTest.java
@@ -39,7 +39,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("SqlNoDataSourceInspection")
 @EnabledInNativeImage
@@ -68,15 +68,14 @@ class PostgresTest {
         }
         String absolutePath = Paths.get("src/test/resources/test-native/yaml/proxy/databases/postgresql").toAbsolutePath().toString();
         proxyTestingServer = new ProxyTestingServer(absolutePath);
-        Awaitility.await().atMost(Duration.ofSeconds(30L)).ignoreExceptions().until(() -> {
-            getConnection("root", "root", "jdbc:postgresql://127.0.0.1:" + proxyTestingServer.getProxyPort() + "/postgres").close();
-            return true;
-        });
+        // TODO lingh remove
+        Awaitility.await().timeout(5L, TimeUnit.MINUTES).pollDelay(30L, TimeUnit.SECONDS).until(() -> true);
+        getConnection("root", "root", "jdbc:postgresql://127.0.0.1:" + proxyTestingServer.getProxyPort() + "/postgres").close();
     }
     
     @AfterEach
     void afterEach() {
-        proxyTestingServer.close(Collections.singletonList("sharding_db"));
+        proxyTestingServer.close();
     }
     
     /**

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/transactions/base/SeataTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/transactions/base/SeataTest.java
@@ -41,7 +41,6 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -95,7 +94,7 @@ class SeataTest {
     void afterEach() {
         Awaitility.await().pollDelay(5L, TimeUnit.SECONDS).until(() -> true);
         System.clearProperty(serviceDefaultGroupListKey);
-        proxyTestingServer.close(Collections.singletonList("sharding_db"));
+        proxyTestingServer.close();
     }
     
     /**

--- a/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native/reachability-metadata.json
+++ b/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native/reachability-metadata.json
@@ -26,6 +26,19 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.commons.util.ProxyTestingServer"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.commons.util.ProxyTestingServer",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.test.natived.jdbc.transactions.xa.NarayanaTest"
       },
       "type": "org.apache.shardingsphere.test.natived.jdbc.transactions.xa.NarayanaTest",
@@ -53,6 +66,19 @@
       "allDeclaredMethods": true,
       "allPublicMethods": true,
       "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.jdbc.modes.cluster.ZookeeperTest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.jdbc.modes.cluster.ZookeeperTest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
     },
     {
       "condition": {
@@ -116,6 +142,19 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.jdbc.transactions.base.SeataTest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.jdbc.transactions.base.SeataTest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.PostgresTest"
       },
       "type": "org.apache.shardingsphere.test.natived.jdbc.databases.PostgresTest",
@@ -156,6 +195,19 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.MySQLTest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.jdbc.databases.MySQLTest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.OpenGaussTest"
       },
       "type": "org.apache.shardingsphere.test.natived.jdbc.databases.OpenGaussTest",
@@ -163,6 +215,19 @@
       "allDeclaredMethods": true,
       "allPublicMethods": true,
       "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.OpenGaussTest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.jdbc.databases.OpenGaussTest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
     },
     {
       "condition": {
@@ -176,6 +241,19 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.hive.ZookeeperServiceDiscoveryTest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.jdbc.databases.hive.ZookeeperServiceDiscoveryTest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.hive.IcebergTest"
       },
       "type": "org.apache.shardingsphere.test.natived.jdbc.databases.hive.IcebergTest",
@@ -183,6 +261,19 @@
       "allDeclaredConstructors": true,
       "allDeclaredMethods": true,
       "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.hive.IcebergTest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.jdbc.databases.hive.IcebergTest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
     },
     {
       "condition": {
@@ -196,6 +287,19 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.hive.AcidTableTest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.jdbc.databases.hive.AcidTableTest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.hive.SystemSchemasTest"
       },
       "type": "org.apache.shardingsphere.test.natived.jdbc.databases.hive.SystemSchemasTest",
@@ -203,6 +307,19 @@
       "allDeclaredConstructors": true,
       "allDeclaredMethods": true,
       "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.hive.SystemSchemasTest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.jdbc.databases.hive.SystemSchemasTest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
     },
     {
       "condition": {
@@ -216,6 +333,19 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.FirebirdTest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.jdbc.databases.FirebirdTest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.PrestoTest"
       },
       "type": "org.apache.shardingsphere.test.natived.jdbc.databases.PrestoTest",
@@ -223,6 +353,19 @@
       "allDeclaredConstructors": true,
       "allDeclaredMethods": true,
       "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.PrestoTest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.jdbc.databases.PrestoTest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
     },
     {
       "condition": {
@@ -236,6 +379,19 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.jdbc.databases.DorisFETest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.jdbc.databases.DorisFETest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.test.natived.proxy.databases.MySQLTest"
       },
       "type": "org.apache.shardingsphere.test.natived.proxy.databases.MySQLTest",
@@ -246,6 +402,19 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.proxy.databases.MySQLTest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.proxy.databases.MySQLTest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.test.natived.proxy.databases.PostgresTest"
       },
       "type": "org.apache.shardingsphere.test.natived.proxy.databases.PostgresTest",
@@ -253,6 +422,19 @@
       "allDeclaredMethods": true,
       "allPublicMethods": true,
       "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.test.natived.proxy.databases.PostgresTest"
+      },
+      "type": {
+        "lambda": {
+          "declaringClass": "org.apache.shardingsphere.test.natived.proxy.databases.PostgresTest",
+          "interfaces": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      }
     },
     {
       "condition": {


### PR DESCRIPTION
For https://github.com/apache/shardingsphere/issues/29052 .

Changes proposed in this pull request:
  - Support building Proxy Native via GraalVM CE for JDK 25. This involves the patch at https://github.com/oracle/graal/issues/7476 and https://github.com/oracle/graal/pull/10441 . There is now a way to define the JSON for lambda classes created by `awaitility`. Due to GraalVM's changes to memory allocation for Github Actions scenarios, `-DjvmArgs=-XX:MaxRAMPercentage=85.0` is no longer required. This is the successor to https://github.com/apache/shardingsphere/pull/37356 .
  - Bump GraalVM Native Build Tools to `0.11.3`. This involves the patch at https://github.com/graalvm/native-build-tools/pull/748 .
  - Fix incorrect host paths in the seata documentation.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
