### PR TITLE
Fix nativeTest under GraalVM Native Image with clickhouse-server `25.12`

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,19 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-wrapperVersion=3.3.2
+wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/clickhouse/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/clickhouse/_index.cn.md
@@ -29,7 +29,7 @@ ShardingSphere 对 ClickHouse JDBC Driver 的支持位于可选模块中。
         <groupId>com.clickhouse</groupId>
         <artifactId>clickhouse-jdbc</artifactId>
         <classifier>all</classifier>
-        <version>0.9.4</version>
+        <version>0.9.5</version>
     </dependency>
 </dependencies>
 ```
@@ -43,7 +43,7 @@ ShardingSphere 对 ClickHouse JDBC Driver 的支持位于可选模块中。
 ```yaml
 services:
   clickhouse-server:
-    image: clickhouse/clickhouse-server:25.10.3.100
+    image: clickhouse/clickhouse-server:25.12.1.649
     environment:
       CLICKHOUSE_SKIP_USER_SETUP: "1"
     ports:

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/clickhouse/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/clickhouse/_index.en.md
@@ -29,7 +29,7 @@ the possible Maven dependencies are as follows,
         <groupId>com.clickhouse</groupId>
         <artifactId>clickhouse-jdbc</artifactId>
         <classifier>all</classifier>
-        <version>0.9.4</version>
+        <version>0.9.5</version>
     </dependency>
 </dependencies>
 ```
@@ -43,7 +43,7 @@ Write a Docker Compose file to start ClickHouse.
 ```yaml
 services:
   clickhouse-server:
-    image: clickhouse/clickhouse-server:25.10.3.100
+    image: clickhouse/clickhouse-server:25.12.1.649
     environment:
       CLICKHOUSE_SKIP_USER_SETUP: "1"
     ports:

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/firebird/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/firebird/_index.cn.md
@@ -28,7 +28,7 @@ ShardingSphere 对 Firebird JDBC Driver 的支持位于可选模块中。
     <dependency>
         <groupId>org.firebirdsql.jdbc</groupId>
         <artifactId>jaybird</artifactId>
-        <version>5.0.6.java8</version>
+        <version>5.0.10.java8</version>
     </dependency>
 </dependencies>
 ```
@@ -58,7 +58,7 @@ services:
 通过第三方工具在 Firebird 内创建业务库。
 
 包括 DBeaver Community 在内的第三方工具无法为 Firebird 创建 databases，
-下以 Maven 模块 `org.firebirdsql.jdbc:jaybird:5.0.6.java8` 的 Java API 为例，
+下以 Maven 模块 `org.firebirdsql.jdbc:jaybird:5.0.10.java8` 的 Java API 为例，
 
 ```java
 import org.firebirdsql.management.FBManager;

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/firebird/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/firebird/_index.en.md
@@ -28,7 +28,7 @@ the possible Maven dependencies are as follows,
     <dependency>
         <groupId>org.firebirdsql.jdbc</groupId>
         <artifactId>jaybird</artifactId>
-        <version>5.0.6.java8</version>
+        <version>5.0.10.java8</version>
     </dependency>
 </dependencies>
 ```
@@ -58,7 +58,7 @@ services:
 Create some business databases in Firebird through third-party tools.
 
 Third-party tools including DBeaver Community cannot create databases for Firebird.
-Below is the Java API of the Maven module `org.firebirdsql.jdbc:jaybird:5.0.6.java8` as an example.
+Below is the Java API of the Maven module `org.firebirdsql.jdbc:jaybird:5.0.10.java8` as an example.
 
 ```java
 import org.firebirdsql.management.FBManager;

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
@@ -2495,12 +2495,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.jdbc.datasource.JDBCBackendDataSource"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
       },
       "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.2
+# Apache Maven Wrapper startup batch script, version 3.3.4
 #
 # Optional ENV vars
 # -----------------
@@ -105,14 +105,17 @@ trim() {
   printf "%s" "${1}" | tr -d '[:space:]'
 }
 
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
 # parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
   case "${key-}" in
   distributionUrl) distributionUrl=$(trim "${value-}") ;;
   distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
   esac
-done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
-[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
 
 case "${distributionUrl##*/}" in
 maven-mvnd-*bin.*)
@@ -130,7 +133,7 @@ maven-mvnd-*bin.*)
   distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
   ;;
 maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
