### PR TITLE
Disable JMX for zookeeper service in example e2e

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -258,6 +258,8 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       zookeeper:
         image: zookeeper:3.6.3
+        env:
+          JMXDISABLE: "true"
         ports:
           - 2181:2181
         options: --health-cmd="echo ruok | nc localhost 2181" --health-interval=10s --health-timeout=5s --health-retries=3


### PR DESCRIPTION
Try to fix example e2e failed: https://github.com/apache/shardingsphere/actions/runs/22038832245/job/63676343591

<img width="1221" height="614" alt="PixPin_2026-02-16_00-56-00" src="https://github.com/user-attachments/assets/b975da1e-9e1d-4d84-a555-8b66586ff0b2" />


Ref `JMXDISABLE`: https://github.com/apache/zookeeper/blob/release-3.6.3/bin/zkServer.sh