### PR TITLE
promote shardingsphere-bom to top-level module

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
-        <artifactId>shardingsphere-distribution</artifactId>
+        <artifactId>shardingsphere</artifactId>
         <version>5.5.4-SNAPSHOT</version>
     </parent>
     <artifactId>shardingsphere-bom</artifactId>
@@ -1267,23 +1267,4 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <skipIfEmpty>true</skipIfEmpty>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -29,7 +29,6 @@
     
     <modules>
         <module>src</module>
-        <module>bom</module>
         <module>agent</module>
         <module>jdbc</module>
         <module>proxy</module>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         
         <module>test</module>
         
+        <module>bom</module>
         <module>distribution</module>
     </modules>
     


### PR DESCRIPTION
Fix #38291

## Summary

  This PR promotes `shardingsphere-bom` to a top-level module and decouples it from `distribution` inheritance.

  ## What Changed

  - Added `bom` as a root module in `pom.xml`
  - Removed `bom` from `distribution/pom.xml` modules
  - Moved `distribution/bom/pom.xml` to `bom/pom.xml`
  - Changed BOM parent from `shardingsphere-distribution` to `shardingsphere`
  - Removed redundant BOM plugin overrides (`maven-jar-plugin`, `maven-deploy-plugin`)

  ## Why

BOM is a consumer-facing dependency-management artifact. Making it top-level and inheriting directly from root avoids unnecessary coupling to `shardingsphere-distribution` during POM resolution.

  ## Verification

  - `./mvnw -pl bom -am -DskipTests -DskipITs -Dspotless.skip=true validate` (pass)
  - `./mvnw -pl bom -DskipTests -DskipITs -Dspotless.skip=true package` (pass)

