### PR TITLE
Fix stale generated values in prepared statement executeBatch

### DIFF
--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatement.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatement.java
@@ -101,6 +101,8 @@ public final class ShardingSpherePreparedStatement extends AbstractPreparedState
     
     private final Collection<Comparable<?>> generatedValues = new LinkedList<>();
     
+    private boolean hasBatchGeneratedValues;
+    
     private final boolean statementsCacheable;
     
     private Map<String, Integer> columnLabelAndIndexMap;
@@ -285,6 +287,7 @@ public final class ShardingSpherePreparedStatement extends AbstractPreparedState
         statements.clear();
         parameterSets.clear();
         generatedValues.clear();
+        hasBatchGeneratedValues = false;
     }
     
     private Optional<GeneratedKeyContext> findGeneratedKey() {
@@ -317,6 +320,10 @@ public final class ShardingSpherePreparedStatement extends AbstractPreparedState
     
     @Override
     public void addBatch() {
+        if (!hasBatchGeneratedValues) {
+            generatedValues.clear();
+            hasBatchGeneratedValues = true;
+        }
         currentResultSet = null;
         QueryContext queryContext = createQueryContext();
         this.queryContext = queryContext;
@@ -328,6 +335,9 @@ public final class ShardingSpherePreparedStatement extends AbstractPreparedState
     @Override
     public int[] executeBatch() throws SQLException {
         try {
+            if (!hasBatchGeneratedValues) {
+                generatedValues.clear();
+            }
             return executeBatchExecutor.executeBatch(usedDatabase, sqlStatementContext, generatedValues, statementOption,
                     (StatementAddCallback<PreparedStatement>) (statements, parameterSets) -> this.statements.addAll(statements),
                     this::replaySetParameter,
@@ -351,6 +361,7 @@ public final class ShardingSpherePreparedStatement extends AbstractPreparedState
         closeCurrentBatchGeneratedKeysResultSet();
         executeBatchExecutor.clear();
         clearParameters();
+        hasBatchGeneratedValues = false;
     }
     
     private void closeCurrentBatchGeneratedKeysResultSet() {

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatementTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatementTest.java
@@ -52,6 +52,26 @@ class ShardingSpherePreparedStatementTest {
     @SuppressWarnings("unchecked")
     @Test
     void assertClearBatchResetsCachedGeneratedKeysResultSet() throws SQLException, ReflectiveOperationException {
+        ShardingSpherePreparedStatement preparedStatement = createPreparedStatement();
+        ResultSet cachedResultSet = new GeneratedKeysResultSet();
+        Plugins.getMemberAccessor().set(ShardingSpherePreparedStatement.class.getDeclaredField("currentBatchGeneratedKeysResultSet"), preparedStatement, cachedResultSet);
+        ((Collection<Comparable<?>>) Plugins.getMemberAccessor().get(ShardingSpherePreparedStatement.class.getDeclaredField("generatedValues"), preparedStatement)).add(1L);
+        preparedStatement.clearBatch();
+        ResultSet actual = preparedStatement.getGeneratedKeys();
+        assertThat(actual, not(cachedResultSet));
+        assertFalse(actual.isClosed());
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    void assertExecuteBatchClearsGeneratedValuesWithoutPendingBatches() throws SQLException, ReflectiveOperationException {
+        ShardingSpherePreparedStatement preparedStatement = createPreparedStatement();
+        ((Collection<Comparable<?>>) Plugins.getMemberAccessor().get(ShardingSpherePreparedStatement.class.getDeclaredField("generatedValues"), preparedStatement)).add(1L);
+        preparedStatement.executeBatch();
+        assertFalse(preparedStatement.getGeneratedKeys().next());
+    }
+    
+    private ShardingSpherePreparedStatement createPreparedStatement() throws SQLException {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
         when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "SQL92"));
         when(database.getRuleMetaData()).thenReturn(new RuleMetaData(Collections.emptyList()));
@@ -64,13 +84,6 @@ class ShardingSpherePreparedStatementTest {
         ShardingSphereConnection connection = mock(ShardingSphereConnection.class, RETURNS_DEEP_STUBS);
         when(connection.getContextManager().getMetaDataContexts().getMetaData()).thenReturn(metaData);
         when(connection.getCurrentDatabaseName()).thenReturn("foo_db");
-        ShardingSpherePreparedStatement preparedStatement = new ShardingSpherePreparedStatement(connection, "SELECT 1", Statement.RETURN_GENERATED_KEYS);
-        ResultSet cachedResultSet = new GeneratedKeysResultSet();
-        Plugins.getMemberAccessor().set(ShardingSpherePreparedStatement.class.getDeclaredField("currentBatchGeneratedKeysResultSet"), preparedStatement, cachedResultSet);
-        ((Collection<Comparable<?>>) Plugins.getMemberAccessor().get(ShardingSpherePreparedStatement.class.getDeclaredField("generatedValues"), preparedStatement)).add(1L);
-        preparedStatement.clearBatch();
-        ResultSet actual = preparedStatement.getGeneratedKeys();
-        assertThat(actual, not(cachedResultSet));
-        assertFalse(actual.isClosed());
+        return new ShardingSpherePreparedStatement(connection, "SELECT 1", Statement.RETURN_GENERATED_KEYS);
     }
 }


### PR DESCRIPTION
## Summary
- clear prepared statement batch generated key cache at new-batch boundaries to avoid stale IDs leaking into later executeBatch() calls
- keep generated keys available for the current batch result while preserving existing non-batch generated-key behavior
- add regression test for stale generated values when executeBatch() is invoked without pending batches

## Issue
Fixes #36281

## Verification
- ./mvnw -pl jdbc -DskipITs -Dspotless.skip=true -Dtest=ShardingSpherePreparedStatementTest test -Dsurefire.failIfNoSpecifiedTests=false
- ./mvnw -pl jdbc -DskipITs test
- ./mvnw -pl jdbc -Pcheck checkstyle:check
- ./mvnw -pl jdbc -Pcheck spotless:check
- ./mvnw -pl jdbc -Pcheck -DskipITs test
