### PR TITLE
Restore the slf4j version to 2.0.17

### DIFF
--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -260,7 +260,7 @@ The text of each license is the standard Apache 2.0 license.
     jackson-dataformat-yaml 2.16.1: http://github.com/FasterXML/jackson, Apache 2.0
     jackson-datatype-jdk8 2.16.1: http://github.com/FasterXML/jackson-modules-java8, Apache 2.0
     jackson-datatype-jsr310 2.16.1: http://github.com/FasterXML/jackson, Apache 2.0
-    jcl-over-slf4j 1.7.36: https://github.com/qos-ch/slf4j, Apache 2.0
+    jcl-over-slf4j 2.0.17: https://github.com/qos-ch/slf4j, Apache 2.0
     jetcd-api 0.7.7: https://github.com/etcd-io/jetcd, Apache 2.0
     jetcd-common 0.7.7: https://github.com/etcd-io/jetcd, Apache 2.0
     jetcd-core 0.7.7: https://github.com/etcd-io/jetcd, Apache 2.0
@@ -345,8 +345,8 @@ The following components are provided under the EPL License. See project link fo
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
     jakarta.transaction-api 1.3.3: https://github.com/jakartaee/transactions, EPL 2.0
-    logback-classic 1.2.13: https://github.com/qos-ch/logback, EPL 1.0
-    logback-core 1.2.13: https://github.com/qos-ch/logback, EPL 1.0
+    logback-classic 1.3.16: https://github.com/qos-ch/logback, EPL 1.0
+    logback-core 1.3.16: https://github.com/qos-ch/logback, EPL 1.0
     mchange-commons-java 0.2.15: https://github.com/swaldman/mchange-commons-java, EPL 1.0
     h2 2.2.224: https://github.com/h2database/h2database, EPL 1.0
 
@@ -362,5 +362,5 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     bctls-jdk18on 1.79: https://www.bouncycastle.org, MIT
     bcutil-jdk18on 1.79: https://www.bouncycastle.org, MIT
     checker-qual 3.39.0: https://github.com/typetools/checker-framework/blob/master/checker-qual, MIT
-    jul-to-slf4j 1.7.36: https://www.slf4j.org, MIT
-    slf4j-api 1.7.36: https://www.slf4j.org, MIT
+    jul-to-slf4j 2.0.17: https://www.slf4j.org, MIT
+    slf4j-api 2.0.17: https://www.slf4j.org, MIT

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.cn.md
@@ -35,12 +35,10 @@ spring.datasource.url=jdbc:shardingsphere:classpath:xxx.yaml
 
 直接使用该数据源；或者将 ShardingSphereDataSource 配置在 JPA、Hibernate、MyBatis 等 ORM 框架中配合使用。
 
-## 针对 Spring Boot OSS 3 的处理
+## 针对 Spring Boot 3+ 的处理
 
-Spring Boot OSS 3 对 Jakarta EE 和 Java 17 进行了 “大爆炸” 升级，涉及大量复杂情况。
-
-ShardingSphere 的 XA 分布式事务尚未在 Spring Boot OSS 3 上就绪，此限制同样适用于其他基于 Jakarta EE 9+ 的 Web Framework，如
-Quarkus 3，Micronaut Framework 4 和 Helidon 3。
+ShardingSphere 的 XA 分布式事务尚未在 Spring Boot 3+ 上就绪，此限制同样适用于其他基于 Jakarta EE 9+ 的 Web Framework，如
+Quarkus 3，Micronaut Framework 4 和 Helidon 3+。
 
 用户仅需要配置如下。
 
