### PR TITLE
Change the base JDK of the ShardingSphere Agent image to JDK 25

### DIFF
--- a/distribution/agent/Dockerfile
+++ b/distribution/agent/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM eclipse-temurin:23-jdk
+FROM eclipse-temurin:25-jdk
 LABEL org.opencontainers.image.authors="ShardingSphere dev@shardingsphere.apache.org"
 ARG DIRECTORY_NAME
 ARG JAR_NAME


### PR DESCRIPTION
Fixes #37682 .

Changes proposed in this pull request:
  - Change the base JDK of the ShardingSphere Agent image to JDK 25.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
