### PR TITLE
Refactor SplitPipelineJobByUniqueKeyException constructor

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/SplitPipelineJobByUniqueKeyException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/SplitPipelineJobByUniqueKeyException.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.data.pipeline.core.exception.job;
 
 import org.apache.shardingsphere.infra.exception.external.sql.sqlstate.XOpenSQLState;
+import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
 
 import java.sql.SQLException;
 
@@ -28,7 +29,7 @@ public final class SplitPipelineJobByUniqueKeyException extends PipelineJobExcep
     
     private static final long serialVersionUID = -7804078676439253443L;
     
-    public SplitPipelineJobByUniqueKeyException(final String tableName, final String uniqueKey, final SQLException cause) {
-        super(XOpenSQLState.GENERAL_ERROR, 4, String.format("Can not split by unique key '%s' for table '%s'.", uniqueKey, tableName), cause);
+    public SplitPipelineJobByUniqueKeyException(final QualifiedTable qualifiedTable, final String uniqueKey, final SQLException cause) {
+        super(XOpenSQLState.GENERAL_ERROR, 4, String.format("Can not split by unique key '%s' for table '%s'.", uniqueKey, qualifiedTable.format()), cause);
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/InventoryRecordsCountCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/InventoryRecordsCountCalculator.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSourc
 import org.apache.shardingsphere.data.pipeline.core.exception.job.SplitPipelineJobByUniqueKeyException;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.InventoryDumperContext;
 import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.sql.PipelinePrepareSQLBuilder;
+import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -63,7 +64,7 @@ public final class InventoryRecordsCountCalculator {
             return getCount(dataSource, sqlBuilder.buildCountSQL(schemaName, actualTableName));
         } catch (final SQLException ex) {
             String uniqueKey = dumperContext.hasUniqueKey() ? dumperContext.getUniqueKeyColumns().get(0).getName() : "";
-            throw new SplitPipelineJobByUniqueKeyException(dumperContext.getActualTableName(), uniqueKey, ex);
+            throw new SplitPipelineJobByUniqueKeyException(new QualifiedTable(schemaName, dumperContext.getActualTableName()), uniqueKey, ex);
         }
     }
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/InventoryPositionCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/InventoryPositionCalculator.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.data.pipeline.core.preparer.inventory.calculator.position;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSource;
 import org.apache.shardingsphere.data.pipeline.core.ingest.dumper.inventory.query.Range;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.IngestPosition;
@@ -40,6 +41,7 @@ import java.util.List;
  * Inventory position calculator.
  */
 @RequiredArgsConstructor
+@Slf4j
 public final class InventoryPositionCalculator {
     
     private final PipelineDataSource dataSource;
@@ -66,6 +68,7 @@ public final class InventoryPositionCalculator {
         if (dataTypeOption.isStringDataType(firstColumnDataType)) {
             return getStringPositions();
         }
+        log.info("Unsupported unique key type, unique key columns: {}", uniqueKeyColumns);
         return Collections.singletonList(UniqueKeyIngestPosition.ofUnsplit());
     }
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/estimated/InventoryPositionEstimatedCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/estimated/InventoryPositionEstimatedCalculator.java
@@ -65,7 +65,7 @@ public final class InventoryPositionEstimatedCalculator {
             BigDecimal upperBound = resultSet.getBigDecimal(2);
             return Range.closed(null == lowerBound ? null : lowerBound.toBigInteger(), null == upperBound ? null : upperBound.toBigInteger());
         } catch (final SQLException ex) {
-            throw new SplitPipelineJobByUniqueKeyException(qualifiedTable.getTableName(), uniqueKey, ex);
+            throw new SplitPipelineJobByUniqueKeyException(qualifiedTable, uniqueKey, ex);
         }
     }
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/exact/InventoryPositionExactCalculator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/preparer/inventory/calculator/position/exact/InventoryPositionExactCalculator.java
@@ -86,7 +86,7 @@ public final class InventoryPositionExactCalculator {
                 return positionHandler.createIngestPosition(Range.closed(minValue, maxValue));
             }
         } catch (final SQLException ex) {
-            throw new SplitPipelineJobByUniqueKeyException(qualifiedTable.getTableName(), uniqueKey, ex);
+            throw new SplitPipelineJobByUniqueKeyException(qualifiedTable, uniqueKey, ex);
         }
     }
     
@@ -121,7 +121,7 @@ public final class InventoryPositionExactCalculator {
                 }
             }
         } catch (final SQLException ex) {
-            throw new SplitPipelineJobByUniqueKeyException(qualifiedTable.getTableName(), uniqueKey, ex);
+            throw new SplitPipelineJobByUniqueKeyException(qualifiedTable, uniqueKey, ex);
         }
         return result;
     }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Refactor SplitPipelineJobByUniqueKeyException constructor

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
