### PR TITLE
Revert "Validate YAML dataSources before swap to avoid NPE"

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/resource/YamlDataSourceConfigurationSwapper.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/resource/YamlDataSourceConfigurationSwapper.java
@@ -56,7 +56,6 @@ public final class YamlDataSourceConfigurationSwapper {
      * @return data sources
      */
     public Map<String, DataSource> swapToDataSources(final Map<String, Map<String, Object>> yamlDataSources, final boolean cacheEnabled) {
-        Preconditions.checkArgument(null != yamlDataSources && !yamlDataSources.isEmpty(), "Data sources can not be empty.");
         return DataSourcePoolCreator.create(yamlDataSources.entrySet().stream().collect(Collectors.toMap(Entry::getKey, entry -> swapToDataSourcePoolProperties(entry.getValue()))), cacheEnabled);
     }
     

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/yaml/config/swapper/resource/YamlDataSourceConfigurationSwapperTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/yaml/config/swapper/resource/YamlDataSourceConfigurationSwapperTest.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -31,7 +30,6 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class YamlDataSourceConfigurationSwapperTest {
     
@@ -49,18 +47,6 @@ class YamlDataSourceConfigurationSwapperTest {
         assertThat(actual1.getUrl(), is("jdbc:mock://127.0.0.1/ds_1"));
         assertThat(actual1.getUsername(), is("root"));
         assertThat(actual1.getPassword(), is("root"));
-    }
-    
-    @Test
-    void assertSwapToDataSourcesWithNullConfig() {
-        IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToDataSources(null));
-        assertThat(actual.getMessage(), is("Data sources can not be empty."));
-    }
-    
-    @Test
-    void assertSwapToDataSourcesWithEmptyConfig() {
-        IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToDataSources(Collections.emptyMap()));
-        assertThat(actual.getMessage(), is("Data sources can not be empty."));
     }
     
     @Test


### PR DESCRIPTION
Reverts apache/shardingsphere#37448