### PR TITLE
Update proxy docker image log level to INFO in E2E

### DIFF
--- a/test/e2e/fixture/src/test/assembly/conf/logback.xml
+++ b/test/e2e/fixture/src/test/assembly/conf/logback.xml
@@ -22,7 +22,7 @@
             <pattern>[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
-    <logger name="org.apache.shardingsphere" level="error" additivity="false">
+    <logger name="org.apache.shardingsphere" level="info" additivity="false">
         <appender-ref ref="console" />
     </logger>
     
@@ -33,7 +33,7 @@
     <logger name="io.netty" level="error" />
     
     <root>
-        <level value="error" />
+        <level value="info" />
         <appender-ref ref="console" />
     </root>
 </configuration>

--- a/test/e2e/operation/pipeline/src/test/resources/env/logback.xml
+++ b/test/e2e/operation/pipeline/src/test/resources/env/logback.xml
@@ -34,7 +34,7 @@
     <logger name="com.zaxxer.hikari.pool.ProxyConnection" level="OFF" />
     <logger name="org.apache.zookeeper.ZooKeeper" level="WARN" />
     <root>
-        <level value="ERROR" />
+        <level value="INFO" />
         <appender-ref ref="console" />
     </root>
 </configuration>


### PR DESCRIPTION
Change default log level is `INFO`, when we run `SET DIST VARIABLE sql_show = TRUE` in E2E code, then we could find `Logic SQL` and `Actual SQL` for troubleshooting.

Changes proposed in this pull request:
  - Update proxy docker image log level to INFO in E2E

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
