### PR TITLE
Introduce SystemSchemaProvider SPI for live MySQL system schema loading

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/schema/SystemSchemaProvider.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/schema/SystemSchemaProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.connector.core.metadata.database.schema;
+
+import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPI;
+import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * System schema provider.
+ */
+@SingletonSPI
+public interface SystemSchemaProvider extends DatabaseTypedSPI {
+    
+    /**
+     * Get system tables for schema.
+     *
+     * @param schemaName schema name
+     * @return system tables
+     */
+    Optional<Collection<String>> getSystemTables(String schemaName);
+    
+    /**
+     * Get system schema input streams.
+     *
+     * @param schemaName schema name
+     * @return system schema input streams
+     */
+    Optional<Collection<InputStream>> getSystemSchemaInputStreams(String schemaName);
+}

--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/database/schema/MySQLSystemSchemaProvider.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/database/schema/MySQLSystemSchemaProvider.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.database.connector.mysql.metadata.database.schema;
+
+import com.cedarsoftware.util.CaseInsensitiveSet;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.database.connector.core.GlobalDataSourceRegistry;
+import org.apache.shardingsphere.database.connector.core.metadata.database.schema.SystemSchemaProvider;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Optional;
+import javax.sql.DataSource;
+
+/**
+ * MySQL system schema provider.
+ */
+@Slf4j
+public final class MySQLSystemSchemaProvider implements SystemSchemaProvider {
+    
+    private static final String SYSTEM_TABLE_SQL = "SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA=?";
+    
+    private static final String TABLE_TYPE_SQL = "SELECT TABLE_TYPE FROM information_schema.TABLES WHERE TABLE_SCHEMA=? AND TABLE_NAME=?";
+    
+    private static final String TABLE_TYPE_VIEW = "VIEW";
+    
+    private static final String YAML_TABLE_TEMPLATE = "name: %s%s%stype: %s%scolumns: {}%s";
+    
+    @Override
+    public Optional<Collection<String>> getSystemTables(final String schemaName) {
+        if (null == schemaName) {
+            return Optional.empty();
+        }
+        Map<String, DataSource> cachedDataSources = GlobalDataSourceRegistry.getInstance().getCachedDataSources();
+        if (cachedDataSources.isEmpty()) {
+            return Optional.empty();
+        }
+        DataSource dataSource = cachedDataSources.values().iterator().next();
+        return loadSystemTableNames(schemaName, dataSource);
+    }
+    
+    @Override
+    public Optional<Collection<InputStream>> getSystemSchemaInputStreams(final String schemaName) {
+        if (null == schemaName) {
+            return Optional.empty();
+        }
+        Map<String, DataSource> cachedDataSources = GlobalDataSourceRegistry.getInstance().getCachedDataSources();
+        if (cachedDataSources.isEmpty()) {
+            return Optional.empty();
+        }
+        DataSource dataSource = cachedDataSources.values().iterator().next();
+        Optional<Collection<String>> tableNames = loadSystemTableNames(schemaName, dataSource);
+        if (!tableNames.isPresent()) {
+            return Optional.empty();
+        }
+        Collection<InputStream> result = new LinkedList<>();
+        for (String tableName : tableNames.get()) {
+            String tableType = loadTableType(schemaName, tableName, dataSource);
+            result.add(new ByteArrayInputStream(buildTableYaml(tableName, tableType).getBytes(StandardCharsets.UTF_8)));
+        }
+        return Optional.of(result);
+    }
+    
+    @Override
+    public String getDatabaseType() {
+        return "MySQL";
+    }
+    
+    private Optional<Collection<String>> loadSystemTableNames(final String schemaName, final DataSource dataSource) {
+        Collection<String> result = new CaseInsensitiveSet<>();
+        try (
+                Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(SYSTEM_TABLE_SQL)) {
+            preparedStatement.setString(1, schemaName);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                while (resultSet.next()) {
+                    result.add(resultSet.getString("TABLE_NAME"));
+                }
+            }
+        } catch (final SQLException ex) {
+            log.debug("Load MySQL system tables failed for schema {}", schemaName, ex);
+            return Optional.empty();
+        }
+        return result.isEmpty() ? Optional.empty() : Optional.of(result);
+    }
+    
+    private String loadTableType(final String schemaName, final String tableName, final DataSource dataSource) {
+        try (
+                Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(TABLE_TYPE_SQL)) {
+            preparedStatement.setString(1, schemaName);
+            preparedStatement.setString(2, tableName);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                if (resultSet.next()) {
+                    return TABLE_TYPE_VIEW.equalsIgnoreCase(resultSet.getString("TABLE_TYPE")) ? "VIEW" : "TABLE";
+                }
+            }
+        } catch (final SQLException ex) {
+            log.debug("Load MySQL system table type failed for {}.{}", schemaName, tableName, ex);
+        }
+        return "TABLE";
+    }
+    
+    private String buildTableYaml(final String tableName, final String tableType) {
+        return String.format(YAML_TABLE_TEMPLATE, tableName, System.lineSeparator(), System.lineSeparator(), tableType, System.lineSeparator(), System.lineSeparator());
+    }
+}

