### PR TITLE
Upgrade JDK-8 and JDK-11 to JDK-17 in GitHub action workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,18 +47,18 @@ jobs:
     uses: ./.github/workflows/required-reusable.yml
 
   ci:
-    name: CI - Compile by JDK 11 and Run on JDK 8
+    name: CI
     if: github.repository == 'apache/shardingsphere'
     needs: global-environment
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6.0.1
-      - name: Setup JDK 11 for Build
+      - name: Setup JDK for Build
         uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v5.0.1
         with:
           path: |
@@ -70,10 +70,10 @@ jobs:
             apache-shardingsphere-maven-third-party-
       - name: Build Project with Maven
         run: ./mvnw clean install -B -ntp -DskipTests -T1C
-      - name: Setup JDK 8 for Test
+      - name: Setup JDK for Test
         uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: 8
-      - name: Run Tests with JDK 8
+          java-version: 17
+      - name: Run Tests
         run: ./mvnw install -T1C -B -ntp -fae

--- a/.github/workflows/e2e-operation.yml
+++ b/.github/workflows/e2e-operation.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           cache: 'maven'
       - name: Build ${{ matrix.operation }} E2E Image
         if: (env.skip_current_step == 'false')

--- a/.github/workflows/e2e-sql.yml
+++ b/.github/workflows/e2e-sql.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v5.0.1
         with:
           path: |
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - name: Download E2E Image
         if: matrix.adapter == 'proxy'
         uses: actions/download-artifact@v4

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - name: Build Project
         run: |
           ./mvnw -B clean install -Prelease,default-dep
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v5.0.1
         with:
           path: |
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.HUB }}
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: 17
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.HUB }}
@@ -201,7 +201,7 @@ jobs:
       - uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v5.0.1
         with:
           path: |
@@ -263,7 +263,7 @@ jobs:
       - uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v5.0.1
         with:
           path: |

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
@@ -196,11 +196,11 @@ jobs:
     timeout-minutes: 80
     steps:
       - uses: actions/checkout@v6.0.1
-      - name: Setup JDK 11
+      - name: Setup JDK
         uses: actions/setup-java@v5.1.0
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v5.0.1
         with:
           path: |
@@ -213,11 +213,11 @@ jobs:
             shardingsphere-maven-third-party-
       - name: Install Project
         run: ./mvnw clean install -DskipTests -T1C
-      - name: Set up JDK 8 for Jacoco
+      - name: Set up JDK for Jacoco
         uses: actions/setup-java@v5.1.0
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
       - name: Build with maven and execute jacoco aggregation script
         run: |
           ./mvnw -V -B -ntp verify -Djacoco.skip=false -Dmaven.test.failure.ignore=true -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false &&

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        java-version: [ 11, 17, 21, '25-ea' ]
+        java-version: [ 17, 21, '25-ea' ]
     steps:
       - name: Support Long Paths in Windows
         if: matrix.os == 'windows-latest'
@@ -65,47 +65,7 @@ jobs:
         run: ./mvnw clean install -B -ntp -T1C
       - name: Build Examples with Maven
         run: ./mvnw clean package -B -f examples/pom.xml -T1C
-  
-  ci-jdk8:
-    if: ${{ needs.global-environment.outputs.GLOBAL_JOB_ENABLED == 'true' }}
-    name: CI - JDK 8 on ${{ matrix.os }}
-    needs: global-environment
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 150
-    strategy:
-      max-parallel: 15
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-    steps:
-      - name: Support Long Paths in Windows
-        if: matrix.os == 'windows-latest'
-        run: git config --global core.longpaths true
-      - uses: actions/checkout@v6.0.1
-      - uses: actions/setup-java@v5.1.0
-        with:
-          distribution: 'temurin'
-          java-version: 11
-      - uses: actions/cache@v5.0.1
-        with:
-          path: |
-            ~/.m2/repository
-            !~/.m2/repository/org/apache/shardingsphere
-            ~/.m2/repository/org/apache/shardingsphere/elasticjob
-          key: ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-cache-${{ github.sha }}
-          restore-keys: |
-            ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-cache-
-            ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-
-      - name: Build prod with Maven
-        run: ./mvnw clean install -DskipTests -B -ntp -T1C
-      - name: Setup JDK 8 for Test
-        uses: actions/setup-java@v5.1.0
-        with:
-          distribution: 'zulu'
-          java-version: 8
-      - name: Run Tests with JDK 8
-        run: ./mvnw test -B -ntp -fae -T1C
-  
+
   ci-native-test:
     if: ${{ needs.global-environment.outputs.GLOBAL_JOB_ENABLED == 'true' }}
     name: NativeTest CI - GraalVM CE on ${{ matrix.os }}

--- a/.github/workflows/nightly-e2e-operation.yml
+++ b/.github/workflows/nightly-e2e-operation.yml
@@ -44,7 +44,7 @@ jobs:
       max-parallel: 15
       fail-fast: false
       matrix:
-        java-version: [ 11, 21 ]
+        java-version: [ 17, 21 ]
         operation: [ transaction, pipeline, showprocesslist ]
         image: [
           { type: "e2e.docker.database.mysql.images", version: "mysql:5.7" },

--- a/.github/workflows/nightly-sql-parser.yml
+++ b/.github/workflows/nightly-sql-parser.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-java@v5.1.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v5.0.1
         with:
           path: |

--- a/.github/workflows/schedule-report.yml
+++ b/.github/workflows/schedule-report.yml
@@ -71,11 +71,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6.0.1
-      - name: Setup JDK 11
+      - name: Setup JDK
         uses: actions/setup-java@v5.1.0
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v5.0.1
         with:
           path: |
@@ -87,11 +87,11 @@ jobs:
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-
       - name: Install Project
         run: ./mvnw clean install -DskipTests -T1C
-      - name: Set up JDK 8 for Jacoco
+      - name: Set up JDK for Jacoco
         uses: actions/setup-java@v5.1.0
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
       - name: Build with maven and execute jacoco aggregation script
         run: |
           ./mvnw -V -B -ntp verify -Djacoco.skip=false -Dmaven.test.failure.ignore=true -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false &&


### PR DESCRIPTION
Related to #37801

Changes proposed in this pull request:
  - Upgrade JDK-8 and JDK-11 to JDK-17 in GitHub action workflows. Prepare to upgrade Java17 for E2E module

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
