### PR TITLE
Extract ProxyDatabaseTypeUtils.isOracleBranch for pipeline E2E

### DIFF
--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/cases/PipelineContainerComposer.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/cases/PipelineContainerComposer.java
@@ -33,7 +33,6 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.database.connector.mysql.type.MySQLDatabaseType;
 import org.apache.shardingsphere.database.connector.opengauss.type.OpenGaussDatabaseType;
-import org.apache.shardingsphere.database.connector.oracle.type.OracleDatabaseType;
 import org.apache.shardingsphere.database.connector.postgresql.type.PostgreSQLDatabaseType;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.util.props.PropertiesBuilder;
@@ -53,6 +52,7 @@ import org.apache.shardingsphere.test.e2e.operation.pipeline.framework.container
 import org.apache.shardingsphere.test.e2e.operation.pipeline.framework.container.compose.docker.PipelineDockerContainerComposer;
 import org.apache.shardingsphere.test.e2e.operation.pipeline.framework.container.compose.natived.PipelineNativeContainerComposer;
 import org.apache.shardingsphere.test.e2e.operation.pipeline.framework.param.PipelineTestParameter;
+import org.apache.shardingsphere.test.e2e.operation.pipeline.util.ProxyDatabaseTypeUtils;
 import org.awaitility.Awaitility;
 
 import javax.sql.DataSource;
@@ -249,7 +249,7 @@ public final class PipelineContainerComposer implements AutoCloseable {
      * @throws SQLException SQL exception
      */
     public void registerStorageUnit(final String storageUnitName) throws SQLException {
-        String username = databaseType instanceof OracleDatabaseType ? storageUnitName : getUsername();
+        String username = ProxyDatabaseTypeUtils.isOracleBranch(databaseType) ? storageUnitName : getUsername();
         String registerStorageUnitTemplate = "REGISTER STORAGE UNIT ${ds} ( URL='${url}', USER='${user}', PASSWORD='${password}')".replace("${ds}", storageUnitName)
                 .replace("${user}", username)
                 .replace("${password}", getPassword())
@@ -304,7 +304,7 @@ public final class PipelineContainerComposer implements AutoCloseable {
      * @return actual JDBC URL template
      */
     public String getActualJdbcUrlTemplate(final String databaseName, final boolean isInContainer) {
-        if (databaseType instanceof OracleDatabaseType) {
+        if (ProxyDatabaseTypeUtils.isOracleBranch(databaseType)) {
             return getActualJdbcUrlTemplate(databaseName, isInContainer, 0);
         }
         return appendExtraParameter(getActualJdbcUrlTemplate(databaseName, isInContainer, 0));

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/util/ProxyDatabaseTypeUtils.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/util/ProxyDatabaseTypeUtils.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.test.e2e.operation.pipeline.util;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.database.connector.oracle.type.OracleDatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 
 import java.util.Collection;
@@ -45,5 +46,15 @@ public final class ProxyDatabaseTypeUtils {
     
     private static Collection<String> getUnsupportedProxyDatabaseTypes() {
         return Collections.singleton("Oracle");
+    }
+    
+    /**
+     * Is oracle branch database type.
+     *
+     * @param databaseType database type
+     * @return true if is oracle branch database type, else false
+     */
+    public static boolean isOracleBranch(final DatabaseType databaseType) {
+        return databaseType.getTrunkDatabaseType().orElse(databaseType) instanceof OracleDatabaseType;
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Extract ProxyDatabaseTypeUtils.isOracleBranch for pipeline E2E

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
