### PR TITLE
Use Java 17 in pipeline E2E

### DIFF
--- a/test/e2e/operation/pipeline/pom.xml
+++ b/test/e2e/operation/pipeline/pom.xml
@@ -27,6 +27,7 @@
     <name>${project.artifactId}</name>
     
     <properties>
+        <maven.compiler.release>17</maven.compiler.release>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
     


### PR DESCRIPTION
Fixes #37801.

Changes proposed in this pull request:
  - Add maven.compiler.release 17 in pipeline E2E module

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
