### PR TITLE
Fix: Handle MySQL NULL schema behavior

### DIFF
--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoader.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoader.java
@@ -206,10 +206,10 @@ public final class MySQLMetaDataLoader implements DialectMetaDataLoader {
     }
     
     private String getDatabaseName(final Connection connection, final Collection<String> tableNames) throws SQLException {
-
         String catalog = connection.getCatalog();
-        String databaseName = (catalog==null || catalog.isEmpty()) ?  GlobalDataSourceRegistry.getInstance().getCachedDatabaseTables().get(tableNames.iterator().next())  : catalog;
-        return  databaseName;
+        return (null == catalog || catalog.isEmpty())
+                ? GlobalDataSourceRegistry.getInstance().getCachedDatabaseTables().get(tableNames.iterator().next())
+                : catalog;
     }
     
     @Override

--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoader.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoader.java
@@ -206,7 +206,10 @@ public final class MySQLMetaDataLoader implements DialectMetaDataLoader {
     }
     
     private String getDatabaseName(final Connection connection, final Collection<String> tableNames) throws SQLException {
-        return "".equals(connection.getCatalog()) ? GlobalDataSourceRegistry.getInstance().getCachedDatabaseTables().get(tableNames.iterator().next()) : connection.getCatalog();
+
+        String catalog = connection.getCatalog();
+        String databaseName = (catalog==null || catalog.isEmpty()) ?  GlobalDataSourceRegistry.getInstance().getCachedDatabaseTables().get(tableNames.iterator().next())  : catalog;
+        return  databaseName;
     }
     
     @Override

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoaderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoaderTest.java
@@ -82,14 +82,14 @@ class MySQLMetaDataLoaderTest {
         assertThat(actual.size(), is(1));
         assertTrue(actual.iterator().next().getTables().isEmpty());
     }
-
+    
     @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
     @Test
-    void assertLoadWithNullCatalog() throws SQLException{
+    void assertLoadWithNullCatalog() throws SQLException {
         DataSource dataSource = mockDataSource();
         ResultSet tableMetaDataResultSet = mockTableMetaDataResultSet();
         when(dataSource.getConnection().prepareStatement(TABLE_METADATA_SQL_WITH_TABLE).executeQuery()).thenReturn(tableMetaDataResultSet);
-
+        
         ResultSet simpleIndexMetaDataResultSet = mockSimpleIndexMetaDataResultSet();
         when(dataSource.getConnection().prepareStatement(INDEX_METADATA_SQL).executeQuery()).thenReturn(simpleIndexMetaDataResultSet);
         when(dataSource.getConnection().prepareStatement(VIEW_METADATA_SQL).executeQuery()).thenReturn(mock(ResultSet.class));
@@ -100,8 +100,7 @@ class MySQLMetaDataLoaderTest {
             when(dataSource.getConnection().getCatalog()).thenReturn(null);
             DataTypeRegistry.load(dataSource, "MySQL");
             Collection<SchemaMetaData> actual = dialectMetaDataLoader.load(
-                    new MetaDataLoaderMaterial(Collections.singletonList("tbl"), "foo_ds", dataSource, databaseType, null)
-            );
+                    new MetaDataLoaderMaterial(Collections.singletonList("tbl"), "foo_ds", dataSource, databaseType, null));
             assertTableMetaData(actual, false, false);
         } finally {
             if (null == previous) {
@@ -110,7 +109,6 @@ class MySQLMetaDataLoaderTest {
                 cachedDatabaseTables.put("tbl", previous);
             }
         }
-
     }
     
     @SuppressWarnings({"JDBCResourceOpenedButNotSafelyClosed", "resource"})

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoaderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoaderTest.java
@@ -82,6 +82,36 @@ class MySQLMetaDataLoaderTest {
         assertThat(actual.size(), is(1));
         assertTrue(actual.iterator().next().getTables().isEmpty());
     }
+
+    @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
+    @Test
+    void assertLoadWithNullCatalog() throws SQLException{
+        DataSource dataSource = mockDataSource();
+        ResultSet tableMetaDataResultSet = mockTableMetaDataResultSet();
+        when(dataSource.getConnection().prepareStatement(TABLE_METADATA_SQL_WITH_TABLE).executeQuery()).thenReturn(tableMetaDataResultSet);
+
+        ResultSet simpleIndexMetaDataResultSet = mockSimpleIndexMetaDataResultSet();
+        when(dataSource.getConnection().prepareStatement(INDEX_METADATA_SQL).executeQuery()).thenReturn(simpleIndexMetaDataResultSet);
+        when(dataSource.getConnection().prepareStatement(VIEW_METADATA_SQL).executeQuery()).thenReturn(mock(ResultSet.class));
+        when(dataSource.getConnection().prepareStatement(CONSTRAINT_METADATA_SQL).executeQuery()).thenReturn(mock(ResultSet.class));
+        Map<String, String> cachedDatabaseTables = GlobalDataSourceRegistry.getInstance().getCachedDatabaseTables();
+        String previous = cachedDatabaseTables.put("tbl", "fallback_db");
+        try {
+            when(dataSource.getConnection().getCatalog()).thenReturn(null);
+            DataTypeRegistry.load(dataSource, "MySQL");
+            Collection<SchemaMetaData> actual = dialectMetaDataLoader.load(
+                    new MetaDataLoaderMaterial(Collections.singletonList("tbl"), "foo_ds", dataSource, databaseType, null)
+            );
+            assertTableMetaData(actual, false, false);
+        } finally {
+            if (null == previous) {
+                cachedDatabaseTables.remove("tbl");
+            } else {
+                cachedDatabaseTables.put("tbl", previous);
+            }
+        }
+
+    }
     
     @SuppressWarnings({"JDBCResourceOpenedButNotSafelyClosed", "resource"})
     @ParameterizedTest(name = "{0}")


### PR DESCRIPTION
Fixes #28469 

Changes proposed in this pull request:
  -Changed `MySQLMetaDataLoader.java` so that it works right when `Connection.`getCatalog() gives back null.
  -Added a specific unit test `assertLoadWithNullCatalog` in `MySQLMetaDataLoaderTest.java` to simulate the `null` catalog behavior and verify the metadata loads successfully.
  -Update the logic that incorrectly fell back to an empty string `""` when the catalog was null(null != ""), preventing the subsequent `TableNotExistsException` and NPEs.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
