### PR TITLE
Implement write methods for PostgreSQLUnspecifiedBinaryProtocolValue

### DIFF
--- a/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValue.java
+++ b/database/protocol/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValue.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.database.protocol.postgresql.packet.command.qu
 
 import org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.extended.bind.PostgreSQLTypeUnspecifiedSQLParameter;
 import org.apache.shardingsphere.database.protocol.postgresql.payload.PostgreSQLPacketPayload;
-import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
 
 /**
  * Binary protocol value for unspecified for PostgreSQL.
@@ -28,7 +27,7 @@ public final class PostgreSQLUnspecifiedBinaryProtocolValue implements PostgreSQ
     
     @Override
     public int getColumnLength(final PostgreSQLPacketPayload payload, final Object value) {
-        throw new UnsupportedSQLOperationException("getColumnLength");
+        return value.toString().getBytes(payload.getCharset()).length;
     }
     
     @Override
@@ -41,6 +40,6 @@ public final class PostgreSQLUnspecifiedBinaryProtocolValue implements PostgreSQ
     
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
-        throw new UnsupportedSQLOperationException("write");
+        payload.writeStringEOF(value.toString());
     }
 }

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValueTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValueTest.java
@@ -36,30 +36,30 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class PostgreSQLUnspecifiedBinaryProtocolValueTest {
-
+    
     @Mock
     private ByteBuf byteBuf;
-
+    
     private PostgreSQLPacketPayload payload;
-
+    
     @BeforeEach
     void setup() {
         payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
     }
-
+    
     @Test
     void assertGetColumnLength() {
         PostgreSQLUnspecifiedBinaryProtocolValue actual = new PostgreSQLUnspecifiedBinaryProtocolValue();
         assertThat(actual.getColumnLength(payload, "val"), is(3));
         assertThat(actual.getColumnLength(payload, new PostgreSQLTypeUnspecifiedSQLParameter("test")), is(4));
     }
-
+    
     @Test
     void assertGetColumnLengthWithMultiByteCharset() {
         PostgreSQLUnspecifiedBinaryProtocolValue actual = new PostgreSQLUnspecifiedBinaryProtocolValue();
         assertThat(actual.getColumnLength(payload, "中文"), is(6));
     }
-
+    
     @Test
     void assertRead() {
         String timestampStr = "2020-08-23 15:57:03+08";
@@ -74,13 +74,13 @@ class PostgreSQLUnspecifiedBinaryProtocolValueTest {
         assertThat(actual.toString(), is(timestampStr));
         assertThat(readBuf.readerIndex(), is(expectedLength));
     }
-
+    
     @Test
     void assertWrite() {
         new PostgreSQLUnspecifiedBinaryProtocolValue().write(payload, "val");
         verify(byteBuf).writeBytes("val".getBytes(StandardCharsets.UTF_8));
     }
-
+    
     @Test
     void assertWriteWithTypeUnspecifiedParameter() {
         new PostgreSQLUnspecifiedBinaryProtocolValue().write(payload, new PostgreSQLTypeUnspecifiedSQLParameter("test"));

--- a/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValueTest.java
+++ b/database/protocol/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValueTest.java
@@ -21,41 +21,69 @@ import io.netty.buffer.ByteBuf;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.ByteBufTestUtils;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.extended.bind.PostgreSQLTypeUnspecifiedSQLParameter;
 import org.apache.shardingsphere.database.protocol.postgresql.payload.PostgreSQLPacketPayload;
-import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 class PostgreSQLUnspecifiedBinaryProtocolValueTest {
-    
+
+    @Mock
+    private ByteBuf byteBuf;
+
+    private PostgreSQLPacketPayload payload;
+
+    @BeforeEach
+    void setup() {
+        payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
+    }
+
     @Test
     void assertGetColumnLength() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLUnspecifiedBinaryProtocolValue().getColumnLength(new PostgreSQLPacketPayload(null, StandardCharsets.UTF_8), "val"));
+        PostgreSQLUnspecifiedBinaryProtocolValue actual = new PostgreSQLUnspecifiedBinaryProtocolValue();
+        assertThat(actual.getColumnLength(payload, "val"), is(3));
+        assertThat(actual.getColumnLength(payload, new PostgreSQLTypeUnspecifiedSQLParameter("test")), is(4));
     }
-    
+
+    @Test
+    void assertGetColumnLengthWithMultiByteCharset() {
+        PostgreSQLUnspecifiedBinaryProtocolValue actual = new PostgreSQLUnspecifiedBinaryProtocolValue();
+        assertThat(actual.getColumnLength(payload, "中文"), is(6));
+    }
+
     @Test
     void assertRead() {
         String timestampStr = "2020-08-23 15:57:03+08";
         int expectedLength = 4 + timestampStr.length();
-        ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(expectedLength);
-        byteBuf.writeInt(timestampStr.length());
-        byteBuf.writeCharSequence(timestampStr, StandardCharsets.ISO_8859_1);
-        byteBuf.readInt();
-        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
-        Object actual = new PostgreSQLUnspecifiedBinaryProtocolValue().read(payload, timestampStr.length());
+        ByteBuf readBuf = ByteBufTestUtils.createByteBuf(expectedLength);
+        readBuf.writeInt(timestampStr.length());
+        readBuf.writeCharSequence(timestampStr, StandardCharsets.ISO_8859_1);
+        readBuf.readInt();
+        PostgreSQLPacketPayload readPayload = new PostgreSQLPacketPayload(readBuf, StandardCharsets.UTF_8);
+        Object actual = new PostgreSQLUnspecifiedBinaryProtocolValue().read(readPayload, timestampStr.length());
         assertThat(actual, isA(PostgreSQLTypeUnspecifiedSQLParameter.class));
         assertThat(actual.toString(), is(timestampStr));
-        assertThat(byteBuf.readerIndex(), is(expectedLength));
+        assertThat(readBuf.readerIndex(), is(expectedLength));
     }
-    
+
     @Test
     void assertWrite() {
-        assertThrows(UnsupportedSQLOperationException.class, () -> new PostgreSQLUnspecifiedBinaryProtocolValue().write(mock(PostgreSQLPacketPayload.class), "val"));
+        new PostgreSQLUnspecifiedBinaryProtocolValue().write(payload, "val");
+        verify(byteBuf).writeBytes("val".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void assertWriteWithTypeUnspecifiedParameter() {
+        new PostgreSQLUnspecifiedBinaryProtocolValue().write(payload, new PostgreSQLTypeUnspecifiedSQLParameter("test"));
+        verify(byteBuf).writeBytes("test".getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
## Problem

`PostgreSQLUnspecifiedBinaryProtocolValue.write()` and `getColumnLength()` throw `UnsupportedSQLOperationException`, preventing unspecified-type values from being written through the PostgreSQL binary protocol path.

## Root Cause

The `write()` and `getColumnLength()` methods were left as stubs throwing `UnsupportedSQLOperationException` when the class was initially created. This is one of the items tracked in #35830.

## Fix

Implemented both methods following the same pattern as `PostgreSQLStringBinaryProtocolValue`:
- `getColumnLength()`: returns the byte length of `value.toString()` using the payload's charset, correctly handling multi-byte characters
- `write()`: writes the string representation via `payload.writeStringEOF(value.toString())`, which works for both plain String values and `PostgreSQLTypeUnspecifiedSQLParameter` instances (which delegate to their inner string via `toString()`)

Removed the unused `UnsupportedSQLOperationException` import.

## Tests Added

| Change Point | Test |
|-------------|------|
| `getColumnLength` returns correct byte length | `assertGetColumnLength` — `"val"` → 3, `PostgreSQLTypeUnspecifiedSQLParameter("test")` → 4 |
| `getColumnLength` handles multi-byte characters | `assertGetColumnLengthWithMultiByteCharset` — `"中文"` → 6 (UTF-8) |
| `write` outputs string bytes to payload | `assertWrite` — verifies `"val"` bytes written to ByteBuf |
| `write` works with `PostgreSQLTypeUnspecifiedSQLParameter` | `assertWriteWithTypeUnspecifiedParameter` — verifies `"test"` bytes written |

## Impact

Only affects the unspecified binary protocol value type in the PostgreSQL protocol module. Enables binary write support for unspecified-type columns. No changes to other protocol value implementations.

Partial fix for #35830