### PR TITLE
Revert openGauss docker image from enmotech/opengauss-lite to opengauss/opengauss to compatible openGauss Nightly E2E SQL errors

### DIFF
--- a/.github/workflows/e2e-operation.yml
+++ b/.github/workflows/e2e-operation.yml
@@ -99,7 +99,7 @@ jobs:
           { type: "e2e.docker.database.mysql.images", version: "mysql:5.7" },
           { type: "e2e.docker.database.mariadb.images", version: "mariadb:11" },
           { type: "e2e.docker.database.postgresql.images", version: "postgres:12-alpine" },
-          { type: "e2e.docker.database.opengauss.images", version: "enmotech/opengauss:3.1.0" }
+          { type: "e2e.docker.database.opengauss.images", version: "opengauss/opengauss:3.1.0" }
         ]
         exclude:
           - operation: transaction
@@ -109,7 +109,7 @@ jobs:
           - operation: showprocesslist
             image: { type: "e2e.docker.database.postgresql.images", version: "postgres:12-alpine" }
           - operation: showprocesslist
-            image: { type: "e2e.docker.database.opengauss.images", version: "enmotech/opengauss:3.1.0" }
+            image: { type: "e2e.docker.database.opengauss.images", version: "opengauss/opengauss:3.1.0" }
     steps:
       - name: Checkout Project
         uses: actions/checkout@v6.0.1

--- a/.github/workflows/nightly-e2e-operation.yml
+++ b/.github/workflows/nightly-e2e-operation.yml
@@ -94,7 +94,7 @@ jobs:
           { type: "e2e.docker.database.postgresql.images", version: "postgres:12-alpine" },
           { type: "e2e.docker.database.postgresql.images", version: "postgres:13-alpine" },
           { type: "e2e.docker.database.postgresql.images", version: "postgres:14-alpine" },
-          { type: "e2e.docker.database.opengauss.images", version: "enmotech/opengauss:3.1.0" }
+          { type: "e2e.docker.database.opengauss.images", version: "opengauss/opengauss:3.1.0" }
         ]
         exclude:
           - operation: transaction
@@ -104,7 +104,7 @@ jobs:
           - operation: showprocesslist
             image: { type: "e2e.docker.database.postgresql.images", version: "postgres:10-alpine,postgres:11-alpine,postgres:12-alpine,postgres:13-alpine,postgres:14-alpine" }
           - operation: showprocesslist
-            image: { type: "e2e.docker.database.opengauss.images", version: "enmotech/opengauss:3.1.0" }
+            image: { type: "e2e.docker.database.opengauss.images", version: "opengauss/opengauss:3.1.0" }
     steps:
       - uses: actions/checkout@v6.0.1
       - name: Setup JDK ${{ matrix.java-version }}

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/storage/option/dialect/opengauss/OpenGaussStorageContainerCreateOption.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/storage/option/dialect/opengauss/OpenGaussStorageContainerCreateOption.java
@@ -39,7 +39,7 @@ public final class OpenGaussStorageContainerCreateOption implements StorageConta
     
     @Override
     public String getDefaultImageName() {
-        return "enmotech/opengauss:3.1.0";
+        return "opengauss/opengauss:3.1.0";
     }
     
     @Override

--- a/test/e2e/operation/pipeline/src/test/resources/env/e2e-env.properties
+++ b/test/e2e/operation/pipeline/src/test/resources/env/e2e-env.properties
@@ -21,7 +21,7 @@ e2e.run.type=
 e2e.docker.database.mysql.images=
 #e2e.docker.database.postgresql.images=postgres:10-alpine,postgres:11-alpine,postgres:12-alpine,postgres:13-alpine,postgres:14-alpine
 e2e.docker.database.postgresql.images=
-#e2e.docker.database.opengauss.images=enmotech/opengauss:3.1.0
+#e2e.docker.database.opengauss.images=opengauss/opengauss:3.1.0
 e2e.docker.database.opengauss.images=
 
 #e2e.native.database.port= MySQL is 3306, PostgreSQL is 5432, openGauss is 5432

--- a/test/e2e/operation/pipeline/src/test/resources/env/scenario/create-table-generator/opengauss/create-table-sql-generator.xml
+++ b/test/e2e/operation/pipeline/src/test/resources/env/scenario/create-table-generator/opengauss/create-table-sql-generator.xml
@@ -56,7 +56,7 @@
                 order_id integer NOT NULL,
                 user_id integer NOT NULL,
                 status character varying(45),
-                creation_date date
+                creation_date timestamp(0) without time zone
                 )
                 WITH (orientation=row, compression=no)
             </sql>

--- a/test/e2e/operation/transaction/src/test/resources/env/e2e-env.properties
+++ b/test/e2e/operation/transaction/src/test/resources/env/e2e-env.properties
@@ -34,7 +34,7 @@ e2e.transaction.xa.providers=Atomikos,Narayana
 e2e.docker.database.mysql.images=
 #e2e.docker.database.postgresql.images=postgres:10-alpine,postgres:11-alpine,postgres:12-alpine,postgres:13-alpine,postgres:14-alpine
 e2e.docker.database.postgresql.images=
-#e2e.docker.database.opengauss.images=enmotech/opengauss:3.1.0
+#e2e.docker.database.opengauss.images=opengauss/opengauss:3.1.0
 e2e.docker.database.opengauss.images=
 
 e2e.native.database.host=127.0.0.1


### PR DESCRIPTION
Related to #37826

Changes proposed in this pull request:
  - Revert openGauss docker image from enmotech/opengauss-lite to opengauss/opengauss

Since there's much openGauss Nightly E2E SQL errors, after discussing with @terrymanu and @strongduanmu , we need to use the same sql_compatibility of openGauss in all of the E2E, so revert it for now. And consider to support several modes for openGauss later.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
