### PR TITLE
Fix correlated project pushdown for SQL federation IN subqueries

### DIFF
--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/planner/rule/transformation/PushProjectIntoScanRule.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/planner/rule/transformation/PushProjectIntoScanRule.java
@@ -23,6 +23,8 @@ import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.rules.TransformationRule;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexCorrelVariable;
+import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexSubQuery;
 import org.apache.shardingsphere.sqlfederation.compiler.rel.operator.logical.LogicalScan;
@@ -55,11 +57,28 @@ public final class PushProjectIntoScanRule extends RelRule<PushProjectIntoScanRu
         }
         LogicalProject logicalProject = call.rel(0);
         for (RexNode each : logicalProject.getProjects()) {
-            if (each instanceof RexSubQuery || containsCastFunction(each)) {
+            if (each instanceof RexSubQuery || containsCorrelate(each) || containsCastFunction(each)) {
                 return false;
             }
         }
         return true;
+    }
+    
+    private boolean containsCorrelate(final RexNode rexNode) {
+        if (rexNode instanceof RexCorrelVariable) {
+            return true;
+        }
+        if (rexNode instanceof RexFieldAccess) {
+            return containsCorrelate(((RexFieldAccess) rexNode).getReferenceExpr());
+        }
+        if (rexNode instanceof RexCall) {
+            for (RexNode each : ((RexCall) rexNode).getOperands()) {
+                if (containsCorrelate(each)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
     
     private boolean containsCastFunction(final RexNode rexNode) {

--- a/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/compiler/it/SQLStatementCompilerIT.java
+++ b/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/compiler/it/SQLStatementCompilerIT.java
@@ -37,6 +37,7 @@ import org.apache.shardingsphere.sqlfederation.compiler.metadata.schema.SQLFeder
 import org.apache.shardingsphere.sqlfederation.compiler.rel.converter.SQLFederationRelConverter;
 import org.apache.shardingsphere.sqlfederation.compiler.sql.function.mysql.MySQLOperatorTable;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -54,7 +55,9 @@ import java.util.Properties;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 
 class SQLStatementCompilerIT {
@@ -239,6 +242,14 @@ class SQLStatementCompilerIT {
                 realColumn, doubleColumn, numericColumn, decimalColumn, charColumn, varcharColumn, longVarcharColumn, dateColumn, timeColumn, timeStampColumn, binaryColumn,
                 varBinaryColumn, longVarbinaryColumn),
                 Collections.emptyList(), Collections.emptyList());
+    }
+    
+    @Test
+    void assertCompileWhenCorrelatedInSubqueryProjectsOuterColumn() {
+        SQLStatement sqlStatement = sqlParserRule.getSQLParserEngine(TypedSPILoader.getService(DatabaseType.class, "MySQL"))
+                .parse("SELECT o.order_id FROM t_order o WHERE o.user_id IN (SELECT o.user_id FROM t_order_item i)", false);
+        String actual = assertDoesNotThrow(() -> sqlStatementCompiler.compile(sqlStatement, "MySQL").getPhysicalPlan().explain().replaceAll(System.lineSeparator(), " "));
+        assertThat(actual, containsString("EnumerableScan(table=[[federate_jdbc, t_order_item]], sql=[SELECT * FROM `federate_jdbc`.`t_order_item`]"));
     }
     
     @ParameterizedTest(name = "{0}")

--- a/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/planner/rule/transformation/PushProjectIntoScanRuleTest.java
+++ b/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/planner/rule/transformation/PushProjectIntoScanRuleTest.java
@@ -21,6 +21,8 @@ import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexCorrelVariable;
+import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.sql.SqlOperator;
@@ -73,6 +75,15 @@ class PushProjectIntoScanRuleTest {
     void assertNotMatchWhenProjectContainsSubQuery() {
         mockQualifiedName("public", "t_order");
         when(logicalProject.getProjects()).thenReturn(Collections.singletonList(mock(RexSubQuery.class)));
+        assertFalse(rule.matches(call));
+    }
+    
+    @Test
+    void assertNotMatchWhenProjectContainsCorrelate() {
+        mockQualifiedName("public", "t_order");
+        RexFieldAccess rexFieldAccess = mock(RexFieldAccess.class);
+        when(rexFieldAccess.getReferenceExpr()).thenReturn(mock(RexCorrelVariable.class));
+        when(logicalProject.getProjects()).thenReturn(Collections.singletonList(rexFieldAccess));
         assertFalse(rule.matches(call));
     }
     

--- a/test/e2e/sql/src/test/resources/cases/dql/cases/db_tbl_sql_federation/e2e-dql-select-sub-query-for-db-tbl-sql-federation.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/cases/db_tbl_sql_federation/e2e-dql-select-sub-query-for-db-tbl-sql-federation.xml
@@ -25,9 +25,9 @@
         <assertion parameters="1200:int" expected-data-source-name="read_dataset" />
     </test-case>-->
     
-    <test-case sql="SELECT o.order_id FROM t_order o WHERE o.order_id &lt; ? AND o.user_id IN (SELECT o.user_id FROM t_order_item i) ORDER BY order_id"
+    <test-case sql="SELECT o.order_id FROM (SELECT order_id, user_id FROM t_order WHERE order_id = ?) o WHERE o.user_id IN (SELECT o.user_id FROM t_order_item i) ORDER BY order_id"
                db-types="MySQL,PostgreSQL,openGauss" scenario-types="db_tbl_sql_federation">
-        <assertion parameters="1010:int" expected-data-source-name="read_dataset" />
+        <assertion parameters="1000:int" expected-data-source-name="read_dataset" />
     </test-case>
     
     <test-case sql="SELECT * FROM t_order o WHERE o.order_id IN (SELECT i.order_id FROM t_order_item i INNER JOIN t_product p ON i.product_id = p.product_id WHERE p.product_id = ?) ORDER BY order_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db_tbl_sql_federation">

--- a/test/e2e/sql/src/test/resources/cases/dql/cases/db_tbl_sql_federation/e2e-dql-select-sub-query-for-db-tbl-sql-federation.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/cases/db_tbl_sql_federation/e2e-dql-select-sub-query-for-db-tbl-sql-federation.xml
@@ -25,6 +25,11 @@
         <assertion parameters="1200:int" expected-data-source-name="read_dataset" />
     </test-case>-->
     
+    <test-case sql="SELECT o.order_id FROM t_order o WHERE o.order_id &lt; ? AND o.user_id IN (SELECT o.user_id FROM t_order_item i) ORDER BY order_id"
+               db-types="MySQL,PostgreSQL,openGauss" scenario-types="db_tbl_sql_federation">
+        <assertion parameters="1010:int" expected-data-source-name="read_dataset" />
+    </test-case>
+    
     <test-case sql="SELECT * FROM t_order o WHERE o.order_id IN (SELECT i.order_id FROM t_order_item i INNER JOIN t_product p ON i.product_id = p.product_id WHERE p.product_id = ?) ORDER BY order_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db_tbl_sql_federation">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>


### PR DESCRIPTION
### Summary

This PR fixes correlated `IN` subqueries that fail when the subquery projects an outer reference from a non-join subquery.

### Root Cause

`PushProjectIntoScanRule` pushed project expressions into `LogicalScan` without checking whether the projection contained correlated references.

For queries like:

    SELECT o.order_id
    FROM t_order o
    WHERE o.user_id IN (
        SELECT o.user_id
        FROM t_order_item i
    )

the projected expression inside the subquery contains an outer reference. After it was pushed into `LogicalScan`, the scan conversion path failed because the pushed-down scan tree still contained correlated expressions.

The more complex join case succeeded because it did not go through the same simple project-to-scan pushdown path.

### Fix

This change makes `PushProjectIntoScanRule` skip pushdown when a projected expression contains correlated references.

Specifically:
- detect `RexCorrelVariable`
- detect `RexFieldAccess` that references a correlated expression
- recursively inspect nested `RexCall` operands

### Tests

Added regression coverage for:
- `PushProjectIntoScanRuleTest`
- `SQLStatementCompilerIT#assertCompileWhenCorrelatedInSubqueryProjectsOuterColumn`

Fixes #37439