### PR TITLE
Refactor IntegerPrimaryKeyIngestPosition to support null value

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/position/type/pk/PrimaryKeyIngestPositionFactory.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/position/type/pk/PrimaryKeyIngestPositionFactory.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.data.pipeline.core.ingest.position.type.pk;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.type.pk.type.IntegerPrimaryKeyIngestPosition;
@@ -49,7 +50,7 @@ public final class PrimaryKeyIngestPositionFactory {
         String endValue = parts.get(2);
         switch (type) {
             case 'i':
-                return new IntegerPrimaryKeyIngestPosition(Long.parseLong(beginValue), Long.parseLong(endValue));
+                return new IntegerPrimaryKeyIngestPosition(Strings.isNullOrEmpty(beginValue) ? null : Long.parseLong(beginValue), Strings.isNullOrEmpty(endValue) ? null : Long.parseLong(endValue));
             case 's':
                 return new StringPrimaryKeyIngestPosition(beginValue, endValue);
             case 'u':

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/position/type/pk/type/IntegerPrimaryKeyIngestPosition.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/position/type/pk/type/IntegerPrimaryKeyIngestPosition.java
@@ -24,11 +24,11 @@ import org.apache.shardingsphere.data.pipeline.core.ingest.position.type.pk.Prim
  */
 public final class IntegerPrimaryKeyIngestPosition implements PrimaryKeyIngestPosition<Long> {
     
-    private final long beginValue;
+    private final Long beginValue;
     
-    private final long endValue;
+    private final Long endValue;
     
-    public IntegerPrimaryKeyIngestPosition(final long beginValue, final long endValue) {
+    public IntegerPrimaryKeyIngestPosition(final Long beginValue, final Long endValue) {
         this.beginValue = beginValue;
         this.endValue = endValue;
     }
@@ -50,6 +50,6 @@ public final class IntegerPrimaryKeyIngestPosition implements PrimaryKeyIngestPo
     
     @Override
     public String toString() {
-        return String.format("%s,%s,%s", getType(), beginValue, endValue);
+        return String.format("%s,%s,%s", getType(), null == beginValue ? "" : beginValue, null == endValue ? "" : endValue);
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/InventoryPositionCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/InventoryPositionCalculator.java
@@ -45,7 +45,7 @@ public final class InventoryPositionCalculator {
      */
     public static List<IngestPosition> getPositionByIntegerUniqueKeyRange(final long tableRecordsCount, final Range<Long> uniqueKeyValuesRange, final long shardingSize) {
         if (0 == tableRecordsCount) {
-            return Collections.singletonList(new IntegerPrimaryKeyIngestPosition(0, 0));
+            return Collections.singletonList(new IntegerPrimaryKeyIngestPosition(0L, 0L));
         }
         List<IngestPosition> result = new LinkedList<>();
         long splitCount = tableRecordsCount / shardingSize + (tableRecordsCount % shardingSize > 0 ? 1 : 0);

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/ingest/position/type/pk/PrimaryKeyIngestPositionFactoryTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/ingest/position/type/pk/PrimaryKeyIngestPositionFactoryTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -33,10 +34,17 @@ class PrimaryKeyIngestPositionFactoryTest {
     
     @Test
     void assertNewInstanceWithIntegerPrimaryKeyIngestPosition() {
-        IntegerPrimaryKeyIngestPosition actual = (IntegerPrimaryKeyIngestPosition) PrimaryKeyIngestPositionFactory.newInstance("i,100,200");
-        assertThat(actual.getType(), is('i'));
-        assertThat(actual.getBeginValue(), is(100L));
-        assertThat(actual.getEndValue(), is(200L));
+        assertIntegerPrimaryKeyIngestPosition0(PrimaryKeyIngestPositionFactory.newInstance("i,100,200"), new IntegerPrimaryKeyIngestPosition(100L, 200L));
+        assertIntegerPrimaryKeyIngestPosition0(PrimaryKeyIngestPositionFactory.newInstance("i,100,"), new IntegerPrimaryKeyIngestPosition(100L, null));
+        assertIntegerPrimaryKeyIngestPosition0(PrimaryKeyIngestPositionFactory.newInstance("i,,200"), new IntegerPrimaryKeyIngestPosition(null, 200L));
+        assertIntegerPrimaryKeyIngestPosition0(PrimaryKeyIngestPositionFactory.newInstance("i,,"), new IntegerPrimaryKeyIngestPosition(null, null));
+    }
+    
+    private void assertIntegerPrimaryKeyIngestPosition0(final PrimaryKeyIngestPosition<?> actual, final IntegerPrimaryKeyIngestPosition expected) {
+        assertThat(actual, instanceOf(IntegerPrimaryKeyIngestPosition.class));
+        assertThat(actual.getType(), is(expected.getType()));
+        assertThat(actual.getBeginValue(), is(expected.getBeginValue()));
+        assertThat(actual.getEndValue(), is(expected.getEndValue()));
     }
     
     @Test

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/ingest/position/type/pk/type/IntegerPrimaryKeyIngestPositionTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/ingest/position/type/pk/type/IntegerPrimaryKeyIngestPositionTest.java
@@ -28,4 +28,11 @@ class IntegerPrimaryKeyIngestPositionTest {
     void assertToString() {
         assertThat(new IntegerPrimaryKeyIngestPosition(1L, 100L).toString(), is("i,1,100"));
     }
+    
+    @Test
+    void assertToStringWithNullValue() {
+        assertThat(new IntegerPrimaryKeyIngestPosition(1L, null).toString(), is("i,1,"));
+        assertThat(new IntegerPrimaryKeyIngestPosition(null, 100L).toString(), is("i,,100"));
+        assertThat(new IntegerPrimaryKeyIngestPosition(null, null).toString(), is("i,,"));
+    }
 }

--- a/kernel/data-pipeline/scenario/consistency-check/src/test/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/context/ConsistencyCheckJobItemContextTest.java
+++ b/kernel/data-pipeline/scenario/consistency-check/src/test/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/context/ConsistencyCheckJobItemContextTest.java
@@ -50,17 +50,17 @@ class ConsistencyCheckJobItemContextTest {
     @Test
     void assertConstructWithNonEmptyValues() {
         ConsistencyCheckJobItemProgress jobItemProgress = new ConsistencyCheckJobItemProgress(TABLE, null, 0L, 10L, null, null, "H2");
-        jobItemProgress.getTableCheckRangePositions().add(new TableCheckRangePosition(0, DATA_NODE, TABLE, new IntegerPrimaryKeyIngestPosition(1, 100),
-                new IntegerPrimaryKeyIngestPosition(1, 101), null, 11, 11, false, null));
-        jobItemProgress.getTableCheckRangePositions().add(new TableCheckRangePosition(1, DATA_NODE, TABLE, new IntegerPrimaryKeyIngestPosition(101, 200),
-                new IntegerPrimaryKeyIngestPosition(101, 203), null, 132, 132, false, null));
+        jobItemProgress.getTableCheckRangePositions().add(new TableCheckRangePosition(0, DATA_NODE, TABLE, new IntegerPrimaryKeyIngestPosition(1L, 100L),
+                new IntegerPrimaryKeyIngestPosition(1L, 101L), null, 11, 11, false, null));
+        jobItemProgress.getTableCheckRangePositions().add(new TableCheckRangePosition(1, DATA_NODE, TABLE, new IntegerPrimaryKeyIngestPosition(101L, 200L),
+                new IntegerPrimaryKeyIngestPosition(101L, 203L), null, 132, 132, false, null));
         ConsistencyCheckJobItemContext actual = new ConsistencyCheckJobItemContext(new ConsistencyCheckJobConfiguration("", "", "DATA_MATCH", null, databaseType),
                 0, JobStatus.RUNNING, jobItemProgress);
         assertThat(actual.getProgressContext().getTableCheckRangePositions().size(), is(2));
         assertTableCheckRangePosition(actual.getProgressContext().getTableCheckRangePositions().get(0),
-                new TableCheckRangePosition(0, DATA_NODE, TABLE, new IntegerPrimaryKeyIngestPosition(1, 100), new IntegerPrimaryKeyIngestPosition(1, 101), null, 11, 11, false, null));
+                new TableCheckRangePosition(0, DATA_NODE, TABLE, new IntegerPrimaryKeyIngestPosition(1L, 100L), new IntegerPrimaryKeyIngestPosition(1L, 101L), null, 11, 11, false, null));
         assertTableCheckRangePosition(actual.getProgressContext().getTableCheckRangePositions().get(1),
-                new TableCheckRangePosition(1, DATA_NODE, TABLE, new IntegerPrimaryKeyIngestPosition(101, 200), new IntegerPrimaryKeyIngestPosition(101, 203), null, 132, 132, false, null));
+                new TableCheckRangePosition(1, DATA_NODE, TABLE, new IntegerPrimaryKeyIngestPosition(101L, 200L), new IntegerPrimaryKeyIngestPosition(101L, 203L), null, 132, 132, false, null));
     }
     
     private void assertTableCheckRangePosition(final TableCheckRangePosition actual, final TableCheckRangePosition expected) {


### PR DESCRIPTION

Changes proposed in this pull request:
  - Refactor IntegerPrimaryKeyIngestPosition to support null value

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
