### PR TITLE
Fix print_version in proxy start scripts

### DIFF
--- a/distribution/proxy/src/main/resources/bin/start.bat
+++ b/distribution/proxy/src/main/resources/bin/start.bat
@@ -100,7 +100,7 @@ goto exit
  goto exit
 
 :print_version
- java -classpath %CLASS_PATH% org.apache.shardingsphere.infra.autogen.version.ShardingSphereVersion
+ java -classpath %CLASS_PATH% org.apache.shardingsphere.infra.version.ShardingSphereVersion
  goto exit
 
 :exit

--- a/distribution/proxy/src/main/resources/bin/start.sh
+++ b/distribution/proxy/src/main/resources/bin/start.sh
@@ -129,7 +129,7 @@ if [ "$1" == "-h" ] || [ "$1" == "--help" ] ; then
 fi
 
 print_version() {
-    $JAVA ${JAVA_OPTS} ${JAVA_MEM_OPTS} -classpath ${CLASS_PATH} org.apache.shardingsphere.infra.autogen.version.ShardingSphereVersion
+    $JAVA ${JAVA_OPTS} ${JAVA_MEM_OPTS} -classpath ${CLASS_PATH} org.apache.shardingsphere.infra.version.ShardingSphereVersion
     exit 0
 }
 

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/version/ShardingSphereVersion.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/version/ShardingSphereVersion.java
@@ -67,6 +67,27 @@ public final class ShardingSphereVersion {
         BUILD_DIRTY = Boolean.parseBoolean(gitProps.getProperty("git.dirty", "false"));
     }
     
+    /**
+     * Main method.
+     *
+     * @param args args
+     */
+    public static void main(final String[] args) {
+        System.out.print(getVerboseVersion());
+    }
+    
+    private static String getVerboseVersion() {
+        String result = "";
+        result += String.format("ShardingSphere-%s%n", VERSION);
+        if (IS_SNAPSHOT && !BUILD_COMMIT_ID.isEmpty()) {
+            result += String.format("Commit ID: %s%s%n", BUILD_DIRTY ? "dirty-" : "", BUILD_COMMIT_ID);
+            result += String.format("Commit Message: %s%n", BUILD_COMMIT_MESSAGE_SHORT);
+            result += BUILD_TAG.isEmpty() ? String.format("Branch: %s%n", BUILD_BRANCH) : String.format("Tag: %s%n", BUILD_TAG);
+            result += String.format("Build time: %s%n", BUILD_TIME);
+        }
+        return result;
+    }
+    
     private static String loadVersion() {
         Optional<String> versionFromGeneratedPropsFile = loadVersionFromGeneratedPropertiesFile();
         if (versionFromGeneratedPropsFile.isPresent()) {

--- a/src/resources/checkstyle.xml
+++ b/src/resources/checkstyle.xml
@@ -223,7 +223,7 @@
         <module name="TodoComment" />
         <module name="TrailingComment" />
         <module name="UncommentedMain">
-            <property name="excludedClasses" value="\.Bootstrap" />
+            <property name="excludedClasses" value="\.Bootstrap$|ShardingSphereVersion$" />
         </module>
         <module name="UpperEll" />
         


### PR DESCRIPTION
Fixes #37811.

After fix:

```shell
% bin/start.sh -v
we find java version: java17, full_version=17.0.12, full_path=/Users/raigor/env/java/zulu17.52.17-ca-jdk17.0.12-macosx_aarch64/zulu-17.jdk/Contents/Home/bin/java
ShardingSphere-5.5.3-SNAPSHOT
Commit ID: dirty-2bd4668ac7a006ab89d2beaaeb88628bd8469589
Commit Message: Config single rule in example template (#37810)
Branch: show-version
Build time: 2025-06-10T04:48:22+0800
```


