### PR TITLE
mysql-proxy: skip admin for no-FROM multi-expression selects; add tests

### DIFF
--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/factory/withoutfrom/MySQLSelectWithoutFromAdminExecutorFactory.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/factory/withoutfrom/MySQLSelectWithoutFromAdminExecutorFactory.java
@@ -93,7 +93,15 @@ public final class MySQLSelectWithoutFromAdminExecutorFactory {
             return Optional.of(new NoResourceShowExecutor(sqlStatement));
         }
         boolean isUseDatabase = null != databaseName || sqlStatement.getFrom().isPresent();
+        if (!isUseDatabase && hasMultipleProjections(sqlStatement)) {
+            return Optional.empty();
+        }
         return isUseDatabase ? Optional.empty() : Optional.of(new UnicastResourceShowExecutor(sqlStatement, sql));
+    }
+    
+    private static boolean hasMultipleProjections(final SelectStatement sqlStatement) {
+        Collection<ProjectionSegment> projections = sqlStatement.getProjections().getProjections();
+        return projections.size() > 1;
     }
     
     private static boolean isEmptyResource(final ShardingSphereMetaData metaData) {


### PR DESCRIPTION
Fixes #37276.

- Root cause: when not using a database and executing no-FROM multi-expression SELECT, query is routed to admin branch;
            UnicastResourceShowExecutor rebuilds headers and rows from different sources, causing column-count mismatch and
            IndexOutOfBoundsException in DatabaseAdminQueryProxyBackendHandler.
          - Fix: routing-only. For normal no-FROM multi-expression SELECTs (non-sysvar, non-special functions), return Optional.empty() to use the
            standard pipeline; keep sysvar/special functions/no-resource behavior unchanged. No silent truncate/padding, aligned with maintainer’s
            suggestion.
          - Tests: add a test to assert skipping admin for multi-expression no-FROM; add a regression test to assert multi sysvars still use
            MySQLSystemVariableQueryExecutor.
          - Impact: minimal, routing only; no behavior change for existing admin executors.

      - Many thanks for the helpful feedback. Please let me know if anything else is required or the code is improper.

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
