### PR TITLE
Update proxy bootstrap maven dev profile: add data-pipeline-feature-sharding

### DIFF
--- a/proxy/bootstrap/pom.xml
+++ b/proxy/bootstrap/pom.xml
@@ -172,6 +172,12 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.shardingsphere</groupId>
+                    <artifactId>shardingsphere-data-pipeline-feature-sharding</artifactId>
+                    <version>${project.version}</version>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.shardingsphere</groupId>
                     <artifactId>shardingsphere-sharding-mysql</artifactId>
                     <version>${project.version}</version>
                     <scope>runtime</scope>


### PR DESCRIPTION

Changes proposed in this pull request:
  - Update proxy bootstrap maven dev profile: add data-pipeline-feature-sharding. Avoid running Bootstrap in IDE missing dependency cause MySQLMigrationGeneralE2EIT failure

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
