### PR TITLE
Move createColumnLabelAndIndexMap to ProjectionsContext

### DIFF
--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/ProjectionsContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/ProjectionsContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.binder.context.segment.select.projection;
 
+import com.cedarsoftware.util.CaseInsensitiveMap;
 import lombok.Getter;
 import lombok.ToString;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.AggregationDistinctProjection;
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -56,6 +58,8 @@ public final class ProjectionsContext {
     
     private final boolean containsLastInsertIdProjection;
     
+    private final Map<String, Integer> columnLabelAndIndexMap;
+    
     public ProjectionsContext(final int startIndex, final int stopIndex, final boolean distinctRow, final Collection<Projection> projections) {
         this.startIndex = startIndex;
         this.stopIndex = stopIndex;
@@ -64,6 +68,7 @@ public final class ProjectionsContext {
         aggregationDistinctProjections = createAggregationDistinctProjections();
         expandProjections = createExpandProjections();
         containsLastInsertIdProjection = isContainsLastInsertIdProjection(projections);
+        columnLabelAndIndexMap = createColumnLabelAndIndexMap(expandProjections);
     }
     
     private Collection<AggregationDistinctProjection> createAggregationDistinctProjections() {
@@ -168,6 +173,15 @@ public final class ProjectionsContext {
             }
         }
         return false;
+    }
+    
+    private Map<String, Integer> createColumnLabelAndIndexMap(final List<Projection> expandProjections) {
+        Map<String, Integer> result = new CaseInsensitiveMap<>(expandProjections.size(), 1F);
+        for (int columnIndex = expandProjections.size(); columnIndex > 0; columnIndex--) {
+            Projection projection = expandProjections.get(columnIndex - 1);
+            result.put(DerivedColumn.isDerivedColumnName(projection.getColumnLabel()) ? projection.getExpression() : projection.getColumnLabel(), columnIndex);
+        }
+        return result;
     }
     
     /**

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/ProjectionsContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/ProjectionsContextTest.java
@@ -41,6 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ProjectionsContextTest {
     
@@ -168,13 +169,16 @@ class ProjectionsContextTest {
     
     @Test
     void assertNotFindColumnProjectionWithNotColumnProjection() {
-        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, true, Collections.singleton(mock(Projection.class)));
+        Projection mockProjection = mock(Projection.class);
+        when(mockProjection.getColumnLabel()).thenReturn("label");
+        when(mockProjection.getExpression()).thenReturn("expression");
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, true, Collections.singleton(mockProjection));
         assertFalse(projectionsContext.findColumnProjection(1).isPresent());
     }
     
     @Test
     void assertFindColumnProjection() {
-        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, true, Collections.singleton(mock(ColumnProjection.class)));
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, true, Collections.singleton(getColumnProjection()));
         assertTrue(projectionsContext.findColumnProjection(1).isPresent());
     }
 }

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/SelectStatementContextTest.java
@@ -257,12 +257,11 @@ class SelectStatementContextTest {
         subqueryProjections.getProjections().add(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("order_id"))));
         subSelectStatement.setProjections(subqueryProjections);
         SubqueryExpressionSegment subqueryExpressionSegment = new SubqueryExpressionSegment(new SubquerySegment(0, 0, subSelectStatement, ""));
-        SubqueryProjectionSegment projectionSegment = mock(SubqueryProjectionSegment.class);
         WhereSegment whereSegment = new WhereSegment(0, 0, subqueryExpressionSegment);
         SelectStatement selectStatement = new SelectStatement(databaseType);
         selectStatement.setWhere(whereSegment);
         SubquerySegment subquerySegment = new SubquerySegment(0, 0, subSelectStatement, "");
-        when(projectionSegment.getSubquery()).thenReturn(subquerySegment);
+        SubqueryProjectionSegment projectionSegment = new SubqueryProjectionSegment(subquerySegment, "");
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
         projectionsSegment.getProjections().add(projectionSegment);
         selectStatement.setProjections(projectionsSegment);

--- a/infra/merge/src/main/java/org/apache/shardingsphere/infra/merge/MergeEngine.java
+++ b/infra/merge/src/main/java/org/apache/shardingsphere/infra/merge/MergeEngine.java
@@ -98,7 +98,7 @@ public final class MergeEngine {
         return Optional.empty();
     }
     
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings("rawtypes")
     private MergedResult decorate(final MergedResult mergedResult, final QueryContext queryContext) throws SQLException {
         MergedResult result = null;
         for (ResultProcessEngine each : engines) {

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetUtils.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetUtils.java
@@ -20,14 +20,11 @@ package org.apache.shardingsphere.driver.jdbc.core.resultset;
 import com.cedarsoftware.util.CaseInsensitiveMap;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.infra.binder.context.segment.select.projection.DerivedColumn;
-import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
 
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -46,21 +43,11 @@ public final class ShardingSphereResultSetUtils {
      */
     public static Map<String, Integer> createColumnLabelAndIndexMap(final SQLStatementContext sqlStatementContext, final ResultSetMetaData resultSetMetaData) throws SQLException {
         if (sqlStatementContext instanceof SelectStatementContext && ((SelectStatementContext) sqlStatementContext).containsDerivedProjections()) {
-            return createColumnLabelAndIndexMapWithExpandProjections((SelectStatementContext) sqlStatementContext);
+            return ((SelectStatementContext) sqlStatementContext).getProjectionsContext().getColumnLabelAndIndexMap();
         }
         Map<String, Integer> result = new CaseInsensitiveMap<>(resultSetMetaData.getColumnCount(), 1F);
         for (int columnIndex = resultSetMetaData.getColumnCount(); columnIndex > 0; columnIndex--) {
             result.put(resultSetMetaData.getColumnLabel(columnIndex), columnIndex);
-        }
-        return result;
-    }
-    
-    private static Map<String, Integer> createColumnLabelAndIndexMapWithExpandProjections(final SelectStatementContext statementContext) {
-        List<Projection> actualProjections = statementContext.getProjectionsContext().getExpandProjections();
-        Map<String, Integer> result = new CaseInsensitiveMap<>(actualProjections.size(), 1F);
-        for (int columnIndex = actualProjections.size(); columnIndex > 0; columnIndex--) {
-            Projection projection = actualProjections.get(columnIndex - 1);
-            result.put(DerivedColumn.isDerivedColumnName(projection.getColumnLabel()) ? projection.getExpression() : projection.getColumnLabel(), columnIndex);
         }
         return result;
     }

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetUtilsTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetUtilsTest.java
@@ -57,7 +57,8 @@ class ShardingSphereResultSetUtilsTest {
         List<Projection> projections = new ArrayList<>(2);
         projections.add(new ColumnProjection(null, "col1", null, mock(DatabaseType.class)));
         projections.add(new ColumnProjection(null, "col2", null, mock(DatabaseType.class)));
-        when(selectStatementContext.getProjectionsContext()).thenReturn(new ProjectionsContext(0, 0, false, projections));
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, projections);
+        when(selectStatementContext.getProjectionsContext()).thenReturn(projectionsContext);
         Map<String, Integer> expected = new HashMap<>(2, 1F);
         expected.put("col1", 1);
         expected.put("col2", 2);

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/response/header/query/QueryHeaderBuilderEngineTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/response/header/query/QueryHeaderBuilderEngineTest.java
@@ -78,7 +78,10 @@ class QueryHeaderBuilderEngineTest {
     
     @Test
     void assertBuildWithProjectionsColumnIndexOutOfRange() {
-        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(mock(Projection.class)));
+        Projection projection = mock(Projection.class);
+        when(projection.getColumnLabel()).thenReturn("label");
+        when(projection.getColumnName()).thenReturn("column");
+        ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, false, Collections.singleton(projection));
         assertThrows(ColumnIndexOutOfRangeException.class, () -> new QueryHeaderBuilderEngine(databaseType).build(projectionsContext, mock(), mock(), 2));
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Move createColumnLabelAndIndexMap to ProjectionsContext

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
