### PR TITLE
Enhance MySQLTextResultSetRowPacket and MySQLDateBinaryProtocolValue to support LocalDateTime and LocalTime when value contains scale

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 ## Release 5.5.4-SNAPSHOT
 
+### Enhancements
+
+1. Enhance MySQLTextResultSetRowPacket and MySQLDateBinaryProtocolValue to support LocalDateTime and LocalTime when value contains scale - [#37881](https://github.com/apache/shardingsphere/pull/37881)
+
 ### Bug Fixes
 
 ## Release 5.5.3

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLDateBinaryProtocolValueTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLDateBinaryProtocolValueTest.java
@@ -140,7 +140,7 @@ class MySQLDateBinaryProtocolValueTest {
     @Test
     void assertWriteWithElevenBytes() {
         MySQLDateBinaryProtocolValue actual = new MySQLDateBinaryProtocolValue();
-        actual.write(payload, Timestamp.valueOf("1970-01-14 12:10:30.1"));
+        actual.write(payload, Timestamp.valueOf("1970-01-14 12:10:30.123"));
         verify(payload).writeInt1(11);
         verify(payload).writeInt2(1970);
         verify(payload).writeInt1(1);
@@ -148,6 +148,49 @@ class MySQLDateBinaryProtocolValueTest {
         verify(payload).writeInt1(12);
         verify(payload).writeInt1(10);
         verify(payload).writeInt1(30);
-        verify(payload).writeInt4(100000);
+        verify(payload).writeInt4(123000);
+    }
+    
+    @Test
+    void assertWriteLocalDateTimeWithMaxNanos() {
+        MySQLDateBinaryProtocolValue actual = new MySQLDateBinaryProtocolValue();
+        LocalDateTime dateTime = LocalDateTime.of(1970, 1, 14, 12, 10, 29, 999_999_999);
+        actual.write(payload, dateTime);
+        verify(payload).writeInt1(11);
+        verify(payload).writeInt2(1970);
+        verify(payload).writeInt1(1);
+        verify(payload).writeInt1(14);
+        verify(payload).writeInt1(12);
+        verify(payload).writeInt1(10);
+        verify(payload).writeInt1(29);
+        verify(payload).writeInt4(999999);
+    }
+    
+    @Test
+    void assertWriteLocalDateTimeWithBoundaryNanos() {
+        MySQLDateBinaryProtocolValue actual = new MySQLDateBinaryProtocolValue();
+        actual.write(payload, LocalDateTime.of(1970, 1, 14, 12, 10, 29, 1000));
+        verify(payload).writeInt1(11);
+        verify(payload).writeInt2(1970);
+        verify(payload).writeInt1(1);
+        verify(payload).writeInt1(14);
+        verify(payload).writeInt1(12);
+        verify(payload).writeInt1(10);
+        verify(payload).writeInt1(29);
+        verify(payload).writeInt4(1);
+    }
+    
+    @Test
+    void assertWriteLocalDateTimeWithMicrosecondPrecision() {
+        MySQLDateBinaryProtocolValue actual = new MySQLDateBinaryProtocolValue();
+        actual.write(payload, LocalDateTime.of(1970, 1, 14, 12, 10, 29, 123456789));
+        verify(payload).writeInt1(11);
+        verify(payload).writeInt2(1970);
+        verify(payload).writeInt1(1);
+        verify(payload).writeInt1(14);
+        verify(payload).writeInt1(12);
+        verify(payload).writeInt1(10);
+        verify(payload).writeInt1(29);
+        verify(payload).writeInt4(123456);
     }
 }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/merge/dal/EncryptDALResultDecorator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/merge/dal/EncryptDALResultDecorator.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.encrypt.merge.dal;
 
-import com.sphereex.dbplusengine.sql.parser.statement.core.statement.attribute.type.ViewInResultSetSQLStatementAttribute;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.attribute.type.ViewInResultSetSQLStatementAttribute;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.encrypt.merge.dal.show.EncryptShowColumnsMergedResult;
 import org.apache.shardingsphere.encrypt.merge.dal.show.EncryptShowCreateTableMergedResult;

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResult.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResult.java
@@ -34,6 +34,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Optional;
@@ -100,6 +101,9 @@ public final class JDBCStreamQueryResult extends AbstractStreamQueryResult {
         }
         if (Time.class == type) {
             return resultSet.getTime(columnIndex);
+        }
+        if (LocalTime.class == type) {
+            return resultSet.getObject(columnIndex, LocalTime.class);
         }
         if (Timestamp.class == type) {
             return resultSet.getTimestamp(columnIndex);

--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/exception/SQLFederationUnsupportedSQLException.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/exception/SQLFederationUnsupportedSQLException.java
@@ -27,6 +27,6 @@ public final class SQLFederationUnsupportedSQLException extends SQLFederationSQL
     private static final long serialVersionUID = -8571244162760408846L;
     
     public SQLFederationUnsupportedSQLException(final String sql, final String reason) {
-        super(XOpenSQLState.SYNTAX_ERROR, 1, reason, "SQL federation does not support SQL '%s'.", sql);
+        super(XOpenSQLState.SYNTAX_ERROR, 1, reason.replace("%", "%%"), "SQL federation does not support SQL '" + sql + "'.");
     }
 }

--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/segment/expression/ExpressionConverter.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/segment/expression/ExpressionConverter.java
@@ -92,7 +92,7 @@ public final class ExpressionConverter {
             return Optional.empty();
         }
         if (segment instanceof LiteralExpressionSegment) {
-            return LiteralExpressionConverter.convert((LiteralExpressionSegment) segment);
+            return LiteralExpressionConverter.convert((LiteralExpressionSegment) segment, null);
         }
         if (segment instanceof CommonExpressionSegment) {
             // TODO

--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/sql/dialect/impl/CustomMySQLSQLDialect.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/sql/dialect/impl/CustomMySQLSQLDialect.java
@@ -17,8 +17,19 @@
 
 package org.apache.shardingsphere.sqlfederation.compiler.sql.dialect.impl;
 
+import org.apache.calcite.sql.SqlAbstractDateTimeLiteral;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.SqlWriter.FrameTypeEnum;
 import org.apache.calcite.sql.dialect.MysqlSqlDialect;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.TimestampWithTimeZoneString;
+import org.apache.calcite.util.Util;
+import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 
 /**
  * Custom MySQL SQL dialect.
@@ -36,5 +47,46 @@ public final class CustomMySQLSQLDialect extends MysqlSqlDialect {
         builder.append(literalQuoteString);
         builder.append(value.replace(literalEndQuoteString, literalEscapedQuote));
         builder.append(literalEndQuoteString);
+    }
+    
+    @Override
+    public void unparseCall(final SqlWriter writer, final SqlCall call, final int leftPrec, final int rightPrec) {
+        if (SqlKind.CAST == call.getOperator().getKind()) {
+            SqlNode parameter1 = call.getOperandList().get(0);
+            SqlNode parameter2 = call.getOperandList().get(1);
+            String typeName = parameter2 instanceof SqlDataTypeSpec ? Util.last(((SqlDataTypeSpec) parameter2).getTypeName().names) : null;
+            if (SqlTypeName.DOUBLE.getName().equals(typeName)) {
+                unparseCastDouble(writer, parameter1, typeName);
+                return;
+            }
+        }
+        super.unparseCall(writer, call, leftPrec, rightPrec);
+    }
+    
+    private void unparseCastDouble(final SqlWriter writer, final SqlNode parameter1, final String typeName) {
+        writer.keyword("CAST");
+        parameter1.unparse(writer, 0, 0);
+        writer.sep("AS");
+        writer.keyword(typeName);
+        writer.endList(writer.startList(FrameTypeEnum.FUN_CALL, "(", ")"));
+    }
+    
+    @Override
+    public void unparseDateTimeLiteral(final SqlWriter writer, final SqlAbstractDateTimeLiteral literal, final int leftPrec, final int rightPrec) {
+        if (SqlTypeName.TIMESTAMP_TZ == literal.getTypeName()) {
+            writer.literal(SqlTypeName.TIMESTAMP.getName() + " '" + toFormattedString(literal) + "'");
+        } else {
+            super.unparseDateTimeLiteral(writer, literal, leftPrec, rightPrec);
+        }
+    }
+    
+    private String toFormattedString(final SqlAbstractDateTimeLiteral literal) {
+        TimestampWithTimeZoneString timestampWithTimeZone = (TimestampWithTimeZoneString) literal.getValue();
+        int precision = literal.getPrec();
+        if (precision > 0) {
+            timestampWithTimeZone = timestampWithTimeZone.round(precision);
+        }
+        ShardingSpherePreconditions.checkState(precision >= 0, () -> new IllegalArgumentException("The precision of timestamp with time zone must be non-negative."));
+        return timestampWithTimeZone.getLocalTimestampString().toString(precision);
     }
 }

--- a/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/segment/expression/ExpressionConverterTest.java
+++ b/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/segment/expression/ExpressionConverterTest.java
@@ -114,7 +114,7 @@ class ExpressionConverterTest {
     void assertConvertDelegatesToAllSupportedConverters() {
         SqlNode expectedLiteralNode = mock(SqlNode.class);
         LiteralExpressionSegment literalSegment = new LiteralExpressionSegment(0, 0, "literal");
-        when(LiteralExpressionConverter.convert(literalSegment)).thenReturn(Optional.of(expectedLiteralNode));
+        when(LiteralExpressionConverter.convert(literalSegment, null)).thenReturn(Optional.of(expectedLiteralNode));
         SqlNode expectedListNode = mock(SqlNode.class);
         ListExpression listSegment = new ListExpression(0, 0);
         when(ListExpressionConverter.convert(listSegment)).thenReturn(Optional.of(expectedListNode));

--- a/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/segment/expression/impl/LiteralExpressionConverterTest.java
+++ b/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/segment/expression/impl/LiteralExpressionConverterTest.java
@@ -50,55 +50,55 @@ class LiteralExpressionConverterTest {
     
     @Test
     void assertConvertNullLiteral() {
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, null)).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, null), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getTypeName(), is(SqlTypeName.NULL));
     }
     
     @Test
     void assertConvertTrimFlags() {
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, "both")).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, "both"), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getValueAs(String.class), is("both"));
-        SqlLiteral leading = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, "LEADING")).orElse(null);
+        SqlLiteral leading = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, "LEADING"), null).orElse(null);
         assertNotNull(leading);
         assertThat(leading.getValueAs(String.class), is("LEADING"));
-        SqlLiteral trailing = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, "trailing")).orElse(null);
+        SqlLiteral trailing = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, "trailing"), null).orElse(null);
         assertNotNull(trailing);
         assertThat(trailing.getValueAs(String.class), is("trailing"));
     }
     
     @Test
     void assertConvertTimeUnitName() {
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, "year")).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, "year"), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getValueAs(String.class), is("year"));
     }
     
     @Test
     void assertConvertApproximateNumber() {
-        SqlNumericLiteral actual = (SqlNumericLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, new Float("1.5"))).orElse(null);
+        SqlNumericLiteral actual = (SqlNumericLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, new Float("1.5")), null).orElse(null);
         assertNotNull(actual);
         assertFalse(actual.isExact());
     }
     
     @Test
     void assertConvertExactNumber() {
-        SqlNumericLiteral actual = (SqlNumericLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, 10)).orElse(null);
+        SqlNumericLiteral actual = (SqlNumericLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, 10), null).orElse(null);
         assertNotNull(actual);
         assertTrue(actual.isExact());
     }
     
     @Test
     void assertConvertStringLiteral() {
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, "text")).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, "text"), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getValueAs(String.class), is("text"));
     }
     
     @Test
     void assertConvertBooleanLiteral() {
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, true)).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, true), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getValueAs(Boolean.class), is(true));
     }
@@ -108,7 +108,7 @@ class LiteralExpressionConverterTest {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2020, Calendar.JANUARY, 1, 0, 0, 0);
         calendar.set(Calendar.MILLISECOND, 0);
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, calendar)).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, calendar), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getTypeName(), is(SqlTypeName.DATE));
     }
@@ -118,7 +118,7 @@ class LiteralExpressionConverterTest {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2020, Calendar.JANUARY, 1, 1, 1, 1);
         calendar.set(Calendar.MILLISECOND, 1);
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, calendar)).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, calendar), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getTypeName(), is(SqlTypeName.TIMESTAMP));
     }
@@ -126,15 +126,15 @@ class LiteralExpressionConverterTest {
     @Test
     void assertConvertTimestampDate() {
         Timestamp timestamp = Timestamp.valueOf("2023-01-02 03:04:05");
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, timestamp)).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, timestamp), null).orElse(null);
         assertNotNull(actual);
-        assertThat(actual.getTypeName(), is(SqlTypeName.TIMESTAMP));
+        assertThat(actual.getTypeName(), is(SqlTypeName.TIMESTAMP_TZ));
     }
     
     @Test
     void assertConvertTimeDate() {
         Time time = new Time(new TimeString("01:02:03").getMillisOfDay());
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, time)).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, time), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getTypeName(), is(SqlTypeName.TIME));
     }
@@ -142,28 +142,28 @@ class LiteralExpressionConverterTest {
     @Test
     void assertConvertUtilDate() {
         java.sql.Date date = java.sql.Date.valueOf("2020-01-01");
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, date)).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, date), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getTypeName(), is(SqlTypeName.DATE));
     }
     
     @Test
     void assertConvertLocalDate() {
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, LocalDate.of(2020, 1, 1))).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, LocalDate.of(2020, 1, 1)), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getTypeName(), is(SqlTypeName.DATE));
     }
     
     @Test
     void assertConvertLocalTime() {
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, LocalTime.of(1, 2, 3))).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, LocalTime.of(1, 2, 3)), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getTypeName(), is(SqlTypeName.TIME));
     }
     
     @Test
     void assertConvertLocalDateTime() {
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, LocalDateTime.of(2020, 1, 1, 1, 1, 1))).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, LocalDateTime.of(2020, 1, 1, 1, 1, 1)), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getTypeName(), is(SqlTypeName.TIMESTAMP));
     }
@@ -171,26 +171,26 @@ class LiteralExpressionConverterTest {
     @Test
     void assertConvertZonedDateTime() {
         ZonedDateTime zonedDateTime = ZonedDateTime.of(LocalDateTime.of(2020, 1, 1, 1, 1, 1), ZoneId.of("UTC"));
-        assertThrows(CalciteException.class, () -> LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, zonedDateTime)));
+        assertThrows(CalciteException.class, () -> LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, zonedDateTime), null));
     }
     
     @Test
     void assertConvertBinary() {
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, new byte[]{1, 2})).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, new byte[]{1, 2}), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getTypeName(), is(SqlTypeName.BINARY));
     }
     
     @Test
     void assertConvertEnumLiteral() {
-        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, SampleEnum.VALUE)).orElse(null);
+        SqlLiteral actual = (SqlLiteral) LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, SampleEnum.VALUE), null).orElse(null);
         assertNotNull(actual);
         assertThat(actual.getValueAs(String.class), is("VALUE"));
     }
     
     @Test
     void assertConvertReturnsEmptyForUnsupportedType() {
-        Optional<?> actual = LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, new Object()));
+        Optional<?> actual = LiteralExpressionConverter.convert(new LiteralExpressionSegment(0, 0, new Object()), null);
         assertFalse(actual.isPresent());
     }
 }

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/attribute/type/ViewInResultSetSQLStatementAttribute.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/attribute/type/ViewInResultSetSQLStatementAttribute.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.sphereex.dbplusengine.sql.parser.statement.core.statement.attribute.type;
+package org.apache.shardingsphere.sql.parser.statement.core.statement.attribute.type;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/parser/sql/statement/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/statement/mysql/dal/show/view/MySQLShowCreateViewStatement.java
+++ b/parser/sql/statement/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/statement/mysql/dal/show/view/MySQLShowCreateViewStatement.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.sql.parser.statement.mysql.dal.show.view;
 
-import com.sphereex.dbplusengine.sql.parser.statement.core.statement.attribute.type.ViewInResultSetSQLStatementAttribute;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.attribute.type.ViewInResultSetSQLStatementAttribute;
 import lombok.Getter;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Enhance MySQLTextResultSetRowPacket and MySQLDateBinaryProtocolValue to support LocalDateTime and LocalTime when value contains scale

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
