### PR TITLE
Fix example e2e, use generated init.sql to prepare environments

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -273,12 +273,20 @@ jobs:
           key: ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-
-      - name: Prepare Environments
-        run: sh .github/workflows/resources/scripts/nightly-build-example/init-mysql-container.sh
       - name: Build with Maven
         run: ./mvnw -B -T1C -ntp clean install -DskipITs -DskipTests
       - name: Generate Examples
         run: ./mvnw -B clean install -f examples/shardingsphere-jdbc-example-generator/pom.xml -Pexample-generator -Dmodes=${{ matrix.mode }} -Dtransactions=${{ matrix.transaction }} -Dfeatures=${{ matrix.feature }} -Dframeworks=${{ matrix.framework }}
+      - name: Prepare Environments
+        run: |
+          INIT_SQL_PATH="examples/shardingsphere-jdbc-example-generator/target/generated-sources/shardingsphere-jdbc-sample/${{ matrix.feature }}--${{ matrix.framework }}--${{ matrix.mode }}--${{ matrix.transaction }}/init.sql"
+          if [ -f "$INIT_SQL_PATH" ]; then
+            echo "Executing generated init.sql for feature: ${{ matrix.feature }}"
+            sh .github/workflows/resources/scripts/nightly-build-example/init-mysql-container.sh "$INIT_SQL_PATH"
+          else
+            echo "Warning: init.sql not found at $INIT_SQL_PATH"
+            exit 1
+          fi
       - name: Test Examples
         run : ./mvnw -B test -f examples/shardingsphere-jdbc-example-generator/target/generated-sources/shardingsphere-jdbc-sample/${{ matrix.feature }}--${{ matrix.framework }}--${{ matrix.mode }}--${{ matrix.transaction }}/pom.xml -Pexample-generator -Dexec.cleanupDaemonThreads=false
       - name: Package Examples

--- a/.github/workflows/resources/scripts/nightly-build-example/init-mysql-container.sh
+++ b/.github/workflows/resources/scripts/nightly-build-example/init-mysql-container.sh
@@ -14,13 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-mysql -uroot -h127.0.0.1 -p123456 -e 'DROP DATABASE IF EXISTS demo_ds_0;DROP DATABASE IF EXISTS demo_ds_1;DROP DATABASE IF EXISTS demo_ds_2;CREATE DATABASE demo_ds_0;CREATE DATABASE demo_ds_1;CREATE DATABASE demo_ds_2;'
-mysql -uroot -h127.0.0.1 -p123456 -e 'USE demo_ds_0;CREATE TABLE IF NOT EXISTS t_order(order_id BIGINT NOT NULL AUTO_INCREMENT, order_type INT(11), user_id INT NOT NULL, address_id BIGINT NOT NULL, status VARCHAR(50), PRIMARY KEY (order_id));'
-mysql -uroot -h127.0.0.1 -p123456 -e 'USE demo_ds_0;CREATE TABLE IF NOT EXISTS t_order_item(order_item_id BIGINT NOT NULL AUTO_INCREMENT, order_id BIGINT NOT NULL, user_id INT NOT NULL, phone VARCHAR(50), status VARCHAR(50), PRIMARY KEY (order_item_id));'
-mysql -uroot -h127.0.0.1 -p123456 -e 'USE demo_ds_0;CREATE TABLE IF NOT EXISTS t_address (address_id BIGINT NOT NULL, address_name VARCHAR(100) NOT NULL, PRIMARY KEY (address_id));'
-mysql -uroot -h127.0.0.1 -p123456 -e 'USE demo_ds_1;CREATE TABLE IF NOT EXISTS t_order(order_id BIGINT NOT NULL AUTO_INCREMENT, order_type INT(11), user_id INT NOT NULL, address_id BIGINT NOT NULL, status VARCHAR(50), PRIMARY KEY (order_id));'
-mysql -uroot -h127.0.0.1 -p123456 -e 'USE demo_ds_2;CREATE TABLE IF NOT EXISTS t_order(order_id BIGINT NOT NULL AUTO_INCREMENT, order_type INT(11), user_id INT NOT NULL, address_id BIGINT NOT NULL, status VARCHAR(50), PRIMARY KEY (order_id));'
-mysql -uroot -h127.0.0.1 -p123456 -e 'USE demo_ds_1;CREATE TABLE IF NOT EXISTS t_order_item(order_item_id BIGINT NOT NULL AUTO_INCREMENT, order_id BIGINT NOT NULL, user_id INT NOT NULL, phone VARCHAR(50), status VARCHAR(50), PRIMARY KEY (order_item_id));'
-mysql -uroot -h127.0.0.1 -p123456 -e 'USE demo_ds_2;CREATE TABLE IF NOT EXISTS t_order_item(order_item_id BIGINT NOT NULL AUTO_INCREMENT, order_id BIGINT NOT NULL, user_id INT NOT NULL, phone VARCHAR(50), status VARCHAR(50), PRIMARY KEY (order_item_id));'
-mysql -uroot -h127.0.0.1 -p123456 -e 'USE demo_ds_1;CREATE TABLE IF NOT EXISTS t_address (address_id BIGINT NOT NULL, address_name VARCHAR(100) NOT NULL, PRIMARY KEY (address_id));'
-mysql -uroot -h127.0.0.1 -p123456 -e 'USE demo_ds_2;CREATE TABLE IF NOT EXISTS t_address (address_id BIGINT NOT NULL, address_name VARCHAR(100) NOT NULL, PRIMARY KEY (address_id));'
+
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <init.sql path>"
+    exit 1
+fi
+
+INIT_SQL_PATH=$1
+
+if [ ! -f "$INIT_SQL_PATH" ]; then
+    echo "Error: init.sql file not found at $INIT_SQL_PATH"
+    exit 1
+fi
+
+echo "Executing init.sql: $INIT_SQL_PATH"
+mysql -uroot -h127.0.0.1 -p123456 < "$INIT_SQL_PATH"
+echo "init.sql execution completed."

