### PR TITLE
Upgrade openGauss docker image from opengauss:3.1.0 to opengauss-lite:5.1.0

### DIFF
--- a/.github/workflows/e2e-operation.yml
+++ b/.github/workflows/e2e-operation.yml
@@ -64,7 +64,7 @@ jobs:
           { type: "e2e.docker.database.mysql.images", version: "mysql:5.7" },
           { type: "e2e.docker.database.mariadb.images", version: "mariadb:11" },
           { type: "e2e.docker.database.postgresql.images", version: "postgres:12-alpine" },
-          { type: "e2e.docker.database.opengauss.images", version: "enmotech/opengauss:3.1.0" }
+          { type: "e2e.docker.database.opengauss.images", version: "enmotech/opengauss-lite:5.1.0" }
         ]
         exclude:
           - operation: transaction
@@ -74,7 +74,7 @@ jobs:
           - operation: showprocesslist
             image: { type: "e2e.docker.database.postgresql.images", version: "postgres:12-alpine" }
           - operation: showprocesslist
-            image: { type: "e2e.docker.database.opengauss.images", version: "enmotech/opengauss:3.1.0" }
+            image: { type: "e2e.docker.database.opengauss.images", version: "enmotech/opengauss-lite:5.1.0" }
     steps:
       - env:
           changed_operations: ${{ needs.detect-changed-files.outputs.changed_operations }}

--- a/.github/workflows/nightly-e2e-operation.yml
+++ b/.github/workflows/nightly-e2e-operation.yml
@@ -59,7 +59,7 @@ jobs:
           { type: "e2e.docker.database.postgresql.images", version: "postgres:12-alpine" },
           { type: "e2e.docker.database.postgresql.images", version: "postgres:13-alpine" },
           { type: "e2e.docker.database.postgresql.images", version: "postgres:14-alpine" },
-          { type: "e2e.docker.database.opengauss.images", version: "enmotech/opengauss:3.1.0" }
+          { type: "e2e.docker.database.opengauss.images", version: "enmotech/opengauss-lite:5.1.0" }
         ]
         exclude:
           - operation: transaction
@@ -69,7 +69,7 @@ jobs:
           - operation: showprocesslist
             image: { type: "e2e.docker.database.postgresql.images", version: "postgres:10-alpine,postgres:11-alpine,postgres:12-alpine,postgres:13-alpine,postgres:14-alpine" }
           - operation: showprocesslist
-            image: { type: "e2e.docker.database.opengauss.images", version: "enmotech/opengauss:3.1.0" }
+            image: { type: "e2e.docker.database.opengauss.images", version: "enmotech/opengauss-lite:5.1.0" }
     steps:
       - uses: actions/checkout@v6.0.1
       - name: Setup JDK ${{ matrix.java-version }}

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/storage/option/dialect/opengauss/OpenGaussStorageContainerCreateOption.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/storage/option/dialect/opengauss/OpenGaussStorageContainerCreateOption.java
@@ -39,7 +39,7 @@ public final class OpenGaussStorageContainerCreateOption implements StorageConta
     
     @Override
     public String getDefaultImageName() {
-        return "enmotech/opengauss:3.1.0";
+        return "enmotech/opengauss-lite:5.1.0";
     }
     
     @Override

--- a/test/e2e/operation/pipeline/src/test/resources/env/e2e-env.properties
+++ b/test/e2e/operation/pipeline/src/test/resources/env/e2e-env.properties
@@ -21,7 +21,7 @@ e2e.run.type=
 e2e.docker.database.mysql.images=
 #e2e.docker.database.postgresql.images=postgres:10-alpine,postgres:11-alpine,postgres:12-alpine,postgres:13-alpine,postgres:14-alpine
 e2e.docker.database.postgresql.images=
-#e2e.docker.database.opengauss.images=enmotech/opengauss:3.1.0
+#e2e.docker.database.opengauss.images=enmotech/opengauss-lite:5.1.0
 e2e.docker.database.opengauss.images=
 
 #e2e.native.database.port= MySQL is 3306, PostgreSQL is 5432, openGauss is 5432

--- a/test/e2e/operation/transaction/src/test/resources/env/e2e-env.properties
+++ b/test/e2e/operation/transaction/src/test/resources/env/e2e-env.properties
@@ -34,7 +34,7 @@ e2e.transaction.xa.providers=Atomikos,Narayana
 e2e.docker.database.mysql.images=
 #e2e.docker.database.postgresql.images=postgres:10-alpine,postgres:11-alpine,postgres:12-alpine,postgres:13-alpine,postgres:14-alpine
 e2e.docker.database.postgresql.images=
-#e2e.docker.database.opengauss.images=enmotech/opengauss:3.1.0
+#e2e.docker.database.opengauss.images=enmotech/opengauss-lite:5.1.0
 e2e.docker.database.opengauss.images=
 
 e2e.native.database.host=127.0.0.1


### PR DESCRIPTION
Related to #37826

Changes proposed in this pull request:
  - Upgrade openGauss docker image from opengauss:3.1.0 to opengauss-lite:5.1.0

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
