### PR TITLE
Upgrade actions/setup-java from v5.1.0 to v5.2.0, fix DeprecationWarning

### DIFF
--- a/.github/workflows/resources/actions/setup-build-environment/action.yml
+++ b/.github/workflows/resources/actions/setup-build-environment/action.yml
@@ -68,7 +68,7 @@ runs:
   steps:
     - name: Setup Java (Temurin)
       if: inputs.distribution != 'graalvm'
-      uses: actions/setup-java@v5.1.0
+      uses: actions/setup-java@v5.2.0
       with:
         distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java-version }}


### PR DESCRIPTION

Changes proposed in this pull request:
  - Upgrade actions/setup-java from v5.1.0 to v5.2.0, fix DeprecationWarning

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
