### PR TITLE
finished adding type aware parser for time and timstamp

### DIFF
--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacketTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacketTest.java
@@ -32,7 +32,14 @@ import org.mockito.quality.Strictness;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -91,6 +98,74 @@ class PostgreSQLDataRowPacketTest {
         byte[] valueBytes = "value".getBytes(StandardCharsets.UTF_8);
         verify(payload).writeInt4(valueBytes.length);
         verify(payload).writeBytes(valueBytes);
+    }
+    
+    @Test
+    void assertWriteWithLocalTime() {
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(new LinkedList<>(Arrays.asList(
+                LocalTime.of(10, 0, 0, 123_456_000),
+                LocalTime.of(10, 0, 0, 000_000_001),
+                LocalTime.of(10, 0, 0, 123_450_000))));
+        actual.write(payload);
+        byte[] res1 = "10:00:00.123456".getBytes(StandardCharsets.UTF_8);
+        byte[] res2 = "10:00:00".getBytes(StandardCharsets.UTF_8);
+        byte[] res3 = "10:00:00.12345".getBytes(StandardCharsets.UTF_8);
+        verify(payload).writeInt4(res1.length);
+        verify(payload).writeBytes(res1);
+        verify(payload).writeInt4(res2.length);
+        verify(payload).writeBytes(res2);
+        verify(payload).writeInt4(res3.length);
+        verify(payload).writeBytes(res3);
+    }
+    
+    @Test
+    void assertWriteWithLocalDateTime() {
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(new LinkedList<>(Arrays.asList(
+                LocalDateTime.of(2022, 10, 12, 10, 0, 0, 123_456_000),
+                LocalDateTime.of(2022, 10, 12, 10, 0, 0, 000_000_000),
+                LocalDateTime.of(2022, 10, 12, 10, 0, 0, 123_450_000))));
+        actual.write(payload);
+        byte[] res1 = "2022-10-12 10:00:00.123456".getBytes(StandardCharsets.UTF_8);
+        byte[] res2 = "2022-10-12 10:00:00".getBytes(StandardCharsets.UTF_8);
+        byte[] res3 = "2022-10-12 10:00:00.12345".getBytes(StandardCharsets.UTF_8);
+        verify(payload).writeInt4(res1.length);
+        verify(payload).writeBytes(res1);
+        verify(payload).writeInt4(res2.length);
+        verify(payload).writeBytes(res2);
+        verify(payload).writeInt4(res3.length);
+        verify(payload).writeBytes(res3);
+    }
+    
+    @Test
+    void assertWriteWithOffsetDateTime() {
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(new LinkedList<>(Arrays.asList(
+                OffsetDateTime.of(2022, 10, 12, 10, 0, 0, 123_456_000, ZoneOffset.ofHoursMinutes(5, 30)),
+                OffsetDateTime.of(2022, 10, 12, 10, 0, 0, 000_000_000, ZoneOffset.ofHoursMinutes(5, 30)),
+                OffsetDateTime.of(2022, 10, 12, 10, 0, 0, 123_450_000, ZoneOffset.ofHoursMinutes(5, 30)))));
+        actual.write(payload);
+        byte[] res1 = "2022-10-12 04:30:00.123456+00".getBytes(StandardCharsets.UTF_8);
+        byte[] res2 = "2022-10-12 04:30:00+00".getBytes(StandardCharsets.UTF_8);
+        byte[] res3 = "2022-10-12 04:30:00.12345+00".getBytes(StandardCharsets.UTF_8);
+        verify(payload).writeInt4(res1.length);
+        verify(payload).writeBytes(res1);
+        verify(payload).writeInt4(res2.length);
+        verify(payload).writeBytes(res2);
+        verify(payload).writeInt4(res3.length);
+        verify(payload).writeBytes(res3);
+    }
+    
+    @Test
+    void assertWriteWithOffsetTime() {
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(new LinkedList<>(Arrays.asList(
+                OffsetTime.of(10, 0, 0, 123_450_000, ZoneOffset.ofHoursMinutes(5, 30)),
+                OffsetTime.of(10, 0, 0, 000_000_000, ZoneOffset.ofHoursMinutes(5, 30)))));
+        actual.write(payload);
+        byte[] res1 = "10:00:00.123450+05:30".getBytes(StandardCharsets.UTF_8);
+        byte[] res2 = "10:00:00+05:30".getBytes(StandardCharsets.UTF_8);
+        verify(payload).writeInt4(res1.length);
+        verify(payload).writeBytes(res1);
+        verify(payload).writeInt4(res2.length);
+        verify(payload).writeBytes(res2);
     }
     
     @Test


### PR DESCRIPTION
 Fixes #37437 
 

 Before committing this PR, I'm sure that I have checked the following options:

 * [x]  My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
 * [x]  I have self-reviewed the commit code.
 * [ ]  I have (or in comment I request) added corresponding labels for the pull request.
 * [x]  I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
 * [ ]  I have made corresponding changes to the documentation.
 * [x]  I have added corresponding unit tests for my changes.
 * [ ]  I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)

 ## Changes proposed in this pull request:
In the PostgreSQL text protocol write path (PostgreSQLDataRowPacket#writeTextValue), used type-aware formatting for timestamp/timestamptz/date/time instead of generic toString().
## PostgreSQL 17 Temporal Data Behavior

| Data Type | Input | Output |
|-----------|-------|--------|
| `TIME` | `'10:00:00'` | `10:00:00` |
| `TIME` | `'10:00:00.0'` | `10:00:00` |
| `TIME` | `'10:00:00.1'` | `10:00:00.1` |
| `TIMETZ` | `'10:00:00+05:30'` | `10:00:00+05:30` |
| `TIMETZ` | `'10:00:00.1+05:30'` | `10:00:00.100000+05:30` |
| `TIMETZ` | `'10:00:00.0'` | `10:00:00` |
| `TIMESTAMP` | `'2026-02-04 10:00:00'` | `2026-02-04 10:00:00` |
| `TIMESTAMP` | `'2026-02-04 10:00:00.0'` | `2026-02-04 10:00:00` |
| `TIMESTAMP` | `'2026-02-04 10:00:00.1'` | `2026-02-04 10:00:00.1` |
| `TIMESTAMPTZ` | `'2026-02-04 10:00:00.0+05:30'` | `2026-02-04 04:30:00+00` |
| `TIMESTAMPTZ` | `'2026-02-04 10:00:00.1+05:30'` | `2026-02-04 04:30:00.1+00` |


**Key Points:**
- `.0` fractional seconds are truncated
- `TIMETZ` pads fractional seconds to 6 digits
- `TIMESTAMPTZ` converts to UTC when timezone is specified