### PR TITLE
Fix DISTINCT rewrite to preserve global deduplication across shards

### DIFF
--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
@@ -45,6 +45,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simp
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubquerySegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionsSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ShorthandProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.GroupBySegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.OrderBySegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.item.IndexOrderByItemSegment;
@@ -376,6 +377,20 @@ class ShardingDQLResultMergerTest {
         MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createSQLServerDatabase(), mock(ConnectionContext.class));
         assertThat(actual, isA(TopAndRowNumberDecoratorMergedResult.class));
         assertThat(((TopAndRowNumberDecoratorMergedResult) actual).getMergedResult(), isA(GroupByMemoryMergedResult.class));
+    }
+    
+    @Test
+    void assertBuildGroupByMemoryMergedResultWithDistinctRow() throws SQLException {
+        SelectStatement selectStatement = buildSelectStatement(new SelectStatement(mysqlDatabaseType));
+        ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
+        projectionsSegment.setDistinctRow(true);
+        projectionsSegment.getProjections().add(new ShorthandProjectionSegment(0, 0));
+        selectStatement.setProjections(projectionsSegment);
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        SelectStatementContext selectStatementContext = new SelectStatementContext(
+                selectStatement, createShardingSphereMetaData(database), "foo_db", Collections.emptyList());
+        ShardingDQLResultMerger resultMerger = new ShardingDQLResultMerger(mysqlDatabaseType);
+        assertThat(resultMerger.merge(createQueryResults(), selectStatementContext, createDatabase(), mock(ConnectionContext.class)), isA(GroupByMemoryMergedResult.class));
     }
     
     @Test

--- a/infra/rewrite/core/src/main/java/org/apache/shardingsphere/infra/rewrite/engine/RouteSQLRewriteEngine.java
+++ b/infra/rewrite/core/src/main/java/org/apache/shardingsphere/infra/rewrite/engine/RouteSQLRewriteEngine.java
@@ -106,6 +106,10 @@ public final class RouteSQLRewriteEngine {
             return false;
         }
         SelectStatementContext statementContext = (SelectStatementContext) sqlStatementContext;
+        if (statementContext.getProjectionsContext().isDistinctRow()) {
+            statementContext.setNeedAggregateRewrite(false);
+            return false;
+        }
         boolean containsSubqueryJoinQuery = statementContext.isContainsSubquery() || statementContext.isContainsJoinQuery();
         boolean containsOrderByLimitClause = !statementContext.getOrderByContext().getItems().isEmpty() || statementContext.getPaginationContext().isHasPagination();
         boolean containsLockClause = statementContext.getSqlStatement().getLock().isPresent();

--- a/infra/rewrite/core/src/test/java/org/apache/shardingsphere/infra/rewrite/engine/RouteSQLRewriteEngineTest.java
+++ b/infra/rewrite/core/src/test/java/org/apache/shardingsphere/infra/rewrite/engine/RouteSQLRewriteEngineTest.java
@@ -129,6 +129,32 @@ class RouteSQLRewriteEngineTest {
     }
     
     @Test
+    void assertRewriteWithStandardParameterBuilderWhenDistinctRow() {
+        SelectStatementContext statementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
+        when(statementContext.getOrderByContext().getItems()).thenReturn(Collections.emptyList());
+        when(statementContext.getPaginationContext().isHasPagination()).thenReturn(false);
+        when(statementContext.getProjectionsContext().isDistinctRow()).thenReturn(true);
+        DatabaseType databaseType = mock(DatabaseType.class);
+        when(statementContext.getSqlStatement().getDatabaseType()).thenReturn(databaseType);
+        when(statementContext.getSqlStatement().getLock().isPresent()).thenReturn(false);
+        ShardingSphereDatabase database = mockDatabase(databaseType);
+        QueryContext queryContext = mockQueryContext(statementContext, "SELECT ?");
+        SQLRewriteContext sqlRewriteContext = new SQLRewriteContext(database, queryContext);
+        RouteContext routeContext = new RouteContext();
+        RouteUnit firstRouteUnit = new RouteUnit(new RouteMapper("ds", "ds_0"), Collections.singletonList(new RouteMapper("tbl", "tbl_0")));
+        RouteUnit secondRouteUnit = new RouteUnit(new RouteMapper("ds", "ds_0"), Collections.singletonList(new RouteMapper("tbl", "tbl_1")));
+        routeContext.getRouteUnits().add(firstRouteUnit);
+        routeContext.getRouteUnits().add(secondRouteUnit);
+        RouteSQLRewriteResult actual = new RouteSQLRewriteEngine(
+                new SQLTranslatorRule(new DefaultSQLTranslatorRuleConfigurationBuilder().build()), database, mock(RuleMetaData.class)).rewrite(sqlRewriteContext, routeContext, queryContext);
+        assertThat(actual.getSqlRewriteUnits().size(), is(2));
+        assertThat(actual.getSqlRewriteUnits().get(firstRouteUnit).getSql(), is("SELECT ?"));
+        assertThat(actual.getSqlRewriteUnits().get(firstRouteUnit).getParameters(), is(Collections.singletonList(1)));
+        assertThat(actual.getSqlRewriteUnits().get(secondRouteUnit).getSql(), is("SELECT ?"));
+        assertThat(actual.getSqlRewriteUnits().get(secondRouteUnit).getParameters(), is(Collections.singletonList(1)));
+    }
+    
+    @Test
     void assertRewriteWithGroupedParameterBuilderForBroadcast() {
         InsertStatementContext statementContext = mock(InsertStatementContext.class, RETURNS_DEEP_STUBS);
         when(statementContext.getTablesContext().getDatabaseName().isPresent()).thenReturn(false);


### PR DESCRIPTION
## Summary
Prevent SELECT DISTINCT from being rewritten into per-shard DISTINCT + UNION ALL, which breaks global deduplication across shards.

## Issue
Fixes #37852.

## Changes
- Skip aggregate rewrite when DISTINCT is present to preserve global semantics.
- Add rewrite-layer test to ensure DISTINCT queries are not aggregated.
- Add merge-layer test to ensure DISTINCT is handled via global deduplication.

## Behavior Change
- DISTINCT queries across shards are no longer aggregated into UNION ALL at rewrite time, preserving global de-duplication semantics.

## Risk
- Low; change only affects DISTINCT rewrite decision. Non-DISTINCT queries follow existing aggregate rewrite logic.

## Tests
- ./mvnw -pl infra/rewrite/core -am -DskipITs -Dspotless.skip=true -Dtest=RouteSQLRewriteEngineTest -Dsurefire.failIfNoSpecifiedTests=false test
- ./mvnw -pl features/sharding/core -am -DskipITs -Dspotless.skip=true -Dtest=ShardingDQLResultMergerTest -Dsurefire.failIfNoSpecifiedTests=false test