### PR TITLE
Improve IntegerRangeSplittingIterator to support BigInteger

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/IntegerRangeSplittingIterator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/inventory/query/IntegerRangeSplittingIterator.java
@@ -26,38 +26,38 @@ import java.util.NoSuchElementException;
  *
  * <p>It's not thread-safe.</p>
  */
-public final class IntegerRangeSplittingIterator implements Iterator<Range<Long>> {
+public final class IntegerRangeSplittingIterator implements Iterator<Range<BigInteger>> {
     
-    private final BigInteger maximum;
+    private final BigInteger upperBound;
     
     private final BigInteger stepSize;
     
     private BigInteger current;
     
-    public IntegerRangeSplittingIterator(final long minimum, final long maximum, final long stepSize) {
-        if (minimum > maximum) {
-            throw new IllegalArgumentException("minimum greater than maximum");
+    public IntegerRangeSplittingIterator(final BigInteger lowerBound, final BigInteger upperBound, final BigInteger stepSize) {
+        if (lowerBound.compareTo(upperBound) > 0) {
+            throw new IllegalArgumentException("lower bounder greater than upper bound");
         }
-        if (stepSize < 0L) {
+        if (stepSize.compareTo(BigInteger.ZERO) < 0) {
             throw new IllegalArgumentException("step size is less than zero");
         }
-        this.maximum = BigInteger.valueOf(maximum);
-        this.stepSize = BigInteger.valueOf(stepSize);
-        current = BigInteger.valueOf(minimum);
+        this.upperBound = upperBound;
+        this.stepSize = stepSize;
+        current = lowerBound;
     }
     
     @Override
     public boolean hasNext() {
-        return current.compareTo(maximum) <= 0;
+        return current.compareTo(upperBound) <= 0;
     }
     
     @Override
-    public Range<Long> next() {
+    public Range<BigInteger> next() {
         if (!hasNext()) {
             throw new NoSuchElementException("");
         }
-        BigInteger upperLimit = min(maximum, current.add(stepSize));
-        Range<Long> result = Range.closed(current.longValue(), upperLimit.longValue());
+        BigInteger upperLimit = min(upperBound, current.add(stepSize));
+        Range<BigInteger> result = Range.closed(current, upperLimit);
         current = upperLimit.add(BigInteger.ONE);
         return result;
     }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/estimated/InventoryPositionEstimatedCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/estimated/InventoryPositionEstimatedCalculator.java
@@ -75,18 +75,18 @@ public final class InventoryPositionEstimatedCalculator {
      * @return positions
      */
     public static List<IngestPosition> getIntegerPositions(final long tableRecordsCount, final Range<Long> uniqueKeyValuesRange, final long shardingSize) {
-        Long minimum = uniqueKeyValuesRange.getLowerBound();
-        Long maximum = uniqueKeyValuesRange.getUpperBound();
-        if (0 == tableRecordsCount || null == minimum || null == maximum) {
+        Long lowerBound = uniqueKeyValuesRange.getLowerBound();
+        Long upperBound = uniqueKeyValuesRange.getUpperBound();
+        if (0 == tableRecordsCount || null == lowerBound || null == upperBound) {
             return Collections.singletonList(new IntegerPrimaryKeyIngestPosition(null, null));
         }
         List<IngestPosition> result = new LinkedList<>();
         long splitCount = tableRecordsCount / shardingSize + (tableRecordsCount % shardingSize > 0 ? 1 : 0);
-        long stepSize = BigInteger.valueOf(maximum).subtract(BigInteger.valueOf(minimum)).divide(BigInteger.valueOf(splitCount)).longValue();
-        IntegerRangeSplittingIterator rangeIterator = new IntegerRangeSplittingIterator(minimum, maximum, stepSize);
+        BigInteger stepSize = BigInteger.valueOf(upperBound).subtract(BigInteger.valueOf(lowerBound)).divide(BigInteger.valueOf(splitCount));
+        IntegerRangeSplittingIterator rangeIterator = new IntegerRangeSplittingIterator(BigInteger.valueOf(lowerBound), BigInteger.valueOf(upperBound), stepSize);
         while (rangeIterator.hasNext()) {
-            Range<Long> range = rangeIterator.next();
-            result.add(new IntegerPrimaryKeyIngestPosition(range.getLowerBound(), range.getUpperBound()));
+            Range<BigInteger> range = rangeIterator.next();
+            result.add(new IntegerPrimaryKeyIngestPosition(range.getLowerBound().longValue(), range.getUpperBound().longValue()));
         }
         return result;
     }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Improve IntegerRangeSplittingIterator to support BigInteger

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
