### PR TITLE
Simplify Operation E2E Maven cache

### DIFF
--- a/.github/workflows/e2e-operation.yml
+++ b/.github/workflows/e2e-operation.yml
@@ -88,23 +88,12 @@ jobs:
       - name: Checkout Project
         if: (env.skip_current_step == 'false')
         uses: actions/checkout@v6.0.1
-      - name: Retrieve Maven Caches
-        if: (env.skip_current_step == 'false')
-        uses: actions/cache@v5.0.1
-        with:
-          path: |
-            ~/.m2/repository
-            !~/.m2/repository/org/apache/shardingsphere
-            ~/.m2/repository/org/apache/shardingsphere/elasticjob
-          key: apache-shardingsphere-maven-third-party-e2e-cache-${{ github.sha }}
-          restore-keys: |
-            apache-shardingsphere-maven-third-party-e2e-cache-
-            apache-shardingsphere-maven-third-party-
       - if: (env.skip_current_step == 'false')
         uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
           java-version: 11
+          cache: 'maven'
       - name: Build ${{ matrix.operation }} E2E Image
         if: (env.skip_current_step == 'false')
         run: ./mvnw -B clean install -am -pl test/e2e/operation/${{ matrix.operation }} -Pe2e.env.docker -DskipTests

--- a/.github/workflows/nightly-e2e-operation.yml
+++ b/.github/workflows/nightly-e2e-operation.yml
@@ -67,22 +67,12 @@ jobs:
             image: { type: "e2e.docker.database.opengauss.images", version: "opengauss/opengauss:3.1.0" }
     steps:
       - uses: actions/checkout@v6.0.1
-      - name: Retrieve Maven Caches
-        uses: actions/cache@v5.0.1
-        with:
-          path: |
-            ~/.m2/repository
-            !~/.m2/repository/org/apache/shardingsphere
-            ~/.m2/repository/org/apache/shardingsphere/elasticjob
-          key: ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-e2e-cache-${{ github.sha }}
-          restore-keys: |
-            ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-e2e-cache-
-            ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-
       - name: Setup JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
+          cache: 'maven'
       - name: Build ${{ matrix.operation }} E2E Image
         run: ./mvnw -B clean install -am -pl test/e2e/operation/${{ matrix.operation }} -Pe2e.env.docker -DskipTests
       - name: Run ${{ matrix.operation }} on ${{ matrix.image.version }}


### PR DESCRIPTION
Changes proposed in this pull request:
  - Replace actions/cache to actions/setup-java cache: 'maven'. 1) Reduce code lines, 2) Remove `github.sha` in key of actions/cache

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
