### PR TITLE
Fixes the build of fully statically linked GraalVM Native Images

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -145,13 +145,16 @@ jobs:
           restore-keys: |
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-cache-
             ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-maven-third-party-
-      - name: Push Docker Image by arm64 or x64
+      - name: Push dynamic linked Docker Image by x64 or arm64
         run: |
           ./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.push.native.linux" -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }} "-DskipTests" clean package
-      - name: Push Docker Image by x64
+      - name: Push mostly static linked Docker Image by x64
         if: matrix.os == 'ubuntu-latest'
         run: |
           ./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.push.native.linux" -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }}-mostly "-Dproxy.native.dockerfile=Dockerfile-linux-mostly" "-DskipTests" clean package
+      - name: Push fully static linked Docker Image by x64
+        if: matrix.os == 'ubuntu-latest'
+        run: |
           ./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.push.native.linux" -Dproxy.native.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.native.image.tag=${{ github.sha }}-static "-Dproxy.native.dockerfile=Dockerfile-linux-static" "-DskipTests" clean package
 
   build-agent-image:

--- a/distribution/proxy-native/Dockerfile-linux-static
+++ b/distribution/proxy-native/Dockerfile-linux-static
@@ -16,7 +16,7 @@
 #
 
 FROM ghcr.io/graalvm/native-image-community:24.0.2-muslib AS nativebuild
-ENV NATIVE_IMAGE_OPTIONS="--static,--libc=musl"
+ENV NATIVE_IMAGE_OPTIONS="--static --libc=musl"
 WORKDIR /build
 COPY ./ .
 RUN --mount=type=cache,target=/root/.m2 ./mvnw -am -pl distribution/proxy-native -T1C -DskipTests "-Prelease.native" clean package

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -298,7 +298,7 @@ services:
 
 ##### 静态编译所需的本地工具链
 
-开发者如需构建 `大部分静态链接的 GraalVM Native Image` 或 `完全静态链接的 GraalVM Native Image`，
+开发者如需构建 `完全静态链接的 GraalVM Native Image`，
 则需要按 https://www.graalvm.org/latest/reference-manual/native-image/guides/build-static-executables/ 要求，从源代码构建 musl。
 
 #### 构建动态链接的 GraalVM Native Image

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -301,7 +301,7 @@ However, it is not necessary to install Container Runtime.
 
 ##### Native toolchain for static compilation
 
-Developers who want to build a `mostly statically linked GraalVM Native Image` or a `fully statically linked GraalVM Native Image`,
+Developers who want to build a `fully statically linked GraalVM Native Image`,
 will need to build musl from source as described in https://www.graalvm.org/latest/reference-manual/native-image/guides/build-static-executables/ .
 
 #### Build a dynamically linked GraalVM Native Image


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/issues/37847 .

Changes proposed in this pull request:
  - Fixes the build of fully statically linked GraalVM Native Images.
  - The current PR can be verified locally using `./mvnw -am -pl distribution/proxy-native -T1C "-Pdocker.build.native.linux" "-Dproxy.native.dockerfile=Dockerfile-linux-static" "-Dproxy.native.image.tag=5.5.3-SNAPSHOT-static" "-DskipTests" clean package`. I checked https://github.com/hpi-swa/trufflesqueak/commit/187e2ed7b02653c230b285e7a722097163a4928e and confirmed that this is a breakthrough change from GraalVM CE for JDK 24.0.1 to GraalVM CE for JDK 24.0.2.
```
#8 94.84 ========================================================================================================================
#8 94.85 GraalVM Native Image: Generating 'shardingsphere-proxy-native' (static executable)...
#8 94.85 ========================================================================================================================
#8 94.85 For detailed information and explanations on the build output, visit:
#8 94.85 https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/BuildOutput.md
#8 94.85 ------------------------------------------------------------------------------------------------------------------------
#8 100.6 [1/8] Initializing...                                                                                   (11.1s @ 0.33GB)
#8 100.6  Java version: 24.0.2+11, vendor version: GraalVM CE 24.0.2+11.1
#8 100.6  Graal compiler: optimization level: 2, target machine: x86-64-v3
#8 100.6  C compiler: x86_64-linux-musl-gcc (linux, x86_64, 10.2.1)
#8 100.6  Garbage collector: Serial GC (max heap size: 80% of RAM)
#8 100.6  2 user-specific feature(s):
#8 100.6  - com.oracle.svm.polyglot.groovy.GroovyIndyInterfaceFeature
#8 100.6  - com.oracle.svm.thirdparty.gson.GsonFeature
#8 100.6 ------------------------------------------------------------------------------------------------------------------------
#8 100.6  1 experimental option(s) unlocked:
#8 100.6  - '-H:+IncludeAllLocales' (origin(s): command line)
#8 100.6 ------------------------------------------------------------------------------------------------------------------------
#8 100.6  Picked up NATIVE_IMAGE_OPTIONS:
#8 100.6  - '--static'
#8 100.6  - '--libc=musl'
#8 100.6 ------------------------------------------------------------------------------------------------------------------------
```
  - Update the documentation. Compiling mostly static linked GraalVM Native Images does not require downloading `musl-toolchain-1.2.5-oracle-00001-linux-amd64.tar.gz`.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
