### PR TITLE
finished adding type aware parser for time and timstamp

### DIFF
--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacket.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacket.java
@@ -30,7 +30,21 @@ import org.apache.shardingsphere.database.protocol.postgresql.payload.PostgreSQL
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.regex.Pattern;
 
 /**
  * Data row packet for PostgreSQL.
@@ -39,18 +53,40 @@ import java.util.Collection;
 @Getter
 public final class PostgreSQLDataRowPacket extends PostgreSQLIdentifierPacket {
     
+    private static final Pattern OFFSET_PATTERN = Pattern.compile("^[+-](?:0[0-9]|1[0-4]):[0-5][0-9](?::[0-5][0-9])?$");
+    
     private static final byte[] HEX_DIGITS = "0123456789abcdef".getBytes(StandardCharsets.US_ASCII);
     
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH:mm:ss")
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+            .toFormatter();
+    
+    private static final DateTimeFormatter TIME_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("HH:mm:ss")
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+            .toFormatter();
+    
     private final Collection<Object> data;
+    
+    private final Collection<Integer> columnTypes;
     
     @Override
     protected void write(final PostgreSQLPacketPayload payload) {
         payload.writeInt2(data.size());
+        Iterator<Integer> columnTypeIterator;
+        
+        if (columnTypes != null) {
+            columnTypeIterator = columnTypes.iterator();
+        } else {
+            columnTypeIterator = Collections.nCopies(data.size(), Types.VARCHAR).iterator();
+        }
         for (Object each : data) {
+            int columnType = columnTypeIterator.hasNext() ? columnTypeIterator.next() : Types.VARCHAR;
             if (each instanceof BinaryCell) {
                 writeBinaryValue(payload, (BinaryCell) each);
             } else {
-                writeTextValue(payload, each);
+                writeTextValue(payload, each, columnType);
             }
         }
     }
@@ -66,7 +102,7 @@ public final class PostgreSQLDataRowPacket extends PostgreSQLIdentifierPacket {
         binaryProtocolValue.write(payload, value);
     }
     
-    private void writeTextValue(final PostgreSQLPacketPayload payload, final Object each) {
+    private void writeTextValue(final PostgreSQLPacketPayload payload, final Object each, final int columnType) {
         if (null == each) {
             payload.writeInt4(0xFFFFFFFF);
         } else if (each instanceof byte[]) {
@@ -79,11 +115,72 @@ public final class PostgreSQLDataRowPacket extends PostgreSQLIdentifierPacket {
             byte[] columnData = ((Boolean) each ? "t" : "f").getBytes(payload.getCharset());
             payload.writeInt4(columnData.length);
             payload.writeBytes(columnData);
+        } else if (Types.TIME_WITH_TIMEZONE == columnType) {
+            String formatted = "";
+            if (each instanceof LocalTime) {
+                formatted = TIME_FORMATTER.format((LocalTime) each);
+            } else if (each instanceof OffsetTime) {
+                formatted = TIME_FORMATTER.format(((OffsetTime) each).withOffsetSameInstant(ZoneOffset.UTC).toLocalTime());
+            } else {
+                formatted = formatToPostgresTimestamp(each.toString());
+            }
+            byte[] columnData = formatted.getBytes(payload.getCharset());
+            payload.writeInt4(columnData.length);
+            payload.writeBytes(columnData);
+        } else if (Types.TIMESTAMP_WITH_TIMEZONE == columnType) {
+            String formatted = "";
+            if (each instanceof LocalDateTime) {
+                formatted = DATE_TIME_FORMATTER.format((LocalDateTime) each);
+            } else if (each instanceof OffsetDateTime) {
+                formatted = DATE_TIME_FORMATTER.format(((OffsetDateTime) each).withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime());
+            } else if (each instanceof Timestamp) {
+                formatted = DATE_TIME_FORMATTER.format(((Timestamp) each).toLocalDateTime());
+            } else {
+                formatted = formatToPostgresTimestamp(each.toString());
+            }
+            
+            byte[] columnData = formatted.getBytes(payload.getCharset());
+            payload.writeInt4(columnData.length);
+            payload.writeBytes(columnData);
+        } else if (Types.TIME == columnType) {
+            String formatted = "";
+            if (each instanceof LocalTime) {
+                formatted = TIME_FORMATTER.format((LocalTime) each);
+            } else if (each instanceof Time) {
+                formatted = TIME_FORMATTER.format(((Time) each).toLocalTime());
+                
+            } else {
+                formatted = formatToPostgresTimestamp(each.toString());
+            }
+            byte[] columnData = formatted.getBytes(payload.getCharset());
+            payload.writeInt4(columnData.length);
+            payload.writeBytes(columnData);
+        } else if (Types.TIMESTAMP == columnType) {
+            String formatted = "";
+            if (each instanceof LocalDateTime) {
+                formatted = DATE_TIME_FORMATTER.format((LocalDateTime) each);
+            } else if (each instanceof Timestamp) {
+                formatted = DATE_TIME_FORMATTER.format(((Timestamp) each).toLocalDateTime());
+            } else {
+                formatted = formatToPostgresTimestamp(each.toString());
+            }
+            byte[] columnData = formatted.getBytes(payload.getCharset());
+            payload.writeInt4(columnData.length);
+            payload.writeBytes(columnData);
         } else {
             byte[] columnData = each.toString().getBytes(payload.getCharset());
             payload.writeInt4(columnData.length);
             payload.writeBytes(columnData);
         }
+    }
+    
+    private String formatToPostgresTimestamp(final String s) {
+        String cleaned = s.replaceAll("([+\\-]\\d{2}:?\\d{2}|Z)$", "").trim();
+        if (cleaned.contains(".")) {
+            return cleaned.replaceAll("(\\.\\d+?)0+(?=[Z+\\-\\s]|$)", "$1")
+                    .replaceAll("\\.0*(?=[Z+\\-\\s]|$)", "");
+        }
+        return s;
     }
     
     private byte[] encodeByteaText(final byte[] value) {

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacketTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacketTest.java
@@ -27,13 +27,27 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,6 +57,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class PostgreSQLDataRowPacketTest {
     
     @Mock
@@ -55,7 +70,8 @@ class PostgreSQLDataRowPacketTest {
     @MethodSource("textValueCases")
     void assertWriteWithTextValue(final String name, final Object value, final byte[] expectedBytes) {
         when(payload.getCharset()).thenReturn(StandardCharsets.UTF_8);
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(value));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(value),
+                Collections.singleton(Types.INTEGER));
         actual.write((PacketPayload) payload);
         verify(payload).writeInt2(1);
         verify(payload).writeInt4(expectedBytes.length);
@@ -64,7 +80,8 @@ class PostgreSQLDataRowPacketTest {
     
     @Test
     void assertWriteWithNullValue() {
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(null));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(null),
+                Collections.singleton(Types.INTEGER));
         actual.write((PacketPayload) payload);
         verify(payload).writeInt2(1);
         verify(payload).writeInt4(0xFFFFFFFF);
@@ -73,7 +90,8 @@ class PostgreSQLDataRowPacketTest {
     @Test
     void assertWriteWithByteArrayValue() {
         byte[] value = new byte[]{'a'};
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singletonList(value));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singletonList(value),
+                Collections.singleton(Types.VARCHAR));
         actual.write((PacketPayload) payload);
         byte[] expectedBytes = buildExpectedByteaText(value);
         verify(payload).writeInt2(1);
@@ -95,27 +113,219 @@ class PostgreSQLDataRowPacketTest {
     }
     
     @Test
-    void assertWriteWithSQLXMLValue() throws SQLException {
-        when(payload.getCharset()).thenReturn(StandardCharsets.UTF_8);
+    void assertWriteWithSQLXML() throws SQLException {
         when(sqlxml.getString()).thenReturn("value");
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(sqlxml));
-        actual.write((PacketPayload) payload);
+        when(payload.getCharset()).thenReturn(StandardCharsets.UTF_8);
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(sqlxml), Collections.singleton(Types.SQLXML));
+        actual.write(payload);
         byte[] valueBytes = "value".getBytes(StandardCharsets.UTF_8);
-        verify(payload).writeInt2(1);
         verify(payload).writeInt4(valueBytes.length);
         verify(payload).writeBytes(valueBytes);
     }
     
     @Test
+    void assertWriteWithLocalDateTime() {
+        when(payload.getCharset()).thenReturn(StandardCharsets.UTF_8);
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(new LinkedList<>(Arrays.asList(
+                Timestamp.valueOf(LocalDateTime.of(2022, 10, 12, 10, 0, 0)),
+                Timestamp.valueOf(LocalDateTime.of(2022, 10, 12, 10, 0, 0, 0)),
+                Timestamp.valueOf(LocalDateTime.of(2022, 10, 12, 10, 0, 0, 100_000_001)),
+                Timestamp.valueOf(LocalDateTime.of(2022, 10, 12, 10, 0, 0, 123_456_000)),
+                LocalDateTime.of(2022, 10, 12, 10, 0, 0, 123_450_000),
+                "2022-10-12 10:10:10.0000",
+                "2022-10-12 10:10:10.1000")),
+                new LinkedList<>(Arrays.asList(
+                        Types.TIMESTAMP,
+                        Types.TIMESTAMP,
+                        Types.TIMESTAMP,
+                        Types.TIMESTAMP,
+                        Types.TIMESTAMP,
+                        Types.TIMESTAMP,
+                        Types.TIMESTAMP)));
+        actual.write(payload);
+        InOrder inOrder = Mockito.inOrder(payload);
+        byte[] res1 = "2022-10-12 10:00:00".getBytes(StandardCharsets.UTF_8);
+        byte[] res2 = "2022-10-12 10:00:00".getBytes(StandardCharsets.UTF_8);
+        byte[] res3 = "2022-10-12 10:00:00.1".getBytes(StandardCharsets.UTF_8);
+        byte[] res4 = "2022-10-12 10:00:00.123456".getBytes(StandardCharsets.UTF_8);
+        byte[] res5 = "2022-10-12 10:00:00.12345".getBytes(StandardCharsets.UTF_8);
+        byte[] res6 = "2022-10-12 10:10:10".getBytes(StandardCharsets.UTF_8);
+        byte[] res7 = "2022-10-12 10:10:10.1".getBytes(StandardCharsets.UTF_8);
+        inOrder.verify(payload).writeInt4(res1.length);
+        inOrder.verify(payload).writeBytes(res1);
+        inOrder.verify(payload).writeInt4(res2.length);
+        inOrder.verify(payload).writeBytes(res2);
+        inOrder.verify(payload).writeInt4(res3.length);
+        inOrder.verify(payload).writeBytes(res3);
+        inOrder.verify(payload).writeInt4(res4.length);
+        inOrder.verify(payload).writeBytes(res4);
+        inOrder.verify(payload).writeInt4(res5.length);
+        inOrder.verify(payload).writeBytes(res5);
+        inOrder.verify(payload).writeInt4(res6.length);
+        inOrder.verify(payload).writeBytes(res6);
+        inOrder.verify(payload).writeInt4(res7.length);
+        inOrder.verify(payload).writeBytes(res7);
+    }
+    
+    @Test
+    void assertWriteWithOffsetDateTime() {
+        when(payload.getCharset()).thenReturn(StandardCharsets.UTF_8);
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(new LinkedList<>(Arrays.asList(
+                OffsetDateTime.of(2022, 10, 12, 10, 0, 0, 0, ZoneOffset.ofHoursMinutesSeconds(5, 30, 1)),
+                OffsetDateTime.of(2022, 10, 12, 10, 0, 0, 100_000_000, ZoneOffset.ofHoursMinutes(5, 30)),
+                OffsetDateTime.of(2022, 10, 12, 10, 0, 0, 123_456_000, ZoneOffset.ofHoursMinutes(5, 30)),
+                OffsetDateTime.of(2022, 10, 12, 10, 0, 0, 123_450_000, ZoneOffset.ofHoursMinutes(2, 30)),
+                Timestamp.valueOf(LocalDateTime.of(2022, 10, 12, 10, 0, 0, 123_456_000)),
+                OffsetDateTime.of(2022, 10, 12, 10, 0, 0, 0, ZoneOffset.ofHoursMinutes(-2, -30)),
+                "2022-10-12 10:00:00.1200+00:00",
+                "2022-10-12 10:00:00.0+00:00",
+                LocalDateTime.of(2022, 10, 12, 10, 0, 0, 123_456_000))),
+                new LinkedList<>(Arrays.asList(
+                        Types.TIMESTAMP_WITH_TIMEZONE,
+                        Types.TIMESTAMP_WITH_TIMEZONE,
+                        Types.TIMESTAMP_WITH_TIMEZONE,
+                        Types.TIMESTAMP_WITH_TIMEZONE,
+                        Types.TIMESTAMP_WITH_TIMEZONE,
+                        Types.TIMESTAMP_WITH_TIMEZONE,
+                        Types.TIMESTAMP_WITH_TIMEZONE,
+                        Types.TIMESTAMP_WITH_TIMEZONE,
+                        Types.TIMESTAMP_WITH_TIMEZONE,
+                        Types.TIMESTAMP_WITH_TIMEZONE)));
+        actual.write(payload);
+        InOrder inOrder = Mockito.inOrder(payload);
+        byte[] res1 = "2022-10-12 04:29:59".getBytes(StandardCharsets.UTF_8);
+        byte[] res2 = "2022-10-12 04:30:00.1".getBytes(StandardCharsets.UTF_8);
+        byte[] res3 = "2022-10-12 04:30:00.123456".getBytes(StandardCharsets.UTF_8);
+        byte[] res4 = "2022-10-12 07:30:00.12345".getBytes(StandardCharsets.UTF_8);
+        byte[] res5 = "2022-10-12 10:00:00.123456".getBytes(StandardCharsets.UTF_8);
+        byte[] res6 = "2022-10-12 12:30:00".getBytes(StandardCharsets.UTF_8);
+        byte[] res7 = "2022-10-12 10:00:00.12".getBytes(StandardCharsets.UTF_8);
+        byte[] res8 = "2022-10-12 10:00:00".getBytes(StandardCharsets.UTF_8);
+        byte[] res9 = "2022-10-12 10:00:00.123456".getBytes(StandardCharsets.UTF_8);
+        
+        inOrder.verify(payload).writeInt4(res1.length);
+        inOrder.verify(payload).writeBytes(res1);
+        inOrder.verify(payload).writeInt4(res2.length);
+        inOrder.verify(payload).writeBytes(res2);
+        inOrder.verify(payload).writeInt4(res3.length);
+        inOrder.verify(payload).writeBytes(res3);
+        inOrder.verify(payload).writeInt4(res4.length);
+        inOrder.verify(payload).writeBytes(res4);
+        inOrder.verify(payload).writeInt4(res5.length);
+        inOrder.verify(payload).writeBytes(res5);
+        inOrder.verify(payload).writeInt4(res6.length);
+        inOrder.verify(payload).writeBytes(res6);
+        inOrder.verify(payload).writeInt4(res7.length);
+        inOrder.verify(payload).writeBytes(res7);
+        inOrder.verify(payload).writeInt4(res8.length);
+        inOrder.verify(payload).writeBytes(res8);
+        inOrder.verify(payload).writeInt4(res9.length);
+        inOrder.verify(payload).writeBytes(res9);
+        
+    }
+    
+    @Test
+    void assertWriteWithOffsetTime() {
+        when(payload.getCharset()).thenReturn(StandardCharsets.UTF_8);
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(new LinkedList<>(Arrays.asList(
+                OffsetTime.of(10, 0, 0, 0, ZoneOffset.ofHoursMinutes(5, 30)),
+                OffsetTime.of(10, 0, 0, 100_000_000, ZoneOffset.ofHoursMinutes(-2, -30)),
+                OffsetTime.of(10, 0, 0, 100_000_000, ZoneOffset.ofHoursMinutes(5, 30)),
+                OffsetTime.of(10, 0, 0, 123_456_000, ZoneOffset.ofHoursMinutes(5, 30)),
+                OffsetTime.of(10, 0, 0, 123_450_000, ZoneOffset.ofHoursMinutes(5, 30)),
+                "10:00:00.1200+00:00",
+                "10:00:00.0+00:00",
+                LocalTime.of(10, 0, 12, 123_000_000))),
+                new LinkedList<>(Arrays.asList(
+                        Types.TIME_WITH_TIMEZONE,
+                        Types.TIME_WITH_TIMEZONE,
+                        Types.TIME_WITH_TIMEZONE,
+                        Types.TIME_WITH_TIMEZONE,
+                        Types.TIME_WITH_TIMEZONE,
+                        Types.TIME_WITH_TIMEZONE,
+                        Types.TIME_WITH_TIMEZONE,
+                        Types.TIME_WITH_TIMEZONE)));
+        actual.write(payload);
+        InOrder inOrder = Mockito.inOrder(payload);
+        byte[] res1 = "04:30:00".getBytes(StandardCharsets.UTF_8);
+        byte[] res2 = "12:30:00.1".getBytes(StandardCharsets.UTF_8);
+        byte[] res3 = "04:30:00.1".getBytes(StandardCharsets.UTF_8);
+        byte[] res4 = "04:30:00.123456".getBytes(StandardCharsets.UTF_8);
+        byte[] res5 = "04:30:00.12345".getBytes(StandardCharsets.UTF_8);
+        byte[] res6 = "10:00:00.12".getBytes(StandardCharsets.UTF_8);
+        byte[] res7 = "10:00:00".getBytes(StandardCharsets.UTF_8);
+        inOrder.verify(payload).writeInt4(res1.length);
+        inOrder.verify(payload).writeBytes(res1);
+        inOrder.verify(payload).writeInt4(res2.length);
+        inOrder.verify(payload).writeBytes(res2);
+        inOrder.verify(payload).writeInt4(res3.length);
+        inOrder.verify(payload).writeBytes(res3);
+        inOrder.verify(payload).writeInt4(res4.length);
+        inOrder.verify(payload).writeBytes(res4);
+        inOrder.verify(payload).writeInt4(res5.length);
+        inOrder.verify(payload).writeBytes(res5);
+        inOrder.verify(payload).writeInt4(res6.length);
+        inOrder.verify(payload).writeBytes(res6);
+        inOrder.verify(payload).writeInt4(res7.length);
+        inOrder.verify(payload).writeBytes(res7);
+        
+    }
+    
+    @Test
+    void assertWriteWithLocalTime() {
+        when(payload.getCharset()).thenReturn(StandardCharsets.UTF_8);
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(new LinkedList<>(Arrays.asList(
+                Time.valueOf(LocalTime.of(10, 0, 0, 0)),
+                LocalTime.of(10, 0, 0, 100_000_000),
+                Time.valueOf(LocalTime.of(10, 0)),
+                LocalTime.of(10, 0, 0),
+                LocalTime.of(10, 0, 0, 123_450_000),
+                "10:00:00.1200",
+                "10:00:00.0")),
+                new LinkedList<>(Arrays.asList(
+                        Types.TIME,
+                        Types.TIME,
+                        Types.TIME,
+                        Types.TIME,
+                        Types.TIME,
+                        Types.TIME,
+                        Types.TIME)));
+        actual.write(payload);
+        InOrder inOrder = Mockito.inOrder(payload);
+        byte[] res1 = "10:00:00".getBytes(StandardCharsets.UTF_8);
+        byte[] res2 = "10:00:00.1".getBytes(StandardCharsets.UTF_8);
+        byte[] res3 = "10:00:00".getBytes(StandardCharsets.UTF_8);
+        byte[] res4 = "10:00:00".getBytes(StandardCharsets.UTF_8);
+        byte[] res5 = "10:00:00.12345".getBytes(StandardCharsets.UTF_8);
+        byte[] res6 = "10:00:00.12".getBytes(StandardCharsets.UTF_8);
+        byte[] res7 = "10:00:00".getBytes(StandardCharsets.UTF_8);
+        inOrder.verify(payload).writeInt4(res1.length);
+        inOrder.verify(payload).writeBytes(res1);
+        inOrder.verify(payload).writeInt4(res2.length);
+        inOrder.verify(payload).writeBytes(res2);
+        inOrder.verify(payload).writeInt4(res3.length);
+        inOrder.verify(payload).writeBytes(res3);
+        inOrder.verify(payload).writeInt4(res4.length);
+        inOrder.verify(payload).writeBytes(res4);
+        inOrder.verify(payload).writeInt4(res5.length);
+        inOrder.verify(payload).writeBytes(res5);
+        inOrder.verify(payload).writeInt4(res6.length);
+        inOrder.verify(payload).writeBytes(res6);
+        inOrder.verify(payload).writeInt4(res7.length);
+        inOrder.verify(payload).writeBytes(res7);
+    }
+    
+    @Test
     void assertWriteWithSQLXMLError() throws SQLException {
         when(sqlxml.getString()).thenThrow(new SQLException("mock"));
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singletonList(sqlxml));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singletonList(sqlxml), Collections.singleton(Types.SQLXML));
         assertThrows(IllegalStateException.class, () -> actual.write((PacketPayload) payload));
     }
     
     @Test
     void assertWriteWithBinaryNullValue() {
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.nCopies(1, new BinaryCell(PostgreSQLBinaryColumnType.INT4, null)));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.nCopies(1, new BinaryCell(PostgreSQLBinaryColumnType.INT4, null)),
+                Collections.singleton(PostgreSQLBinaryColumnType.INT4.getValue()));
         actual.write((PacketPayload) payload);
         verify(payload).writeInt2(1);
         verify(payload).writeInt4(0xFFFFFFFF);
@@ -124,7 +334,8 @@ class PostgreSQLDataRowPacketTest {
     @Test
     void assertWriteWithBinaryInt4Value() {
         int value = 12345678;
-        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(new BinaryCell(PostgreSQLBinaryColumnType.INT4, value)));
+        PostgreSQLDataRowPacket actual = new PostgreSQLDataRowPacket(Collections.singleton(new BinaryCell(PostgreSQLBinaryColumnType.INT4, value)),
+                Collections.singleton(PostgreSQLBinaryColumnType.INT4.getValue()));
         actual.write((PacketPayload) payload);
         verify(payload).writeInt2(1);
         verify(payload).writeInt4(4);
@@ -133,7 +344,7 @@ class PostgreSQLDataRowPacketTest {
     
     @Test
     void assertGetIdentifier() {
-        assertThat(new PostgreSQLDataRowPacket(Collections.emptyList()).getIdentifier(), is(PostgreSQLMessagePacketType.DATA_ROW));
+        assertThat(new PostgreSQLDataRowPacket(Collections.emptyList(), Collections.emptyList()).getIdentifier(), is(PostgreSQLMessagePacketType.DATA_ROW));
     }
     
     private static Stream<Arguments> textValueCases() {

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/extractor/ColumnExtractor.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/extractor/ColumnExtractor.java
@@ -46,6 +46,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.ite
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.item.OrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.HavingSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.CollectionTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.JoinTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SubqueryTableSegment;
@@ -193,6 +194,7 @@ public final class ColumnExtractor {
                 result.addAll(extract(each));
             }
         }
+        expression.getWindow().ifPresent(optional -> extractColumnsInWindowItemSegment(optional, result));
     }
     
     private static void extractColumnsInFunctionSegment(final FunctionSegment expression, final Collection<ColumnSegment> result) {
@@ -201,6 +203,32 @@ public final class ColumnExtractor {
                 result.add((ColumnSegment) each);
             } else {
                 result.addAll(extract(each));
+            }
+        }
+        expression.getWindow().ifPresent(optional -> extractColumnsInWindowItemSegment(optional, result));
+    }
+    
+    private static void extractColumnsInWindowItemSegment(final WindowItemSegment windowItemSegment, final Collection<ColumnSegment> result) {
+        if (null != windowItemSegment.getPartitionListSegments()) {
+            for (ExpressionSegment each : windowItemSegment.getPartitionListSegments()) {
+                result.addAll(extract(each));
+            }
+        }
+        if (null != windowItemSegment.getOrderBySegment()) {
+            extractColumnsInOrderBySegment(windowItemSegment.getOrderBySegment(), result);
+        }
+        if (null != windowItemSegment.getFrameClause()) {
+            result.addAll(extract(windowItemSegment.getFrameClause()));
+        }
+    }
+    
+    private static void extractColumnsInOrderBySegment(final OrderBySegment orderBySegment, final Collection<ColumnSegment> result) {
+        for (OrderByItemSegment each : orderBySegment.getOrderByItems()) {
+            if (each instanceof ColumnOrderByItemSegment) {
+                result.add(((ColumnOrderByItemSegment) each).getColumn());
+            }
+            if (each instanceof ExpressionOrderByItemSegment) {
+                result.addAll(extract(((ExpressionOrderByItemSegment) each).getExpr()));
             }
         }
     }

--- a/parser/sql/statement/core/src/test/java/org/apache/shardingsphere/sql/parser/statement/core/extractor/ColumnExtractorTest.java
+++ b/parser/sql/statement/core/src/test/java/org/apache/shardingsphere/sql/parser/statement/core/extractor/ColumnExtractorTest.java
@@ -49,6 +49,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.ite
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.HavingSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.AliasSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.CollectionTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.JoinTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SubqueryTableSegment;
@@ -143,8 +144,14 @@ class ColumnExtractorTest {
                         Arrays.asList("foo_between_function_column", "foo_between_binary_left", "bar_between_binary_right")),
                 Arguments.of("AggregationProjectionWithFunctionParameters", createAggregationProjectionExpression(),
                         Arrays.asList("foo_agg_direct", "foo_agg_func_direct", "foo_agg_func_binary_left", "bar_agg_func_binary_right")),
+                Arguments.of("AggregationProjectionWithWindow", createAggregationProjectionWithWindow(),
+                        Arrays.asList("foo_agg_window_param", "foo_agg_window_partition", "bar_agg_window_partition_func",
+                                "foo_agg_window_order_column", "foo_agg_window_order_expr_left", "bar_agg_window_order_expr_right", "foo_agg_window_frame_column")),
                 Arguments.of("FunctionSegmentWithNestedBinary", createFunctionWithColumnAndBinaryParameter(),
-                        Arrays.asList("foo_function_direct", "foo_function_binary_left", "bar_function_binary_right")));
+                        Arrays.asList("foo_function_direct", "foo_function_binary_left", "bar_function_binary_right")),
+                Arguments.of("FunctionSegmentWithWindow", createFunctionWithWindow(),
+                        Arrays.asList("foo_function_param", "foo_window_partition", "bar_window_partition_func",
+                                "foo_window_order_column", "foo_window_order_expr_left", "bar_window_order_expr_right", "foo_window_frame_column")));
     }
     
     private static Collection<WhereSegment> createWhereSegments() {
@@ -265,6 +272,13 @@ class ColumnExtractorTest {
         return result;
     }
     
+    private static AggregationProjectionSegment createAggregationProjectionWithWindow() {
+        AggregationProjectionSegment result = new AggregationProjectionSegment(0, 0, AggregationType.SUM, "SUM(expr) OVER window");
+        result.getParameters().add(createColumnSegment("foo_agg_window_param"));
+        result.setWindow(createWindowItemSegment("agg_window"));
+        return result;
+    }
+    
     private static FunctionSegment createFunctionWithSingleColumnParameter(final String columnName) {
         FunctionSegment result = new FunctionSegment(0, 0, "FUNC", "func");
         result.getParameters().add(createColumnSegment(columnName));
@@ -276,6 +290,29 @@ class ColumnExtractorTest {
         result.getParameters().add(createColumnSegment("foo_function_direct"));
         result.getParameters().add(createBinaryOperation("foo_function_binary_left", "bar_function_binary_right"));
         return result;
+    }
+    
+    private static FunctionSegment createFunctionWithWindow() {
+        FunctionSegment result = new FunctionSegment(0, 0, "RANK", "RANK() OVER window");
+        result.getParameters().add(createColumnSegment("foo_function_param"));
+        result.setWindow(createWindowItemSegment("window"));
+        return result;
+    }
+    
+    private static WindowItemSegment createWindowItemSegment(final String name) {
+        WindowItemSegment result = new WindowItemSegment(0, 0);
+        result.setPartitionListSegments(Arrays.asList(createColumnSegment("foo_" + name + "_partition"), createFunctionWithSingleColumnParameter("bar_" + name + "_partition_func")));
+        result.setOrderBySegment(createWindowOrderBySegment(name));
+        result.setFrameClause(createFunctionWithSingleColumnParameter("foo_" + name + "_frame_column"));
+        return result;
+    }
+    
+    private static OrderBySegment createWindowOrderBySegment(final String name) {
+        Collection<OrderByItemSegment> orderByItems = new LinkedList<>();
+        orderByItems.add(new ColumnOrderByItemSegment(createColumnSegment("foo_" + name + "_order_column"), OrderDirection.ASC, NullsOrderType.FIRST));
+        orderByItems.add(new ExpressionOrderByItemSegment(0, 0, "order_by_expr", OrderDirection.ASC, NullsOrderType.FIRST,
+                createBinaryOperation("foo_" + name + "_order_expr_left", "bar_" + name + "_order_expr_right")));
+        return new OrderBySegment(0, 0, orderByItems);
     }
     
     private static ColumnSegment createColumnSegment(final String columnName) {

--- a/proxy/frontend/dialect/opengauss/src/main/java/org/apache/shardingsphere/proxy/frontend/opengauss/command/query/simple/OpenGaussComQueryExecutor.java
+++ b/proxy/frontend/dialect/opengauss/src/main/java/org/apache/shardingsphere/proxy/frontend/opengauss/command/query/simple/OpenGaussComQueryExecutor.java
@@ -67,6 +67,9 @@ public final class OpenGaussComQueryExecutor implements QueryCommandExecutor {
     @Getter
     private volatile ResponseType responseType;
     
+    @Getter
+    private Collection<Integer> columnTypes;
+    
     public OpenGaussComQueryExecutor(final PortalContext portalContext, final PostgreSQLComQueryPacket packet, final ConnectionSession connectionSession) throws SQLException {
         this.portalContext = portalContext;
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "openGauss");
@@ -92,7 +95,9 @@ public final class OpenGaussComQueryExecutor implements QueryCommandExecutor {
     private Collection<PostgreSQLColumnDescription> createColumnDescriptions(final QueryResponseHeader queryResponseHeader) {
         Collection<PostgreSQLColumnDescription> result = new LinkedList<>();
         int columnIndex = 0;
+        columnTypes = new LinkedList<>();
         for (QueryHeader each : queryResponseHeader.getQueryHeaders()) {
+            columnTypes.add(each.getColumnType());
             result.add(new PostgreSQLColumnDescription(each.getColumnLabel(), ++columnIndex, each.getColumnType(), each.getColumnLength(), each.getColumnTypeName()));
         }
         return result;
@@ -126,7 +131,7 @@ public final class OpenGaussComQueryExecutor implements QueryCommandExecutor {
     
     @Override
     public PostgreSQLPacket getQueryRowPacket() throws SQLException {
-        return new PostgreSQLDataRowPacket(proxyBackendHandler.getRowData().getData());
+        return new PostgreSQLDataRowPacket(proxyBackendHandler.getRowData().getData(), columnTypes);
     }
     
     @Override

--- a/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/Portal.java
+++ b/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/Portal.java
@@ -70,6 +70,9 @@ public final class Portal {
     private final String name;
     
     @Getter
+    private Collection<Integer> columnTypes;
+    
+    @Getter
     private final SQLStatement sqlStatement;
     
     private final List<PostgreSQLValueFormat> resultFormats;
@@ -129,8 +132,10 @@ public final class Portal {
     private Collection<PostgreSQLColumnDescription> createColumnDescriptions(final QueryResponseHeader queryResponseHeader) {
         Collection<PostgreSQLColumnDescription> result = new LinkedList<>();
         int columnIndex = 0;
+        columnTypes = new LinkedList<>();
         for (QueryHeader each : queryResponseHeader.getQueryHeaders()) {
             PostgreSQLValueFormat valueFormat = determineValueFormat(columnIndex);
+            columnTypes.add(each.getColumnType());
             result.add(new PostgreSQLColumnDescription(each.getColumnLabel(), ++columnIndex, each.getColumnType(), each.getColumnLength(), each.getColumnTypeName(), valueFormat.getCode()));
         }
         return result;
@@ -148,6 +153,9 @@ public final class Portal {
         List<DatabasePacket> result = new LinkedList<>();
         for (int i = 0; i < fetchSize && hasNext(); i++) {
             result.add(nextPacket());
+        }
+        if (responseHeader instanceof QueryResponseHeader) {
+            createRowDescriptionPacket((QueryResponseHeader) responseHeader);
         }
         if (responseHeader instanceof UpdateResponseHeader && sqlStatement instanceof SetStatement) {
             result.addAll(createParameterStatusResponse((SetStatement) sqlStatement));
@@ -171,7 +179,7 @@ public final class Portal {
     }
     
     private PostgreSQLPacket nextPacket() throws SQLException {
-        return new PostgreSQLDataRowPacket(getData(proxyBackendHandler.getRowData()));
+        return new PostgreSQLDataRowPacket(getData(proxyBackendHandler.getRowData()), columnTypes);
     }
     
     private List<Object> getData(final QueryResponseRow queryResponseRow) {

--- a/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutor.java
+++ b/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutor.java
@@ -65,6 +65,9 @@ public final class PostgreSQLComQueryExecutor implements QueryCommandExecutor {
     private final ProxyBackendHandler proxyBackendHandler;
     
     @Getter
+    private Collection<Integer> columnTypes;
+    
+    @Getter
     private volatile ResponseType responseType;
     
     public PostgreSQLComQueryExecutor(final PortalContext portalContext, final PostgreSQLComQueryPacket packet, final ConnectionSession connectionSession) throws SQLException {
@@ -92,7 +95,9 @@ public final class PostgreSQLComQueryExecutor implements QueryCommandExecutor {
     private Collection<PostgreSQLColumnDescription> createColumnDescriptions(final QueryResponseHeader queryResponseHeader) {
         Collection<PostgreSQLColumnDescription> result = new LinkedList<>();
         int columnIndex = 0;
+        columnTypes = new LinkedList<>();
         for (QueryHeader each : queryResponseHeader.getQueryHeaders()) {
+            columnTypes.add(each.getColumnType());
             result.add(new PostgreSQLColumnDescription(each.getColumnLabel(), ++columnIndex, each.getColumnType(), each.getColumnLength(), each.getColumnTypeName()));
         }
         return result;
@@ -127,7 +132,7 @@ public final class PostgreSQLComQueryExecutor implements QueryCommandExecutor {
     
     @Override
     public PostgreSQLPacket getQueryRowPacket() throws SQLException {
-        return new PostgreSQLDataRowPacket(proxyBackendHandler.getRowData().getData());
+        return new PostgreSQLDataRowPacket(proxyBackendHandler.getRowData().getData(), columnTypes);
     }
     
     @Override


### PR DESCRIPTION
 Fixes #37437 
 

 Before committing this PR, I'm sure that I have checked the following options:

 * [x]  My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
 * [x]  I have self-reviewed the commit code.
 * [ ]  I have (or in comment I request) added corresponding labels for the pull request.
 * [x]  I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
 * [ ]  I have made corresponding changes to the documentation.
 * [x]  I have added corresponding unit tests for my changes.
 * [ ]  I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)

 ## Changes proposed in this pull request:
In the PostgreSQL text protocol write path (PostgreSQLDataRowPacket#writeTextValue), used type-aware formatting for timestamp/timestamptz/date/time instead of generic toString().
## PostgreSQL 17 Temporal Data Behavior

| Data Type | Input | Output |
|-----------|-------|--------|
| `TIME` | `'10:00:00'` | `10:00:00` |
| `TIME` | `'10:00:00.0'` | `10:00:00` |
| `TIME` | `'10:00:00.1'` | `10:00:00.1` |
| `TIMETZ` | `'10:00:00+05:30'` | `10:00:00+05:30` |
| `TIMETZ` | `'10:00:00.1+05:30'` | `10:00:00.100000+05:30` |
| `TIMETZ` | `'10:00:00.0'` | `10:00:00` |
| `TIMESTAMP` | `'2026-02-04 10:00:00'` | `2026-02-04 10:00:00` |
| `TIMESTAMP` | `'2026-02-04 10:00:00.0'` | `2026-02-04 10:00:00` |
| `TIMESTAMP` | `'2026-02-04 10:00:00.1'` | `2026-02-04 10:00:00.1` |
| `TIMESTAMPTZ` | `'2026-02-04 10:00:00.0+05:30'` | `2026-02-04 04:30:00+00` |
| `TIMESTAMPTZ` | `'2026-02-04 10:00:00.1+05:30'` | `2026-02-04 04:30:00.1+00` |


**Key Points:**
- `.0` fractional seconds are truncated
- `TIMETZ` pads fractional seconds to 6 digits
- `TIMESTAMPTZ` converts to UTC when timezone is specified