### PR TITLE
Fixes the missing `slf4j-api` JAR for `shardingsphere-agent-core`

### DIFF
--- a/agent/core/pom.xml
+++ b/agent/core/pom.xml
@@ -46,6 +46,11 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     
     <build>


### PR DESCRIPTION
Fixes #37652 .

Changes proposed in this pull request:
  - Fixes the missing `slf4j-api` JAR for `shardingsphere-agent-core`.
> Marked `slf4j-api` in `agent/core` as `provided` so the shaded agent jar no longer embeds SLF4J classes and defers to the host’s logging implementation.

  - Verify using the following steps. It's hard to say what unit tests are needed for this.
```shell
sdk install java 23.0.2-graalce
sdk use java 23.0.2-graalce

git clone -b fix-logback-agent git@github.com:linghengqian/shardingsphere.git
cd ./shardingsphere/
git reset --hard 766ad698600fc0db6a0b7587ce22ea250fcaa71e
./mvnw clean install -Prelease -T1C -DskipTests -Djacoco.skip=true -Dcheckstyle.skip=true -Drat.skip=true -Dmaven.javadoc.skip=true
./mvnw -am -pl distribution/agent -Prelease,docker -T1C -DskipTests clean package
cd ../

git clone git@github.com:linghengqian/shardingsphere-agent-master-test.git
cd ./shardingsphere-agent-master-test/
./mvnw clean test
./mvnw clean package -T1C -DskipTests
docker compose up -d
docker compose logs --follow shardingsphere-agent-master-test
```
  - <img width="2880" height="1698" alt="image" src="https://github.com/user-attachments/assets/f80ebbe6-7d0b-4864-9e7f-aa4f49eb2852" />


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
