### PR TITLE
support oracle blob type.(https://github.com/apache/shardingsphere/is…

### DIFF
--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractPreparedStatementAdapter.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractPreparedStatementAdapter.java
@@ -300,7 +300,7 @@ public abstract class AbstractPreparedStatementAdapter extends AbstractUnsupport
             }
         }
     }
-
+    
     private void handleOracleInputStreamSetBlob(final PreparedStatement preparedStatement, final int index, final Object each) throws SQLException {
         try {
             long length = -1;


### PR DESCRIPTION


Fixes #37504 

Changes proposed in this pull request:
  -
AbstractPreparedStatementAdapter， support blob type with ojdbc6
---

Before committing this PR, I'm sure that I have checked the following options:

- [ √] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ √] I have self-reviewed the commit code.
- [ √] I have (or in comment I request) added corresponding labels for the pull request.
- [ √] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
