### PR TITLE
Make DriverDataSourceCache as static in ShardingSphereDriver

### DIFF
--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/ShardingSphereDriver.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/ShardingSphereDriver.java
@@ -41,7 +41,7 @@ public final class ShardingSphereDriver implements Driver {
     
     private static final int MINOR_DRIVER_VERSION = 5;
     
-    private final DriverDataSourceCache dataSourceCache = new DriverDataSourceCache();
+    private static final DriverDataSourceCache DATA_SOURCE_CACHE = new DriverDataSourceCache();
     
     static {
         try {
@@ -54,7 +54,7 @@ public final class ShardingSphereDriver implements Driver {
     @HighFrequencyInvocation(canBeCached = true)
     @Override
     public Connection connect(final String url, final Properties info) throws SQLException {
-        return acceptsURL(url) ? dataSourceCache.get(url, DRIVER_URL_PREFIX).getConnection() : null;
+        return acceptsURL(url) ? DATA_SOURCE_CACHE.get(url, DRIVER_URL_PREFIX).getConnection() : null;
     }
     
     @Override


### PR DESCRIPTION
When multiple ShardingSphereDriver instances are created in a JDBC application, because dataSourceCache is not static, the caches of the multiple ShardingSphereDrivers are not shared, resulting in multiple logical data sources for the same jdbcUrl.

Setting `DriverDataSourceCache` to static can avoid this problem.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
