### PR TITLE
workflow: add concurrency settings to missed nightly workflows

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -27,6 +27,10 @@ on:
         type: string
         description: 'Commit ID to build. Default is the latest commit on the default branch.'
 
+concurrency:
+  group: nightly-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -DskipITs -DskipTests -Dspotless.apply.skip=true
   HUB: ghcr.io/apache/shardingsphere

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -22,6 +22,10 @@ on:
     - cron: '0 23 * * 1-5' # Once a day between Monday and Friday. UTC time
   workflow_dispatch:
 
+concurrency:
+  group: nightly-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -22,6 +22,10 @@ on:
     - cron: '0 13 * * 1-5' # Once a day between Monday and Friday. UTC time
   workflow_dispatch:
 
+concurrency:
+  group: nightly-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 

--- a/.github/workflows/nightly-sql-parser.yml
+++ b/.github/workflows/nightly-sql-parser.yml
@@ -22,6 +22,10 @@ on:
     - cron: '0 18 * * 1-5' # Once a day between Monday and Friday. UTC time
   workflow_dispatch:
 
+concurrency:
+  group: nightly-sql-parser-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dspotless.apply.skip=true
   RUNS_ON: ubuntu-latest

--- a/.github/workflows/schedule-report.yml
+++ b/.github/workflows/schedule-report.yml
@@ -22,6 +22,10 @@ on:
     - cron: '0 17 * * *'  # Once a day. UTC time 17:00
   workflow_dispatch:
 
+concurrency:
+  group: schedule-report-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 


### PR DESCRIPTION

Changes proposed in this pull request:
  - workflow: add concurrency settings to missed nightly workflows

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
