### PR TITLE
Fixes the instability test of Doris FE

### DIFF
--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/DorisFETest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/DorisFETest.java
@@ -53,8 +53,7 @@ class DorisFETest {
     private final GenericContainer<?> container = new GenericContainer<>("dyrnq/doris:4.0.0")
             .withEnv("RUN_MODE", "standalone")
             .withEnv("SKIP_CHECK_ULIMIT", "true")
-            .withExposedPorts(9030)
-            .withStartupTimeout(Duration.ofMinutes(10L));
+            .withExposedPorts(9030);
     
     private DataSource logicDataSource;
     

--- a/test/native/src/test/resources/testcontainers.properties
+++ b/test/native/src/test/resources/testcontainers.properties
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+pull.timeout = 240


### PR DESCRIPTION
For #35052 .

Changes proposed in this pull request:
  - Fixes the instability test of Doris FE.
  - In Windows Server 2025 CI, `org.apache.shardingsphere.test.natived.jdbc.databases.DorisFETest` is not running stably because `dyrnq/doris:4.0.0` is a full 11.5 GB, which can easily take more than 2 minutes to download. `withStartupTimeout` is useless in this scenario; the pull timeout for testcontainers can only be configured through `testcontainers.properties`. See https://java.testcontainers.org/features/configuration/ .
  - <img width="2150" height="488" alt="image" src="https://github.com/user-attachments/assets/49ee0fda-3696-4945-bdb2-30449398bdb0" />

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
