### PR TITLE
Mark logback-classic in agent/core as provided

### DIFF
--- a/agent/core/pom.xml
+++ b/agent/core/pom.xml
@@ -58,6 +58,11 @@
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.cn.md
@@ -35,12 +35,10 @@ spring.datasource.url=jdbc:shardingsphere:classpath:xxx.yaml
 
 直接使用该数据源；或者将 ShardingSphereDataSource 配置在 JPA、Hibernate、MyBatis 等 ORM 框架中配合使用。
 
-## 针对 Spring Boot OSS 3 的处理
+## 针对 Spring Boot 3+ 的处理
 
-Spring Boot OSS 3 对 Jakarta EE 和 Java 17 进行了 “大爆炸” 升级，涉及大量复杂情况。
-
-ShardingSphere 的 XA 分布式事务尚未在 Spring Boot OSS 3 上就绪，此限制同样适用于其他基于 Jakarta EE 9+ 的 Web Framework，如
-Quarkus 3，Micronaut Framework 4 和 Helidon 3。
+ShardingSphere 的 XA 分布式事务尚未在 Spring Boot 3+ 上就绪，此限制同样适用于其他基于 Jakarta EE 9+ 的 Web Framework，如
+Quarkus 3，Micronaut Framework 4 和 Helidon 3+。
 
 用户仅需要配置如下。
 
