### PR TITLE
Re-enable `jazzdelightsme.WingetPathUpdater` in Windows Server 2025 CI

### DIFF
--- a/test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
+++ b/test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
@@ -20,7 +20,7 @@
 # This file is only used in the PowerShell 7 of ShardingSphere in GitHub Actions environment and should not be executed manually in a development environment.
 # Background information can be found at https://github.com/apache/shardingsphere/pull/35905 .
 iex "& { $(irm https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1) } -Force"
-irm https://raw.githubusercontent.com/jazzdelightsme/WingetPathUpdater/v1.2/WingetPathUpdaterInstall.ps1 | iex
+winget install --id jazzdelightsme.WingetPathUpdater --source winget
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
 ./test/native/src/test/resources/test-native/ps1/wait-for-rancher-desktop-backend.ps1


### PR DESCRIPTION
For #35052 .

Changes proposed in this pull request:
  - Re-enable `jazzdelightsme.WingetPathUpdater` in Windows Server 2025 CI.
  - The use of `jazzdelightsme.WingetPathUpdater` was briefly removed in #37724 . However, `jazzdelightsme.WingetPathUpdater` has recently been reinstated in `microsoft/winget-pkgs`, see https://github.com/jazzdelightsme/WingetPathUpdater/issues/9 and https://github.com/microsoft/winget-pkgs/pull/340129 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