--- a/database/connector/dialect/mysql/src/main/resources/META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.database.schema.SystemSchemaProvider
+++ b/database/connector/dialect/mysql/src/main/resources/META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.database.schema.SystemSchemaProvider
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.database.connector.mysql.metadata.database.schema.MySQLSystemSchemaProvider

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/database/system/MySQLKernelSupportedSystemTableTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/database/system/MySQLKernelSupportedSystemTableTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.database.connector.mysql.metadata.database.system;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectKernelSupportedSystemTable;
+import org.apache.shardingsphere.database.connector.core.metadata.database.schema.SystemSchemaProvider;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
@@ -34,6 +35,8 @@ class MySQLKernelSupportedSystemTableTest {
     
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
     
+    private final SystemSchemaProvider systemSchemaProvider = DatabaseTypedSPILoader.getService(SystemSchemaProvider.class, databaseType);
+    
     private final DialectKernelSupportedSystemTable kernelSupportedSystemTable = DatabaseTypedSPILoader.getService(DialectKernelSupportedSystemTable.class, databaseType);
     
     @Test
@@ -42,5 +45,10 @@ class MySQLKernelSupportedSystemTableTest {
         assertThat(actual.size(), is(1));
         assertThat(actual.keySet().iterator().next(), is("sys"));
         assertThat(actual.get("sys"), hasItem("sys_config"));
+    }
+    
+    @Test
+    void assertSystemSchemaProviderType() {
+        assertThat(systemSchemaProvider.getDatabaseType(), is("MySQL"));
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilder.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilder.java
@@ -78,7 +78,7 @@ public final class SystemSchemaBuilder {
     private static ShardingSphereSchema createSchema(final String schemaName, final DatabaseType databaseType, final boolean isSystemSchemaMetadataEnabled) {
         Collection<ShardingSphereTable> tables = new LinkedList<>();
         SystemTable systemTable = new SystemTable(databaseType);
-        for (InputStream each : SystemSchemaManager.getAllInputStreams(databaseType.getType(), schemaName)) {
+        for (InputStream each : SystemSchemaManager.getAllInputStreams(databaseType.getType(), schemaName, isSystemSchemaMetadataEnabled)) {
             YamlShardingSphereTable metaData = new Yaml().loadAs(each, YamlShardingSphereTable.class);
             if (isSystemSchemaMetadataEnabled || systemTable.isSupportedSystemTable(schemaName, metaData.getName())) {
                 tables.add(TABLE_SWAPPER.swapToObject(metaData));

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -21,11 +21,15 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManagerTestSupport;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.infra.util.props.PropertiesBuilder;
 import org.apache.shardingsphere.infra.util.props.PropertiesBuilder.Property;
 import org.junit.jupiter.api.Test;
 
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
@@ -37,25 +41,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SystemSchemaBuilderTest {
     
     @Test
-    void assertBuildForMySQL() {
+    void assertBuildForMySQL() throws SQLException {
+        setUpMySQLSystemSchemaDataSource();
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
         ConfigurationProperties configProps = new ConfigurationProperties(PropertiesBuilder.build());
         Map<String, ShardingSphereSchema> actualInformationSchema = SystemSchemaBuilder.build("information_schema", databaseType, configProps);
         assertThat(actualInformationSchema.size(), is(1));
         assertTrue(actualInformationSchema.containsKey("information_schema"));
-        assertThat(actualInformationSchema.get("information_schema").getAllTables().size(), is(95));
+        assertThat(actualInformationSchema.get("information_schema").getAllTables().size(), is(3));
         Map<String, ShardingSphereSchema> actualMySQLSchema = SystemSchemaBuilder.build("mysql", databaseType, configProps);
         assertThat(actualMySQLSchema.size(), is(1));
         assertTrue(actualMySQLSchema.containsKey("mysql"));
-        assertThat(actualMySQLSchema.get("mysql").getAllTables().size(), is(40));
+        assertThat(actualMySQLSchema.get("mysql").getAllTables().size(), is(1));
         Map<String, ShardingSphereSchema> actualPerformanceSchema = SystemSchemaBuilder.build("performance_schema", databaseType, configProps);
         assertThat(actualPerformanceSchema.size(), is(1));
         assertTrue(actualPerformanceSchema.containsKey("performance_schema"));
-        assertThat(actualPerformanceSchema.get("performance_schema").getAllTables().size(), is(114));
+        assertThat(actualPerformanceSchema.get("performance_schema").getAllTables().size(), is(1));
         Map<String, ShardingSphereSchema> actualSysSchema = SystemSchemaBuilder.build("sys", databaseType, configProps);
         assertThat(actualSysSchema.size(), is(1));
         assertTrue(actualSysSchema.containsKey("sys"));
-        assertThat(actualSysSchema.get("sys").getAllTables().size(), is(53));
+        assertThat(actualSysSchema.get("sys").getAllTables().size(), is(1));
     }
     
     @Test
@@ -103,5 +108,12 @@ class SystemSchemaBuilderTest {
         ShardingSphereSchema shardingsphereSchema = actual.get("shardingsphere");
         assertThat(shardingsphereSchema.getAllTables().size(), is(1));
         assertTrue(shardingsphereSchema.containsTable("cluster_information"));
+    }
+    
+    private void setUpMySQLSystemSchemaDataSource() throws SQLException {
+        SystemSchemaManagerTestSupport.setUpMySQLSystemSchemaDataSource("information_schema", Arrays.asList("columns", "tables", "schemata"));
+        SystemSchemaManagerTestSupport.setUpMySQLSystemSchemaDataSource("mysql", Collections.singletonList("db"));
+        SystemSchemaManagerTestSupport.setUpMySQLSystemSchemaDataSource("performance_schema", Collections.singletonList("events_waits_current"));
+        SystemSchemaManagerTestSupport.setUpMySQLSystemSchemaDataSource("sys", Collections.singletonList("sys_config"));
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/manager/SystemSchemaManagerTestSupport.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/manager/SystemSchemaManagerTestSupport.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.metadata.database.schema.manager;
+
+import org.apache.shardingsphere.database.connector.core.GlobalDataSourceRegistry;
+import org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class SystemSchemaManagerTestSupport {
+    
+    private static final Map<String, Collection<String>> SCHEMA_TABLES = new LinkedHashMap<>();
+    
+    private static final AtomicReference<String> SCHEMA_NAME_REF = new AtomicReference<>();
+    
+    private static final AtomicReference<MockedDataSource> DATA_SOURCE_REF = new AtomicReference<>();
+    
+    private SystemSchemaManagerTestSupport() {
+    }
+    
+    /**
+     * Set up MySQL system schema data source.
+     *
+     * @param schemaName schema name
+     * @param tableNames table names
+     * @throws SQLException SQL exception
+     */
+    public static void setUpMySQLSystemSchemaDataSource(final String schemaName, final Collection<String> tableNames) throws SQLException {
+        if (null == DATA_SOURCE_REF.get()) {
+            initMySQLSystemSchemaDataSource();
+        }
+        SCHEMA_TABLES.put(schemaName, tableNames);
+    }
+    
+    /**
+     * Build table result set.
+     *
+     * @param tableNames table names
+     * @return table result set
+     * @throws SQLException SQL exception
+     */
+    public static ResultSet buildTableResultSet(final Collection<String> tableNames) throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        List<String> names = new ArrayList<>(tableNames);
+        AtomicReference<String> current = new AtomicReference<>();
+        when(result.next()).thenAnswer(invocation -> {
+            if (names.isEmpty()) {
+                return false;
+            }
+            current.set(names.remove(0));
+            return true;
+        });
+        when(result.getString("TABLE_NAME")).thenAnswer(invocation -> current.get());
+        return result;
+    }
+    
+    private static ResultSet buildTableTypeResultSet() throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        when(result.next()).thenReturn(true, false);
+        when(result.getString("TABLE_TYPE")).thenReturn("BASE TABLE");
+        return result;
+    }
+    
+    private static void initMySQLSystemSchemaDataSource() throws SQLException {
+        GlobalDataSourceRegistry.getInstance().getCachedDataSources().clear();
+        Connection connection = mock(Connection.class);
+        MockedDataSource dataSource = new MockedDataSource(connection);
+        PreparedStatement tableStatement = mock(PreparedStatement.class);
+        PreparedStatement typeStatement = mock(PreparedStatement.class);
+        when(connection.prepareStatement("SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA=?")).thenReturn(tableStatement);
+        when(connection.prepareStatement("SELECT TABLE_TYPE FROM information_schema.TABLES WHERE TABLE_SCHEMA=? AND TABLE_NAME=?")).thenReturn(typeStatement);
+        doAnswer(invocation -> {
+            SCHEMA_NAME_REF.set(invocation.getArgument(1, String.class));
+            return null;
+        }).when(tableStatement).setString(eq(1), anyString());
+        doNothing().when(typeStatement).setString(eq(1), anyString());
+        doNothing().when(typeStatement).setString(eq(2), anyString());
+        when(tableStatement.executeQuery()).thenAnswer(invocation -> buildTableResultSet(SCHEMA_TABLES.getOrDefault(SCHEMA_NAME_REF.get(), Collections.emptyList())));
+        when(typeStatement.executeQuery()).thenAnswer(invocation -> buildTableTypeResultSet());
+        GlobalDataSourceRegistry.getInstance().getCachedDataSources().put("mysql", dataSource);
+        DATA_SOURCE_REF.set(dataSource);
+    }
+}

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/MySQLAdminExecutorCreatorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/MySQLAdminExecutorCreatorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.proxy.backend.mysql.handler.admin;
 
+import org.apache.shardingsphere.database.connector.core.GlobalDataSourceRegistry;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.CommonSQLStatementContext;
@@ -73,6 +74,10 @@ import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockS
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -84,6 +89,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -315,7 +323,8 @@ class MySQLAdminExecutorCreatorTest {
     }
     
     @Test
-    void assertCreateWithSelectStatementFromInformationSchemaOfDefaultExecutorTables() {
+    void assertCreateWithSelectStatementFromInformationSchemaOfDefaultExecutorTables() throws SQLException {
+        setUpMySQLSystemSchemaDataSource("information_schema", "ENGINES");
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
         when(database.getName()).thenReturn("information_schema");
         when(database.getProtocolType()).thenReturn(databaseType);
@@ -329,6 +338,20 @@ class MySQLAdminExecutorCreatorTest {
         Optional<DatabaseAdminExecutor> actual = new MySQLAdminExecutorCreator().create(sqlStatementContext, "SELECT ENGINE from ENGINES", "information_schema", Collections.emptyList());
         assertTrue(actual.isPresent());
         assertThat(actual.get(), isA(DatabaseMetaDataExecutor.class));
+    }
+    
+    private void setUpMySQLSystemSchemaDataSource(final String schemaName, final String tableName) throws SQLException {
+        GlobalDataSourceRegistry.getInstance().getCachedDataSources().clear();
+        Connection connection = mock(Connection.class);
+        MockedDataSource dataSource = new MockedDataSource(connection);
+        PreparedStatement tableStatement = mock(PreparedStatement.class);
+        ResultSet tableResultSet = mock(ResultSet.class);
+        when(tableResultSet.next()).thenReturn(true, false);
+        when(tableResultSet.getString("TABLE_NAME")).thenReturn(tableName);
+        when(connection.prepareStatement("SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA=?")).thenReturn(tableStatement);
+        doNothing().when(tableStatement).setString(eq(1), anyString());
+        when(tableStatement.executeQuery()).thenReturn(tableResultSet);
+        GlobalDataSourceRegistry.getInstance().getCachedDataSources().put("mysql", dataSource);
     }
     
     @Test


### PR DESCRIPTION
For #37766 .

Changes proposed in this pull request:
  - Introduce SystemSchemaProvider SPI for live MySQL system schema loading.
  - This SPI can be extended to Postgres, OpenGauss, and Oracle in other PRs.
  - There are many MySQL-compatible databases, including but not limited to ClickHouse, MariaDB, Doris, and H2. Moreover, the content of `information_schema` is basically different for each database. Otherwise, databases like ClickHouse would not be able to implement geographic information columns. There's no point in keeping hundreds of predefined empty tables; it's better to retrieve a data source from the available data sources and query it.
  - I could actually delete the hundreds of files in the current PR ( https://github.com/apache/shardingsphere/tree/master/database/connector/dialect/mysql/src/main/resources/schema/mysql ). However, to facilitate the review of the new SPI, I want to delete those hundreds of files in a separate PR.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
