### PR TITLE
Bump Netty to 4.2.9

### DIFF
--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -241,15 +241,15 @@ The text of each license is the standard Apache 2.0 license.
     failureaccess 1.0.1: https://github.com/google/guava, Apache 2.0
     freemarker 2.3.31: https://freemarker.apache.org/, Apache 2.0
     groovy 4.0.22: https://groovy.apache.org/, Apache 2.0
-    grpc-api 1.65.1: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-context 1.65.1: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-core 1.65.1: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-grpclb 1.65.1: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-netty 1.65.1: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-protobuf 1.65.1: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-protobuf-lite 1.65.1: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-stub 1.65.1: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-util 1.65.1: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-api 1.75.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-context 1.75.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-core 1.75.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-grpclb 1.75.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-netty 1.75.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-protobuf 1.75.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-protobuf-lite 1.75.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-stub 1.75.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-util 1.75.0: https://github.com/grpc/grpc-java, Apache 2.0
     gson 2.10.1: https://github.com/google/gson, Apache 2.0
     guava 33.4.6-jre: https://github.com/google/guava, Apache 2.0
     HikariCP 4.0.3: https://github.com/brettwooldridge/HikariCP, Apache 2.0
@@ -270,27 +270,28 @@ The text of each license is the standard Apache 2.0 license.
     json-simple 1.1.1: https://code.google.com/archive/p/json-simple/, Apache 2.0
     jspecify 1.0.0: https://jspecify.dev/, Apache 2.0
     memory 0.9.0: https://datasketches.github.io/, Apache 2.0
-    netty-buffer 4.1.121.Final: https://github.com/netty, Apache 2.0
-    netty-codec 4.1.121.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http 4.1.121.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http2 4.1.121.Final: https://github.com/netty, Apache 2.0
-    netty-codec-socks 4.1.121.Final: https://github.com/netty, Apache 2.0
-    netty-common 4.1.121.Final: https://github.com/netty, Apache 2.0
-    netty-handler 4.1.121.Final: https://github.com/netty, Apache 2.0
-    netty-handler-proxy 4.1.121.Final: https://github.com/netty, Apache 2.0
-    netty-resolver 4.1.121.Final: https://github.com/netty, Apache 2.0
-    netty-transport 4.1.121.Final: https://github.com/netty, Apache 2.0
-    netty-transport-classes-epoll 4.1.121.Final: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.121.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.121.Final-linux-x86_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-unix-common 4.1.121.Final: https://github.com/netty, Apache 2.0
-    netty-tcnative-boringssl-static 2.0.65.Final: https://github.com/netty/netty-tcnative, Apache 2.0
-    netty-tcnative-boringssl-static 2.0.65.Final-linux-aarch_64: https://github.com/netty/netty-tcnative, Apache 2.0
-    netty-tcnative-boringssl-static 2.0.65.Final-linux-x86_64: https://github.com/netty/netty-tcnative, Apache 2.0
-    netty-tcnative-boringssl-static 2.0.65.Final-osx-aarch_64: https://github.com/netty/netty-tcnative, Apache 2.0
-    netty-tcnative-boringssl-static 2.0.65.Final-osx-x86_64: https://github.com/netty/netty-tcnative, Apache 2.0
-    netty-tcnative-boringssl-static 2.0.65.Final-windows-x86_64: https://github.com/netty/netty-tcnative, Apache 2.0
-    netty-tcnative-classes 2.0.65.Final: https://github.com/netty/netty-tcnative, Apache 2.0
+    netty-buffer 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-codec 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http2 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-codec-protobuf 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-codec-socks 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-common 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-handler 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-handler-proxy 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-resolver 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-transport 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-transport-classes-epoll 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.2.9.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.2.9.Final-linux-x86_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-unix-common 4.2.9.Final: https://github.com/netty, Apache 2.0
+    netty-tcnative-boringssl-static 2.0.74.Final: https://github.com/netty/netty-tcnative, Apache 2.0
+    netty-tcnative-boringssl-static 2.0.74.Final-linux-aarch_64: https://github.com/netty/netty-tcnative, Apache 2.0
+    netty-tcnative-boringssl-static 2.0.74.Final-linux-x86_64: https://github.com/netty/netty-tcnative, Apache 2.0
+    netty-tcnative-boringssl-static 2.0.74.Final-osx-aarch_64: https://github.com/netty/netty-tcnative, Apache 2.0
+    netty-tcnative-boringssl-static 2.0.74.Final-osx-x86_64: https://github.com/netty/netty-tcnative, Apache 2.0
+    netty-tcnative-boringssl-static 2.0.74.Final-windows-x86_64: https://github.com/netty/netty-tcnative, Apache 2.0
+    netty-tcnative-classes 2.0.74.Final: https://github.com/netty/netty-tcnative, Apache 2.0
     perfmark-api 0.26.0: https://github.com/perfmark/perfmark, Apache 2.0
     proto-google-common-protos 2.29.0: https://github.com/googleapis/common-protos-java, Apache 2.0
     proj4j 1.2.2: https://github.com/locationtech/proj4j, Apache 2.0

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/com.clickhouse/clickhouse-jdbc/0.9.4-all/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/com.clickhouse/clickhouse-jdbc/0.9.4-all/reachability-metadata.json
@@ -140,15 +140,9 @@
     },
     {
       "condition": {
-        "typeReached": "com.clickhouse.client.api.internal.HttpAPIClientHelper"
-      },
-      "glob": "client-v2-version.properties"
-    },
-    {
-      "condition": {
         "typeReached": "com.clickhouse.client.internal.net.jpountz.util.Native"
       },
-      "glob": "com/clickhouse/client/internal/net/jpountz/util/win32/amd64/liblz4-java.so"
+      "glob": "com/clickhouse/client/internal/net/jpountz/util/**/amd64/liblz4-java.so"
     },
     {
       "condition": {
@@ -162,6 +156,5 @@
       },
       "glob": "jdbc-v2-version.properties"
     }