@@ -56,23 +54,28 @@ Quarkus 3，Micronaut Framework 4 和 Helidon 3。
 </project>
 ```
 
-## 针对低版本的 Spring Boot OSS 2 的特殊处理
+## 针对低版本的 Spring Boot 2 的特殊处理
 
-ShardingSphere 的所有特性均可在 Spring Boot OSS 2 上使用，但低版本的 Spring Boot OSS 可能需要手动指定 SnakeYAML 的版本为 2.2 。 
+除开 ShardingSphere Agent，ShardingSphere JDBC 的所有特性均可在 Spring Boot 2 上使用，
+但低版本的 Spring Boot 可能需要手动指定 SnakeYAML 的版本为 `2.2` 。 
 这在 Maven 的 `pom.xml` 体现为如下内容。
 
 ```xml
 <project>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>2.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-jdbc</artifactId>
             <version>${shardingsphere.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>2.2</version>
         </dependency>
     </dependencies>
 </project>
@@ -85,7 +88,6 @@ ShardingSphere 的所有特性均可在 Spring Boot OSS 2 上使用，但低版�
     <properties>
         <snakeyaml.version>2.2</snakeyaml.version>
     </properties>
-    
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
@@ -95,3 +97,7 @@ ShardingSphere 的所有特性均可在 Spring Boot OSS 2 上使用，但低版�
     </dependencies>
 </project>
 ```
+
+对于 Spring Boot 2，如果开发者正在通过 SLF4J 或 Logback 管理日志，
+可能会遇到 https://github.com/spring-projects/spring-boot/issues/34708 的问题。
+开发者应考虑自行维护 Spring Boot 2 的源码。

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.en.md
@@ -35,14 +35,13 @@ The YAML configuration file in 'spring.datasource.url' currently support in mult
 
 Use this data source directly; or configure ShardingSphereDataSource to be used in conjunction with ORM frameworks such as JPA, Hibernate, and MyBatis.
 
-## Handling for Spring Boot OSS 3
+## Handling for Spring Boot 3+
 
-Spring Boot OSS 3 has made a "big bang" upgrade to Jakarta EE and Java 17, with all complications involved.
+ShardingSphere's XA distributed transactions are not yet ready for Spring Boot 3+. 
+This limitation also applies to other Jakarta EE 9+ based web frameworks, 
+such as Quarkus 3, Micronaut Framework 4, and Helidon 3+.
 
-ShardingSphere's XA distributed transactions are not yet ready on Spring Boot OSS 3. This limitation also applies to other 
-Jakarta EE 9+ based Web Frameworks, such as Quarkus 3, Micronaut Framework 4 and Helidon 3.
-
-Users only need to configure as follows.
+Users only need to configure the following.
 
 ```xml
 <project>
@@ -56,38 +55,41 @@ Users only need to configure as follows.
 </project>
 ```
 
-## Special handling for earlier versions of Spring Boot OSS 2
+## Special Handling for Lower Versions of Spring Boot 2
 
-All features of ShardingSphere are available on Spring Boot OSS 2, but earlier versions of Spring Boot OSS may require 
-manually specifying version 2.2 for SnakeYAML.
-This is reflected in Maven's `pom.xml` as follows.
+Aside from ShardingSphere Agent, all ShardingSphere JDBC features are available in Spring Boot 2.
+However, lower versions of Spring Boot may require manually specifying the SnakeYAML version as `2.2`.
+This is reflected in the Maven `pom.xml` as follows.
 
 ```xml
 <project>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>2.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-jdbc</artifactId>
             <version>${shardingsphere.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>2.2</version>
-        </dependency>
     </dependencies>
 </project>
 ```
 
-If the user created the Spring Boot project from https://start.spring.io/, users can simplify configuration by
-following things.
+If a user created a Spring Boot project via https://start.spring.io/ , 
+the configuration can be simplified as follows.
 
 ```xml
 <project>
     <properties>
         <snakeyaml.version>2.2</snakeyaml.version>
     </properties>
-    
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
@@ -97,3 +99,7 @@ following things.
     </dependencies>
 </project>
 ```
+
+For Spring Boot 2, if developers are managing logs via SLF4J or Logback,
+they may encounter the issue described in https://github.com/spring-projects/spring-boot/issues/34708 .
+Developers should consider maintaining the Spring Boot 2 source code themselves.

--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,8 @@
         
         <elasticjob.version>3.0.4</elasticjob.version>
         
-        <slf4j.version>1.7.36</slf4j.version>
-        <logback.version>1.2.13</logback.version>
+        <slf4j.version>2.0.17</slf4j.version>
+        <logback.version>1.3.16</logback.version>
         <commons-logging.version>1.2</commons-logging.version>
         
         <lombok.version>1.18.42</lombok.version>
@@ -481,19 +481,10 @@
             
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
+                <artifactId>slf4j-bom</artifactId>
                 <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jul-to-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-                <scope>runtime</scope>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Fixes #37652 .

Changes proposed in this pull request:
  - Restore the slf4j version to 2.0.17. 
  - For a recap of the previous points, refer to https://github.com/apache/shardingsphere/pull/29008 and https://github.com/apache/shardingsphere-elasticjob/issues/2425 . I think it's 2026 already, and Spring Boot 3 is far more popular than Spring Boot 2.
  - Helidon 4 has been released, with updated descriptions. See https://helidon.io/docs/v4/about/intro .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
