### PR TITLE
jdbc: add MySQL-compatible typed string conversion

### DIFF
--- a/.github/workflows/e2e-sql.yml
+++ b/.github/workflows/e2e-sql.yml
@@ -34,6 +34,7 @@ permissions:
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dspotless.apply.skip=true
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+  TESTCONTAINERS_RYUK_DISABLED: true
 
 jobs:
   global-environment:

--- a/.github/workflows/e2e-sql.yml
+++ b/.github/workflows/e2e-sql.yml
@@ -34,7 +34,6 @@ permissions:
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dspotless.apply.skip=true
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
-  TESTCONTAINERS_RYUK_DISABLED: true
 
 jobs:
   global-environment:

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtils.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtils.java
@@ -133,7 +133,7 @@ public final class ResultSetUtils {
     }
     
     private static boolean isMySQLCompatibleConversion(final DatabaseType protocolType) {
-        return null != protocolType && ("MySQL".equals(protocolType.getType()) || protocolType.getTrunkDatabaseType().map(optional -> "MySQL".equals(optional.getType())).orElse(false));
+        return null != protocolType && "MySQL".equals(protocolType.getType());
     }
     
     private static Optional<Object> convertStringValue(final String value, final Class<?> convertType, final boolean isMySQLCompatibleConversion) {
@@ -160,7 +160,7 @@ public final class ResultSetUtils {
     private static Optional<Object> convertMySQLStringValue(final String value, final Class<?> convertType) {
         String trimmedValue = value.trim();
         if (trimmedValue.isEmpty()) {
-            throw new UnsupportedDataTypeConversionException(convertType, value);
+            return Optional.of(convertMySQLEmptyValue(convertType, value));
         }
         try {
             switch (convertType.getName()) {
@@ -169,16 +169,16 @@ public final class ResultSetUtils {
                     return Optional.of(convertMySQLBooleanValue(trimmedValue, convertType, value));
                 case "byte":
                 case "java.lang.Byte":
-                    return Optional.of(new BigDecimal(trimmedValue).byteValueExact());
+                    return Optional.of(convertMySQLIntegerValue(trimmedValue).byteValueExact());
                 case "short":
                 case "java.lang.Short":
-                    return Optional.of(new BigDecimal(trimmedValue).shortValueExact());
+                    return Optional.of(convertMySQLIntegerValue(trimmedValue).shortValueExact());
                 case "int":
                 case "java.lang.Integer":
-                    return Optional.of(new BigDecimal(trimmedValue).intValueExact());
+                    return Optional.of(convertMySQLIntegerValue(trimmedValue).intValueExact());
                 case "long":
                 case "java.lang.Long":
-                    return Optional.of(new BigDecimal(trimmedValue).longValueExact());
+                    return Optional.of(convertMySQLIntegerValue(trimmedValue).longValueExact());
                 case "double":
                 case "java.lang.Double":
                     return Optional.of(Double.parseDouble(trimmedValue));
@@ -192,6 +192,44 @@ public final class ResultSetUtils {
             }
         } catch (final NumberFormatException | ArithmeticException ignored) {
             throw new UnsupportedDataTypeConversionException(convertType, value);
+        }
+    }
+    
+    private static BigDecimal convertMySQLIntegerValue(final String value) {
+        if (value.indexOf('.') > -1 || value.indexOf('e') > -1 || value.indexOf('E') > -1) {
+            double doubleValue = Double.parseDouble(value);
+            return BigDecimal.valueOf(doubleValue).setScale(0, RoundingMode.DOWN);
+        }
+        return new BigDecimal(value);
+    }
+    
+    private static Object convertMySQLEmptyValue(final Class<?> convertType, final String originalValue) {
+        switch (convertType.getName()) {
+            case "boolean":
+            case "java.lang.Boolean":
+                return false;
+            case "byte":
+            case "java.lang.Byte":
+                return (byte) 0;
+            case "short":
+            case "java.lang.Short":
+                return (short) 0;
+            case "int":
+            case "java.lang.Integer":
+                return 0;
+            case "long":
+            case "java.lang.Long":
+                return 0L;
+            case "float":
+            case "java.lang.Float":
+                return 0.0F;
+            case "double":
+            case "java.lang.Double":
+                return 0.0D;
+            case "java.math.BigDecimal":
+                return BigDecimal.ZERO;
+            default:
+                throw new UnsupportedDataTypeConversionException(convertType, originalValue);
         }
     }
     

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtils.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtils.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.d
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
@@ -75,11 +76,15 @@ public final class ResultSetUtils {
      *
      * @param value original value
      * @param convertType expected class type
-     * @param isMySQLCompatibleConversion is MySQL compatible conversion or not
+     * @param protocolType protocol database type
      * @return converted value
      * @throws SQLFeatureNotSupportedException SQL feature not supported exception
      */
-    public static Object convertValue(final Object value, final Class<?> convertType, final boolean isMySQLCompatibleConversion) throws SQLFeatureNotSupportedException {
+    public static Object convertValue(final Object value, final Class<?> convertType, final DatabaseType protocolType) throws SQLFeatureNotSupportedException {
+        return convertValue(value, convertType, isMySQLCompatibleConversion(protocolType));
+    }
+    
+    private static Object convertValue(final Object value, final Class<?> convertType, final boolean isMySQLCompatibleConversion) throws SQLFeatureNotSupportedException {
         ShardingSpherePreconditions.checkNotNull(convertType, () -> new SQLFeatureNotSupportedException("Type can not be null"));
         if (null == value) {
             return convertNullValue(convertType);
@@ -125,6 +130,10 @@ public final class ResultSetUtils {
         } catch (final ClassCastException ignored) {
             throw new SQLFeatureNotSupportedException("getObject with type, cannot convert " + value.getClass().getName() + ":" + value + " to " + convertType.getName());
         }
+    }
+    
+    private static boolean isMySQLCompatibleConversion(final DatabaseType protocolType) {
+        return null != protocolType && ("MySQL".equals(protocolType.getType()) || protocolType.getTrunkDatabaseType().map(optional -> "MySQL".equals(optional.getType())).orElse(false));
     }
     
     private static Optional<Object> convertStringValue(final String value, final Class<?> convertType, final boolean isMySQLCompatibleConversion) {

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtils.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtils.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.exception.kernel.data.UnsupportedDataTypeConversionException;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -42,8 +43,8 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Date;
-import java.util.Locale;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * Result set utility class.
@@ -58,6 +59,10 @@ public final class ResultSetUtils {
                     + "[.SSSSSSSSS][.SSSSSSSS][.SSSSSSS][.SSSSSS][.SSSSS][.SSSS][.SSS][.SS][.S]"
                     + "[ ]"
                     + "[XXXXX][XXXX][XXX][XX][X]");
+    
+    private static final Pattern MYSQL_INTEGER_PATTERN = Pattern.compile("-?\\d+");
+    
+    private static final Pattern MYSQL_FLOATING_PATTERN = Pattern.compile("-?\\d*\\.\\d*");
     
     /**
      * Convert value via expected class type.
@@ -158,35 +163,34 @@ public final class ResultSetUtils {
     }
     
     private static Optional<Object> convertMySQLStringValue(final String value, final Class<?> convertType) {
-        String trimmedValue = value.trim();
-        if (trimmedValue.isEmpty()) {
+        if (value.isEmpty()) {
             return Optional.of(convertMySQLEmptyValue(convertType, value));
         }
         try {
             switch (convertType.getName()) {
                 case "boolean":
                 case "java.lang.Boolean":
-                    return Optional.of(convertMySQLBooleanValue(trimmedValue, convertType, value));
+                    return Optional.of(convertMySQLBooleanValue(value, convertType));
                 case "byte":
                 case "java.lang.Byte":
-                    return Optional.of(convertMySQLIntegerValue(trimmedValue).byteValueExact());
+                    return Optional.of(convertMySQLByteValue(value, convertType));
                 case "short":
                 case "java.lang.Short":
-                    return Optional.of(convertMySQLIntegerValue(trimmedValue).shortValueExact());
+                    return Optional.of(convertMySQLIntegerValue(value).shortValueExact());
                 case "int":
                 case "java.lang.Integer":
-                    return Optional.of(convertMySQLIntegerValue(trimmedValue).intValueExact());
+                    return Optional.of(convertMySQLIntegerValue(value).intValueExact());
                 case "long":
                 case "java.lang.Long":
-                    return Optional.of(convertMySQLIntegerValue(trimmedValue).longValueExact());
+                    return Optional.of(convertMySQLIntegerValue(value).longValueExact());
                 case "double":
                 case "java.lang.Double":
-                    return Optional.of(Double.parseDouble(trimmedValue));
+                    return Optional.of(Double.parseDouble(value));
                 case "float":
                 case "java.lang.Float":
-                    return Optional.of(Float.parseFloat(trimmedValue));
+                    return Optional.of(Float.parseFloat(value));
                 case "java.math.BigDecimal":
-                    return Optional.of(new BigDecimal(trimmedValue));
+                    return Optional.of(new BigDecimal(value));
                 default:
                     return Optional.empty();
             }
@@ -233,21 +237,38 @@ public final class ResultSetUtils {
         }
     }
     
-    private static Boolean convertMySQLBooleanValue(final String trimmedValue, final Class<?> convertType, final String originalValue) {
-        if ("1".equals(trimmedValue) || "-1".equals(trimmedValue)) {
+    private static byte convertMySQLByteValue(final String value, final Class<?> convertType) {
+        if (1 != value.length()) {
+            throw new UnsupportedDataTypeConversionException(convertType, value);
+        }
+        return (byte) value.charAt(0);
+    }
+    
+    private static Boolean convertMySQLBooleanValue(final String value, final Class<?> convertType) {
+        if ("Y".equalsIgnoreCase(value) || "yes".equalsIgnoreCase(value) || "T".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value)) {
             return true;
         }
-        if ("0".equals(trimmedValue)) {
+        if ("N".equalsIgnoreCase(value) || "no".equalsIgnoreCase(value) || "F".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
             return false;
         }
-        String normalizedValue = trimmedValue.toLowerCase(Locale.ENGLISH);
-        if ("true".equals(normalizedValue) || "t".equals(normalizedValue) || "yes".equals(normalizedValue) || "y".equals(normalizedValue)) {
-            return true;
+        if (value.contains("e") || value.contains("E") || MYSQL_FLOATING_PATTERN.matcher(value).matches()) {
+            return convertMySQLDoubleToBoolean(Double.parseDouble(value));
         }
-        if ("false".equals(normalizedValue) || "f".equals(normalizedValue) || "no".equals(normalizedValue) || "n".equals(normalizedValue)) {
-            return false;
+        if (MYSQL_INTEGER_PATTERN.matcher(value).matches()) {
+            if ('-' == value.charAt(0) || value.length() <= 18 && value.charAt(0) >= '0' && value.charAt(0) <= '8') {
+                return longToBoolean(Long.parseLong(value));
+            }
+            return convertMySQLBigIntegerToBoolean(new BigDecimal(value).toBigInteger());
         }
-        throw new UnsupportedDataTypeConversionException(convertType, originalValue);
+        throw new UnsupportedDataTypeConversionException(convertType, value);
+    }
+    
+    private static boolean convertMySQLDoubleToBoolean(final double value) {
+        return value > 0.0D || -1.0D == value;
+    }
+    
+    private static boolean convertMySQLBigIntegerToBoolean(final BigInteger value) {
+        return value.signum() > 0 || BigInteger.valueOf(-1L).equals(value);
     }
     
     private static Object convertNullValue(final Class<?> convertType) {

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtils.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtils.java
@@ -41,6 +41,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -66,6 +67,19 @@ public final class ResultSetUtils {
      * @throws SQLFeatureNotSupportedException SQL feature not supported exception
      */
     public static Object convertValue(final Object value, final Class<?> convertType) throws SQLFeatureNotSupportedException {
+        return convertValue(value, convertType, false);
+    }
+    
+    /**
+     * Convert value via expected class type.
+     *
+     * @param value original value
+     * @param convertType expected class type
+     * @param isMySQLCompatibleConversion is MySQL compatible conversion or not
+     * @return converted value
+     * @throws SQLFeatureNotSupportedException SQL feature not supported exception
+     */
+    public static Object convertValue(final Object value, final Class<?> convertType, final boolean isMySQLCompatibleConversion) throws SQLFeatureNotSupportedException {
         ShardingSpherePreconditions.checkNotNull(convertType, () -> new SQLFeatureNotSupportedException("Type can not be null"));
         if (null == value) {
             return convertNullValue(convertType);
@@ -94,17 +108,17 @@ public final class ResultSetUtils {
         if (value instanceof byte[]) {
             return convertByteArrayValue((byte[]) value, convertType);
         }
-        if (boolean.class.equals(convertType)) {
-            return convertBooleanValue(value);
-        }
         if (String.class.equals(convertType)) {
             return value.toString();
         }
         if (value instanceof String) {
-            Optional<Object> result = convertStringValue((String) value, convertType);
+            Optional<Object> result = convertStringValue((String) value, convertType, isMySQLCompatibleConversion);
             if (result.isPresent()) {
                 return result.get();
             }
+        }
+        if (boolean.class.equals(convertType)) {
+            return convertBooleanValue(value);
         }
         try {
             return convertType.cast(value);
@@ -113,7 +127,7 @@ public final class ResultSetUtils {
         }
     }
     
-    private static Optional<Object> convertStringValue(final String value, final Class<?> convertType) {
+    private static Optional<Object> convertStringValue(final String value, final Class<?> convertType, final boolean isMySQLCompatibleConversion) {
         if (byte[].class.equals(convertType)) {
             return Optional.of(value.getBytes(StandardCharsets.UTF_8));
         }
@@ -128,7 +142,65 @@ public final class ResultSetUtils {
         if (Time.class.equals(convertType)) {
             return Optional.of(Time.valueOf(LocalTime.from(LOOSE_DATE_TIME_FORMATTER.parse(value))));
         }
+        if (isMySQLCompatibleConversion) {
+            return convertMySQLStringValue(value, convertType);
+        }
         return Optional.empty();
+    }
+    
+    private static Optional<Object> convertMySQLStringValue(final String value, final Class<?> convertType) {
+        String trimmedValue = value.trim();
+        if (trimmedValue.isEmpty()) {
+            throw new UnsupportedDataTypeConversionException(convertType, value);
+        }
+        try {
+            switch (convertType.getName()) {
+                case "boolean":
+                case "java.lang.Boolean":
+                    return Optional.of(convertMySQLBooleanValue(trimmedValue, convertType, value));
+                case "byte":
+                case "java.lang.Byte":
+                    return Optional.of(new BigDecimal(trimmedValue).byteValueExact());
+                case "short":
+                case "java.lang.Short":
+                    return Optional.of(new BigDecimal(trimmedValue).shortValueExact());
+                case "int":
+                case "java.lang.Integer":
+                    return Optional.of(new BigDecimal(trimmedValue).intValueExact());
+                case "long":
+                case "java.lang.Long":
+                    return Optional.of(new BigDecimal(trimmedValue).longValueExact());
+                case "double":
+                case "java.lang.Double":
+                    return Optional.of(Double.parseDouble(trimmedValue));
+                case "float":
+                case "java.lang.Float":
+                    return Optional.of(Float.parseFloat(trimmedValue));
+                case "java.math.BigDecimal":
+                    return Optional.of(new BigDecimal(trimmedValue));
+                default:
+                    return Optional.empty();
+            }
+        } catch (final NumberFormatException | ArithmeticException ignored) {
+            throw new UnsupportedDataTypeConversionException(convertType, value);
+        }
+    }
+    
+    private static Boolean convertMySQLBooleanValue(final String trimmedValue, final Class<?> convertType, final String originalValue) {
+        if ("1".equals(trimmedValue) || "-1".equals(trimmedValue)) {
+            return true;
+        }
+        if ("0".equals(trimmedValue)) {
+            return false;
+        }
+        String normalizedValue = trimmedValue.toLowerCase(Locale.ENGLISH);
+        if ("true".equals(normalizedValue) || "t".equals(normalizedValue) || "yes".equals(normalizedValue) || "y".equals(normalizedValue)) {
+            return true;
+        }
+        if ("false".equals(normalizedValue) || "f".equals(normalizedValue) || "no".equals(normalizedValue) || "n".equals(normalizedValue)) {
+            return false;
+        }
+        throw new UnsupportedDataTypeConversionException(convertType, originalValue);
     }
     
     private static Object convertNullValue(final Class<?> convertType) {

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtils.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtils.java
@@ -20,14 +20,12 @@ package org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.d
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.exception.kernel.data.UnsupportedDataTypeConversionException;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -44,7 +42,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 /**
  * Result set utility class.
@@ -60,10 +57,6 @@ public final class ResultSetUtils {
                     + "[ ]"
                     + "[XXXXX][XXXX][XXX][XX][X]");
     
-    private static final Pattern MYSQL_INTEGER_PATTERN = Pattern.compile("-?\\d+");
-    
-    private static final Pattern MYSQL_FLOATING_PATTERN = Pattern.compile("-?\\d*\\.\\d*");
-    
     /**
      * Convert value via expected class type.
      *
@@ -73,23 +66,6 @@ public final class ResultSetUtils {
      * @throws SQLFeatureNotSupportedException SQL feature not supported exception
      */
     public static Object convertValue(final Object value, final Class<?> convertType) throws SQLFeatureNotSupportedException {
-        return convertValue(value, convertType, false);
-    }
-    
-    /**
-     * Convert value via expected class type.
-     *
-     * @param value original value
-     * @param convertType expected class type
-     * @param protocolType protocol database type
-     * @return converted value
-     * @throws SQLFeatureNotSupportedException SQL feature not supported exception
-     */
-    public static Object convertValue(final Object value, final Class<?> convertType, final DatabaseType protocolType) throws SQLFeatureNotSupportedException {
-        return convertValue(value, convertType, isMySQLCompatibleConversion(protocolType));
-    }
-    
-    private static Object convertValue(final Object value, final Class<?> convertType, final boolean isMySQLCompatibleConversion) throws SQLFeatureNotSupportedException {
         ShardingSpherePreconditions.checkNotNull(convertType, () -> new SQLFeatureNotSupportedException("Type can not be null"));
         if (null == value) {
             return convertNullValue(convertType);
@@ -122,7 +98,7 @@ public final class ResultSetUtils {
             return value.toString();
         }
         if (value instanceof String) {
-            Optional<Object> result = convertStringValue((String) value, convertType, isMySQLCompatibleConversion);
+            Optional<Object> result = convertStringValue((String) value, convertType);
             if (result.isPresent()) {
                 return result.get();
             }
@@ -137,11 +113,7 @@ public final class ResultSetUtils {
         }
     }
     
-    private static boolean isMySQLCompatibleConversion(final DatabaseType protocolType) {
-        return null != protocolType && "MySQL".equals(protocolType.getType());
-    }
-    
-    private static Optional<Object> convertStringValue(final String value, final Class<?> convertType, final boolean isMySQLCompatibleConversion) {
+    private static Optional<Object> convertStringValue(final String value, final Class<?> convertType) {
         if (byte[].class.equals(convertType)) {
             return Optional.of(value.getBytes(StandardCharsets.UTF_8));
         }
@@ -156,119 +128,7 @@ public final class ResultSetUtils {
         if (Time.class.equals(convertType)) {
             return Optional.of(Time.valueOf(LocalTime.from(LOOSE_DATE_TIME_FORMATTER.parse(value))));
         }
-        if (isMySQLCompatibleConversion) {
-            return convertMySQLStringValue(value, convertType);
-        }
         return Optional.empty();
-    }
-    
-    private static Optional<Object> convertMySQLStringValue(final String value, final Class<?> convertType) {
-        if (value.isEmpty()) {
-            return Optional.of(convertMySQLEmptyValue(convertType, value));
-        }
-        try {
-            switch (convertType.getName()) {
-                case "boolean":
-                case "java.lang.Boolean":
-                    return Optional.of(convertMySQLBooleanValue(value, convertType));
-                case "byte":
-                case "java.lang.Byte":
-                    return Optional.of(convertMySQLByteValue(value, convertType));
-                case "short":
-                case "java.lang.Short":
-                    return Optional.of(convertMySQLIntegerValue(value).shortValueExact());
-                case "int":
-                case "java.lang.Integer":
-                    return Optional.of(convertMySQLIntegerValue(value).intValueExact());
-                case "long":
-                case "java.lang.Long":
-                    return Optional.of(convertMySQLIntegerValue(value).longValueExact());
-                case "double":
-                case "java.lang.Double":
-                    return Optional.of(Double.parseDouble(value));
-                case "float":
-                case "java.lang.Float":
-                    return Optional.of(Float.parseFloat(value));
-                case "java.math.BigDecimal":
-                    return Optional.of(new BigDecimal(value));
-                default:
-                    return Optional.empty();
-            }
-        } catch (final NumberFormatException | ArithmeticException ignored) {
-            throw new UnsupportedDataTypeConversionException(convertType, value);
-        }
-    }
-    
-    private static BigDecimal convertMySQLIntegerValue(final String value) {
-        if (value.indexOf('.') > -1 || value.indexOf('e') > -1 || value.indexOf('E') > -1) {
-            double doubleValue = Double.parseDouble(value);
-            return BigDecimal.valueOf(doubleValue).setScale(0, RoundingMode.DOWN);
-        }
-        return new BigDecimal(value);
-    }
-    
-    private static Object convertMySQLEmptyValue(final Class<?> convertType, final String originalValue) {
-        switch (convertType.getName()) {
-            case "boolean":
-            case "java.lang.Boolean":
-                return false;
-            case "byte":
-            case "java.lang.Byte":
-                return (byte) 0;
-            case "short":
-            case "java.lang.Short":
-                return (short) 0;
-            case "int":
-            case "java.lang.Integer":
-                return 0;
-            case "long":
-            case "java.lang.Long":
-                return 0L;
-            case "float":
-            case "java.lang.Float":
-                return 0.0F;
-            case "double":
-            case "java.lang.Double":
-                return 0.0D;
-            case "java.math.BigDecimal":
-                return BigDecimal.ZERO;
-            default:
-                throw new UnsupportedDataTypeConversionException(convertType, originalValue);
-        }
-    }
-    
-    private static byte convertMySQLByteValue(final String value, final Class<?> convertType) {
-        if (1 != value.length()) {
-            throw new UnsupportedDataTypeConversionException(convertType, value);
-        }
-        return (byte) value.charAt(0);
-    }
-    
-    private static Boolean convertMySQLBooleanValue(final String value, final Class<?> convertType) {
-        if ("Y".equalsIgnoreCase(value) || "yes".equalsIgnoreCase(value) || "T".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value)) {
-            return true;
-        }
-        if ("N".equalsIgnoreCase(value) || "no".equalsIgnoreCase(value) || "F".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
-            return false;
-        }
-        if (value.contains("e") || value.contains("E") || MYSQL_FLOATING_PATTERN.matcher(value).matches()) {
-            return convertMySQLDoubleToBoolean(Double.parseDouble(value));
-        }
-        if (MYSQL_INTEGER_PATTERN.matcher(value).matches()) {
-            if ('-' == value.charAt(0) || value.length() <= 18 && value.charAt(0) >= '0' && value.charAt(0) <= '8') {
-                return longToBoolean(Long.parseLong(value));
-            }
-            return convertMySQLBigIntegerToBoolean(new BigDecimal(value).toBigInteger());
-        }
-        throw new UnsupportedDataTypeConversionException(convertType, value);
-    }
-    
-    private static boolean convertMySQLDoubleToBoolean(final double value) {
-        return value > 0.0D || -1.0D == value;
-    }
-    
-    private static boolean convertMySQLBigIntegerToBoolean(final BigInteger value) {
-        return value.signum() > 0 || BigInteger.valueOf(-1L).equals(value);
     }
     
     private static Object convertNullValue(final Class<?> convertType) {

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtilsTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtilsTest.java
@@ -149,8 +149,13 @@ class ResultSetUtilsTest {
     }
     
     @Test
-    void assertConvertStringToByteWithMySQLProtocolType() throws SQLException {
-        assertThat(ResultSetUtils.convertValue("127", Byte.class, createMySQLProtocolType()), is((Object) Byte.valueOf((byte) 127)));
+    void assertConvertSingleCharacterStringToByteWithMySQLProtocolType() throws SQLException {
+        assertThat(ResultSetUtils.convertValue("1", Byte.class, createMySQLProtocolType()), is((Object) Byte.valueOf((byte) '1')));
+    }
+    
+    @Test
+    void assertConvertMultiCharacterStringToByteWithMySQLProtocolType() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue("127", Byte.class, createMySQLProtocolType()));
     }
     
     @Test
@@ -160,7 +165,12 @@ class ResultSetUtilsTest {
     
     @Test
     void assertConvertStringToIntegerWithMySQLProtocolType() throws SQLException {
-        assertThat(ResultSetUtils.convertValue(" 123 ", Integer.class, createMySQLProtocolType()), is((Object) Integer.valueOf(123)));
+        assertThat(ResultSetUtils.convertValue("123", Integer.class, createMySQLProtocolType()), is((Object) Integer.valueOf(123)));
+    }
+    
+    @Test
+    void assertConvertStringWithWhitespacesToIntegerWithMySQLProtocolType() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue(" 123 ", Integer.class, createMySQLProtocolType()));
     }
     
     @Test
@@ -198,6 +208,21 @@ class ResultSetUtilsTest {
     void assertConvertNumericStringZeroToBooleanWithMySQLProtocolType() throws SQLException {
         assertFalse((boolean) ResultSetUtils.convertValue("0", boolean.class, createMySQLProtocolType()));
     }
+    
+    @Test
+    void assertConvertNumericStringTwoToBooleanWithMySQLProtocolType() throws SQLException {
+        assertTrue((boolean) ResultSetUtils.convertValue("2", boolean.class, createMySQLProtocolType()));
+    }
+    
+    @Test
+    void assertConvertFloatingStringToBooleanWithMySQLProtocolType() throws SQLException {
+        assertTrue((boolean) ResultSetUtils.convertValue("0.1", boolean.class, createMySQLProtocolType()));
+    }
+    
+    @Test
+    void assertConvertExponentStringToBooleanWithMySQLProtocolType() throws SQLException {
+        assertTrue((boolean) ResultSetUtils.convertValue("1e3", boolean.class, createMySQLProtocolType()));
+    }
 
     @Test
     void assertConvertInvalidStringToBooleanWithMySQLProtocolType() {
@@ -206,14 +231,14 @@ class ResultSetUtilsTest {
 
     @Test
     void assertConvertEmptyStringToIntWithMySQLProtocolType() throws SQLException {
-        int actualValue = (int) ResultSetUtils.convertValue("   ", int.class, createMySQLProtocolType());
+        int actualValue = (int) ResultSetUtils.convertValue("", int.class, createMySQLProtocolType());
         int expectedValue = 0;
         assertThat(actualValue, is(expectedValue));
     }
     
     @Test
     void assertConvertEmptyStringToBooleanWithMySQLProtocolType() throws SQLException {
-        boolean actualValue = (boolean) ResultSetUtils.convertValue("   ", boolean.class, createMySQLProtocolType());
+        boolean actualValue = (boolean) ResultSetUtils.convertValue("", boolean.class, createMySQLProtocolType());
         assertFalse(actualValue);
     }
     

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtilsTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtilsTest.java
@@ -126,6 +126,26 @@ class ResultSetUtilsTest {
     }
     
     @Test
+    void assertConvertStringToIntegerWithMySQLCompatibility() throws SQLException {
+        assertThat(ResultSetUtils.convertValue(" 123 ", Integer.class, true), is(123));
+    }
+    
+    @Test
+    void assertConvertStringToBooleanWithMySQLCompatibility() throws SQLException {
+        assertTrue((boolean) ResultSetUtils.convertValue("true", Boolean.class, true));
+    }
+    
+    @Test
+    void assertConvertInvalidStringToIntegerWithMySQLCompatibility() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue("abc", Integer.class, true));
+    }
+    
+    @Test
+    void assertConvertStringToIntegerWithoutMySQLCompatibility() {
+        assertThrows(SQLFeatureNotSupportedException.class, () -> ResultSetUtils.convertValue("123", Integer.class));
+    }
+    
+    @Test
     void assertConvertDateValue() throws SQLException {
         Date now = new Date();
         assertThat(ResultSetUtils.convertValue(now, Date.class), is(now));

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtilsTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtilsTest.java
@@ -203,7 +203,7 @@ class ResultSetUtilsTest {
         assertTrue((boolean) ResultSetUtils.convertValue("1", boolean.class, createMySQLProtocolType()));
         assertTrue((boolean) ResultSetUtils.convertValue("-1", boolean.class, createMySQLProtocolType()));
     }
-
+    
     @Test
     void assertConvertNumericStringZeroToBooleanWithMySQLProtocolType() throws SQLException {
         assertFalse((boolean) ResultSetUtils.convertValue("0", boolean.class, createMySQLProtocolType()));
@@ -223,12 +223,12 @@ class ResultSetUtilsTest {
     void assertConvertExponentStringToBooleanWithMySQLProtocolType() throws SQLException {
         assertTrue((boolean) ResultSetUtils.convertValue("1e3", boolean.class, createMySQLProtocolType()));
     }
-
+    
     @Test
     void assertConvertInvalidStringToBooleanWithMySQLProtocolType() {
         assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue("unknown", Boolean.class, createMySQLProtocolType()));
     }
-
+    
     @Test
     void assertConvertEmptyStringToIntWithMySQLProtocolType() throws SQLException {
         int actualValue = (int) ResultSetUtils.convertValue("", int.class, createMySQLProtocolType());

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtilsTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.d
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.exception.kernel.data.UnsupportedDataTypeConversionException;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,7 @@ import java.time.LocalTime;
 import java.time.Month;
 import java.time.OffsetDateTime;
 import java.util.Date;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -45,8 +47,24 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ResultSetUtilsTest {
+    
+    private DatabaseType createMySQLProtocolType() {
+        DatabaseType result = mock(DatabaseType.class);
+        when(result.getType()).thenReturn("MySQL");
+        when(result.getTrunkDatabaseType()).thenReturn(Optional.empty());
+        return result;
+    }
+    
+    private DatabaseType createPostgreSQLProtocolType() {
+        DatabaseType result = mock(DatabaseType.class);
+        when(result.getType()).thenReturn("PostgreSQL");
+        when(result.getTrunkDatabaseType()).thenReturn(Optional.empty());
+        return result;
+    }
     
     @Test
     void assertConvertNullType() {
@@ -126,23 +144,63 @@ class ResultSetUtilsTest {
     }
     
     @Test
-    void assertConvertStringToIntegerWithMySQLCompatibility() throws SQLException {
-        assertThat(ResultSetUtils.convertValue(" 123 ", Integer.class, true), is(123));
+    void assertConvertStringToBooleanWithMySQLProtocolType() throws SQLException {
+        assertTrue((boolean) ResultSetUtils.convertValue("true", Boolean.class, createMySQLProtocolType()));
     }
     
     @Test
-    void assertConvertStringToBooleanWithMySQLCompatibility() throws SQLException {
-        assertTrue((boolean) ResultSetUtils.convertValue("true", Boolean.class, true));
+    void assertConvertStringToByteWithMySQLProtocolType() throws SQLException {
+        assertThat(ResultSetUtils.convertValue("127", Byte.class, createMySQLProtocolType()), is((Object) Byte.valueOf((byte) 127)));
     }
     
     @Test
-    void assertConvertInvalidStringToIntegerWithMySQLCompatibility() {
-        assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue("abc", Integer.class, true));
+    void assertConvertStringToShortWithMySQLProtocolType() throws SQLException {
+        assertThat(ResultSetUtils.convertValue("32767", Short.class, createMySQLProtocolType()), is((Object) Short.valueOf((short) 32767)));
+    }
+    
+    @Test
+    void assertConvertStringToIntegerWithMySQLProtocolType() throws SQLException {
+        assertThat(ResultSetUtils.convertValue(" 123 ", Integer.class, createMySQLProtocolType()), is((Object) Integer.valueOf(123)));
+    }
+    
+    @Test
+    void assertConvertStringToLongWithMySQLProtocolType() throws SQLException {
+        assertThat(ResultSetUtils.convertValue("123456", Long.class, createMySQLProtocolType()), is((Object) Long.valueOf(123456L)));
+    }
+    
+    @Test
+    void assertConvertStringToFloatWithMySQLProtocolType() throws SQLException {
+        assertThat(ResultSetUtils.convertValue("3.14", Float.class, createMySQLProtocolType()), is((Object) Float.valueOf(3.14F)));
+    }
+    
+    @Test
+    void assertConvertStringToDoubleWithMySQLProtocolType() throws SQLException {
+        assertThat(ResultSetUtils.convertValue("3.1415926", Double.class, createMySQLProtocolType()), is((Object) Double.valueOf(3.1415926D)));
+    }
+    
+    @Test
+    void assertConvertStringToBigDecimalWithMySQLProtocolType() throws SQLException {
+        assertThat(ResultSetUtils.convertValue("123.45", BigDecimal.class, createMySQLProtocolType()), is((Object) new BigDecimal("123.45")));
+    }
+    
+    @Test
+    void assertConvertInvalidStringToIntegerWithMySQLProtocolType() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue("abc", Integer.class, createMySQLProtocolType()));
+    }
+    
+    @Test
+    void assertConvertInvalidStringToBooleanWithMySQLProtocolType() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue("unknown", Boolean.class, createMySQLProtocolType()));
+    }
+    
+    @Test
+    void assertConvertEmptyStringToIntegerWithMySQLProtocolType() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue("   ", Integer.class, createMySQLProtocolType()));
     }
     
     @Test
     void assertConvertStringToIntegerWithoutMySQLCompatibility() {
-        assertThrows(SQLFeatureNotSupportedException.class, () -> ResultSetUtils.convertValue("123", Integer.class));
+        assertThrows(SQLFeatureNotSupportedException.class, () -> ResultSetUtils.convertValue("123", Integer.class, createPostgreSQLProtocolType()));
     }
     
     @Test

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtilsTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtilsTest.java
@@ -189,13 +189,46 @@ class ResultSetUtilsTest {
     }
     
     @Test
+    void assertConvertNumericStringOneToBooleanWithMySQLProtocolType() throws SQLException {
+        assertTrue((boolean) ResultSetUtils.convertValue("1", boolean.class, createMySQLProtocolType()));
+        assertTrue((boolean) ResultSetUtils.convertValue("-1", boolean.class, createMySQLProtocolType()));
+    }
+
+    @Test
+    void assertConvertNumericStringZeroToBooleanWithMySQLProtocolType() throws SQLException {
+        assertFalse((boolean) ResultSetUtils.convertValue("0", boolean.class, createMySQLProtocolType()));
+    }
+
+    @Test
     void assertConvertInvalidStringToBooleanWithMySQLProtocolType() {
         assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue("unknown", Boolean.class, createMySQLProtocolType()));
     }
+
+    @Test
+    void assertConvertEmptyStringToIntWithMySQLProtocolType() throws SQLException {
+        int actualValue = (int) ResultSetUtils.convertValue("   ", int.class, createMySQLProtocolType());
+        int expectedValue = 0;
+        assertThat(actualValue, is(expectedValue));
+    }
     
     @Test
-    void assertConvertEmptyStringToIntegerWithMySQLProtocolType() {
-        assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue("   ", Integer.class, createMySQLProtocolType()));
+    void assertConvertEmptyStringToBooleanWithMySQLProtocolType() throws SQLException {
+        boolean actualValue = (boolean) ResultSetUtils.convertValue("   ", boolean.class, createMySQLProtocolType());
+        assertFalse(actualValue);
+    }
+    
+    @Test
+    void assertConvertDecimalStringToIntWithMySQLProtocolType() throws SQLException {
+        int actualValue = (int) ResultSetUtils.convertValue("123.45", int.class, createMySQLProtocolType());
+        int expectedValue = 123;
+        assertThat(actualValue, is(expectedValue));
+    }
+    
+    @Test
+    void assertConvertExponentStringToIntWithMySQLProtocolType() throws SQLException {
+        int actualValue = (int) ResultSetUtils.convertValue("1e3", int.class, createMySQLProtocolType());
+        int expectedValue = 1000;
+        assertThat(actualValue, is(expectedValue));
     }
     
     @Test

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtilsTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtilsTest.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.d
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.exception.kernel.data.UnsupportedDataTypeConversionException;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +37,6 @@ import java.time.LocalTime;
 import java.time.Month;
 import java.time.OffsetDateTime;
 import java.util.Date;
-import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -47,24 +45,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class ResultSetUtilsTest {
-    
-    private DatabaseType createMySQLProtocolType() {
-        DatabaseType result = mock(DatabaseType.class);
-        when(result.getType()).thenReturn("MySQL");
-        when(result.getTrunkDatabaseType()).thenReturn(Optional.empty());
-        return result;
-    }
-    
-    private DatabaseType createPostgreSQLProtocolType() {
-        DatabaseType result = mock(DatabaseType.class);
-        when(result.getType()).thenReturn("PostgreSQL");
-        when(result.getTrunkDatabaseType()).thenReturn(Optional.empty());
-        return result;
-    }
     
     @Test
     void assertConvertNullType() {
@@ -144,121 +126,8 @@ class ResultSetUtilsTest {
     }
     
     @Test
-    void assertConvertStringToBooleanWithMySQLProtocolType() throws SQLException {
-        assertTrue((boolean) ResultSetUtils.convertValue("true", Boolean.class, createMySQLProtocolType()));
-    }
-    
-    @Test
-    void assertConvertSingleCharacterStringToByteWithMySQLProtocolType() throws SQLException {
-        assertThat(ResultSetUtils.convertValue("1", Byte.class, createMySQLProtocolType()), is((Object) Byte.valueOf((byte) '1')));
-    }
-    
-    @Test
-    void assertConvertMultiCharacterStringToByteWithMySQLProtocolType() {
-        assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue("127", Byte.class, createMySQLProtocolType()));
-    }
-    
-    @Test
-    void assertConvertStringToShortWithMySQLProtocolType() throws SQLException {
-        assertThat(ResultSetUtils.convertValue("32767", Short.class, createMySQLProtocolType()), is((Object) Short.valueOf((short) 32767)));
-    }
-    
-    @Test
-    void assertConvertStringToIntegerWithMySQLProtocolType() throws SQLException {
-        assertThat(ResultSetUtils.convertValue("123", Integer.class, createMySQLProtocolType()), is((Object) Integer.valueOf(123)));
-    }
-    
-    @Test
-    void assertConvertStringWithWhitespacesToIntegerWithMySQLProtocolType() {
-        assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue(" 123 ", Integer.class, createMySQLProtocolType()));
-    }
-    
-    @Test
-    void assertConvertStringToLongWithMySQLProtocolType() throws SQLException {
-        assertThat(ResultSetUtils.convertValue("123456", Long.class, createMySQLProtocolType()), is((Object) Long.valueOf(123456L)));
-    }
-    
-    @Test
-    void assertConvertStringToFloatWithMySQLProtocolType() throws SQLException {
-        assertThat(ResultSetUtils.convertValue("3.14", Float.class, createMySQLProtocolType()), is((Object) Float.valueOf(3.14F)));
-    }
-    
-    @Test
-    void assertConvertStringToDoubleWithMySQLProtocolType() throws SQLException {
-        assertThat(ResultSetUtils.convertValue("3.1415926", Double.class, createMySQLProtocolType()), is((Object) Double.valueOf(3.1415926D)));
-    }
-    
-    @Test
-    void assertConvertStringToBigDecimalWithMySQLProtocolType() throws SQLException {
-        assertThat(ResultSetUtils.convertValue("123.45", BigDecimal.class, createMySQLProtocolType()), is((Object) new BigDecimal("123.45")));
-    }
-    
-    @Test
-    void assertConvertInvalidStringToIntegerWithMySQLProtocolType() {
-        assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue("abc", Integer.class, createMySQLProtocolType()));
-    }
-    
-    @Test
-    void assertConvertNumericStringOneToBooleanWithMySQLProtocolType() throws SQLException {
-        assertTrue((boolean) ResultSetUtils.convertValue("1", boolean.class, createMySQLProtocolType()));
-        assertTrue((boolean) ResultSetUtils.convertValue("-1", boolean.class, createMySQLProtocolType()));
-    }
-    
-    @Test
-    void assertConvertNumericStringZeroToBooleanWithMySQLProtocolType() throws SQLException {
-        assertFalse((boolean) ResultSetUtils.convertValue("0", boolean.class, createMySQLProtocolType()));
-    }
-    
-    @Test
-    void assertConvertNumericStringTwoToBooleanWithMySQLProtocolType() throws SQLException {
-        assertTrue((boolean) ResultSetUtils.convertValue("2", boolean.class, createMySQLProtocolType()));
-    }
-    
-    @Test
-    void assertConvertFloatingStringToBooleanWithMySQLProtocolType() throws SQLException {
-        assertTrue((boolean) ResultSetUtils.convertValue("0.1", boolean.class, createMySQLProtocolType()));
-    }
-    
-    @Test
-    void assertConvertExponentStringToBooleanWithMySQLProtocolType() throws SQLException {
-        assertTrue((boolean) ResultSetUtils.convertValue("1e3", boolean.class, createMySQLProtocolType()));
-    }
-    
-    @Test
-    void assertConvertInvalidStringToBooleanWithMySQLProtocolType() {
-        assertThrows(UnsupportedDataTypeConversionException.class, () -> ResultSetUtils.convertValue("unknown", Boolean.class, createMySQLProtocolType()));
-    }
-    
-    @Test
-    void assertConvertEmptyStringToIntWithMySQLProtocolType() throws SQLException {
-        int actualValue = (int) ResultSetUtils.convertValue("", int.class, createMySQLProtocolType());
-        int expectedValue = 0;
-        assertThat(actualValue, is(expectedValue));
-    }
-    
-    @Test
-    void assertConvertEmptyStringToBooleanWithMySQLProtocolType() throws SQLException {
-        boolean actualValue = (boolean) ResultSetUtils.convertValue("", boolean.class, createMySQLProtocolType());
-        assertFalse(actualValue);
-    }
-    
-    @Test
-    void assertConvertDecimalStringToIntWithMySQLProtocolType() throws SQLException {
-        int actualValue = (int) ResultSetUtils.convertValue("123.45", int.class, createMySQLProtocolType());
-        int expectedValue = 123;
-        assertThat(actualValue, is(expectedValue));
-    }
-    
-    @Test
-    void assertConvertExponentStringToIntWithMySQLProtocolType() throws SQLException {
-        int actualValue = (int) ResultSetUtils.convertValue("1e3", int.class, createMySQLProtocolType());
-        int expectedValue = 1000;
-        assertThat(actualValue, is(expectedValue));
-    }
-    
-    @Test
-    void assertConvertStringToIntegerWithoutMySQLCompatibility() {
-        assertThrows(SQLFeatureNotSupportedException.class, () -> ResultSetUtils.convertValue("123", Integer.class, createPostgreSQLProtocolType()));
+    void assertConvertStringToInteger() {
+        assertThrows(SQLFeatureNotSupportedException.class, () -> ResultSetUtils.convertValue("123", Integer.class));
     }
     
     @Test

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/DialectResultSetValueConverter.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/DialectResultSetValueConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.driver.jdbc.core.resultset;
+
+import org.apache.shardingsphere.infra.spi.annotation.SingletonSPI;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPI;
+
+import java.sql.SQLFeatureNotSupportedException;
+
+/**
+ * Dialect result set value converter.
+ */
+@SingletonSPI
+public interface DialectResultSetValueConverter extends TypedSPI {
+    
+    /**
+     * Convert value via expected class type.
+     *
+     * @param value original value
+     * @param convertType expected class type
+     * @return converted value
+     * @throws SQLFeatureNotSupportedException SQL feature not supported exception
+     */
+    Object convertValue(Object value, Class<?> convertType) throws SQLFeatureNotSupportedException;
+}

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/MySQLResultSetValueConverter.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/MySQLResultSetValueConverter.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.driver.jdbc.core.resultset;
+
+import org.apache.shardingsphere.infra.exception.kernel.data.UnsupportedDataTypeConversionException;
+import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.driver.jdbc.type.util.ResultSetUtils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.regex.Pattern;
+
+/**
+ * MySQL result set value converter.
+ */
+public final class MySQLResultSetValueConverter implements DialectResultSetValueConverter {
+    
+    private static final Pattern FLOATING_POINT_PATTERN = Pattern.compile("-?\\d*\\.\\d*");
+    
+    private static final Pattern INTEGER_PATTERN = Pattern.compile("-?\\d+");
+    
+    @Override
+    public Object convertValue(final Object value, final Class<?> convertType) throws SQLFeatureNotSupportedException {
+        if (!(value instanceof String)) {
+            return ResultSetUtils.convertValue(value, convertType);
+        }
+        String stringValue = (String) value;
+        try {
+            switch (convertType.getName()) {
+                case "boolean":
+                case "java.lang.Boolean":
+                    return stringValue.isEmpty() ? false : convertBooleanValue(stringValue, convertType);
+                case "byte":
+                case "java.lang.Byte":
+                    return stringValue.isEmpty() ? (byte) 0 : convertByteValue(stringValue, convertType);
+                case "short":
+                case "java.lang.Short":
+                    return stringValue.isEmpty() ? (short) 0 : convertIntegralValue(stringValue, convertType).shortValueExact();
+                case "int":
+                case "java.lang.Integer":
+                    return stringValue.isEmpty() ? 0 : convertIntegralValue(stringValue, convertType).intValueExact();
+                case "long":
+                case "java.lang.Long":
+                    return stringValue.isEmpty() ? 0L : convertIntegralValue(stringValue, convertType).longValueExact();
+                case "double":
+                case "java.lang.Double":
+                    return stringValue.isEmpty() ? 0.0D : convertNumericValue(stringValue, convertType).doubleValue();
+                case "float":
+                case "java.lang.Float":
+                    return stringValue.isEmpty() ? 0.0F : convertNumericValue(stringValue, convertType).floatValue();
+                case "java.math.BigDecimal":
+                    return stringValue.isEmpty() ? BigDecimal.ZERO : convertNumericValue(stringValue, convertType);
+                default:
+                    return ResultSetUtils.convertValue(value, convertType);
+            }
+        } catch (final NumberFormatException | ArithmeticException ignored) {
+            throw new UnsupportedDataTypeConversionException(convertType, value);
+        }
+    }
+    
+    @Override
+    public String getType() {
+        return "MySQL";
+    }
+    
+    private byte convertByteValue(final String value, final Class<?> convertType) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        if (1 != bytes.length) {
+            throw new UnsupportedDataTypeConversionException(convertType, value);
+        }
+        return bytes[0];
+    }
+    
+    private Boolean convertBooleanValue(final String value, final Class<?> convertType) {
+        if ("Y".equalsIgnoreCase(value) || "yes".equalsIgnoreCase(value) || "T".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("N".equalsIgnoreCase(value) || "no".equalsIgnoreCase(value) || "F".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        if (value.contains("e") || value.contains("E") || FLOATING_POINT_PATTERN.matcher(value).matches()) {
+            return convertDoubleToBoolean(Double.parseDouble(value));
+        }
+        if (INTEGER_PATTERN.matcher(value).matches()) {
+            return isSignedLong(value) ? longToBoolean(Long.parseLong(value)) : convertBigIntegerToBoolean(new BigInteger(value));
+        }
+        throw new UnsupportedDataTypeConversionException(convertType, value);
+    }
+    
+    private BigDecimal convertIntegralValue(final String value, final Class<?> convertType) {
+        if (value.contains("e") || value.contains("E") || FLOATING_POINT_PATTERN.matcher(value).matches()) {
+            return BigDecimal.valueOf(Double.parseDouble(value)).setScale(0, RoundingMode.DOWN);
+        }
+        if (INTEGER_PATTERN.matcher(value).matches()) {
+            return convertIntegerValue(value);
+        }
+        throw new UnsupportedDataTypeConversionException(convertType, value);
+    }
+    
+    private BigDecimal convertNumericValue(final String value, final Class<?> convertType) {
+        if (value.contains("e") || value.contains("E") || FLOATING_POINT_PATTERN.matcher(value).matches()) {
+            return BigDecimal.valueOf(Double.parseDouble(value));
+        }
+        if (INTEGER_PATTERN.matcher(value).matches()) {
+            return convertIntegerValue(value);
+        }
+        throw new UnsupportedDataTypeConversionException(convertType, value);
+    }
+    
+    private BigDecimal convertIntegerValue(final String value) {
+        return isSignedLong(value) ? BigDecimal.valueOf(Long.parseLong(value)) : new BigDecimal(new BigInteger(value));
+    }
+    
+    private boolean isSignedLong(final String value) {
+        return '-' == value.charAt(0) || value.length() <= 18 && value.charAt(0) >= '0' && value.charAt(0) <= '8';
+    }
+    
+    private boolean longToBoolean(final long value) {
+        return -1L == value || value > 0L;
+    }
+    
+    private boolean convertDoubleToBoolean(final double value) {
+        return value > 0.0D || -1.0D == value;
+    }
+    
+    private boolean convertBigIntegerToBoolean(final BigInteger value) {
+        return value.signum() > 0 || BigInteger.valueOf(-1L).equals(value);
+    }
+}

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.driver.jdbc.core.resultset;
 import lombok.Getter;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.driver.jdbc.adapter.AbstractResultSetAdapter;
-import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement;
 import org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement;
 import org.apache.shardingsphere.infra.annotation.HighFrequencyInvocation;
@@ -409,16 +408,12 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
     }
     
     private DatabaseType getProtocolType() {
-        ShardingSphereConnection connection = getConnection();
-        return null == connection ? null : connection.getContextManager().getMetaDataContexts().getMetaData().getDatabase(connection.getCurrentDatabaseName()).getProtocolType();
-    }
-    
-    private ShardingSphereConnection getConnection() {
         if (getStatement() instanceof ShardingSpherePreparedStatement) {
-            return ((ShardingSpherePreparedStatement) getStatement()).getConnection();
+            return ((ShardingSpherePreparedStatement) getStatement()).getUsedDatabase().getProtocolType();
         }
         if (getStatement() instanceof ShardingSphereStatement) {
-            return ((ShardingSphereStatement) getStatement()).getConnection();
+            ShardingSphereStatement statement = (ShardingSphereStatement) getStatement();
+            return statement.getConnection().getContextManager().getMetaDataContexts().getMetaData().getDatabase(statement.getUsedDatabaseName()).getProtocolType();
         }
         return null;
     }

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
@@ -66,12 +66,15 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
     
     private final MergedResult mergeResultSet;
     
+    private final DatabaseType protocolType;
+    
     @Getter
     private final Map<String, Integer> columnLabelAndIndexMap;
     
     public ShardingSphereResultSet(final List<ResultSet> resultSets, final MergedResult mergeResultSet, final Statement statement, final SQLStatementContext sqlStatementContext) throws SQLException {
         super(resultSets, statement, sqlStatementContext);
         this.mergeResultSet = mergeResultSet;
+        protocolType = getProtocolType(statement);
         columnLabelAndIndexMap = ShardingSphereResultSetUtils.createColumnLabelAndIndexMap(sqlStatementContext, resultSets.get(0).getMetaData());
     }
     
@@ -79,6 +82,7 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
                                    final SQLStatementContext sqlStatementContext, final Map<String, Integer> columnLabelAndIndexMap) {
         super(resultSets, statement, sqlStatementContext);
         this.mergeResultSet = mergeResultSet;
+        protocolType = getProtocolType(statement);
         this.columnLabelAndIndexMap = columnLabelAndIndexMap;
     }
     
@@ -386,9 +390,9 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
             return (T) getClob(columnIndex);
         }
         if (LocalDateTime.class.equals(type) || LocalDate.class.equals(type) || LocalTime.class.equals(type) || OffsetDateTime.class.equals(type)) {
-            return (T) ResultSetUtils.convertValue(mergeResultSet.getValue(columnIndex, Timestamp.class), type, isMySQLProtocolType());
+            return (T) ResultSetUtils.convertValue(mergeResultSet.getValue(columnIndex, Timestamp.class), type, protocolType);
         }
-        return (T) ResultSetUtils.convertValue(mergeResultSet.getValue(columnIndex, type), type, isMySQLProtocolType());
+        return (T) ResultSetUtils.convertValue(mergeResultSet.getValue(columnIndex, type), type, protocolType);
     }
     
     @Override
@@ -402,18 +406,13 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
         return result;
     }
     
-    private boolean isMySQLProtocolType() {
-        DatabaseType protocolType = getProtocolType();
-        return null != protocolType && ("MySQL".equals(protocolType.getType()) || protocolType.getTrunkDatabaseType().map(optional -> "MySQL".equals(optional.getType())).orElse(false));
-    }
-    
-    private DatabaseType getProtocolType() {
-        if (getStatement() instanceof ShardingSpherePreparedStatement) {
-            return ((ShardingSpherePreparedStatement) getStatement()).getUsedDatabase().getProtocolType();
+    private DatabaseType getProtocolType(final Statement statement) {
+        if (statement instanceof ShardingSpherePreparedStatement) {
+            return ((ShardingSpherePreparedStatement) statement).getUsedDatabase().getProtocolType();
         }
-        if (getStatement() instanceof ShardingSphereStatement) {
-            ShardingSphereStatement statement = (ShardingSphereStatement) getStatement();
-            return statement.getConnection().getContextManager().getMetaDataContexts().getMetaData().getDatabase(statement.getUsedDatabaseName()).getProtocolType();
+        if (statement instanceof ShardingSphereStatement) {
+            ShardingSphereStatement shardingSphereStatement = (ShardingSphereStatement) statement;
+            return shardingSphereStatement.getConnection().getContextManager().getMetaDataContexts().getMetaData().getDatabase(shardingSphereStatement.getUsedDatabaseName()).getProtocolType();
         }
         return null;
     }

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
@@ -18,7 +18,11 @@
 package org.apache.shardingsphere.driver.jdbc.core.resultset;
 
 import lombok.Getter;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.driver.jdbc.adapter.AbstractResultSetAdapter;
+import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
+import org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement;
+import org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement;
 import org.apache.shardingsphere.infra.annotation.HighFrequencyInvocation;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
@@ -383,9 +387,9 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
             return (T) getClob(columnIndex);
         }
         if (LocalDateTime.class.equals(type) || LocalDate.class.equals(type) || LocalTime.class.equals(type) || OffsetDateTime.class.equals(type)) {
-            return (T) ResultSetUtils.convertValue(mergeResultSet.getValue(columnIndex, Timestamp.class), type);
+            return (T) ResultSetUtils.convertValue(mergeResultSet.getValue(columnIndex, Timestamp.class), type, isMySQLProtocolType());
         }
-        return (T) ResultSetUtils.convertValue(mergeResultSet.getValue(columnIndex, type), type);
+        return (T) ResultSetUtils.convertValue(mergeResultSet.getValue(columnIndex, type), type, isMySQLProtocolType());
     }
     
     @Override
@@ -397,5 +401,25 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
         Integer result = columnLabelAndIndexMap.get(columnLabel);
         ShardingSpherePreconditions.checkNotNull(result, () -> new SQLFeatureNotSupportedException(String.format("Can not get index from column label `%s`.", columnLabel)));
         return result;
+    }
+    
+    private boolean isMySQLProtocolType() {
+        DatabaseType protocolType = getProtocolType();
+        return null != protocolType && ("MySQL".equals(protocolType.getType()) || protocolType.getTrunkDatabaseType().map(optional -> "MySQL".equals(optional.getType())).orElse(false));
+    }
+    
+    private DatabaseType getProtocolType() {
+        ShardingSphereConnection connection = getConnection();
+        return null == connection ? null : connection.getContextManager().getMetaDataContexts().getMetaData().getDatabase(connection.getCurrentDatabaseName()).getProtocolType();
+    }
+    
+    private ShardingSphereConnection getConnection() {
+        if (getStatement() instanceof ShardingSpherePreparedStatement) {
+            return ((ShardingSpherePreparedStatement) getStatement()).getConnection();
+        }
+        if (getStatement() instanceof ShardingSphereStatement) {
+            return ((ShardingSphereStatement) getStatement()).getConnection();
+        }
+        return null;
     }
 }

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.infra.annotation.HighFrequencyInvocation;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.driver.jdbc.type.util.ResultSetUtils;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
 
 import java.io.InputStream;
@@ -66,7 +67,7 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
     
     private final MergedResult mergeResultSet;
     
-    private final DatabaseType protocolType;
+    private final DialectResultSetValueConverter dialectResultSetValueConverter;
     
     @Getter
     private final Map<String, Integer> columnLabelAndIndexMap;
@@ -74,7 +75,8 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
     public ShardingSphereResultSet(final List<ResultSet> resultSets, final MergedResult mergeResultSet, final Statement statement, final SQLStatementContext sqlStatementContext) throws SQLException {
         super(resultSets, statement, sqlStatementContext);
         this.mergeResultSet = mergeResultSet;
-        protocolType = getProtocolType(statement);
+        DatabaseType protocolType = getProtocolType(statement);
+        dialectResultSetValueConverter = getDialectResultSetValueConverter(protocolType);
         columnLabelAndIndexMap = ShardingSphereResultSetUtils.createColumnLabelAndIndexMap(sqlStatementContext, resultSets.get(0).getMetaData());
     }
     
@@ -82,7 +84,8 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
                                    final SQLStatementContext sqlStatementContext, final Map<String, Integer> columnLabelAndIndexMap) {
         super(resultSets, statement, sqlStatementContext);
         this.mergeResultSet = mergeResultSet;
-        protocolType = getProtocolType(statement);
+        DatabaseType protocolType = getProtocolType(statement);
+        dialectResultSetValueConverter = getDialectResultSetValueConverter(protocolType);
         this.columnLabelAndIndexMap = columnLabelAndIndexMap;
     }
     
@@ -390,9 +393,9 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
             return (T) getClob(columnIndex);
         }
         if (LocalDateTime.class.equals(type) || LocalDate.class.equals(type) || LocalTime.class.equals(type) || OffsetDateTime.class.equals(type)) {
-            return (T) ResultSetUtils.convertValue(mergeResultSet.getValue(columnIndex, Timestamp.class), type, protocolType);
+            return (T) convertValue(mergeResultSet.getValue(columnIndex, Timestamp.class), type);
         }
-        return (T) ResultSetUtils.convertValue(mergeResultSet.getValue(columnIndex, type), type, protocolType);
+        return (T) convertValue(mergeResultSet.getValue(columnIndex, type), type);
     }
     
     @Override
@@ -415,5 +418,13 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
             return shardingSphereStatement.getConnection().getContextManager().getMetaDataContexts().getMetaData().getDatabase(shardingSphereStatement.getUsedDatabaseName()).getProtocolType();
         }
         return null;
+    }
+    
+    private DialectResultSetValueConverter getDialectResultSetValueConverter(final DatabaseType protocolType) {
+        return null == protocolType ? null : TypedSPILoader.findService(DialectResultSetValueConverter.class, protocolType.getType()).orElse(null);
+    }
+    
+    private Object convertValue(final Object value, final Class<?> type) throws SQLFeatureNotSupportedException {
+        return null == dialectResultSetValueConverter ? ResultSetUtils.convertValue(value, type) : dialectResultSetValueConverter.convertValue(value, type);
     }
 }

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatement.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatement.java
@@ -81,6 +81,7 @@ public final class ShardingSpherePreparedStatement extends AbstractPreparedState
     
     private final SQLStatementContext sqlStatementContext;
     
+    @Getter
     private final ShardingSphereDatabase usedDatabase;
     
     private final StatementOption statementOption;

--- a/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSphereStatement.java
+++ b/jdbc/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSphereStatement.java
@@ -80,6 +80,7 @@ public final class ShardingSphereStatement extends AbstractStatementAdapter {
     
     private final List<Statement> statements;
     
+    @Getter
     private String usedDatabaseName;
     
     private QueryContext queryContext;

--- a/jdbc/src/main/resources/META-INF/services/org.apache.shardingsphere.driver.jdbc.core.resultset.DialectResultSetValueConverter
+++ b/jdbc/src/main/resources/META-INF/services/org.apache.shardingsphere.driver.jdbc.core.resultset.DialectResultSetValueConverter
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.driver.jdbc.core.resultset.MySQLResultSetValueConverter

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/MySQLResultSetValueConverterTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/MySQLResultSetValueConverterTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.driver.jdbc.core.resultset;
+
+import org.apache.shardingsphere.infra.exception.kernel.data.UnsupportedDataTypeConversionException;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MySQLResultSetValueConverterTest {
+    
+    private final DialectResultSetValueConverter actual = TypedSPILoader.getService(DialectResultSetValueConverter.class, "MySQL");
+    
+    @Test
+    void assertGetType() {
+        assertThat(actual.getType(), is("MySQL"));
+    }
+    
+    @Test
+    void assertConvertStringToBoolean() throws SQLException {
+        assertTrue((boolean) actual.convertValue("true", Boolean.class));
+    }
+    
+    @Test
+    void assertConvertSingleCharacterStringToByte() throws SQLException {
+        assertThat(actual.convertValue("1", Byte.class), is((Object) Byte.valueOf((byte) '1')));
+    }
+    
+    @Test
+    void assertConvertMultiCharacterStringToByte() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> actual.convertValue("127", Byte.class));
+    }
+    
+    @Test
+    void assertConvertSingleMultiByteCharacterStringToByte() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> actual.convertValue("你", Byte.class));
+    }
+    
+    @Test
+    void assertConvertStringToShort() throws SQLException {
+        assertThat(actual.convertValue("32767", Short.class), is((Object) Short.valueOf((short) 32767)));
+    }
+    
+    @Test
+    void assertConvertStringToInteger() throws SQLException {
+        assertThat(actual.convertValue("123", Integer.class), is((Object) Integer.valueOf(123)));
+    }
+    
+    @Test
+    void assertConvertStringWithWhitespacesToInteger() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> actual.convertValue(" 123 ", Integer.class));
+    }
+    
+    @Test
+    void assertConvertLeadingPlusStringToInteger() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> actual.convertValue("+123", Integer.class));
+    }
+    
+    @Test
+    void assertConvertStringToLong() throws SQLException {
+        assertThat(actual.convertValue("123456", Long.class), is((Object) Long.valueOf(123456L)));
+    }
+    
+    @Test
+    void assertConvertStringToFloat() throws SQLException {
+        assertThat(actual.convertValue("3.14", Float.class), is((Object) Float.valueOf(3.14F)));
+    }
+    
+    @Test
+    void assertConvertStringToDouble() throws SQLException {
+        assertThat(actual.convertValue("3.1415926", Double.class), is((Object) Double.valueOf(3.1415926D)));
+    }
+    
+    @Test
+    void assertConvertStringToBigDecimal() throws SQLException {
+        assertThat(actual.convertValue("123.45", BigDecimal.class), is((Object) new BigDecimal("123.45")));
+    }
+    
+    @Test
+    void assertConvertLeadingPlusStringToBigDecimal() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> actual.convertValue("+123.45", BigDecimal.class));
+    }
+    
+    @Test
+    void assertConvertInvalidStringToInteger() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> actual.convertValue("abc", Integer.class));
+    }
+    
+    @Test
+    void assertConvertNumericStringOneToBoolean() throws SQLException {
+        assertTrue((boolean) actual.convertValue("1", boolean.class));
+        assertTrue((boolean) actual.convertValue("-1", boolean.class));
+    }
+    
+    @Test
+    void assertConvertNumericStringZeroToBoolean() throws SQLException {
+        assertFalse((boolean) actual.convertValue("0", boolean.class));
+    }
+    
+    @Test
+    void assertConvertNumericStringTwoToBoolean() throws SQLException {
+        assertTrue((boolean) actual.convertValue("2", boolean.class));
+    }
+    
+    @Test
+    void assertConvertFloatingStringToBoolean() throws SQLException {
+        assertTrue((boolean) actual.convertValue("0.1", boolean.class));
+    }
+    
+    @Test
+    void assertConvertExponentStringToBoolean() throws SQLException {
+        assertTrue((boolean) actual.convertValue("1e3", boolean.class));
+    }
+    
+    @Test
+    void assertConvertInvalidStringToBoolean() {
+        assertThrows(UnsupportedDataTypeConversionException.class, () -> actual.convertValue("unknown", Boolean.class));
+    }
+    
+    @Test
+    void assertConvertEmptyStringToInt() throws SQLException {
+        int actualValue = (int) actual.convertValue("", int.class);
+        int expectedValue = 0;
+        assertThat(actualValue, is(expectedValue));
+    }
+    
+    @Test
+    void assertConvertEmptyStringToBoolean() throws SQLException {
+        boolean actualValue = (boolean) actual.convertValue("", boolean.class);
+        assertFalse(actualValue);
+    }
+    
+    @Test
+    void assertConvertDecimalStringToInt() throws SQLException {
+        int actualValue = (int) actual.convertValue("123.45", int.class);
+        int expectedValue = 123;
+        assertThat(actualValue, is(expectedValue));
+    }
+    
+    @Test
+    void assertConvertExponentStringToInt() throws SQLException {
+        int actualValue = (int) actual.convertValue("1e3", int.class);
+        int expectedValue = 1000;
+        assertThat(actualValue, is(expectedValue));
+    }
+    
+    @Test
+    void assertConvertStringToTimestamp() throws SQLException {
+        Timestamp actualValue = (Timestamp) actual.convertValue("2021-12-23 19:30:00", Timestamp.class);
+        Timestamp expectedValue = Timestamp.valueOf("2021-12-23 19:30:00");
+        assertThat(actualValue, is(expectedValue));
+    }
+}

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
@@ -606,18 +606,25 @@ class ShardingSphereResultSetTest {
     
     @Test
     void assertGetObjectWithIntegerFromStringUsesUsedDatabaseProtocolForStatement() throws SQLException {
+        ShardingSphereConnection statementConnection = mock(ShardingSphereConnection.class, RETURNS_DEEP_STUBS);
+        MetaDataContexts statementMetaDataContexts = mock(MetaDataContexts.class, RETURNS_DEEP_STUBS);
+        when(statementMetaDataContexts.getMetaData().getProps()).thenReturn(new ConfigurationProperties(new Properties()));
         DatabaseType currentDatabaseProtocolType = mock(DatabaseType.class);
         when(currentDatabaseProtocolType.getType()).thenReturn("PostgreSQL");
         when(currentDatabaseProtocolType.getTrunkDatabaseType()).thenReturn(Optional.empty());
         DatabaseType usedDatabaseProtocolType = mock(DatabaseType.class);
         when(usedDatabaseProtocolType.getType()).thenReturn("MySQL");
         when(usedDatabaseProtocolType.getTrunkDatabaseType()).thenReturn(Optional.empty());
-        when(connection.getCurrentDatabaseName()).thenReturn("current_db");
-        when(statement.getUsedDatabaseName()).thenReturn("used_db");
-        when(metaDataContexts.getMetaData().getDatabase("current_db").getProtocolType()).thenReturn(currentDatabaseProtocolType);
-        when(metaDataContexts.getMetaData().getDatabase("used_db").getProtocolType()).thenReturn(usedDatabaseProtocolType);
+        ShardingSphereStatement usedDatabaseStatement = mock(ShardingSphereStatement.class);
+        when(statementConnection.getCurrentDatabaseName()).thenReturn("current_db");
+        when(statementConnection.getContextManager().getMetaDataContexts()).thenReturn(statementMetaDataContexts);
+        when(statementMetaDataContexts.getMetaData().getDatabase("current_db").getProtocolType()).thenReturn(currentDatabaseProtocolType);
+        when(statementMetaDataContexts.getMetaData().getDatabase("used_db").getProtocolType()).thenReturn(usedDatabaseProtocolType);
+        when(usedDatabaseStatement.getConnection()).thenReturn(statementConnection);
+        when(usedDatabaseStatement.getUsedDatabaseName()).thenReturn("used_db");
+        ShardingSphereResultSet usedDatabaseResultSet = new ShardingSphereResultSet(getResultSets(), mergeResultSet, usedDatabaseStatement, createSQLStatementContext());
         when(mergeResultSet.getValue(1, Integer.class)).thenReturn("123");
-        assertThat(shardingSphereResultSet.getObject(1, Integer.class), is(123));
+        assertThat(usedDatabaseResultSet.getObject(1, Integer.class), is(123));
     }
     
     @Test

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
@@ -19,10 +19,12 @@ package org.apache.shardingsphere.driver.jdbc.core.resultset;
 
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
+import org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSpherePreparedStatement;
 import org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement;
 import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,6 +75,12 @@ class ShardingSphereResultSetTest {
     
     private DatabaseType protocolType;
     
+    private ShardingSphereConnection connection;
+    
+    private MetaDataContexts metaDataContexts;
+    
+    private ShardingSphereStatement statement;
+    
     @BeforeEach
     void setUp() throws SQLException {
         mergeResultSet = mock(MergedResult.class);
@@ -97,8 +105,8 @@ class ShardingSphereResultSetTest {
     }
     
     private ShardingSphereStatement getShardingSphereStatement() {
-        ShardingSphereConnection connection = mock(ShardingSphereConnection.class, RETURNS_DEEP_STUBS);
-        MetaDataContexts metaDataContexts = mock(MetaDataContexts.class, RETURNS_DEEP_STUBS);
+        connection = mock(ShardingSphereConnection.class, RETURNS_DEEP_STUBS);
+        metaDataContexts = mock(MetaDataContexts.class, RETURNS_DEEP_STUBS);
         when(metaDataContexts.getMetaData().getProps()).thenReturn(new ConfigurationProperties(new Properties()));
         when(connection.getCurrentDatabaseName()).thenReturn("logic_db");
         protocolType = mock(DatabaseType.class);
@@ -106,9 +114,10 @@ class ShardingSphereResultSetTest {
         when(protocolType.getTrunkDatabaseType()).thenReturn(Optional.empty());
         when(metaDataContexts.getMetaData().getDatabase("logic_db").getProtocolType()).thenReturn(protocolType);
         when(connection.getContextManager().getMetaDataContexts()).thenReturn(metaDataContexts);
-        ShardingSphereStatement result = mock(ShardingSphereStatement.class);
-        when(result.getConnection()).thenReturn(connection);
-        return result;
+        statement = mock(ShardingSphereStatement.class);
+        when(statement.getConnection()).thenReturn(connection);
+        when(statement.getUsedDatabaseName()).thenReturn("logic_db");
+        return statement;
     }
     
     @Test
@@ -593,6 +602,36 @@ class ShardingSphereResultSetTest {
         when(protocolType.getType()).thenReturn("PostgreSQL");
         when(mergeResultSet.getValue(1, Integer.class)).thenReturn("123");
         assertThrows(SQLException.class, () -> shardingSphereResultSet.getObject(1, Integer.class));
+    }
+    
+    @Test
+    void assertGetObjectWithIntegerFromStringUsesUsedDatabaseProtocolForStatement() throws SQLException {
+        DatabaseType currentDatabaseProtocolType = mock(DatabaseType.class);
+        when(currentDatabaseProtocolType.getType()).thenReturn("PostgreSQL");
+        when(currentDatabaseProtocolType.getTrunkDatabaseType()).thenReturn(Optional.empty());
+        DatabaseType usedDatabaseProtocolType = mock(DatabaseType.class);
+        when(usedDatabaseProtocolType.getType()).thenReturn("MySQL");
+        when(usedDatabaseProtocolType.getTrunkDatabaseType()).thenReturn(Optional.empty());
+        when(connection.getCurrentDatabaseName()).thenReturn("current_db");
+        when(statement.getUsedDatabaseName()).thenReturn("used_db");
+        when(metaDataContexts.getMetaData().getDatabase("current_db").getProtocolType()).thenReturn(currentDatabaseProtocolType);
+        when(metaDataContexts.getMetaData().getDatabase("used_db").getProtocolType()).thenReturn(usedDatabaseProtocolType);
+        when(mergeResultSet.getValue(1, Integer.class)).thenReturn("123");
+        assertThat(shardingSphereResultSet.getObject(1, Integer.class), is(123));
+    }
+    
+    @Test
+    void assertGetObjectWithIntegerFromStringUsesUsedDatabaseProtocolForPreparedStatement() throws SQLException {
+        ShardingSpherePreparedStatement preparedStatement = mock(ShardingSpherePreparedStatement.class);
+        ShardingSphereDatabase usedDatabase = mock(ShardingSphereDatabase.class);
+        DatabaseType usedDatabaseProtocolType = mock(DatabaseType.class);
+        when(usedDatabaseProtocolType.getType()).thenReturn("MySQL");
+        when(usedDatabaseProtocolType.getTrunkDatabaseType()).thenReturn(Optional.empty());
+        when(usedDatabase.getProtocolType()).thenReturn(usedDatabaseProtocolType);
+        when(preparedStatement.getUsedDatabase()).thenReturn(usedDatabase);
+        ShardingSphereResultSet preparedResultSet = new ShardingSphereResultSet(getResultSets(), mergeResultSet, preparedStatement, createSQLStatementContext());
+        when(mergeResultSet.getValue(1, Integer.class)).thenReturn("123");
+        assertThat(preparedResultSet.getObject(1, Integer.class), is(123));
     }
     
     @Test

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.driver.jdbc.core.resultset;
 
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement;
 import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
@@ -51,12 +52,14 @@ import java.time.OffsetDateTime;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -67,6 +70,8 @@ class ShardingSphereResultSetTest {
     private MergedResult mergeResultSet;
     
     private ShardingSphereResultSet shardingSphereResultSet;
+    
+    private DatabaseType protocolType;
     
     @BeforeEach
     void setUp() throws SQLException {
@@ -95,6 +100,11 @@ class ShardingSphereResultSetTest {
         ShardingSphereConnection connection = mock(ShardingSphereConnection.class, RETURNS_DEEP_STUBS);
         MetaDataContexts metaDataContexts = mock(MetaDataContexts.class, RETURNS_DEEP_STUBS);
         when(metaDataContexts.getMetaData().getProps()).thenReturn(new ConfigurationProperties(new Properties()));
+        when(connection.getCurrentDatabaseName()).thenReturn("logic_db");
+        protocolType = mock(DatabaseType.class);
+        when(protocolType.getType()).thenReturn("MySQL");
+        when(protocolType.getTrunkDatabaseType()).thenReturn(Optional.empty());
+        when(metaDataContexts.getMetaData().getDatabase("logic_db").getProtocolType()).thenReturn(protocolType);
         when(connection.getContextManager().getMetaDataContexts()).thenReturn(metaDataContexts);
         ShardingSphereStatement result = mock(ShardingSphereStatement.class);
         when(result.getConnection()).thenReturn(connection);
@@ -570,6 +580,19 @@ class ShardingSphereResultSetTest {
         assertThat(shardingSphereResultSet.getObject(1, int.class), is(result));
         when(mergeResultSet.getValue(1, Integer.class)).thenReturn(result);
         assertThat(shardingSphereResultSet.getObject(1, Integer.class), is(result));
+    }
+    
+    @Test
+    void assertGetObjectWithIntegerFromStringInMySQLProtocol() throws SQLException {
+        when(mergeResultSet.getValue(1, Integer.class)).thenReturn("123");
+        assertThat(shardingSphereResultSet.getObject(1, Integer.class), is(123));
+    }
+    
+    @Test
+    void assertGetObjectWithIntegerFromStringInNonMySQLProtocol() throws SQLException {
+        when(protocolType.getType()).thenReturn("PostgreSQL");
+        when(mergeResultSet.getValue(1, Integer.class)).thenReturn("123");
+        assertThrows(SQLException.class, () -> shardingSphereResultSet.getObject(1, Integer.class));
     }
     
     @Test

--- a/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
+++ b/jdbc/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
@@ -599,9 +599,27 @@ class ShardingSphereResultSetTest {
     
     @Test
     void assertGetObjectWithIntegerFromStringInNonMySQLProtocol() throws SQLException {
-        when(protocolType.getType()).thenReturn("PostgreSQL");
         when(mergeResultSet.getValue(1, Integer.class)).thenReturn("123");
-        assertThrows(SQLException.class, () -> shardingSphereResultSet.getObject(1, Integer.class));
+        DatabaseType actualProtocolType = mock(DatabaseType.class);
+        when(actualProtocolType.getType()).thenReturn("PostgreSQL");
+        when(actualProtocolType.getTrunkDatabaseType()).thenReturn(Optional.empty());
+        when(metaDataContexts.getMetaData().getDatabase("logic_db").getProtocolType()).thenReturn(actualProtocolType);
+        ShardingSphereResultSet actualResultSet = new ShardingSphereResultSet(getResultSets(), mergeResultSet, statement, createSQLStatementContext());
+        assertThrows(SQLException.class, () -> actualResultSet.getObject(1, Integer.class));
+    }
+    
+    @Test
+    void assertGetObjectWithIntegerFromStringInTrunkMySQLProtocol() throws SQLException {
+        when(mergeResultSet.getValue(1, Integer.class)).thenReturn("123");
+        DatabaseType trunkDatabaseType = mock(DatabaseType.class);
+        when(trunkDatabaseType.getType()).thenReturn("MySQL");
+        when(trunkDatabaseType.getTrunkDatabaseType()).thenReturn(Optional.empty());
+        DatabaseType actualProtocolType = mock(DatabaseType.class);
+        when(actualProtocolType.getType()).thenReturn("MariaDB");
+        when(actualProtocolType.getTrunkDatabaseType()).thenReturn(Optional.of(trunkDatabaseType));
+        when(metaDataContexts.getMetaData().getDatabase("logic_db").getProtocolType()).thenReturn(actualProtocolType);
+        ShardingSphereResultSet actualResultSet = new ShardingSphereResultSet(getResultSets(), mergeResultSet, statement, createSQLStatementContext());
+        assertThrows(SQLException.class, () -> actualResultSet.getObject(1, Integer.class));
     }
     
     @Test


### PR DESCRIPTION
Fixes #37757.

Changes proposed in this pull request:
  - Add MySQL-compatible typed string conversion for JDBC `getObject(int, Class<T>)` path while keeping strict default behavior for non-MySQL dialects.
  - Add focused unit tests for MySQL conversion success/invalid input and non-MySQL unchanged behavior.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
