### PR TITLE
Update zookeeper image version in example e2e

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -257,7 +257,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       zookeeper:
-        image: zookeeper:3.6.3
+        image: zookeeper:3.8.5-jre-17
         env:
           JMXDISABLE: "true"
         ports:


### PR DESCRIPTION
Related: #38053

Try to fix example e2e failed: https://github.com/apache/shardingsphere/actions/runs/22049138734/job/63703695229

<img width="1181" height="582" alt="PixPin_2026-02-16_11-44-33" src="https://github.com/user-attachments/assets/5d94b6c1-9b38-4bc7-9c3c-133992e4b7e6" />
