### PR TITLE
Fix PostgreSQL proxy timestamp text output adding trailing .0

### DIFF
--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacket.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacket.java
@@ -30,6 +30,8 @@ import org.apache.shardingsphere.database.protocol.postgresql.payload.PostgreSQL
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import java.sql.Timestamp;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 
 /**
@@ -40,6 +42,8 @@ import java.util.Collection;
 public final class PostgreSQLDataRowPacket extends PostgreSQLIdentifierPacket {
     
     private static final byte[] HEX_DIGITS = "0123456789abcdef".getBytes(StandardCharsets.US_ASCII);
+
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     
     private final Collection<Object> data;
     
@@ -79,6 +83,10 @@ public final class PostgreSQLDataRowPacket extends PostgreSQLIdentifierPacket {
             byte[] columnData = ((Boolean) each ? "t" : "f").getBytes(payload.getCharset());
             payload.writeInt4(columnData.length);
             payload.writeBytes(columnData);
+        } else if (each instanceof Timestamp) {
+            byte[] columnData = formatTimestamp((Timestamp) each).getBytes(payload.getCharset());
+            payload.writeInt4(columnData.length);
+            payload.writeBytes(columnData);
         } else {
             byte[] columnData = each.toString().getBytes(payload.getCharset());
             payload.writeInt4(columnData.length);
@@ -86,6 +94,22 @@ public final class PostgreSQLDataRowPacket extends PostgreSQLIdentifierPacket {
         }
     }
     
+    private String formatTimestamp(final Timestamp timestamp) {
+        String baseTime = timestamp.toLocalDateTime().format(TIMESTAMP_FORMATTER);
+        int micros = timestamp.getNanos() / 1000;
+        if (0 == micros) {
+            return baseTime;
+        }
+        StringBuilder result = new StringBuilder(baseTime).append('.');
+        result.append(String.format("%06d", micros));
+        int length = result.length();
+        while (result.charAt(length - 1) == '0') {
+            length--;
+        }
+        result.setLength(length);
+        return result.toString();
+    }
+
     private byte[] encodeByteaText(final byte[] value) {
         byte[] result = new byte[value.length * 2 + 2];
         result[0] = '\\';

--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacket.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacket.java
@@ -42,7 +42,7 @@ import java.util.Collection;
 public final class PostgreSQLDataRowPacket extends PostgreSQLIdentifierPacket {
     
     private static final byte[] HEX_DIGITS = "0123456789abcdef".getBytes(StandardCharsets.US_ASCII);
-
+    
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     
     private final Collection<Object> data;
@@ -109,7 +109,7 @@ public final class PostgreSQLDataRowPacket extends PostgreSQLIdentifierPacket {
         result.setLength(length);
         return result.toString();
     }
-
+    
     private byte[] encodeByteaText(final byte[] value) {
         byte[] result = new byte[value.length * 2 + 2];
         result[0] = '\\';

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacketTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacketTest.java
@@ -148,7 +148,7 @@ class PostgreSQLDataRowPacketTest {
                 Arguments.of("timestamp_microsecond_precision", Timestamp.valueOf("2024-01-15 14:30:45.123456"), "2024-01-15 14:30:45.123456".getBytes(StandardCharsets.UTF_8)),
                 Arguments.of("timestamp_sub_microsecond_nanos", createTimestampWithSubMicrosecondNanos(), "1973-06-03 10:30:01".getBytes(StandardCharsets.UTF_8)));
     }
-
+    
     private static Timestamp createTimestampWithSubMicrosecondNanos() {
         Timestamp result = Timestamp.valueOf("1973-06-03 10:30:01");
         result.setNanos(500);

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacketTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/PostgreSQLDataRowPacketTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.stream.Stream;
 
@@ -140,6 +141,17 @@ class PostgreSQLDataRowPacketTest {
         return Stream.of(
                 Arguments.of("boolean_true", true, "t".getBytes(StandardCharsets.UTF_8)),
                 Arguments.of("boolean_false", false, "f".getBytes(StandardCharsets.UTF_8)),
-                Arguments.of("string_value", "value", "value".getBytes(StandardCharsets.UTF_8)));
+                Arguments.of("string_value", "value", "value".getBytes(StandardCharsets.UTF_8)),
+                Arguments.of("timestamp_no_fractional", Timestamp.valueOf("1973-06-03 10:30:01"), "1973-06-03 10:30:01".getBytes(StandardCharsets.UTF_8)),
+                Arguments.of("timestamp_with_fractional", Timestamp.valueOf("2024-01-15 14:30:45.123"), "2024-01-15 14:30:45.123".getBytes(StandardCharsets.UTF_8)),
+                Arguments.of("timestamp_trailing_zeros_stripped", Timestamp.valueOf("2024-01-15 14:30:45.120"), "2024-01-15 14:30:45.12".getBytes(StandardCharsets.UTF_8)),
+                Arguments.of("timestamp_microsecond_precision", Timestamp.valueOf("2024-01-15 14:30:45.123456"), "2024-01-15 14:30:45.123456".getBytes(StandardCharsets.UTF_8)),
+                Arguments.of("timestamp_sub_microsecond_nanos", createTimestampWithSubMicrosecondNanos(), "1973-06-03 10:30:01".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static Timestamp createTimestampWithSubMicrosecondNanos() {
+        Timestamp result = Timestamp.valueOf("1973-06-03 10:30:01");
+        result.setNanos(500);
+        return result;
     }
 }


### PR DESCRIPTION
## Problem

When querying a `TIMESTAMP` column without fractional seconds through ShardingSphere-Proxy (PostgreSQL protocol), the result includes a trailing `.0` (e.g., `1973-06-03 10:30:01.0`), whereas native PostgreSQL returns `1973-06-03 10:30:01`. This formatting mismatch can break clients and tests relying on stable textual output.

## Root Cause

In `PostgreSQLDataRowPacket#writeTextValue`, non-binary column values fall through to the generic `each.toString()` branch. When the value is a `java.sql.Timestamp`, `Timestamp.toString()` always emits a fractional part (at minimum `.0`), which does not match PostgreSQL's text protocol behavior of omitting trailing zero fractional seconds.

## Fix

- Added a type-aware branch for `java.sql.Timestamp` in `writeTextValue` that formats the timestamp according to PostgreSQL text output rules:
  - Omits the fractional part entirely when there are no fractional seconds
  - Uses microsecond precision (matching PostgreSQL's internal precision) and strips trailing zeros from the fractional part
- The formatting logic is encapsulated in a private `formatTimestamp` method within `PostgreSQLDataRowPacket`

## Tests Added

| Change Point | Test |
|-------------|------|
| Timestamp without fractional seconds omits `.0` | `timestamp_no_fractional` — verifies `1973-06-03 10:30:01` (exact reproduction from issue) |
| Timestamp with fractional seconds preserved | `timestamp_with_fractional` — verifies `2024-01-15 14:30:45.123` |
| Trailing zeros in fractional part stripped | `timestamp_trailing_zeros_stripped` — verifies `.120` becomes `.12` |
| Full microsecond precision supported | `timestamp_microsecond_precision` — verifies `2024-01-15 14:30:45.123456` |

## Impact

Only affects PostgreSQL text protocol timestamp formatting in the proxy. No changes to binary protocol, other data types, or any other module. Existing behavior for all non-Timestamp types is unchanged.

Fixes #37437