### PR TITLE
Replace DataTypePositionHandler.createIngestPosition param to Range

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/exact/DataTypePositionHandler.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/exact/DataTypePositionHandler.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.data.pipeline.core.preparer.inventory.calculator.position.exact;
 
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.Range;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.type.pk.UniqueKeyIngestPosition;
 
 import java.sql.PreparedStatement;
@@ -53,9 +54,8 @@ public interface DataTypePositionHandler<T> {
     /**
      * Create ingest position.
      *
-     * @param lowerBound lower bound
-     * @param upperBound upper bound
+     * @param range range
      * @return ingest position
      */
-    UniqueKeyIngestPosition<T> createIngestPosition(T lowerBound, T upperBound);
+    UniqueKeyIngestPosition<T> createIngestPosition(Range<T> range);
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/exact/IntegerPositionHandler.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/exact/IntegerPositionHandler.java
@@ -43,7 +43,7 @@ public final class IntegerPositionHandler implements DataTypePositionHandler<Big
     }
     
     @Override
-    public UniqueKeyIngestPosition<BigInteger> createIngestPosition(final BigInteger lowerBound, final BigInteger upperBound) {
-        return UniqueKeyIngestPosition.ofInteger(Range.closed(lowerBound, upperBound));
+    public UniqueKeyIngestPosition<BigInteger> createIngestPosition(final Range<BigInteger> range) {
+        return UniqueKeyIngestPosition.ofInteger(range);
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/exact/InventoryPositionExactCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/exact/InventoryPositionExactCalculator.java
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSource;
 import org.apache.shardingsphere.data.pipeline.core.exception.job.SplitPipelineJobByUniqueKeyException;
+import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.Range;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.IngestPosition;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.type.pk.UniqueKeyIngestPosition;
 import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql.PipelinePrepareSQLBuilder;
@@ -73,16 +74,16 @@ public final class InventoryPositionExactCalculator {
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
                 if (!resultSet.next()) {
                     log.info("No any record, return. First query SQL: {}", firstQuerySQL);
-                    return positionHandler.createIngestPosition(null, null);
+                    return positionHandler.createIngestPosition(Range.closed(null, null));
                 }
                 long count = resultSet.getLong(2);
                 T minValue = positionHandler.readColumnValue(resultSet, 3);
                 T maxValue = positionHandler.readColumnValue(resultSet, 1);
                 log.info("First records count: {}, min value: {}, max value: {}, sharding size: {}, first query SQL: {}", count, minValue, maxValue, shardingSize, firstQuerySQL);
                 if (0 == count) {
-                    return positionHandler.createIngestPosition(null, null);
+                    return positionHandler.createIngestPosition(Range.closed(null, null));
                 }
-                return positionHandler.createIngestPosition(minValue, maxValue);
+                return positionHandler.createIngestPosition(Range.closed(minValue, maxValue));
             }
         } catch (final SQLException ex) {
             throw new SplitPipelineJobByUniqueKeyException(qualifiedTable.getTableName(), uniqueKey, ex);
@@ -115,7 +116,7 @@ public final class InventoryPositionExactCalculator {
                     recordsCount += count;
                     T minValue = positionHandler.readColumnValue(resultSet, 3);
                     T maxValue = positionHandler.readColumnValue(resultSet, 1);
-                    result.add(positionHandler.createIngestPosition(minValue, maxValue));
+                    result.add(positionHandler.createIngestPosition(Range.closed(minValue, maxValue)));
                     lowerBound = maxValue;
                 }
             }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/exact/StringPositionHandler.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/exact/StringPositionHandler.java
@@ -40,7 +40,7 @@ public final class StringPositionHandler implements DataTypePositionHandler<Stri
     }
     
     @Override
-    public UniqueKeyIngestPosition<String> createIngestPosition(final String lowerBound, final String upperBound) {
-        return UniqueKeyIngestPosition.ofString(Range.closed(lowerBound, upperBound));
+    public UniqueKeyIngestPosition<String> createIngestPosition(final Range<String> range) {
+        return UniqueKeyIngestPosition.ofString(range);
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Replace DataTypePositionHandler.createIngestPosition param to Range. Prepare for unique key first column splitting support closed or open-closed range

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
