### PR TITLE
Remove documentation for older versions of testcontainers-java

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
@@ -77,8 +77,7 @@ newgrp docker
 
 sudo tee /etc/docker/daemon.json <<EOF
 {
-  "log-driver": "local",
-  "min-api-version": "1.24"
+  "log-driver": "local"
 }
 EOF
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
@@ -79,8 +79,7 @@ newgrp docker
 
 sudo tee /etc/docker/daemon.json <<EOF
 {
-  "log-driver": "local",
-  "min-api-version": "1.24"
+  "log-driver": "local"
 }
 EOF
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -163,8 +163,7 @@ newgrp docker
 
 sudo tee /etc/docker/daemon.json <<EOF
 {
-  "log-driver": "local",
-  "min-api-version": "1.24"
+  "log-driver": "local"
 }
 EOF
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -167,8 +167,7 @@ newgrp docker
 
 sudo tee /etc/docker/daemon.json <<EOF
 {
-  "log-driver": "local",
-  "min-api-version": "1.24"
+  "log-driver": "local"
 }
 EOF
 


### PR DESCRIPTION
Fixes #37642 .

Changes proposed in this pull request:
  - Remove documentation for older versions of testcontainers-java. See https://github.com/apache/shardingsphere/pull/37661 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
