### PR TITLE
Fix test parameter parsing treating leading-zero strings as octal

### DIFF
--- a/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewriter/engine/parameter/SQLRewriteEngineTestParametersBuilder.java
+++ b/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewriter/engine/parameter/SQLRewriteEngineTestParametersBuilder.java
@@ -22,7 +22,6 @@ import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.shardingsphere.test.it.rewriter.engine.type.SQLExecuteType;
 import org.apache.shardingsphere.test.it.rewriter.entity.RewriteAssertionEntity;
 import org.apache.shardingsphere.test.it.rewriter.entity.RewriteAssertionsRootEntity;
@@ -124,7 +123,14 @@ public final class SQLRewriteEngineTestParametersBuilder {
     
     private static Object createInputParameter(final String inputParam) {
         if (StringUtils.isNumeric(inputParam)) {
-            return NumberUtils.createNumber(inputParam);
+            try {
+                return Integer.valueOf(inputParam);
+            } catch (final NumberFormatException ignored) {
+            }
+            try {
+                return Long.valueOf(inputParam);
+            } catch (final NumberFormatException ignored) {
+            }
         }
         return "NULL".equals(inputParam) ? null : inputParam;
     }

--- a/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewriter/engine/parameter/SQLRewriteEngineTestParametersBuilderTest.java
+++ b/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewriter/engine/parameter/SQLRewriteEngineTestParametersBuilderTest.java
@@ -22,58 +22,58 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.nullValue;
 
 class SQLRewriteEngineTestParametersBuilderTest {
-
+    
     @Test
     void assertCreateInputParameterWithRegularInteger() throws Exception {
         assertThat(invokeCreateInputParameter("1"), is(1));
     }
-
+    
     @Test
     void assertCreateInputParameterWithLargeNumber() throws Exception {
         assertThat(invokeCreateInputParameter("1000"), is(1000));
     }
-
+    
     @Test
     void assertCreateInputParameterWithLeadingZeroDigits() throws Exception {
         Object result = invokeCreateInputParameter("04844448888");
-        assertInstanceOf(Long.class, result);
+        assertThat(result, isA(Long.class));
         assertThat(result, is(4844448888L));
     }
-
+    
     @Test
     void assertCreateInputParameterWithLeadingZeroValidOctalLikeDigits() throws Exception {
         Object result = invokeCreateInputParameter("04100001111");
-        assertInstanceOf(Long.class, result);
+        assertThat(result, isA(Long.class));
         assertThat(result, is(4100001111L));
     }
-
+    
     @Test
     void assertCreateInputParameterWithSingleZero() throws Exception {
         assertThat(invokeCreateInputParameter("0"), is(0));
     }
-
+    
     @Test
     void assertCreateInputParameterWithString() throws Exception {
         assertThat(invokeCreateInputParameter("aaa"), is("aaa"));
     }
-
+    
     @Test
     void assertCreateInputParameterWithNull() throws Exception {
         assertThat(invokeCreateInputParameter("NULL"), is(nullValue()));
     }
-
+    
     @Test
     void assertCreateInputParameterWithLongOverflow() throws Exception {
         Object result = invokeCreateInputParameter("99999999999999999999");
-        assertInstanceOf(String.class, result);
+        assertThat(result, isA(String.class));
     }
-
+    
     private static Object invokeCreateInputParameter(final String inputParam) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         Method method = SQLRewriteEngineTestParametersBuilder.class.getDeclaredMethod("createInputParameter", String.class);
         method.setAccessible(true);

--- a/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewriter/engine/parameter/SQLRewriteEngineTestParametersBuilderTest.java
+++ b/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewriter/engine/parameter/SQLRewriteEngineTestParametersBuilderTest.java
@@ -25,7 +25,6 @@ import java.lang.reflect.Method;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
-import static org.hamcrest.Matchers.nullValue;
 
 class SQLRewriteEngineTestParametersBuilderTest {
     
@@ -65,7 +64,7 @@ class SQLRewriteEngineTestParametersBuilderTest {
     
     @Test
     void assertCreateInputParameterWithNull() throws Exception {
-        assertThat(invokeCreateInputParameter("NULL"), is(nullValue()));
+        assertThat(invokeCreateInputParameter("NULL"), is(org.hamcrest.Matchers.nullValue()));
     }
     
     @Test

--- a/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewriter/engine/parameter/SQLRewriteEngineTestParametersBuilderTest.java
+++ b/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewriter/engine/parameter/SQLRewriteEngineTestParametersBuilderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.rewriter.engine.parameter;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class SQLRewriteEngineTestParametersBuilderTest {
+
+    @Test
+    void assertCreateInputParameterWithRegularInteger() throws Exception {
+        assertThat(invokeCreateInputParameter("1"), is(1));
+    }
+
+    @Test
+    void assertCreateInputParameterWithLargeNumber() throws Exception {
+        assertThat(invokeCreateInputParameter("1000"), is(1000));
+    }
+
+    @Test
+    void assertCreateInputParameterWithLeadingZeroDigits() throws Exception {
+        Object result = invokeCreateInputParameter("04844448888");
+        assertInstanceOf(Long.class, result);
+        assertThat(result, is(4844448888L));
+    }
+
+    @Test
+    void assertCreateInputParameterWithLeadingZeroValidOctalLikeDigits() throws Exception {
+        Object result = invokeCreateInputParameter("04100001111");
+        assertInstanceOf(Long.class, result);
+        assertThat(result, is(4100001111L));
+    }
+
+    @Test
+    void assertCreateInputParameterWithSingleZero() throws Exception {
+        assertThat(invokeCreateInputParameter("0"), is(0));
+    }
+
+    @Test
+    void assertCreateInputParameterWithString() throws Exception {
+        assertThat(invokeCreateInputParameter("aaa"), is("aaa"));
+    }
+
+    @Test
+    void assertCreateInputParameterWithNull() throws Exception {
+        assertThat(invokeCreateInputParameter("NULL"), is(nullValue()));
+    }
+
+    @Test
+    void assertCreateInputParameterWithLongOverflow() throws Exception {
+        Object result = invokeCreateInputParameter("99999999999999999999");
+        assertInstanceOf(String.class, result);
+    }
+
+    private static Object invokeCreateInputParameter(final String inputParam) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method method = SQLRewriteEngineTestParametersBuilder.class.getDeclaredMethod("createInputParameter", String.class);
+        method.setAccessible(true);
+        return method.invoke(null, inputParam);
+    }
+}


### PR DESCRIPTION
## Problem

`SQLRewriteEngineTestParametersBuilder.createInputParameter()` uses `NumberUtils.createNumber()` to parse test parameter strings. When a parameter string consists entirely of digits but starts with '0' (e.g., encrypted phone number `04844448888`), `NumberUtils.createNumber()` interprets it as an octal literal per Java conventions, throwing `NumberFormatException` since digits 8 and 9 are invalid in octal.

Even for valid octal-looking strings like `04100001111` (digits 0-7 only), the value is silently parsed as octal instead of decimal, producing a wrong numeric value.

## Root Cause

`StringUtils.isNumeric("04844448888")` returns `true` (all characters are digits), but `NumberUtils.createNumber("04844448888")` follows Java number literal conventions where leading `0` means octal. SQL test parameters should always use decimal interpretation — SQL has no octal number syntax.

## Fix

Replaced `NumberUtils.createNumber()` with `Integer.valueOf()` / `Long.valueOf()` which always parse as decimal:
- Try `Integer.valueOf()` first (preserves existing Integer return type for small values)
- Fall back to `Long.valueOf()` for values exceeding Integer range
- Fall back to returning the original string if both overflow

Removed the unused `NumberUtils` import.

## Tests Added

| Change Point | Test |
|-------------|------|
| Regular integer parsed as decimal Integer | `assertCreateInputParameterWithRegularInteger` — `"1"` → `Integer(1)` |
| Large integer within int range | `assertCreateInputParameterWithLargeNumber` — `"1000"` → `Integer(1000)` |
| Leading-zero string that was crashing (octal with invalid digits) | `assertCreateInputParameterWithLeadingZeroDigits` — `"04844448888"` → `Long(4844448888)` |
| Leading-zero string that was silently mis-parsed as octal | `assertCreateInputParameterWithLeadingZeroValidOctalLikeDigits` — `"04100001111"` → `Long(4100001111)` |
| Single zero | `assertCreateInputParameterWithSingleZero` — `"0"` → `Integer(0)` |
| Non-numeric string | `assertCreateInputParameterWithString` — `"aaa"` → `String("aaa")` |
| NULL literal | `assertCreateInputParameterWithNull` — `"NULL"` → `null` |
| Long overflow fallback | `assertCreateInputParameterWithLongOverflow` — returns String |

## Impact

Only affects the SQL rewrite test parameter builder. No runtime code changes. All existing test parameters (which have no leading-zero numeric values) produce identical results.

Fixes #31001