### PR TITLE
Fix nightly-build.yml generate-and-test-examples job missing needs global-environment

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -166,7 +166,7 @@ jobs:
   generate-and-test-examples:
     name: Example-${{ matrix.feature }}-${{ matrix.framework }}-${{ matrix.mode }}-${{ matrix.transaction }}
     if: github.repository == 'apache/shardingsphere'
-    needs: build-cache
+    needs: [ build-cache, global-environment ]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:


### PR DESCRIPTION

Changes proposed in this pull request:
  - Fix nightly-build.yml generate-and-test-examples job missing needs global-environment

It causes empty cache-prefix, expected `apache-shardingsphere` is missed, so there's `-maven-full-3b9ea1c609e08af645fe2adef4fb8917a78678d2ddc48a847e638979cf391383` cache key in GitHub Caches.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
