### PR TITLE
Replace deprecated commons-lang3 RandomStringUtils.randomAlphanumeric to commons-text RandomStringGenerator

### DIFF
--- a/kernel/data-pipeline/scenario/cdc/core/pom.xml
+++ b/kernel/data-pipeline/scenario/cdc/core/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>shardingsphere-data-pipeline-cdc-protocol</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
         
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>

--- a/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/ack/CDCAckId.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/ack/CDCAckId.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.data.pipeline.cdc.core.ack;
 import com.google.common.base.Splitter;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.shardingsphere.data.pipeline.cdc.util.RandomStrings;
 
 import java.util.List;
 
@@ -42,7 +42,7 @@ public final class CDCAckId {
      * @return ack id
      */
     public static CDCAckId build(final String importerId) {
-        return new CDCAckId(importerId, RandomStringUtils.randomAlphanumeric(16));
+        return new CDCAckId(importerId, RandomStrings.randomAlphanumeric(16));
     }
     
     /**

--- a/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/importer/CDCImporter.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/importer/CDCImporter.java
@@ -23,10 +23,10 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.shardingsphere.data.pipeline.cdc.core.ack.CDCAckId;
 import org.apache.shardingsphere.data.pipeline.cdc.core.ack.CDCAckPosition;
+import org.apache.shardingsphere.data.pipeline.cdc.util.RandomStrings;
 import org.apache.shardingsphere.data.pipeline.core.channel.PipelineChannel;
 import org.apache.shardingsphere.data.pipeline.core.constant.PipelineSQLOperationType;
 import org.apache.shardingsphere.data.pipeline.core.execute.AbstractPipelineLifecycleRunnable;
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
 public final class CDCImporter extends AbstractPipelineLifecycleRunnable implements Importer {
     
     @Getter
-    private final String importerId = RandomStringUtils.randomAlphanumeric(8);
+    private final String importerId = RandomStrings.randomAlphanumeric(8);
     
     private final List<CDCChannelProgressPair> channelProgressPairs;
     

--- a/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/util/RandomStrings.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/util/RandomStrings.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.cdc.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.text.RandomStringGenerator;
+
+/**
+ * Random string utils.
+ */
+@NoArgsConstructor(access = AccessLevel.NONE)
+public final class RandomStrings {
+    
+    private static final RandomStringGenerator GENERATOR;
+    
+    static {
+        char[][] pairs = {{'a', 'z'}, {'A', 'Z'}, {'0', '9'}};
+        GENERATOR = RandomStringGenerator.builder().withinRange(pairs).build();
+    }
+    
+    /**
+     * Generate a random alphanumeric string of the given length.
+     *
+     * @param count desired string length
+     * @return random alphanumeric string
+     */
+    public static String randomAlphanumeric(final int count) {
+        return GENERATOR.generate(count);
+    }
+}

--- a/kernel/data-pipeline/scenario/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/RandomStringsTest.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/RandomStringsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.cdc.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RandomStringsTest {
+    
+    @Test
+    void assertRandomAlphanumeric() {
+        String actual = RandomStrings.randomAlphanumeric(16);
+        assertThat(actual.length(), is(16));
+        assert actual.matches("^[a-zA-Z0-9]+$");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
         <commons-math3.version>3.6.1</commons-math3.version>
         <commons-pool2.version>2.12.0</commons-pool2.version>
         <commons-io.version>2.20.0</commons-io.version>
+        <commons-text.version>1.11.0</commons-text.version>
         <aggdesigner-algorithm.version>6.1</aggdesigner-algorithm.version>
         <caffeine.version>2.9.3</caffeine.version>
         <transmittable-thread-local.version>2.14.2</transmittable-thread-local.version>
@@ -327,6 +328,11 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${commons-text.version}</version>
             </dependency>
             
             <dependency>

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/cases/migration/general/PostgreSQLToMySQLMigrationE2EIT.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/cases/migration/general/PostgreSQLToMySQLMigrationE2EIT.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.test.e2e.operation.pipeline.cases.migration.general;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.shardingsphere.data.pipeline.cdc.util.RandomStrings;
 import org.apache.shardingsphere.data.pipeline.scenario.migration.MigrationJobType;
 import org.apache.shardingsphere.test.e2e.env.runtime.E2ETestEnvironment;
 import org.apache.shardingsphere.test.e2e.env.runtime.type.RunEnvironment.Type;
@@ -82,7 +82,7 @@ class PostgreSQLToMySQLMigrationE2EIT extends AbstractMigrationE2EIT {
             distSQLFacade.waitJobIncrementalStageStarted(jobId);
             try (Connection connection = DriverManager.getConnection(jdbcUrl, "postgres", "postgres")) {
                 connection.createStatement().execute(String.format("INSERT INTO t_order (order_id,user_id,status) VALUES (%s, %s, '%s')", "1000000000", 1, "incremental"));
-                connection.createStatement().execute(String.format("UPDATE t_order SET status='%s' WHERE order_id IN (1,2)", RandomStringUtils.randomAlphanumeric(10)));
+                connection.createStatement().execute(String.format("UPDATE t_order SET status='%s' WHERE order_id IN (1,2)", RandomStrings.randomAlphanumeric(10)));
             }
             distSQLFacade.waitJobIncrementalStageFinished(jobId);
             distSQLFacade.startCheckAndVerify(jobId, "DATA_MATCH");
@@ -110,7 +110,7 @@ class PostgreSQLToMySQLMigrationE2EIT extends AbstractMigrationE2EIT {
             for (int i = 1; i <= 10; i++) {
                 preparedStatement.setObject(1, i);
                 preparedStatement.setObject(2, i + 10);
-                preparedStatement.setObject(3, RandomStringUtils.randomAlphanumeric(10));
+                preparedStatement.setObject(3, RandomStrings.randomAlphanumeric(10));
                 preparedStatement.setObject(4, LocalDateTime.now());
                 preparedStatement.setObject(5, LocalDate.now());
                 preparedStatement.setObject(6, LocalTime.now().withNano(0));

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/framework/helper/PipelineCaseHelper.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/framework/helper/PipelineCaseHelper.java
@@ -21,7 +21,7 @@ import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.shardingsphere.data.pipeline.cdc.util.RandomStrings;
 import org.apache.shardingsphere.infra.algorithm.core.context.AlgorithmSQLContext;
 import org.apache.shardingsphere.infra.algorithm.keygen.spi.KeyGenerateAlgorithm;
 
@@ -55,7 +55,7 @@ public final class PipelineCaseHelper {
      * @return random alphanumeric string
      */
     public static String generateString(final int strLength) {
-        return RandomStringUtils.randomAlphanumeric(strLength);
+        return RandomStrings.randomAlphanumeric(strLength);
     }
     
     /**


### PR DESCRIPTION

Changes proposed in this pull request:
  - Replace deprecated commons-lang3 RandomStringUtils.randomAlphanumeric to commons-text RandomStringGenerator

Background:
- commons-lang3 RandomStringUtils.randomAlphanumeric is deprecated. commons-text RandomStringGenerator is recommended.
- `commons-text` already exists in proxy distribution. Version is `1.11.0`

There is commons-text new version 1.15.0 though, but there is no urgent bugs from `1.11.0`, so `1.11.0` is kept for now.
See https://downloads.apache.org/commons/text/RELEASE-NOTES.txt for more details.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
