### PR TITLE
Rename InventoryPositionCalculator to InventoryPositionEstimatedCalculator

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/estimated/InventoryPositionEstimatedCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/estimated/InventoryPositionEstimatedCalculator.java
@@ -36,14 +36,14 @@ import java.util.List;
 public final class InventoryPositionEstimatedCalculator {
     
     /**
-     * Get position by integer unique key range.
+     * Get positions by integer unique key range.
      *
      * @param tableRecordsCount table records count
      * @param uniqueKeyValuesRange unique key values range
      * @param shardingSize sharding size
-     * @return position collection
+     * @return positions
      */
-    public static List<IngestPosition> getPositionByIntegerUniqueKeyRange(final long tableRecordsCount, final Range<Long> uniqueKeyValuesRange, final long shardingSize) {
+    public static List<IngestPosition> getIntegerPositions(final long tableRecordsCount, final Range<Long> uniqueKeyValuesRange, final long shardingSize) {
         if (0 == tableRecordsCount) {
             return Collections.singletonList(new IntegerPrimaryKeyIngestPosition(0L, 0L));
         }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/splitter/InventoryDumperContextSplitter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/splitter/InventoryDumperContextSplitter.java
@@ -124,7 +124,7 @@ public final class InventoryDumperContextSplitter {
         if (dataTypeOption.isIntegerDataType(firstColumnDataType)) {
             Range<Long> uniqueKeyValuesRange = getUniqueKeyValuesRange(jobItemContext, dumperContext);
             int shardingSize = jobItemContext.getJobProcessContext().getProcessConfiguration().getRead().getShardingSize();
-            return InventoryPositionEstimatedCalculator.getPositionByIntegerUniqueKeyRange(tableRecordsCount, uniqueKeyValuesRange, shardingSize);
+            return InventoryPositionEstimatedCalculator.getIntegerPositions(tableRecordsCount, uniqueKeyValuesRange, shardingSize);
         }
         if (1 == uniqueKeyColumns.size() && dataTypeOption.isStringDataType(firstColumnDataType)) {
             return Collections.singleton(new StringPrimaryKeyIngestPosition(null, null));

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/estimated/InventoryPositionEstimatedCalculatorTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/estimated/InventoryPositionEstimatedCalculatorTest.java
@@ -31,8 +31,8 @@ import static org.hamcrest.Matchers.isA;
 class InventoryPositionEstimatedCalculatorTest {
     
     @Test
-    void assertGetPositionByIntegerUniqueKeyRange() {
-        List<IngestPosition> actualPositions = InventoryPositionEstimatedCalculator.getPositionByIntegerUniqueKeyRange(200L, Range.of(1L, 600L), 100L);
+    void assertGetIntegerPositions() {
+        List<IngestPosition> actualPositions = InventoryPositionEstimatedCalculator.getIntegerPositions(200L, Range.of(1L, 600L), 100L);
         assertThat(actualPositions.size(), is(2));
         for (IngestPosition each : actualPositions) {
             assertThat(each, isA(IntegerPrimaryKeyIngestPosition.class));
@@ -47,28 +47,28 @@ class InventoryPositionEstimatedCalculatorTest {
     }
     
     @Test
-    void assertGetPositionByIntegerUniqueKeyRangeWithZeroTotalRecordsCount() {
-        List<IngestPosition> actualPositions = InventoryPositionEstimatedCalculator.getPositionByIntegerUniqueKeyRange(0L, Range.of(0L, 0L), 1L);
+    void assertGetIntegerPositionsWithZeroTotalRecordsCount() {
+        List<IngestPosition> actualPositions = InventoryPositionEstimatedCalculator.getIntegerPositions(0L, Range.of(0L, 0L), 1L);
         assertThat(actualPositions.size(), is(1));
         assertThat(actualPositions.get(0), isA(IntegerPrimaryKeyIngestPosition.class));
         assertPosition(new IntegerPrimaryKeyIngestPosition(0L, 0L), (IntegerPrimaryKeyIngestPosition) actualPositions.get(0));
     }
     
     @Test
-    void assertGetPositionByIntegerUniqueKeyRangeWithTheSameMinMax() {
-        List<IngestPosition> actualPositions = InventoryPositionEstimatedCalculator.getPositionByIntegerUniqueKeyRange(200L, Range.of(5L, 5L), 100L);
+    void assertGetIntegerPositionsWithTheSameMinMax() {
+        List<IngestPosition> actualPositions = InventoryPositionEstimatedCalculator.getIntegerPositions(200L, Range.of(5L, 5L), 100L);
         assertThat(actualPositions.size(), is(1));
         assertThat(actualPositions.get(0), isA(IntegerPrimaryKeyIngestPosition.class));
         assertPosition(new IntegerPrimaryKeyIngestPosition(5L, 5L), (IntegerPrimaryKeyIngestPosition) actualPositions.get(0));
     }
     
     @Test
-    void assertGetPositionByIntegerUniqueKeyRangeOverflow() {
+    void assertGetIntegerPositionsOverflow() {
         long tableRecordsCount = Long.MAX_VALUE - 1L;
         long shardingSize = tableRecordsCount / 2L;
         long minimum = Long.MIN_VALUE + 1L;
         long maximum = Long.MAX_VALUE;
-        List<IngestPosition> actualPositions = InventoryPositionEstimatedCalculator.getPositionByIntegerUniqueKeyRange(tableRecordsCount, Range.of(minimum, maximum), shardingSize);
+        List<IngestPosition> actualPositions = InventoryPositionEstimatedCalculator.getIntegerPositions(tableRecordsCount, Range.of(minimum, maximum), shardingSize);
         assertThat(actualPositions.size(), is(2));
         for (IngestPosition each : actualPositions) {
             assertThat(each, isA(IntegerPrimaryKeyIngestPosition.class));


### PR DESCRIPTION

Changes proposed in this pull request:
  - Rename InventoryPositionCalculator to InventoryPositionEstimatedCalculator
  - Rename method

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