-  ],
-  "bundles": []
+  ]
 }

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
@@ -2,12 +2,6 @@
   "reflection": [
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "java.beans.PropertyVetoException"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.io.BufferedInputStream"
@@ -131,12 +125,6 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.lang.AutoCloseable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
-      },
-      "type": "java.lang.BaseVirtualThread"
     },
     {
       "condition": {
@@ -296,22 +284,10 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "java.lang.Object",
       "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.algorithm.core.processor.AlgorithmChangedProcessor"
-      },
-      "type": "java.lang.Object"
     },
     {
       "condition": {
@@ -334,13 +310,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.representer.ShardingSphereYamlRepresenter"
       },
       "type": "java.lang.Object"
@@ -348,13 +317,6 @@
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
-      },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
       },
       "type": "java.lang.Object",
       "allDeclaredFields": true
@@ -387,12 +349,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.MetaDataContexts"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
       },
       "type": "java.lang.Object"
@@ -400,24 +356,6 @@
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManager"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
       },
       "type": "java.lang.Object"
     },
@@ -437,18 +375,11 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService"
-      },
       "type": "java.lang.Object"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.statistics.StatisticsPersistService"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService"
       },
       "type": "java.lang.Object"
     },
@@ -473,12 +404,6 @@
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseProxyConnector"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
       },
       "type": "java.lang.Object"
     },
