### PR TITLE
Bump spring-boot-starter-jdbc to 3.2.x in example to support slf4j-api 2.0.x

### DIFF
--- a/examples/shardingsphere-jdbc-example-generator/src/main/resources/template/pom.ftl
+++ b/examples/shardingsphere-jdbc-example-generator/src/main/resources/template/pom.ftl
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
-            <version>2.2.0.RELEASE</version>
+            <version>3.2.12</version>
             <exclusions>
                 <exclusion>
                     <artifactId>snakeyaml</artifactId>
@@ -265,12 +265,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot</artifactId>
-            <version>2.2.0.RELEASE</version>
+            <version>3.2.12</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>2.2.0.RELEASE</version>
+            <version>3.2.12</version>
         </dependency>
     </#if>
         


### PR DESCRIPTION
Related to #37936

Fix example action failed: https://github.com/apache/shardingsphere/actions/runs/21873340065/job/63137141212

<img width="1528" height="652" alt="PixPin_2026-02-11_18-30-38" src="https://github.com/user-attachments/assets/f8687a27-d76e-4bbc-b67b-0b1ebe4fc437" />
