### PR TITLE
Improve nightly-e2e-sql.yml : reuse upload/download-e2e-artifacts composite action

### DIFF
--- a/.github/workflows/nightly-e2e-sql.yml
+++ b/.github/workflows/nightly-e2e-sql.yml
@@ -49,7 +49,6 @@ jobs:
         uses: ./.github/workflows/resources/actions/setup-build-environment
         with:
           java-version: 21
-          cache-prefix: ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}
           cache-suffix: 'e2e-sql'
           cache-save-enabled: 'false'
           enable-docker-setup: 'true'
@@ -59,20 +58,7 @@ jobs:
         with:
           cache-hit: ${{ steps.setup-build-environment.outputs.cache-hit }}
           cache-primary-key: ${{ steps.setup-build-environment.outputs.cache-primary-key }}
-      - name: Package ShardingSphere Maven Repository
-        run: tar -czf /tmp/apache-shardingsphere-maven-repo.tar.gz -C ~/.m2/repository org/apache/shardingsphere
-      - name: Save E2E Image
-        run: docker save -o /tmp/${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-proxy-test.tar apache/shardingsphere-proxy-test:latest
-      - uses: actions/upload-artifact@v4
-        with:
-          name: e2e-image
-          path: /tmp/${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-proxy-test.tar
-          retention-days: 10
-      - uses: actions/upload-artifact@v4
-        with:
-          name: e2e-maven-repo
-          path: /tmp/apache-shardingsphere-maven-repo.tar.gz
-          retention-days: 1
+      - uses: ./.github/workflows/resources/actions/upload-e2e-artifacts
   
   e2e-sql:
     name: E2E - SQL
@@ -119,27 +105,11 @@ jobs:
       - uses: ./.github/workflows/resources/actions/setup-build-environment
         with:
           java-version: 21
-          cache-prefix: ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}
           cache-suffix: 'e2e-sql'
           cache-save-enabled: 'false'
           enable-docker-setup: 'true'
-      - name: Download Maven Repository
-        uses: actions/download-artifact@v4
+      - uses: ./.github/workflows/resources/actions/download-e2e-artifacts
         with:
-          name: e2e-maven-repo
-          path: /tmp/
-      - name: Restore Maven Repository
-        run: |
-          mkdir -p ~/.m2/repository
-          tar -xzf /tmp/apache-shardingsphere-maven-repo.tar.gz -C ~/.m2/repository
-      - name: Download E2E Image
-        if: matrix.adapter == 'proxy'
-        uses: actions/download-artifact@v4
-        with:
-          name: e2e-image
-          path: /tmp/
-      - name: Load E2E Image
-        if: matrix.adapter == 'proxy'
-        run: docker load -i /tmp/${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}-proxy-test.tar
+          load-docker-image: ${{ matrix.adapter == 'proxy' }}
       - name: Run E2E Test
         run: ./mvnw -nsu -B install -f test/e2e/sql/pom.xml -Dspotless.apply.skip=true -De2e.run.type=DOCKER -De2e.artifact.modes=${{ matrix.mode }} -De2e.artifact.adapters=${{ matrix.adapter }} -De2e.run.additional.cases=false -De2e.scenarios=${{ matrix.scenario }} -De2e.artifact.databases=${{ matrix.database }} ${{ matrix.additional-options }}


### PR DESCRIPTION
Related to #38192.

Changes proposed in this pull request:
  - Improve nightly-e2e-sql.yml : reuse upload/download-e2e-artifacts composite action

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