@@ -511,33 +436,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.changed.DefaultDatabaseShardingStrategyChangedProcessor"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.changed.ShardingTableChangedProcessor"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.impl.MySQLNotFunction"
       },
       "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "java.lang.ObjectBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "java.lang.ObjectCustomizer"
     },
     {
       "condition": {
@@ -664,30 +565,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
-      },
-      "type": "java.lang.management.ManagementFactory",
-      "methods": [
-        {
-          "name": "getRuntimeMXBean",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
-      },
-      "type": "java.lang.management.RuntimeMXBean",
-      "methods": [
-        {
-          "name": "getInputArguments",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.lang.reflect.AnnotatedElement"
@@ -738,7 +615,15 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
-      "type": "java.nio.Bits"
+      "type": "java.nio.Bits",
+      "fields": [
+        {
+          "name": "MAX_MEMORY"
+        },
+        {
+          "name": "UNALIGNED"
+        }
+      ]
     },
     {
       "condition": {
@@ -761,7 +646,22 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
-      "type": "java.nio.ByteBuffer"
+      "type": "java.nio.ByteBuffer",
+      "methods": [
+        {
+          "name": "alignedSlice",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "slice",
+          "parameterTypes": [
+            "int",
+            "int"
+          ]
+        }
+      ]
     },
     {
       "condition": {
@@ -917,66 +817,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.broadcast.rule.changed.BroadcastTableChangedProcessor"
-      },
-      "type": "java.util.LinkedHashSet",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "java.util.LinkedHashSet"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.util.List"
@@ -1046,78 +886,6 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.util.OptionalLong"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.algorithm.core.processor.AlgorithmChangedProcessor"
-      },
-      "type": "java.util.Properties",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "java.util.Properties",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "java.util.Properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "java.util.Properties"
     },
     {
       "condition": {
@@ -1432,31 +1200,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setPrivilege",
-          "parameterTypes": [
-            "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
-          ]
-        },
-        {
-          "name": "setUsers",
-          "parameterTypes": [
-            "java.util.Collection"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
       },
       "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"
@@ -1537,64 +1280,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlUserConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setAdmin",
-          "parameterTypes": [
-            "boolean"
-          ]
-        },
-        {
-          "name": "setPassword",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setUser",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlUserConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlUserConfigurationCustomizer"
     },
     {
       "condition": {
@@ -1759,25 +1447,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setTables",
-          "parameterTypes": [
-            "java.util.Collection"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
       },
       "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"
@@ -1826,18 +1495,6 @@
       },
       "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
       "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -2495,6 +2152,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.backend.connector.jdbc.datasource.JDBCBackendDataSource"
+      },
+      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
       },
       "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
@@ -2516,67 +2179,6 @@
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.driver.yaml.YamlJDBCConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setDataSources",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        },
-        {
-          "name": "setMode",
-          "parameterTypes": [
-            "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfiguration"
-          ]
-        },
-        {
-          "name": "setProps",
-          "parameterTypes": [
-            "java.util.Properties"
-          ]
-        },
-        {
-          "name": "setRules",
-          "parameterTypes": [
-            "java.util.Collection"
-          ]
-        },
-        {
-          "name": "setSqlParser",
-          "parameterTypes": [
-            "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration"
-          ]
-        },
-        {
-          "name": "setTransaction",
-          "parameterTypes": [
-            "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.driver.yaml.YamlJDBCConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.driver.yaml.YamlJDBCConfigurationCustomizer"
     },
     {
       "condition": {
@@ -2707,120 +2309,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setEncryptors",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        },
-        {
-          "name": "setTables",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
       },
       "type": "org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setEncryptorName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setAssistedQuery",
-          "parameterTypes": [
-            "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfiguration"
-          ]
-        },
-        {
-          "name": "setCipher",
-          "parameterTypes": [
-            "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfiguration"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -2838,37 +2329,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setColumns",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -3102,55 +2562,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.algorithm.core.processor.AlgorithmChangedProcessor"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setProps",
-          "parameterTypes": [
-            "java.util.Properties"
-          ]
-        },
-        {
-          "name": "setType",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setProps",
-          "parameterTypes": [
-            "java.util.Properties"
-          ]
-        },
-        {
-          "name": "setType",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
@@ -3159,12 +2570,6 @@
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
       },
       "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
     },
@@ -3209,18 +2614,6 @@
       },
       "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
       "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfigurationCustomizer"
     },
     {
       "condition": {
@@ -3896,10 +3289,6 @@
       "allDeclaredFields": true,
       "methods": [
         {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
           "name": "getAttribute",
           "parameterTypes": []
         },
@@ -3910,24 +3299,6 @@
         {
           "name": "getVersion",
           "parameterTypes": []
-        },
-        {
-          "name": "setAttribute",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setDatabaseName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setVersion",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
         }
       ]
     },
@@ -4005,89 +3376,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.util.yaml.YamlConfiguration"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
       },
       "type": "org.apache.shardingsphere.infra.util.yaml.YamlConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setRepository",
-          "parameterTypes": [
-            "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlPersistRepositoryConfiguration"
-          ]
-        },
-        {
-          "name": "setType",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlPersistRepositoryConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setProps",
-          "parameterTypes": [
-            "java.util.Properties"
-          ]
-        },
-        {
-          "name": "setType",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlPersistRepositoryConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlPersistRepositoryConfigurationCustomizer"
     },
     {
       "condition": {
@@ -4097,80 +3388,10 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.MetaDataContexts"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.MetaDataContextsFactory"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManager"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService"
       },
       "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics",
       "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
         {
           "name": "getRows",
           "parameterTypes": []
@@ -4178,52 +3399,8 @@
         {
           "name": "getUniqueKey",
           "parameterTypes": []
-        },
-        {
-          "name": "setRows",
-          "parameterTypes": [
-            "java.util.List"
-          ]
-        },
-        {
-          "name": "setUniqueKey",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.statistics.StatisticsPersistService"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.database.type.CreateDatabaseProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics",
-      "allDeclaredFields": true
     },
     {
       "condition": {
@@ -4293,74 +3470,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereColumn",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setCaseSensitive",
-          "parameterTypes": [
-            "boolean"
-          ]
-        },
-        {
-          "name": "setDataType",
-          "parameterTypes": [
-            "int"
-          ]
-        },
-        {
-          "name": "setGenerated",
-          "parameterTypes": [
-            "boolean"
-          ]
-        },
-        {
-          "name": "setName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setNullable",
-          "parameterTypes": [
-            "boolean"
-          ]
-        },
-        {
-          "name": "setPrimaryKey",
-          "parameterTypes": [
-            "boolean"
-          ]
-        },
-        {
-          "name": "setUnsigned",
-          "parameterTypes": [
-            "boolean"
-          ]
-        },
-        {
-          "name": "setVisible",
-          "parameterTypes": [
-            "boolean"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.builder.SystemSchemaBuilder"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
@@ -4373,38 +3482,6 @@
           "name": "setName",
           "parameterTypes": [
             "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereIndex",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setUnique",
-          "parameterTypes": [
-            "boolean"
           ]
         }
       ]
@@ -4435,21 +3512,6 @@
           "name": "setName",
           "parameterTypes": [
             "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "setType",
-          "parameterTypes": [
-            "org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType"
           ]
         }
       ]
@@ -4472,12 +3534,7 @@
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
-      "allDeclaredFields": true,
       "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
         {
           "name": "getColumns",
           "parameterTypes": []
@@ -4497,24 +3554,6 @@
         {
           "name": "getType",
           "parameterTypes": []
-        },
-        {
-          "name": "setColumns",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        },
-        {
-          "name": "setIndexes",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        },
-        {
-          "name": "setName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
         }
       ]
     },
@@ -4805,77 +3844,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setMaskAlgorithms",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        },
-        {
-          "name": "setTables",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
       },
       "type": "org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskColumnRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setMaskAlgorithm",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskColumnRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskColumnRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -4893,37 +3864,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setColumns",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -6862,60 +5802,10 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserCacheOptionRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setInitialCapacity",
-          "parameterTypes": [
-            "int"
-          ]
-        },
-        {
-          "name": "setMaximumSize",
-          "parameterTypes": [
-            "long"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration",
       "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setParseTreeCache",
-          "parameterTypes": [
-            "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserCacheOptionRuleConfiguration"
-          ]
-        },
-        {
-          "name": "setSqlStatementCache",
-          "parameterTypes": [
-            "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserCacheOptionRuleConfiguration"
-          ]
-        }
-      ]
     },
     {
       "condition": {
@@ -7018,49 +5908,6 @@
         "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setAuthority",
-          "parameterTypes": [
-            "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"
-          ]
-        },
-        {
-          "name": "setMode",
-          "parameterTypes": [
-            "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfiguration"
-          ]
-        },
-        {
-          "name": "setProps",
-          "parameterTypes": [
-            "java.util.Properties"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfigurationCustomizer"
     },
     {
       "condition": {
@@ -7425,40 +6272,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setDataSourceGroups",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
       },
       "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -7484,43 +6300,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setReadDataSourceNames",
-          "parameterTypes": [
-            "java.util.List"
-          ]
-        },
-        {
-          "name": "setWriteDataSourceName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -7699,58 +6478,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setDataSources",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        },
-        {
-          "name": "setDefaultShadowAlgorithmName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setShadowAlgorithms",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        },
-        {
-          "name": "setTables",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
       },
       "type": "org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -7771,43 +6501,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setProductionDataSourceName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setShadowDataSourceName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfigurationCustomizer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfiguration",
@@ -7822,43 +6515,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setDataSourceNames",
-          "parameterTypes": [
-            "java.util.Collection"
-          ]
-        },
-        {
-          "name": "setShadowAlgorithmNames",
-          "parameterTypes": [
-            "java.util.Collection"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfigurationCustomizer"
     },
     {
       "condition": {
@@ -8425,49 +7081,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setAuditors",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        },
-        {
-          "name": "setDefaultDatabaseStrategy",
-          "parameterTypes": [
-            "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"
-          ]
-        },
-        {
-          "name": "setKeyGenerators",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        },
-        {
-          "name": "setShardingAlgorithms",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        },
-        {
-          "name": "setTables",
-          "parameterTypes": [
-            "java.util.Map"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"
@@ -8519,18 +7132,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"
@@ -8556,31 +7157,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setActualDataNodes",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setKeyGenerateStrategy",
-          "parameterTypes": [
-            "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
@@ -8589,12 +7165,6 @@
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"
     },
@@ -8658,174 +7228,15 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.changed.ShardingTableChangedProcessor"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setActualDataNodes",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setKeyGenerateStrategy",
-          "parameterTypes": [
-            "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-          ]
-        },
-        {
-          "name": "setLogicTable",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setColumn",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setKeyGeneratorName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.changed.ShardingTableChangedProcessor"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setColumn",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setKeyGeneratorName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlBaseShardingStrategyConfiguration"
     },
     {
       "condition": {
@@ -8844,25 +7255,6 @@
         "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setStandard",
-          "parameterTypes": [
-            "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-          ]
-        }
-      ]
     },
     {
       "condition": {
@@ -8915,12 +7307,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"
@@ -8941,156 +7327,15 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.changed.DefaultDatabaseShardingStrategyChangedProcessor"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setStandard",
-          "parameterTypes": [
-            "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfigurationBeanInfo"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfigurationCustomizer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setShardingAlgorithmName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setShardingColumn",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.distsql.DistSQLUpdateProxyBackendHandler"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.sharding.rule.changed.DefaultDatabaseShardingStrategyChangedProcessor"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setShardingAlgorithmName",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setShardingColumn",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfigurationCustomizer"
     },
     {
       "condition": {
@@ -10898,31 +9143,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "setDefaultType",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "setProviderType",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
       },
       "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration"
@@ -11026,6 +9246,34 @@
         "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+      },
+      "type": "sun.nio.ch.SelectorImpl",
+      "fields": [
+        {
+          "name": "publicSelectedKeys"
+        },
+        {
+          "name": "selectedKeys"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
+      },
+      "type": "sun.nio.ch.SelectorImpl",
+      "fields": [
+        {
+          "name": "publicSelectedKeys"
+        },
+        {
+          "name": "selectedKeys"
+        }
+      ]
     }
   ],
   "resources": [

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reachability-metadata.json
@@ -116,6 +116,13 @@
       "condition": {
         "typeReached": "com.sun.jmx.mbeanserver.MBeanIntrospector"
       },
+      "type": "com.sun.management.UnixOperatingSystemMXBean",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jmx.mbeanserver.MBeanIntrospector"
+      },
       "type": "java.lang.Deprecated",
       "allPublicMethods": true
     },
@@ -177,6 +184,13 @@
     },
     {
       "condition": {
+        "typeReached": "java.util.LinkedHashSet"
+      },
+      "type": "java.util.LinkedHashSet",
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
         "typeReached": "com.sun.jmx.mbeanserver.DefaultMXBeanMappingFactory"
       },
       "type": "java.lang.StackTraceElement",
@@ -184,10 +198,15 @@
     },
     {
       "condition": {
-        "typeReached": "java.net.HttpURLConnection"
+        "typeReached": "com.sun.beans.finder.ClassFinder"
       },
-      "type": "java.net.SocketTimeoutException",
-      "allPublicConstructors": true
+      "type": "java.lang.ObjectBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.beans.finder.ClassFinder"
+      },
+      "type": "java.lang.ObjectCustomizer"
     },
     {
       "condition": {
@@ -254,17 +273,71 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
+        "typeReached": "com.sun.jmx.mbeanserver.MBeanIntrospector"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "java.net.HttpURLConnection"
+      },
+      "type": "java.net.SocketTimeoutException",
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "java.util.Properties"
+      },
+      "type": "java.util.Properties",
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "sun.security.provider.SecureRandom"
+      },
+      "type": "sun.security.provider.SecureRandom",
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfiguration"
       },
       "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfiguration",
-      "allPublicMethods": true
+      "allPublicMethods": true,
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfigurationCustomizer"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnRuleConfiguration",
-      "allPublicMethods": true
+      "allPublicMethods": true,
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -304,35 +377,88 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskColumnRuleConfiguration",
-      "allPublicMethods": true
+      "allPublicMethods": true,
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskColumnRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskColumnRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskColumnRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskColumnRuleConfigurationCustomizer"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserCacheOptionRuleConfiguration",
-      "allPublicMethods": true
+      "allPublicMethods": true,
+      "allPublicConstructors": true
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration",
-      "allPublicMethods": true
+      "allPublicMethods": true,
+      "allPublicConstructors": true
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfiguration"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration",
-      "allPublicMethods": true
+      "allPublicMethods": true,
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfiguration"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlStandardShardingStrategyConfigurationCustomizer"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.authority.yaml.config.YamlUserConfiguration"
       },
       "type": "org.apache.shardingsphere.authority.yaml.config.YamlUserConfiguration",
-      "allPublicMethods": true
+      "allPublicMethods": true,
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.authority.yaml.config.YamlUserConfiguration"
+      },
+      "type": "org.apache.shardingsphere.authority.yaml.config.YamlUserConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.authority.yaml.config.YamlUserConfiguration"
+      },
+      "type": "org.apache.shardingsphere.authority.yaml.config.YamlUserConfigurationCustomizer"
     },
     {
       "condition": {
@@ -354,14 +480,28 @@
         "typeReached": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics"
       },
       "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatistics",
-      "allPublicMethods": true
+      "allPublicMethods": true,
+      "allPublicConstructors": true
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
       },
       "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration",
