### PR TITLE
Add support for data source unicast route in DAL statement broadcast decider

### DIFF
--- a/infra/route/core/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/DialectDALStatementBroadcastRouteDecider.java
+++ b/infra/route/core/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/DialectDALStatementBroadcastRouteDecider.java
@@ -42,4 +42,12 @@ public interface DialectDALStatementBroadcastRouteDecider extends DatabaseTypedS
      * @return broadcast route or not
      */
     boolean isInstanceBroadcastRoute(DALStatement sqlStatement);
+    
+    /**
+     * Whether data source unicast route.
+     *
+     * @param sqlStatement SQL statement
+     * @return unicast route or not
+     */
+    boolean isDataSourceUnicastRoute(DALStatement sqlStatement);
 }

--- a/infra/route/core/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/TablelessRouteEngineFactory.java
+++ b/infra/route/core/src/main/java/org/apache/shardingsphere/infra/route/engine/tableless/TablelessRouteEngineFactory.java
@@ -130,6 +130,9 @@ public final class TablelessRouteEngineFactory {
         if (dialectDALStatementBroadcastRouteDecider.map(optional -> optional.isInstanceBroadcastRoute(sqlStatement)).orElse(false)) {
             return new TablelessInstanceBroadcastRouteEngine(database);
         }
+        if (dialectDALStatementBroadcastRouteDecider.map(optional -> optional.isDataSourceUnicastRoute(sqlStatement)).orElse(false)) {
+            return new TablelessDataSourceUnicastRouteEngine();
+        }
         throw new NoTablelessRouteInfoException();
     }
 }

--- a/infra/route/core/src/test/java/org/apache/shardingsphere/infra/route/engine/tableless/TablelessRouteEngineFactoryTest.java
+++ b/infra/route/core/src/test/java/org/apache/shardingsphere/infra/route/engine/tableless/TablelessRouteEngineFactoryTest.java
@@ -148,6 +148,20 @@ class TablelessRouteEngineFactoryTest {
     }
     
     @Test
+    void assertNewInstanceForDataSourceUnicastRoute() {
+        DALStatement sqlStatement = mock(DALStatement.class);
+        when(sqlStatement.getDatabaseType()).thenReturn(databaseType);
+        when(sqlStatement.getAttributes()).thenReturn(new SQLStatementAttributes());
+        DialectDALStatementBroadcastRouteDecider dialectDALStatementBroadcastRouteDecider = mock(DialectDALStatementBroadcastRouteDecider.class);
+        when(dialectDALStatementBroadcastRouteDecider.isDataSourceUnicastRoute(sqlStatement)).thenReturn(true);
+        when(DatabaseTypedSPILoader.findService(DialectDALStatementBroadcastRouteDecider.class, databaseType)).thenReturn(Optional.of(dialectDALStatementBroadcastRouteDecider));
+        when(sqlStatementContext.getSqlStatement()).thenReturn(sqlStatement);
+        QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
+        TablelessRouteEngine actual = TablelessRouteEngineFactory.newInstance(queryContext, database);
+        assertThat(actual, isA(TablelessDataSourceUnicastRouteEngine.class));
+    }
+    
+    @Test
     void assertNewInstanceForCloseAllStatement() {
         CursorHeldSQLStatementContext closeStatementContext = mock(CursorHeldSQLStatementContext.class, RETURNS_DEEP_STUBS);
         when(closeStatementContext.getTablesContext().getDatabaseName()).thenReturn(Optional.empty());

--- a/infra/route/dialect/mysql/src/main/java/org/apache/shardingsphere/infra/route/mysql/MySQLDALStatementBroadcastRouteDecider.java
+++ b/infra/route/dialect/mysql/src/main/java/org/apache/shardingsphere/infra/route/mysql/MySQLDALStatementBroadcastRouteDecider.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.sql.parser.statement.mysql.dal.resource.MySQLAl
 import org.apache.shardingsphere.sql.parser.statement.mysql.dal.resource.MySQLCreateResourceGroupStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.dal.resource.MySQLDropResourceGroupStatement;
 import org.apache.shardingsphere.sql.parser.statement.mysql.dal.resource.MySQLSetResourceGroupStatement;
+import org.apache.shardingsphere.sql.parser.statement.mysql.dal.show.variable.MySQLShowVariablesStatement;
 
 import java.util.Optional;
 
@@ -46,6 +47,11 @@ public final class MySQLDALStatementBroadcastRouteDecider implements DialectDALS
     private boolean isResourceGroupStatement(final DALStatement sqlStatement) {
         return sqlStatement instanceof MySQLCreateResourceGroupStatement || sqlStatement instanceof MySQLAlterResourceGroupStatement || sqlStatement instanceof MySQLDropResourceGroupStatement
                 || sqlStatement instanceof MySQLSetResourceGroupStatement;
+    }
+    
+    @Override
+    public boolean isDataSourceUnicastRoute(final DALStatement sqlStatement) {
+        return sqlStatement instanceof MySQLShowVariablesStatement;
     }
     
     @Override

--- a/infra/route/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/route/postgresql/PostgreSQLDALStatementBroadcastRouteDecider.java
+++ b/infra/route/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/route/postgresql/PostgreSQLDALStatementBroadcastRouteDecider.java
@@ -38,6 +38,11 @@ public final class PostgreSQLDALStatementBroadcastRouteDecider implements Dialec
     }
     
     @Override
+    public boolean isDataSourceUnicastRoute(final DALStatement sqlStatement) {
+        return false;
+    }
+    
+    @Override
     public String getDatabaseType() {
         return "PostgreSQL";
     }

--- a/test/e2e/sql/src/test/resources/cases/dal/dataset/show_variables.xml
+++ b/test/e2e/sql/src/test/resources/cases/dal/dataset/show_variables.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="Variable_name" />
+        <column name="Value" />
+    </metadata>
+    <row values="character_set_client, NOT_VERIFY" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dal/e2e-dal-show.xml
+++ b/test/e2e/sql/src/test/resources/cases/dal/e2e-dal-show.xml
@@ -46,4 +46,8 @@
     <test-case db-types="MySQL" scenario-types="db,tbl" sql="SHOW CREATE TABLE t_order">
         <assertion expected-data-file="show_create_table.xml" />
     </test-case>
+
+    <test-case sql="SHOW VARIABLES LIKE 'character_set_client'" db-types="MySQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting" adapters="proxy">
+        <assertion expected-data-file="show_variables.xml" />
+    </test-case>
 </e2e-test-cases>


### PR DESCRIPTION

Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
