### PR TITLE
Update JDK requirement from 11 to 17 in dev guide

### DIFF
--- a/docs/community/content/involved/contribute/dev-env.cn.md
+++ b/docs/community/content/involved/contribute/dev-env.cn.md
@@ -23,7 +23,7 @@ git config --global core.longpaths true
 
 ## 安装 JDK
 
-使用 JDK 11 或以上版本。
+使用 JDK 17 或以上版本。
 
 可以从 [OpenJDK 下载页面]( https://adoptium.net/temurin/releases ) 下载。
 

--- a/docs/community/content/involved/contribute/dev-env.en.md
+++ b/docs/community/content/involved/contribute/dev-env.en.md
@@ -23,7 +23,7 @@ git config --global core.longpaths true
 
 ## JDK Installation
 
-Use JDK 11 or higher.
+Use JDK 17 or higher.
 
 You could download JDK from [OpenJDK Downloads]( https://adoptium.net/temurin/releases ).
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -119,7 +119,7 @@ services:
 
 贡献者必须在设备安装，
 
-1. OpenJDK 11 或更高版本
+1. OpenJDK 17 或更高版本
 2. 可运行 Linux Containers 的 Docker Engine
 
 下文分别讨论在 Ubuntu 与 Windows 下可能的所需操作。

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -121,7 +121,7 @@ An example of adding a MySQL JDBC Driver dependency is as follows. The relevant 
 
 Contributors must have installed on their devices,
 
-1. OpenJDK 11 or higher
+1. OpenJDK 17 or higher
 
 2. Docker Engine that can run Linux Containers
 


### PR DESCRIPTION
Related to #37801

Changes proposed in this pull request:
  - Update JDK requirement from 11 to 17 in dev guide

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