-*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
 esac
 
 # apply MVNW_REPOURL and calculate MAVEN_HOME
@@ -227,7 +230,7 @@ if [ -n "${distributionSha256Sum-}" ]; then
     echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
   elif command -v sha256sum >/dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
   elif command -v shasum >/dev/null; then
@@ -252,8 +255,41 @@ if command -v unzip >/dev/null; then
 else
   tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
 fi
-printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
-mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
 
 clean || :
 exec_maven "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <logback.version>1.2.13</logback.version>
         <commons-logging.version>1.2</commons-logging.version>
         
-        <lombok.version>1.18.38</lombok.version>
+        <lombok.version>1.18.42</lombok.version>
         <jsr305.version>3.0.2</jsr305.version>
         <immutables.version>2.10.1</immutables.version>
         
@@ -124,11 +124,11 @@
         <h2.version>2.2.224</h2.version>
         <opengauss.version>3.1.0-og</opengauss.version>
         <mariadb-java-client.version>2.4.2</mariadb-java-client.version>
-        <clickhouse-jdbc.version>0.9.4</clickhouse-jdbc.version>
+        <clickhouse-jdbc.version>0.9.5</clickhouse-jdbc.version>
         <hive-jdbc.version>4.0.1</hive-jdbc.version>
         <hive-server2-jdbc-driver-thin.version>1.8.2</hive-server2-jdbc-driver-thin.version>
         <presto.version>0.296</presto.version>
-        <jaybird.version>5.0.6.java8</jaybird.version>
+        <jaybird.version>5.0.10.java8</jaybird.version>
         
         <hikari-cp.version>4.0.3</hikari-cp.version>
         

--- a/test/native/src/test/resources/test-native/yaml/jdbc/databases/clickhouse.yaml
+++ b/test/native/src/test/resources/test-native/yaml/jdbc/databases/clickhouse.yaml
@@ -19,15 +19,15 @@ dataSources:
   ds_0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:clickhouse:25.10.3.100:///demo_ds_0?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql
+    jdbcUrl: jdbc:tc:clickhouse:25.12.1.649:///demo_ds_0?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:clickhouse:25.10.3.100:///demo_ds_1?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql
+    jdbcUrl: jdbc:tc:clickhouse:25.12.1.649:///demo_ds_1?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql
   ds_2:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:clickhouse:25.10.3.100:///demo_ds_2?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql
+    jdbcUrl: jdbc:tc:clickhouse:25.12.1.649:///demo_ds_2?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql
 
 rules:
   - !SHARDING


### PR DESCRIPTION
Fixes #37406 .

Changes proposed in this pull request:
  - Fix nativeTest under GraalVM Native Image with clickhouse-server `25.12`. This is the successor to https://github.com/apache/shardingsphere/pull/37421, except that it was previously waiting to be merged with https://github.com/ClickHouse/clickhouse-java/pull/2679 .
  - Fix some edge cases related to GraalVM CE for JDK 24 in https://github.com/apache/shardingsphere/actions/runs/20338203091/job/58430577208 .
    - Bump mvnw to fix the warning log involved in https://github.com/apache/maven/pull/11003 . 
    - Bump lombok to ensure it is indeed not affected by https://github.com/projectlombok/lombok/issues/3852, even though the original issue was closed without being properly fixed.
    - Bump  Firebird JDBC driver used by nativeTest to ensure that https://github.com/FirebirdSQL/jaybird/issues/855 and https://github.com/oracle/graalvm-reachability-metadata/commit/182da47d761b47d5f478af9f7152c3c099511a5a match .
```shell
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::staticFieldBase has been called by com.google.inject.internal.aop.HiddenClassDefiner (file:/home/runner/.m2/wrapper/dists/apache-maven-3.9.11/a2d47e15/lib/guice-5.1.0-classes.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.inject.internal.aop.HiddenClassDefiner
WARNING: sun.misc.Unsafe::staticFieldBase will be removed in a future release

WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit
WARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release

[INFO] [graalvm reachability metadata repository for net.java.dev.jna:jna:5.17.0]: Configuration directory not found. Trying latest version.
[INFO] [graalvm reachability metadata repository for net.java.dev.jna:jna:5.17.0]: Configuration directory is net.java.dev.jna/jna/5.8.0
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