-      "allPublicMethods": true
+      "allPublicMethods": true,
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
+      },
+      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfiguration"
+      },
+      "type": "org.apache.shardingsphere.infra.algorithm.core.yaml.YamlAlgorithmConfigurationCustomizer"
     },
     {
       "condition": {
@@ -557,14 +697,400 @@
     },
     {
       "condition": {
-        "typeReached": "sun.security.provider.SecureRandom"
+        "typeReached": "org.apache.shardingsphere.infra.util.yaml.constructor.ShardingSphereYamlConstructor"
       },
-      "type": "sun.security.provider.SecureRandom",
-      "allPublicConstructors": true
+      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration",
+      "allDeclaredFields": true,
+      "allPublicConstructors": true,
+      "allPublicMethods": true
     },
     {
       "condition": {
-        "typeReached": "com.facebook.presto.jdbc.internal.guava.reflect.Reflection"
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.yaml.YamlJDBCConfiguration"
+      },
+      "type": "org.apache.shardingsphere.driver.yaml.YamlJDBCConfiguration",
+      "allDeclaredFields": true,
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.yaml.YamlJDBCConfiguration"
+      },
+      "type": "org.apache.shardingsphere.driver.yaml.YamlJDBCConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.yaml.YamlJDBCConfiguration"
+      },
+      "type": "org.apache.shardingsphere.driver.yaml.YamlJDBCConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfiguration"
+      },
+      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfiguration"
+      },
+      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfiguration"
+      },
+      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
+      },
+      "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.mask.yaml.config.YamlMaskRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.shadow.yaml.config.YamlShadowRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfiguration"
+      },
+      "type": "org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfiguration"
+      },
+      "type": "org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfiguration"
+      },
+      "type": "org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.mask.yaml.config.rule.YamlMaskTableRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceGroupRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfiguration"
+      },
+      "type": "org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfiguration"
+      },
+      "type": "org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfiguration"
+      },
+      "type": "org.apache.shardingsphere.shadow.yaml.config.datasource.YamlShadowDataSourceConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.util.yaml.constructor.ShardingSphereYamlConstructor"
+      },
+      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlPersistRepositoryConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlPersistRepositoryConfiguration"
+      },
+      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlPersistRepositoryConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlPersistRepositoryConfiguration"
+      },
+      "type": "org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlPersistRepositoryConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfiguration"
+      },
+      "type": "org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfiguration"
+      },
+      "type": "org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfiguration"
+      },
+      "type": "org.apache.shardingsphere.shadow.yaml.config.table.YamlShadowTableConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.broadcast.yaml.config.YamlBroadcastRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeData"
+      },
+      "type": "org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeData",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration"
+      },
+      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "java.lang.reflect.TypeVariable"
       },
       "type": {
         "proxy": [
@@ -606,6 +1132,12 @@
     }
   ],
   "bundles": [
+    {
+      "condition": {
+        "typeReached": "org.postgresql.util.GT"
+      },
+      "name": "org.postgresql.translation.messages"
+    },
     {
       "condition": {
         "typeReached": "org.opengauss.util.GT"

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         
         <jakarta.jakartaee-bom.version>8.0.0</jakarta.jakartaee-bom.version>
         
-        <netty.version>4.1.126.Final</netty.version>
+        <netty.version>4.2.9.Final</netty.version>
         <bouncycastle.version>1.79</bouncycastle.version>
         
         <curator.version>5.7.0</curator.version>

--- a/proxy/frontend/core/pom.xml
+++ b/proxy/frontend/core/pom.xml
@@ -48,6 +48,10 @@
         
         <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-codec-protobuf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
         </dependency>
         <dependency>

--- a/test/native/native-image-filter/extra-filter.json
+++ b/test/native/native-image-filter/extra-filter.json
@@ -18,6 +18,7 @@
     {"includeClasses": "com.oracle.svm.core.**"},
     {"includeClasses": "com.sun.management.**"},
     {"includeClasses": "org.apache.shardingsphere.**"},
+    {"includeClasses": "sun.nio.ch.SelectorImpl"},
     {"includeClasses": "sun.security.provider.SecureRandom"},
 
     {"excludeClasses": "org.apache.shardingsphere.test.natived.**"}

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/TestShardingService.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/TestShardingService.java
@@ -257,13 +257,13 @@ public final class TestShardingService {
     }
     
     /**
-     * Clean environment in Firebird. See <a href="https://github.com/FirebirdSQL/firebird/issues/4203">FirebirdSQL/firebird#4203</a>.
+     * Clean environment without verify. See <a href="https://github.com/FirebirdSQL/firebird/issues/4203">FirebirdSQL/firebird#4203</a>.
      *
      * @throws SQLException An exception that provides information on a database access error or other errors
      */
-    public void cleanEnvironmentInFirebird() throws SQLException {
-        orderRepository.dropTableInFirebird();
-        orderItemRepository.dropTableInFirebird();
-        addressRepository.dropTableInFirebird();
+    public void cleanEnvironmentWithoutVerify() throws SQLException {
+        orderRepository.dropTableWithoutVerify();
+        orderItemRepository.dropTableWithoutVerify();
+        addressRepository.dropTableWithoutVerify();
     }
 }

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/repository/AddressRepository.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/repository/AddressRepository.java
@@ -127,13 +127,13 @@ public final class AddressRepository {
     }
     
     /**
-     * Drop table in Firebird.
+     * Drop table without verify.
      * Docker Image `firebirdsql/firebird` does not work with `DROP TABLE IF EXISTS`.
      * See <a href="https://github.com/FirebirdSQL/firebird/issues/4203">FirebirdSQL/firebird#4203</a> .
      *
      * @throws SQLException SQL exception
      */
-    public void dropTableInFirebird() throws SQLException {
+    public void dropTableWithoutVerify() throws SQLException {
         String sql = "DROP TABLE t_address";
         try (
                 Connection connection = dataSource.getConnection();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/repository/OrderItemRepository.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/repository/OrderItemRepository.java
@@ -150,13 +150,13 @@ public final class OrderItemRepository {
     }
     
     /**
-     * drop table in Firebird.
+     * drop table without verify.
      * Docker Image `firebirdsql/firebird` does not work with `DROP TABLE IF EXISTS`.
      * See <a href="https://github.com/FirebirdSQL/firebird/issues/4203">FirebirdSQL/firebird#4203</a> .
      *
      * @throws SQLException SQL exception
      */
-    public void dropTableInFirebird() throws SQLException {
+    public void dropTableWithoutVerify() throws SQLException {
         String sql = "DROP TABLE t_order_item";
         try (
                 Connection connection = dataSource.getConnection();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/repository/OrderRepository.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/repository/OrderRepository.java
@@ -147,13 +147,13 @@ public final class OrderRepository {
     }
     
     /**
-     * drop table in Firebird.
+     * drop table without verify.
      * Docker Image `firebirdsql/firebird` does not work with `DROP TABLE IF EXISTS`.
      * See <a href="https://github.com/FirebirdSQL/firebird/issues/4203">FirebirdSQL/firebird#4203</a> .
      *
      * @throws SQLException SQL exception
      */
-    public void dropTableInFirebird() throws SQLException {
+    public void dropTableWithoutVerify() throws SQLException {
         String sql = "DROP TABLE t_order";
         try (
                 Connection connection = dataSource.getConnection();

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/DorisFETest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/DorisFETest.java
@@ -50,7 +50,7 @@ class DorisFETest {
     
     @SuppressWarnings("resource")
     @Container
-    private final GenericContainer<?> container = new GenericContainer<>("dyrnq/doris:3.1.0")
+    private final GenericContainer<?> container = new GenericContainer<>("dyrnq/doris:4.0.0")
             .withEnv("RUN_MODE", "standalone")
             .withEnv("SKIP_CHECK_ULIMIT", "true")
             .withExposedPorts(9030)

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/FirebirdTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/FirebirdTest.java
@@ -51,7 +51,7 @@ class FirebirdTest {
         testShardingService = new TestShardingService(logicDataSource);
         initEnvironment();
         testShardingService.processSuccess();
-        testShardingService.cleanEnvironmentInFirebird();
+        testShardingService.cleanEnvironmentWithoutVerify();
     }
     
     /**

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/SQLServerTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/SQLServerTest.java
@@ -56,6 +56,7 @@ class SQLServerTest {
         testShardingService = new TestShardingService(logicDataSource);
         initEnvironment();
         testShardingService.processSuccess();
+        testShardingService.cleanEnvironmentWithoutVerify();
     }
     
     private void initEnvironment() throws SQLException {


### PR DESCRIPTION
For https://github.com/apache/shardingsphere/issues/35052#issuecomment-3681366044 .

Changes proposed in this pull request:
  - Bump Netty to 4.2.9 . This was actually cut from https://github.com/apache/shardingsphere/pull/37357, which is tested for Windows 11. This is because https://github.com/netty/netty/pull/15877 is only available on Netty `4.2.3+`. The underlying reason is that JDK 25's Arena has issues with GraalVM Native Images, and Netty uses Arena as a backup solution in JDK 25, see https://netty.io/wiki/java-24-and-sun.misc.unsafe.html and https://www.graalvm.org/jdk25/reference-manual/native-image/native-code-interoperability/ffm-api/ . That said, this only addresses part of the issues with graalvm ce for jdk 25, or rather, provides a clear path to `"resolve"` https://github.com/openjdk/jdk/pull/25531 . Incidentally, all the issues are on Windows Server 2025, so if we're using the ShardingSphere Proxy Docker image, it's easy to miss these problems. This is because only the Linux container for ShardingSphere Proxy was built, not the Windows container.
  - `io.netty:netty-codec-protobuf` now requires manual dependency declaration; it is no longer implicitly depended on by `io.netty:netty-handler`. However, places like `org.apache.shardingsphere.proxy.frontend.netty.CDCServerHandlerInitializer` still use `io.netty.handler.codec.protobuf.**`. See https://github.com/netty/netty/wiki/Netty-4.2-Migration-Guide .

> The netty-codec module has been split into a number of different sub-modules, which the netty-codec module then depends on. In other words, netty-codec is now multiple jar files instead of one.

  - Update the GraalVM Reachability Meatdata and nativeTest required for this dependency change. This also involves handling the changes in https://github.com/dyrnq/docker-doris/issues/38 and https://learn.microsoft.com/zh-cn/sql/t-sql/statements/drop-table-transact-sql?view=sql-server-ver17#if-exists . Since Netty 4.2.x no longer supports JDK 6 and JDK 7, this has indeed brought about many changes for the graalvm tracing agent.

> From our (the Netty team) perspective, one of the biggest changes is that we are changing the minimum Java version requirement from Java 6 to Java 8. This upgrade is a big quality-of-life improvement for us, but it likely has no impact on anyone else because there are almost no regularly maintained Java projects left that still use Java versions older than Java 8.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
