### PR TITLE
Remove unnecessary clean from maven command in workflow job to speed up

### DIFF
--- a/.github/workflows/e2e-agent.yml
+++ b/.github/workflows/e2e-agent.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Build Project
         run: ./mvnw -B clean install -DskipTests -Prelease,default-dep
       - name: Build Proxy E2E Image
-        run: ./mvnw clean install -DskipTests -Pe2e.env.proxy -f test/e2e/agent/engine/pom.xml
+        run: ./mvnw install -DskipTests -Pe2e.env.proxy -f test/e2e/agent/engine/pom.xml
       - name: Save Proxy E2E Image
         run: docker save -o /tmp/apache-shardingsphere-proxy-agent-test.tar apache/shardingsphere-proxy-agent-test:latest
       - uses: actions/upload-artifact@v4
@@ -76,7 +76,7 @@ jobs:
           path: /tmp/apache-shardingsphere-proxy-agent-test.tar
           retention-days: 10
       - name: Build JDBC E2E Image
-        run: ./mvnw clean install -DskipTests -Pe2e.env.jdbc -f test/e2e/agent/engine/pom.xml
+        run: ./mvnw install -DskipTests -Pe2e.env.jdbc -f test/e2e/agent/engine/pom.xml
       - uses: ./.github/workflows/resources/actions/save-maven-cache
         with:
           cache-hit: ${{ steps.setup-build-environment.outputs.cache-hit }}
@@ -156,4 +156,4 @@ jobs:
       - name: Build Project
         run: ./mvnw -B clean install -am -pl test/e2e/agent/plugins/${{ matrix.feature }}/${{ matrix.plugin }} -DskipTests
       - name: Run E2E Test
-        run: ./mvnw -nsu -B clean install -f test/e2e/agent/plugins/${{ matrix.feature }}/${{ matrix.plugin }}/pom.xml -De2e.env.adapter=${{ matrix.adapter }} -De2e.env.plugin=${{ matrix.plugin }}
+        run: ./mvnw -nsu -B install -f test/e2e/agent/plugins/${{ matrix.feature }}/${{ matrix.plugin }}/pom.xml -De2e.env.adapter=${{ matrix.adapter }} -De2e.env.plugin=${{ matrix.plugin }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Build with Maven
         run: ./mvnw -B -T1C -ntp clean install -DskipITs -DskipTests
       - name: Generate Examples
-        run: ./mvnw -B clean install -f examples/shardingsphere-jdbc-example-generator/pom.xml -Pexample-generator -Dmodes=${{ matrix.mode }} -Dtransactions=${{ matrix.transaction }} -Dfeatures=${{ matrix.feature }} -Dframeworks=${{ matrix.framework }}
+        run: ./mvnw -B install -f examples/shardingsphere-jdbc-example-generator/pom.xml -Pexample-generator -Dmodes=${{ matrix.mode }} -Dtransactions=${{ matrix.transaction }} -Dfeatures=${{ matrix.feature }} -Dframeworks=${{ matrix.framework }}
       - name: Prepare Environments
         run: |
           INIT_SQL_PATH="examples/shardingsphere-jdbc-example-generator/target/generated-sources/shardingsphere-jdbc-sample/${{ matrix.feature }}--${{ matrix.framework }}--${{ matrix.mode }}--${{ matrix.transaction }}/init.sql"

--- a/.github/workflows/nightly-e2e-agent.yml
+++ b/.github/workflows/nightly-e2e-agent.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build Project
         run: ./mvnw -B clean install -DskipTests -Prelease,default-dep
       - name: Build Proxy E2E Image
-        run: ./mvnw clean install -DskipTests -Pe2e.env.proxy -f test/e2e/agent/engine/pom.xml
+        run: ./mvnw install -DskipTests -Pe2e.env.proxy -f test/e2e/agent/engine/pom.xml
       - name: Save Proxy E2E Image
         run: docker save -o /tmp/apache-shardingsphere-proxy-agent-test.tar apache/shardingsphere-proxy-agent-test:latest
       - uses: actions/upload-artifact@v4
@@ -64,7 +64,7 @@ jobs:
           path: /tmp/apache-shardingsphere-proxy-agent-test.tar
           retention-days: 10
       - name: Build JDBC E2E Image
-        run: ./mvnw clean install -DskipTests -Pe2e.env.jdbc -f test/e2e/agent/engine/pom.xml
+        run: ./mvnw install -DskipTests -Pe2e.env.jdbc -f test/e2e/agent/engine/pom.xml
       - uses: ./.github/workflows/resources/actions/save-maven-cache
         with:
           cache-hit: ${{ steps.setup-build-environment.outputs.cache-hit }}
@@ -144,4 +144,4 @@ jobs:
       - name: Build Project
         run: ./mvnw -B clean install -am -pl test/e2e/agent/plugins/${{ matrix.feature }}/${{ matrix.plugin }} -DskipTests
       - name: Run E2E Test
-        run: ./mvnw -nsu -B clean install -f test/e2e/agent/plugins/${{ matrix.feature }}/${{ matrix.plugin }}/pom.xml -De2e.env.adapter=${{ matrix.adapter }} -De2e.env.plugin=${{ matrix.plugin }}
+        run: ./mvnw -nsu -B install -f test/e2e/agent/plugins/${{ matrix.feature }}/${{ matrix.plugin }}/pom.xml -De2e.env.adapter=${{ matrix.adapter }} -De2e.env.plugin=${{ matrix.plugin }}


### PR DESCRIPTION

Changes proposed in this pull request:
  - Remove unnecessary clean from maven command in workflow job to speed up

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