--- a/examples/shardingsphere-jdbc-example-generator/src/main/resources/template/java/repository/jdbc/OrderRepository.ftl
+++ b/examples/shardingsphere-jdbc-example-generator/src/main/resources/template/java/repository/jdbc/OrderRepository.ftl
@@ -38,8 +38,7 @@ public final class OrderRepository {
     }
     
     public void createTableIfNotExists() throws SQLException {
-        String sql = "CREATE TABLE IF NOT EXISTS t_order " +
-                     "(order_id BIGINT NOT NULL AUTO_INCREMENT, order_type INT(11), user_id INT NOT NULL, address_id BIGINT NOT NULL, status VARCHAR(50), PRIMARY KEY (order_id))";
+        String sql = "CREATE TABLE IF NOT EXISTS t_order (order_id BIGINT NOT NULL AUTO_INCREMENT, order_type INT(11), user_id INT NOT NULL, address_id BIGINT NOT NULL, status VARCHAR(50), PRIMARY KEY (order_id))";
         try (Connection connection = dataSource.getConnection();
              Statement statement = connection.createStatement()) {
             statement.executeUpdate(sql);
@@ -65,8 +64,7 @@ public final class OrderRepository {
 <#if feature?contains("shadow")>
 
     public void createTableIfNotExistsShadow() throws SQLException {
-        String sql = "CREATE TABLE IF NOT EXISTS t_order (order_id BIGINT NOT NULL AUTO_INCREMENT, order_type INT(11), user_id INT NOT NULL, address_id BIGINT NOT NULL, status VARCHAR(50), PRIMARY KEY (order_id)) /*
-SHARDINGSPHERE_HINT:shadow=true,foo=bar*/";
+        String sql = "CREATE TABLE IF NOT EXISTS t_order (order_id BIGINT NOT NULL AUTO_INCREMENT, order_type INT(11), user_id INT NOT NULL, address_id BIGINT NOT NULL, status VARCHAR(50), PRIMARY KEY (order_id)) /* SHARDINGSPHERE_HINT:shadow=true,foo=bar*/";
         try (Connection connection = dataSource.getConnection();
              Statement statement = connection.createStatement()) {
             statement.executeUpdate(sql);


### PR DESCRIPTION
Before the fix, example e2e used a uniform `init-mysql-container.sh` script to initialize the environment, creating a consistent table structure. However, this was not suitable for different feature scenarios.

---

<img width="1660" height="354" alt="PixPin_2026-01-24_18-47-52" src="https://github.com/user-attachments/assets/64c1e5fd-c842-4cae-aca0-da537386dd7f" />

> https://github.com/apache/shardingsphere/actions/runs/21292737733/job/61290829352

---

After the fix, the generated `init.sql` script is used to initialize the database, meeting the requirements of different features.