### PR TITLE
Fix resource leak in StatisticsCollectJobWorker - close CoordinatorRegistryCenter on destroy

### DIFF
--- a/kernel/schedule/core/src/main/java/org/apache/shardingsphere/schedule/core/job/statistics/collect/StatisticsCollectJobWorker.java
+++ b/kernel/schedule/core/src/main/java/org/apache/shardingsphere/schedule/core/job/statistics/collect/StatisticsCollectJobWorker.java
@@ -141,6 +141,9 @@ public final class StatisticsCollectJobWorker {
         if (WORKER_INITIALIZED.compareAndSet(true, false)) {
             Optional.ofNullable(scheduleJobBootstrap).ifPresent(ScheduleJobBootstrap::shutdown);
             scheduleJobBootstrap = null;
+            Optional.ofNullable(registryCenter).ifPresent(CoordinatorRegistryCenter::close);
+            registryCenter = null;
+            contextManager = null;
         }
     }
 }


### PR DESCRIPTION
## Changes
Call `registryCenter.close()` in `StatisticsCollectJobWorker.destroy()` to release ZooKeeper connections and CuratorCache instances when the job worker is destroyed. Also null out static fields `registryCenter` and `contextManager` after cleanup to allow garbage collection.

`ZookeeperRegistryCenter.close()` (from ElasticJob) closes all `CuratorCache` entries and the underlying `CuratorFramework` client. Previously, `destroy()` only shut down the `ScheduleJobBootstrap` but left the registry center's ZooKeeper session and background threads running.

Fixes #38242

## Type
- [x] Bugfix