### PR TITLE
Add maven.compiler.release property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,10 @@
     
     <properties>
         <!-- Environments -->
-        <java.version>1.8</java.version>
+        <java.version>8</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven.version.range>[3.0.4,)</maven.version.range>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <remoteresources.skip>true</remoteresources.skip>


### PR DESCRIPTION
Changes proposed in this pull request:
  - Add maven.compiler.release property

References:
- https://github.com/apache/maven/blob/master/pom.xml
- https://maven.apache.org/plugins/maven-compiler-plugin-4.x/examples/set-compiler-release.html

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
