### PR TITLE
workflow: add setup-build-environment action with caching for required checks

### DIFF
--- a/.github/workflows/required-check.yml
+++ b/.github/workflows/required-check.yml
@@ -39,6 +39,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6.0.1
+      - uses: ./.github/workflows/resources/actions/setup-build-environment
+        with:
+          cache-prefix: ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}
+          cache-suffix: 'required-check'
       - name: Run CheckStyle
         run: ./mvnw checkstyle:check -Pcheck -T1C
 
@@ -50,6 +54,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6.0.1
+      - uses: ./.github/workflows/resources/actions/setup-build-environment
+        with:
+          cache-prefix: ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}
+          cache-suffix: 'required-check'
       - name: Run Spotless
         run: ./mvnw spotless:check -Pcheck -T1C
 
@@ -61,5 +69,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6.0.1
+      - uses: ./.github/workflows/resources/actions/setup-build-environment
+        with:
+          cache-prefix: ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}
+          cache-suffix: 'required-check'
       - name: Run Apache Rat
         run: ./mvnw apache-rat:check -Pcheck -T1C


### PR DESCRIPTION
Related to #38192

Changes proposed in this pull request:
  - workflow: add setup-build-environment action with caching for required checks

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