@@ -56,23 +54,28 @@ Quarkus 3，Micronaut Framework 4 和 Helidon 3。
 </project>
 ```
 
-## 针对低版本的 Spring Boot OSS 2 的特殊处理
+## 针对低版本的 Spring Boot 2 的特殊处理
 
-ShardingSphere 的所有特性均可在 Spring Boot OSS 2 上使用，但低版本的 Spring Boot OSS 可能需要手动指定 SnakeYAML 的版本为 2.2 。 
+ShardingSphere JDBC 的所有特性均可在 Spring Boot 2 上使用，
+但低版本的 Spring Boot 可能需要手动指定 SnakeYAML 的版本为 `2.2` 。 
 这在 Maven 的 `pom.xml` 体现为如下内容。
 
 ```xml
 <project>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>2.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-jdbc</artifactId>
             <version>${shardingsphere.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>2.2</version>
         </dependency>
     </dependencies>
 </project>
@@ -85,7 +88,6 @@ ShardingSphere 的所有特性均可在 Spring Boot OSS 2 上使用，但低版�
     <properties>
         <snakeyaml.version>2.2</snakeyaml.version>
     </properties>
-    
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/spring-boot/_index.en.md
@@ -35,14 +35,13 @@ The YAML configuration file in 'spring.datasource.url' currently support in mult
 
 Use this data source directly; or configure ShardingSphereDataSource to be used in conjunction with ORM frameworks such as JPA, Hibernate, and MyBatis.
 
-## Handling for Spring Boot OSS 3
+## Handling for Spring Boot 3+
 
-Spring Boot OSS 3 has made a "big bang" upgrade to Jakarta EE and Java 17, with all complications involved.
+ShardingSphere's XA distributed transactions are not yet ready for Spring Boot 3+. 
+This limitation also applies to other Jakarta EE 9+ based web frameworks, 
+such as Quarkus 3, Micronaut Framework 4, and Helidon 3+.
 
-ShardingSphere's XA distributed transactions are not yet ready on Spring Boot OSS 3. This limitation also applies to other 
-Jakarta EE 9+ based Web Frameworks, such as Quarkus 3, Micronaut Framework 4 and Helidon 3.
-
-Users only need to configure as follows.
+Users only need to configure the following.
 
 ```xml
 <project>
@@ -56,38 +55,41 @@ Users only need to configure as follows.
 </project>
 ```
 
-## Special handling for earlier versions of Spring Boot OSS 2
+## Special Handling for Lower Versions of Spring Boot 2
 
-All features of ShardingSphere are available on Spring Boot OSS 2, but earlier versions of Spring Boot OSS may require 
-manually specifying version 2.2 for SnakeYAML.
-This is reflected in Maven's `pom.xml` as follows.
+All ShardingSphere JDBC features are available in Spring Boot 2.
+However, lower versions of Spring Boot may require manually specifying the SnakeYAML version as `2.2`.
+This is reflected in the Maven `pom.xml` as follows.
 
 ```xml
 <project>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>2.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-jdbc</artifactId>
             <version>${shardingsphere.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>2.2</version>
-        </dependency>
     </dependencies>
 </project>
 ```
 
-If the user created the Spring Boot project from https://start.spring.io/, users can simplify configuration by
-following things.
+If a user created a Spring Boot project via https://start.spring.io/ , 
+the configuration can be simplified as follows.
 
 ```xml
 <project>
     <properties>
         <snakeyaml.version>2.2</snakeyaml.version>
     </properties>
-    
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>


### PR DESCRIPTION
Fixes #37652 .

Changes proposed in this pull request:
  - Mark logback-classic in agent/core as provided.
  - Update the documentation for Spring Boot 4 and ShardingSphere Agent. Helidon 4 has been released, with updated descriptions. See https://helidon.io/docs/v4/about/intro .
  - Writing integration tests for this PR is difficult, so I completed the verification at https://github.com/linghengqian/shardingsphere-agent-master-test . The logs for `shardingsphere-agent-master-test-1 | org.slf4j.spi.SLF4JServiceProvider: Provider ch.qos.logback.classic.spi.LogbackServiceProvider could not be instantiated` in Spring Boot 4 have disappeared.
```bash
sdk install java 25.0.1-graalce
sdk use java 25.0.1-graalce

git clone -b fix-agent-new git@github.com:linghengqian/shardingsphere.git
cd ./shardingsphere/
./mvnw clean install -Prelease -T1C -DskipTests -Djacoco.skip=true -Dcheckstyle.skip=true -Drat.skip=true -Dmaven.javadoc.skip=true
./mvnw -am -pl distribution/agent -Prelease,docker -T1C -DskipTests clean package
cd ../

git clone git@github.com:linghengqian/shardingsphere-agent-master-test.git
cd ./shardingsphere-agent-master-test/
docker compose up -d
docker compose logs --follow shardingsphere-agent-master-test
```
```
shardingsphere-agent-master-test-1  | Jan 20, 2026 12:30:40 AM org.apache.shardingsphere.agent.core.plugin.jar.PluginJarLoader load
shardingsphere-agent-master-test-1  | INFO: Loaded jar: shardingsphere-agent-logging-file-5.5.3-SNAPSHOT.jar
shardingsphere-agent-master-test-1  | Jan 20, 2026 12:30:40 AM org.apache.shardingsphere.agent.core.plugin.jar.PluginJarLoader load
shardingsphere-agent-master-test-1  | INFO: Loaded jar: shardingsphere-agent-plugin-core-5.5.3-SNAPSHOT.jar
shardingsphere-agent-master-test-1  | Jan 20, 2026 12:30:40 AM org.apache.shardingsphere.agent.core.plugin.jar.PluginJarLoader load
shardingsphere-agent-master-test-1  | INFO: Loaded jar: shardingsphere-agent-metrics-core-5.5.3-SNAPSHOT.jar
shardingsphere-agent-master-test-1  | Jan 20, 2026 12:30:40 AM org.apache.shardingsphere.agent.core.plugin.jar.PluginJarLoader load
shardingsphere-agent-master-test-1  | INFO: Loaded jar: shardingsphere-agent-metrics-prometheus-5.5.3-SNAPSHOT.jar
shardingsphere-agent-master-test-1  | Jan 20, 2026 12:30:40 AM org.apache.shardingsphere.agent.core.plugin.jar.PluginJarLoader load
shardingsphere-agent-master-test-1  | INFO: Loaded jar: shardingsphere-agent-tracing-opentelemetry-5.5.3-SNAPSHOT.jar
shardingsphere-agent-master-test-1  | WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
shardingsphere-agent-master-test-1  | WARNING: sun.misc.Unsafe::objectFieldOffset has been called by org.apache.shardingsphere.shade.net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction (file:/usr/agent/shardingsphere-agent.jar)
shardingsphere-agent-master-test-1  | WARNING: Please consider reporting this to the maintainers of class org.apache.shardingsphere.shade.net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction
shardingsphere-agent-master-test-1  | WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
shardingsphere-agent-master-test-1  | 
shardingsphere-agent-master-test-1  |   .   ____          _            __ _ _
shardingsphere-agent-master-test-1  |  /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
shardingsphere-agent-master-test-1  | ( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
shardingsphere-agent-master-test-1  |  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
shardingsphere-agent-master-test-1  |   '  |____| .__|_| |_|_| |_\__, | / / / /
shardingsphere-agent-master-test-1  |  =========|_|==============|___/=/_/_/_/
shardingsphere-agent-master-test-1  | 
shardingsphere-agent-master-test-1  |  :: Spring Boot ::                (v4.0.1)
shardingsphere-agent-master-test-1  | 
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:42.005Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] ShardingsphereAgentMasterTestApplication : Starting ShardingsphereAgentMasterTestApplication v0.0.1-SNAPSHOT using Java 25.0.1 with PID 1 (/app.jar started by root in /)
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:42.008Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] ShardingsphereAgentMasterTestApplication : No active profile set, falling back to 1 default profile: "default"
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:43.821Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] o.s.boot.tomcat.TomcatWebServer          : Tomcat initialized with port 8080 (http)
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:43.834Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:43.835Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/11.0.15]
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:43.861Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] b.w.c.s.WebApplicationContextInitializer : Root WebApplicationContext: initialization completed in 1560 ms
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:44.965Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint beneath base path '/actuator'
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:45.059Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] o.s.boot.tomcat.TomcatWebServer          : Tomcat started on port 8080 (http) with context path '/'
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:45.070Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] ShardingsphereAgentMasterTestApplication : Started ShardingsphereAgentMasterTestApplication in 3.632 seconds (process running for 4.911)
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:45.189Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:45.503Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-2 - Starting...
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:45.708Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] com.zaxxer.hikari.pool.HikariPool        : HikariPool-2 - Added connection conn0: url=jdbc:h2:mem:local_sharding_ds_0 user=SA
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:45.710Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-2 - Start completed.
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:47.081Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] o.a.s.d.j.c.d.ShardingSphereDataSource   : ShardingSphere-JDBC Standalone mode started successfully.
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:47.082Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] o.a.s.d.j.c.d.ShardingSphereDataSource   : Instance id: 031f4523-999f-4d53-b326-ad57f0f6bdc7, IP: 172.19.0.3
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:47.094Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection@6add8aac
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:47.099Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
shardingsphere-agent-master-test-1  | 2026-01-20T00:30:47.125Z  INFO 1 --- [shardingsphere-agent-master-test] [           main] .a.s.a.c.p.PluginLifecycleServiceManager : Start plugin: OpenTelemetry
```
- <img width="2876" height="1468" alt="image" src="https://github.com/user-attachments/assets/ce190e18-04f8-4e48-a669-d047ee0aeabb" />



---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
