### PR TITLE
Support setMaxRows and getMaxRows method in jdbc when not execute sql

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,6 +11,7 @@
 1. SQL Parser: Support parsing MySQL SELECT sql - [#38233](https://github.com/apache/shardingsphere/pull/38233)
 1. SQL Parser: Support parsing MySQL CREATE sql - [#38237](https://github.com/apache/shardingsphere/pull/38237)
 1. SQL Parser: Support mysql subquery table projection alias visit to sql statement - [#38320](https://github.com/apache/shardingsphere/pull/38320)
+1. JDBC: Support setMaxRows and getMaxRows method in jdbc when not execute sql - [#38337](https://github.com/apache/shardingsphere/pull/38337)
 
 ## Release 5.5.3
 

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractStatementAdapter.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractStatementAdapter.java
@@ -52,6 +52,8 @@ public abstract class AbstractStatementAdapter extends WrapperAdapter implements
     
     private int fetchDirection;
     
+    private int maxRows;
+    
     private boolean closeOnCompletion;
     
     private boolean closed;
@@ -123,12 +125,13 @@ public abstract class AbstractStatementAdapter extends WrapperAdapter implements
     // TODO Confirm MaxRows for multiple databases is need special handle. eg: 10 statements maybe MaxRows / 10
     @Override
     public final int getMaxRows() throws SQLException {
-        return getRoutedStatements().isEmpty() ? -1 : getRoutedStatements().iterator().next().getMaxRows();
+        return getRoutedStatements().isEmpty() ? maxRows : getRoutedStatements().iterator().next().getMaxRows();
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public final void setMaxRows(final int max) throws SQLException {
+        maxRows = max;
         getMethodInvocationRecorder().record("setMaxRows", statement -> statement.setMaxRows(max));
         forceExecuteTemplate.execute((Collection) getRoutedStatements(), statement -> statement.setMaxRows(max));
     }

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/ShardingSphereDriverTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/ShardingSphereDriverTest.java
@@ -33,6 +33,7 @@ import java.util.ServiceLoader;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -147,6 +148,54 @@ class ShardingSphereDriverTest {
         try (ResultSet resultSet = statement.executeQuery("SELECT COUNT(1) FROM t_order_0")) {
             assertTrue(resultSet.next());
             assertThat(resultSet.getInt(1), is(1));
+        }
+    }
+    
+    @Test
+    void assertGetMaxRowsWhenSetMaxRowsForStatement() throws SQLException {
+        try (
+                Connection connection = DriverManager.getConnection("jdbc:shardingsphere:classpath:config/driver/driver-fixture-h2-mysql.yaml");
+                Statement statement = connection.createStatement()) {
+            assertThat(connection, isA(ShardingSphereConnection.class));
+            statement.setMaxRows(100);
+            assertThat(statement.getMaxRows(), is(100));
+            statement.execute("DROP TABLE IF EXISTS t_max_rows_test");
+            statement.execute("CREATE TABLE t_max_rows_test (id INT PRIMARY KEY, name VARCHAR(50) NOT NULL)");
+            statement.execute("INSERT INTO t_max_rows_test (id, name) VALUES (1, 'test1')");
+            try (ResultSet resultSet = statement.executeQuery("SELECT id, name FROM t_max_rows_test")) {
+                assertThat(statement.getMaxRows(), is(100));
+                assertTrue(resultSet.next());
+                assertThat(resultSet.getInt(1), is(1));
+                assertThat(resultSet.getString(2), is("test1"));
+                assertFalse(resultSet.next());
+            }
+        }
+    }
+    
+    @Test
+    void assertGetMaxRowsWhenSetMaxRowsForPreparedStatement() throws SQLException {
+        try (
+                Connection connection = DriverManager.getConnection("jdbc:shardingsphere:classpath:config/driver/driver-fixture-h2-mysql.yaml");
+                Statement statement = connection.createStatement()) {
+            assertThat(connection, isA(ShardingSphereConnection.class));
+            statement.execute("DROP TABLE IF EXISTS t_max_rows_ps_test");
+            statement.execute("CREATE TABLE t_max_rows_ps_test (id INT PRIMARY KEY, name VARCHAR(50) NOT NULL)");
+            statement.execute("INSERT INTO t_max_rows_ps_test (id, name) VALUES (1, 'test1')");
+            try (PreparedStatement preparedStatement = connection.prepareStatement("SELECT id, name FROM t_max_rows_ps_test")) {
+                preparedStatement.setMaxRows(100);
+                assertThat(preparedStatement.getMaxRows(), is(100));
+                assertGetMaxRowsAndResultsetWhenSetMaxRowsForPreparedStatement(preparedStatement);
+            }
+        }
+    }
+    
+    private void assertGetMaxRowsAndResultsetWhenSetMaxRowsForPreparedStatement(final PreparedStatement preparedStatement) throws SQLException {
+        try (ResultSet resultSet = preparedStatement.executeQuery()) {
+            assertThat(preparedStatement.getMaxRows(), is(100));
+            assertTrue(resultSet.next());
+            assertThat(resultSet.getInt(1), is(1));
+            assertThat(resultSet.getString(2), is("test1"));
+            assertFalse(resultSet.next());
         }
     }
 }

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/StatementAdapterTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/StatementAdapterTest.java
@@ -191,7 +191,7 @@ class StatementAdapterTest {
     
     @Test
     void assertGetMaxRowsWitRoutedStatements() throws SQLException {
-        assertThat(mockShardingSphereStatement().getMaxRows(), is(-1));
+        assertThat(mockShardingSphereStatement().getMaxRows(), is(0));
     }
     
     @Test


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Support setMaxRows and getMaxRows method in jdbc when not execute sql

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
