### PR TITLE
Support SQLServer session SET QUOTED_IDENTIFIER and TEXTSIZE

### DIFF
--- a/parser/sql/engine/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DALStatement.g4
+++ b/parser/sql/engine/dialect/sqlserver/src/main/antlr4/imports/sqlserver/DALStatement.g4
@@ -23,6 +23,15 @@ explain
     : EXPLAIN WITH_RECOMMENDATIONS? explainableStatement
     ;
 
+set
+    : SET setParameter
+    ;
+
+setParameter
+    : QUOTED_IDENTIFIER (ON | OFF)
+    | TEXTSIZE numberLiterals
+    ;
+
 explainableStatement
     : select | insert | update | delete | createTableAsSelectClause
     ;

--- a/parser/sql/engine/dialect/sqlserver/src/main/antlr4/imports/sqlserver/SQLServerKeyword.g4
+++ b/parser/sql/engine/dialect/sqlserver/src/main/antlr4/imports/sqlserver/SQLServerKeyword.g4
@@ -1415,6 +1415,10 @@ QUOTED_IDENTIFIER
     : Q U O T E D UL_ I D E N T I F I E R
     ;
 
+TEXTSIZE
+    : T E X T S I Z E
+    ;
+
 NUMERIC_ROUNDABORT
     : N U M E R I C UL_ R O U N D A B O R T
     ;

--- a/parser/sql/engine/dialect/sqlserver/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/SQLServerStatement.g4
+++ b/parser/sql/engine/dialect/sqlserver/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/SQLServerStatement.g4
@@ -76,6 +76,7 @@ execute
     | alterLogin
     | call
     | explain
+    | set
     | setUser
     | revert
     | updateStatistics

--- a/test/it/parser/src/main/resources/case/dal/set.xml
+++ b/test/it/parser/src/main/resources/case/dal/set.xml
@@ -123,6 +123,16 @@
             <parameter name="CLIENT_ENCODING" />
         </parameter-assign>
     </set-parameter>
+    <set-parameter sql-case-id="set_quoted_identifier_sqlserver">
+        <parameter-assign value="ON">
+            <parameter name="QUOTED_IDENTIFIER" />
+        </parameter-assign>
+    </set-parameter>
+    <set-parameter sql-case-id="set_textsize_sqlserver">
+        <parameter-assign value="2048">
+            <parameter name="TEXTSIZE" />
+        </parameter-assign>
+    </set-parameter>
     <set-parameter sql-case-id="set_session_authorization" />
     <set-parameter sql-case-id="set_persist_system_variable_doris">
         <parameter-assign value="200">

--- a/test/it/parser/src/main/resources/sql/supported/dal/set.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/set.xml
@@ -45,6 +45,8 @@
     <sql-case id="set_charset_mysql" value="SET NAMES 'utf8'" db-types="MySQL" />
     <sql-case id="set_charset_postgresql" value="SET NAMES 'UTF8'" db-types="PostgreSQL" />
     <sql-case id="set_client_encoding" value="SET CLIENT_ENCODING TO 'UTF8'" db-types="PostgreSQL" />
+    <sql-case id="set_quoted_identifier_sqlserver" value="SET QUOTED_IDENTIFIER ON" db-types="SQLServer" />
+    <sql-case id="set_textsize_sqlserver" value="SET TEXTSIZE 2048" db-types="SQLServer" />
     <sql-case id="set_session_authorization" value="SET SESSION AUTHORIZATION user1 PASSWORD 'password'" db-types="openGauss" />
     <sql-case id="set_persist_system_variable_doris" value="SET PERSIST max_connections = 200" db-types="Doris" />
     <sql-case id="set_persist_only_system_variable_doris" value="SET PERSIST_ONLY time_zone = '+08:00'" db-types="Doris" />


### PR DESCRIPTION
## Summary
Support SQLServer session-level `SET` statements for:
- `SET QUOTED_IDENTIFIER ON|OFF`
- `SET TEXTSIZE <number>`

## Issue
Fixes #37973.

## Changes
- Add SQLServer DAL grammar rules for session-level `SET` statements.
- Add `TEXTSIZE` keyword in SQLServer lexer keywords.
- Wire `set` entry into SQLServer statement execute alternatives.
- Extend SQLServer DAL visitor to build `SetStatement` with `VariableAssignSegment`.
- Add parser IT SQL/case resources for the two SQLServer `SET` statements.

## Tests
- `./mvnw -pl test/it/parser -am -DskipITs -Dspotless.skip=true -Dtest=InternalSQLServerParserIT -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl parser/sql/engine/dialect/sqlserver,test/it/parser -am -Pcheck checkstyle:check`
- `./mvnw -pl parser/sql/engine/dialect/sqlserver,test/it/parser -am spotless:apply -Pcheck`
