### PR TITLE
Fix failing nativeTest on Windows Server 2025

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
@@ -120,6 +120,7 @@ wsl --install
 并设置使用 `dockerd(moby)` 的 `Container Engine`。
 
 ```shell
+[Environment]::SetEnvironmentVariable('DOCKER_API_VERSION','1.44','Machine')
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
 # 打开新的 PowerShell 7 终端
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
@@ -147,6 +148,7 @@ rdctl start --application.start-in-background --container-engine.name=moby --kub
 可在 PowerShell 7 执行如下命令，
 
 ```shell
+[Environment]::SetEnvironmentVariable('DOCKER_API_VERSION','1.44','Machine')
 iex "& { $(irm https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1) } -Force"
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
 # 打开新的 PowerShell 7 终端

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
@@ -125,6 +125,7 @@ After enabling WSL2, download and install `rancher-sandbox/rancher-desktop` usin
 and configure it to use the `dockerd(moby)` `Container Engine`.
 
 ```shell
+[Environment]::SetEnvironmentVariable('DOCKER_API_VERSION','1.44','Machine')
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
 # Open a new PowerShell 7 terminal
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
@@ -152,6 +153,7 @@ they will need to uninstall Docker Engine using the script provided by Microsoft
 You can execute the following command in PowerShell 7:
 
 ```shell
+[Environment]::SetEnvironmentVariable('DOCKER_API_VERSION','1.44','Machine')
 iex "& { $(irm https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1) } -Force"
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
 # Open a new PowerShell 7 terminal

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -199,6 +199,7 @@ wsl --install
 并设置使用 `dockerd(moby)` 的 `Container Engine`。
 
 ```shell
+[Environment]::SetEnvironmentVariable('DOCKER_API_VERSION','1.44','Machine')
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
 # 打开新的 PowerShell 7 终端
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -203,6 +203,7 @@ After enabling WSL2, download and install `rancher-sandbox/rancher-desktop` usin
 and configure `dockerd(moby)` to use the `Container Engine`.
 
 ```shell
+[Environment]::SetEnvironmentVariable('DOCKER_API_VERSION','1.44','Machine')
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
 # Open a new PowerShell 7 terminal
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false

--- a/test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
+++ b/test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
@@ -19,6 +19,7 @@
 
 # This file is only used in the PowerShell 7 of ShardingSphere in GitHub Actions environment and should not be executed manually in a development environment.
 # Background information can be found at https://github.com/apache/shardingsphere/pull/35905 .
+[Environment]::SetEnvironmentVariable('DOCKER_API_VERSION','1.44','Machine')
 iex "& { $(irm https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1) } -Force"
 irm https://raw.githubusercontent.com/jazzdelightsme/WingetPathUpdater/v1.2/WingetPathUpdaterInstall.ps1 | iex
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies


### PR DESCRIPTION
Fixes #37642 .

Changes proposed in this pull request:
  - Fix failing nativeTest on Windows Server 2025. The rancher desktop that includes https://github.com/rancher-sandbox/rancher-desktop/pull/9724 has not yet been released; this is a temporary modification to CI and documentation.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
