### PR TITLE
Minor refactor for sql federation engine and LiteralExpressionConverter

### DIFF
--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/exception/SQLFederationUnsupportedSQLException.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/exception/SQLFederationUnsupportedSQLException.java
@@ -26,7 +26,7 @@ public final class SQLFederationUnsupportedSQLException extends SQLFederationSQL
     
     private static final long serialVersionUID = -8571244162760408846L;
     
-    public SQLFederationUnsupportedSQLException(final String sql, final Exception cause) {
-        super(XOpenSQLState.SYNTAX_ERROR, 1, cause, "SQL federation does not support SQL '%s'.", sql);
+    public SQLFederationUnsupportedSQLException(final String sql, final String reason) {
+        super(XOpenSQLState.SYNTAX_ERROR, 1, reason, "SQL federation does not support SQL '%s'.", sql);
     }
 }

--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/segment/expression/impl/LiteralExpressionConverter.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/segment/expression/impl/LiteralExpressionConverter.java
@@ -28,6 +28,7 @@ import org.apache.calcite.sql.fun.SqlTrimFunction.Flag;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.DateString;
+import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.TimestampWithTimeZoneString;
@@ -92,6 +93,9 @@ public final class LiteralExpressionConverter {
         if (segment.getLiterals() instanceof String) {
             return Optional.of(SqlLiteral.createCharString(literalValue, SqlParserPos.ZERO));
         }
+        if (segment.getLiterals() instanceof NlsString) {
+            return Optional.of(SqlLiteral.createCharString(((NlsString) segment.getLiterals()).getValue(), SqlParserPos.ZERO));
+        }
         if (segment.getLiterals() instanceof Boolean) {
             return Optional.of(SqlLiteral.createBoolean(Boolean.parseBoolean(literalValue), SqlParserPos.ZERO));
         }
@@ -100,6 +104,9 @@ public final class LiteralExpressionConverter {
         }
         if (segment.getLiterals() instanceof Date) {
             return Optional.of(convertDate(segment, literalValue));
+        }
+        if (segment.getLiterals() instanceof TimestampString) {
+            return Optional.of(SqlLiteral.createTimestamp(SqlTypeName.TIMESTAMP, (TimestampString) segment.getLiterals(), 1, SqlParserPos.ZERO));
         }
         if (segment.getLiterals() instanceof LocalDate) {
             return Optional.of(SqlLiteral.createDate(DateString.fromDaysSinceEpoch((int) ((LocalDate) segment.getLiterals()).toEpochDay()), SqlParserPos.ZERO));


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Minor refactor for sql federation engine and LiteralExpressionConverter

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
