### PR TITLE
Extract upload-e2e-artifacts and download-e2e-artifacts for e2e-operation.yml and nightly-e2e-operation.yml

### DIFF
--- a/.github/workflows/e2e-operation.yml
+++ b/.github/workflows/e2e-operation.yml
@@ -74,19 +74,7 @@ jobs:
           FORMATTED_PL=$(echo "$MODULE_LIST" | sed "s|,|,$PREFIX|g" | sed "s|^|$PREFIX|")
           echo "Ready to build: $FORMATTED_PL"
           ./mvnw -B clean install -am -pl "$FORMATTED_PL" -Pe2e.env.docker -DskipTests
-      - name: Package shardingsphere Maven Repository
-        run: |
-          tar -czf /tmp/maven-repo-output.tar.gz -C ~/.m2/repository org/apache/shardingsphere
-      - name: Save E2E Image
-        run: docker save -o /tmp/apache-shardingsphere-proxy-test.tar apache/shardingsphere-proxy-test:latest
-      - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-outputs
-          path: |
-            /tmp/maven-repo-output.tar.gz
-            /tmp/apache-shardingsphere-proxy-test.tar
-          retention-days: 1
+      - uses: ./.github/workflows/resources/actions/upload-e2e-artifacts
 
   e2e-operation:
     name: E2E - ${{ matrix.operation }} on ${{ matrix.image.version }}
@@ -126,16 +114,6 @@ jobs:
         with:
           version: v28.0.4
           set-host: true
-      - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-outputs
-          path: /tmp/
-      - name: Restore shardingsphere Maven Repository
-        run: |
-          mkdir -p ~/.m2/repository
-          tar -xzf /tmp/maven-repo-output.tar.gz -C ~/.m2/repository
-      - name: Load E2E Image
-        run: docker load -i /tmp/apache-shardingsphere-proxy-test.tar
+      - uses: ./.github/workflows/resources/actions/download-e2e-artifacts
       - name: Run ${{ matrix.operation }} on ${{ matrix.image.version }}
         run: ./mvnw -nsu -B install -f test/e2e/operation/${{ matrix.operation }}/pom.xml -De2e.run.type=docker -D${{ matrix.image.type }}=${{ matrix.image.version }}

--- a/.github/workflows/nightly-e2e-operation.yml
+++ b/.github/workflows/nightly-e2e-operation.yml
@@ -64,19 +64,7 @@ jobs:
           FORMATTED_PL=$(echo "$MODULE_LIST" | sed "s|,|,$PREFIX|g" | sed "s|^|$PREFIX|")
           echo "Ready to build: $FORMATTED_PL"
           ./mvnw -B clean install -am -pl "$FORMATTED_PL" -Pe2e.env.docker -DskipTests
-      - name: Package shardingsphere Maven Repository
-        run: |
-          tar -czf /tmp/maven-repo-output.tar.gz -C ~/.m2/repository org/apache/shardingsphere
-      - name: Save E2E Image
-        run: docker save -o /tmp/apache-shardingsphere-proxy-test.tar apache/shardingsphere-proxy-test:latest
-      - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-outputs
-          path: |
-            /tmp/maven-repo-output.tar.gz
-            /tmp/apache-shardingsphere-proxy-test.tar
-          retention-days: 1
+      - uses: ./.github/workflows/resources/actions/upload-e2e-artifacts
 
   e2e-operation-job:
     if: ${{ needs.global-environment.outputs.GLOBAL_IS_NIGHTLY_JOB_EXECUTABLE == 'true' }}
@@ -121,16 +109,6 @@ jobs:
         with:
           version: v28.0.4
           set-host: true
-      - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-outputs
-          path: /tmp/
-      - name: Restore shardingsphere Maven Repository
-        run: |
-          mkdir -p ~/.m2/repository
-          tar -xzf /tmp/maven-repo-output.tar.gz -C ~/.m2/repository
-      - name: Load E2E Image
-        run: docker load -i /tmp/apache-shardingsphere-proxy-test.tar
+      - uses: ./.github/workflows/resources/actions/download-e2e-artifacts
       - name: Run ${{ matrix.operation }} on ${{ matrix.image.version }}
         run: ./mvnw -nsu -B install -f test/e2e/operation/${{ matrix.operation }}/pom.xml -De2e.run.type=docker -D${{ matrix.image.type }}=${{ matrix.image.version }}

--- a/.github/workflows/resources/actions/download-e2e-artifacts/action.yml
+++ b/.github/workflows/resources/actions/download-e2e-artifacts/action.yml
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: 'Download E2E Artifacts'
+description: 'Download and restore E2E build artifacts including Maven repository and Docker image'
+
+runs:
+  using: composite
+  steps:
+    - name: Download Build Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: build-outputs
+        path: /tmp/
+    - name: Restore shardingsphere Maven Repository
+      shell: bash
+      run: |
+        mkdir -p ~/.m2/repository
+        tar -xzf /tmp/maven-repo-output.tar.gz -C ~/.m2/repository
+    - name: Load E2E Image
+      shell: bash
+      run: |
+        docker load -i /tmp/apache-shardingsphere-proxy-test.tar

--- a/.github/workflows/resources/actions/upload-e2e-artifacts/action.yml
+++ b/.github/workflows/resources/actions/upload-e2e-artifacts/action.yml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: 'Upload E2E Artifacts'
+description: 'Package and upload E2E build artifacts including Maven repository and Docker image'
+
+runs:
+  using: composite
+  steps:
+    - name: Package shardingsphere Maven Repository
+      shell: bash
+      run: |
+        tar -czf /tmp/maven-repo-output.tar.gz -C ~/.m2/repository org/apache/shardingsphere
+    - name: Save E2E Image
+      shell: bash
+      run: |
+        docker save -o /tmp/apache-shardingsphere-proxy-test.tar apache/shardingsphere-proxy-test:latest
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-outputs
+        path: |
+          /tmp/maven-repo-output.tar.gz
+          /tmp/apache-shardingsphere-proxy-test.tar
+        retention-days: 1


### PR DESCRIPTION
Related to #37946

Changes proposed in this pull request:
  - Extract upload-e2e-artifacts and download-e2e-artifacts for e2e-operation.yml and nightly-e2e-operation.yml. And also prepare for artifacts cache improvement

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
