### PR TITLE
workflow: increase upload-e2e-artifacts composite action retention days from 1 to 3, improve for cross days pr ci re-run

### DIFF
--- a/.github/workflows/resources/actions/upload-e2e-artifacts/action.yml
+++ b/.github/workflows/resources/actions/upload-e2e-artifacts/action.yml
@@ -36,4 +36,4 @@ runs:
         path: |
           /tmp/maven-repo-output.tar.gz
           /tmp/apache-shardingsphere-proxy-test.tar
-        retention-days: 1
+        retention-days: 3


### PR DESCRIPTION
Related to #38192 

Changes proposed in this pull request:
  - workflow: increase upload-e2e-artifacts composite action retention days from 1 to 3, improve for cross days pr ci re-run

Error example: `Error: Unable to download artifact(s): Artifact not found for name: build-outputs`
<img width="2178" height="504" alt="image" src="https://github.com/user-attachments/assets/1f6d63c5-6794-483a-be4e-19a1146ee85f" />


---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
