### PR TITLE
Fix null-safe identifier matching for quoted normalized lookups

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/StandardIdentifierCaseRule.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/StandardIdentifierCaseRule.java
@@ -50,11 +50,13 @@ public final class StandardIdentifierCaseRule implements IdentifierCaseRule {
     
     @Override
     public boolean matches(final String storedName, final String actualIdentifier, final QuoteCharacter quoteCharacter) {
-        if (QuoteCharacter.NONE != quoteCharacter) {
-            return Objects.equals(storedName, actualIdentifier);
-        }
         if (null == storedName || null == actualIdentifier) {
             return Objects.equals(storedName, actualIdentifier);
+        }
+        if (QuoteCharacter.NONE != quoteCharacter) {
+            return LookupMode.EXACT == quotedLookupMode
+                    ? Objects.equals(storedName, actualIdentifier)
+                    : Objects.equals(normalize(storedName), normalize(actualIdentifier));
         }
         return unquotedStoredNamePredicate.test(storedName) && Objects.equals(normalize(storedName), normalize(actualIdentifier));
     }

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCaseRuleSetsTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCaseRuleSetsTest.java
@@ -59,6 +59,7 @@ class IdentifierCaseRuleSetsTest {
         IdentifierCaseRule actual = IdentifierCaseRuleSets.newInsensitiveRuleSet().getRule(IdentifierScope.TABLE);
         assertThat(actual.getLookupMode(QuoteCharacter.QUOTE), is(LookupMode.EXACT));
         assertTrue(actual.matches("Foo", "FOO", QuoteCharacter.NONE));
+        assertFalse(actual.matches("t_mask", "T_MASK", QuoteCharacter.BACK_QUOTE));
     }
     
     @Test
@@ -66,6 +67,7 @@ class IdentifierCaseRuleSetsTest {
         IdentifierCaseRule actual = IdentifierCaseRuleSets.newMySQLInsensitiveRuleSet().getRule(IdentifierScope.TABLE);
         assertThat(actual.getLookupMode(QuoteCharacter.QUOTE), is(LookupMode.NORMALIZED));
         assertThat(actual.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
+        assertTrue(actual.matches("t_mask", "T_MASK", QuoteCharacter.BACK_QUOTE));
     }
     
     @ParameterizedTest(name = "{0}")

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/StandardIdentifierCaseRuleTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/StandardIdentifierCaseRuleTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StandardIdentifierCaseRuleTest {
     
@@ -55,6 +56,13 @@ class StandardIdentifierCaseRuleTest {
         assertNull(rule.normalize(null));
     }
     
+    @Test
+    void assertMatchesWithQuotedNormalizedLookup() {
+        StandardIdentifierCaseRule actual = new StandardIdentifierCaseRule(LookupMode.NORMALIZED, LookupMode.NORMALIZED,
+                each -> each.toLowerCase(Locale.ENGLISH), each -> each.equals(each.toLowerCase(Locale.ENGLISH)));
+        assertTrue(actual.matches("t_mask", "T_MASK", QuoteCharacter.BACK_QUOTE));
+    }
+    
     @ParameterizedTest(name = "{0}")
     @MethodSource("matchesArguments")
     void assertMatches(final String name, final String storedName, final String actualIdentifier, final QuoteCharacter quoteCharacter, final boolean expected) {
@@ -65,6 +73,8 @@ class StandardIdentifierCaseRuleTest {
         return Stream.of(
                 Arguments.of("quoted_match", "Foo", "Foo", QuoteCharacter.QUOTE, true),
                 Arguments.of("quoted_mismatch", "Foo", "foo", QuoteCharacter.QUOTE, false),
+                Arguments.of("quoted_null_names", null, null, QuoteCharacter.QUOTE, true),
+                Arguments.of("quoted_null_actual_identifier", "Foo", null, QuoteCharacter.QUOTE, false),
                 Arguments.of("unquoted_match", "foo", "FOO", QuoteCharacter.NONE, true),
                 Arguments.of("unquoted_non_default_stored_name", "Foo", "FOO", QuoteCharacter.NONE, false),
                 Arguments.of("unquoted_null_names", null, null, QuoteCharacter.NONE, true),

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProviderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProviderTest.java
@@ -33,10 +33,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.sql.DataSource;
 import java.lang.reflect.Proxy;
+import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -103,95 +105,11 @@ class MySQLIdentifierCaseRuleProviderTest {
     }
     
     private static DataSource mockDataSource(final boolean hasResultSetRow, final int lowerCaseTableNames) throws SQLException {
-        return (DataSource) Proxy.newProxyInstance(DataSource.class.getClassLoader(), new Class[]{DataSource.class},
-                (proxy, method, args) -> handleDataSourceMethod(method.getName(), method.getReturnType(), hasResultSetRow, lowerCaseTableNames));
+        return new FixtureDataSource(hasResultSetRow, lowerCaseTableNames);
     }
     
     private static DataSource mockFailingDataSource() throws SQLException {
-        return (DataSource) Proxy.newProxyInstance(DataSource.class.getClassLoader(), new Class[]{DataSource.class},
-                (proxy, method, args) -> handleFailingDataSourceMethod(method.getName(), method.getReturnType()));
-    }
-    
-    private static Connection createConnection(final boolean hasResultSetRow, final int lowerCaseTableNames) {
-        return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class[]{Connection.class},
-                (proxy, method, args) -> handleConnectionMethod(method.getName(), method.getReturnType(), hasResultSetRow, lowerCaseTableNames));
-    }
-    
-    private static PreparedStatement createPreparedStatement(final boolean hasResultSetRow, final int lowerCaseTableNames) {
-        return (PreparedStatement) Proxy.newProxyInstance(PreparedStatement.class.getClassLoader(), new Class[]{PreparedStatement.class},
-                (proxy, method, args) -> handlePreparedStatementMethod(method.getName(), method.getReturnType(), hasResultSetRow, lowerCaseTableNames));
-    }
-    
-    private static ResultSet createResultSet(final boolean hasResultSetRow, final int lowerCaseTableNames) {
-        boolean[] nextInvoked = new boolean[1];
-        return (ResultSet) Proxy.newProxyInstance(ResultSet.class.getClassLoader(), new Class[]{ResultSet.class},
-                (proxy, method, args) -> handleResultSetMethod(method.getName(), method.getReturnType(), hasResultSetRow, lowerCaseTableNames, nextInvoked));
-    }
-    
-    private static Object handleDataSourceMethod(final String methodName, final Class<?> returnType, final boolean hasResultSetRow,
-                                                 final int lowerCaseTableNames) {
-        switch (methodName) {
-            case "getConnection":
-                return createConnection(hasResultSetRow, lowerCaseTableNames);
-            case "unwrap":
-                return null;
-            case "isWrapperFor":
-                return false;
-            default:
-                return getDefaultValue(returnType);
-        }
-    }
-    
-    private static Object handleFailingDataSourceMethod(final String methodName, final Class<?> returnType) throws SQLException {
-        if ("getConnection".equals(methodName)) {
-            throw new SQLException("expected");
-        }
-        return "isWrapperFor".equals(methodName) ? false : getDefaultValue(returnType);
-    }
-    
-    private static Object handleConnectionMethod(final String methodName, final Class<?> returnType, final boolean hasResultSetRow, final int lowerCaseTableNames) {
-        switch (methodName) {
-            case "prepareStatement":
-                return createPreparedStatement(hasResultSetRow, lowerCaseTableNames);
-            case "close":
-                return null;
-            case "isWrapperFor":
-                return false;
-            default:
-                return getDefaultValue(returnType);
-        }
-    }
-    
-    private static Object handlePreparedStatementMethod(final String methodName, final Class<?> returnType,
-                                                        final boolean hasResultSetRow, final int lowerCaseTableNames) {
-        switch (methodName) {
-            case "executeQuery":
-                return createResultSet(hasResultSetRow, lowerCaseTableNames);
-            case "close":
-                return null;
-            case "isWrapperFor":
-                return false;
-            default:
-                return getDefaultValue(returnType);
-        }
-    }
-    
-    private static Object handleResultSetMethod(final String methodName, final Class<?> returnType, final boolean hasResultSetRow,
-                                                final int lowerCaseTableNames, final boolean[] nextInvoked) {
-        switch (methodName) {
-            case "next":
-                boolean result = hasResultSetRow && !nextInvoked[0];
-                nextInvoked[0] = true;
-                return result;
-            case "getInt":
-                return lowerCaseTableNames;
-            case "close":
-                return null;
-            case "isWrapperFor":
-                return false;
-            default:
-                return getDefaultValue(returnType);
-        }
+        return new FailingFixtureDataSource();
     }
     
     private static Object getDefaultValue(final Class<?> returnType) {
@@ -223,5 +141,124 @@ class MySQLIdentifierCaseRuleProviderTest {
             return '\0';
         }
         return null;
+    }
+    
+    private static final class FixtureDataSource implements DataSource {
+        
+        private final boolean hasResultSetRow;
+        
+        private final int lowerCaseTableNames;
+        
+        private FixtureDataSource(final boolean hasResultSetRow, final int lowerCaseTableNames) {
+            this.hasResultSetRow = hasResultSetRow;
+            this.lowerCaseTableNames = lowerCaseTableNames;
+        }
+        
+        @Override
+        public Connection getConnection() {
+            return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class[]{Connection.class},
+                    (proxy, method, args) -> "prepareStatement".equals(method.getName()) ? createPreparedStatement() : getDefaultValue(method.getReturnType()));
+        }
+        
+        @Override
+        public Connection getConnection(final String username, final String password) {
+            return getConnection();
+        }
+        
+        private PreparedStatement createPreparedStatement() {
+            return (PreparedStatement) Proxy.newProxyInstance(PreparedStatement.class.getClassLoader(), new Class[]{PreparedStatement.class},
+                    (proxy, method, args) -> "executeQuery".equals(method.getName()) ? createResultSet() : getDefaultValue(method.getReturnType()));
+        }
+        
+        private ResultSet createResultSet() {
+            boolean[] nextInvoked = new boolean[1];
+            return (ResultSet) Proxy.newProxyInstance(ResultSet.class.getClassLoader(), new Class[]{ResultSet.class}, (proxy, method, args) -> {
+                if ("next".equals(method.getName())) {
+                    boolean result = hasResultSetRow && !nextInvoked[0];
+                    nextInvoked[0] = true;
+                    return result;
+                }
+                return "getInt".equals(method.getName()) ? lowerCaseTableNames : getDefaultValue(method.getReturnType());
+            });
+        }
+        
+        @Override
+        public <T> T unwrap(final Class<T> iface) {
+            return null;
+        }
+        
+        @Override
+        public boolean isWrapperFor(final Class<?> iface) {
+            return false;
+        }
+        
+        @Override
+        public PrintWriter getLogWriter() {
+            return null;
+        }
+        
+        @Override
+        public void setLogWriter(final PrintWriter out) {
+        }
+        
+        @Override
+        public void setLoginTimeout(final int seconds) {
+        }
+        
+        @Override
+        public int getLoginTimeout() {
+            return 0;
+        }
+        
+        @Override
+        public Logger getParentLogger() {
+            return Logger.getGlobal();
+        }
+    }
+    
+    private static final class FailingFixtureDataSource implements DataSource {
+        
+        @Override
+        public Connection getConnection() throws SQLException {
+            throw new SQLException("expected");
+        }
+        
+        @Override
+        public Connection getConnection(final String username, final String password) throws SQLException {
+            throw new SQLException("expected");
+        }
+        
+        @Override
+        public <T> T unwrap(final Class<T> iface) {
+            return null;
+        }
+        
+        @Override
+        public boolean isWrapperFor(final Class<?> iface) {
+            return false;
+        }
+        
+        @Override
+        public PrintWriter getLogWriter() {
+            return null;
+        }
+        
+        @Override
+        public void setLogWriter(final PrintWriter out) {
+        }
+        
+        @Override
+        public void setLoginTimeout(final int seconds) {
+        }
+        
+        @Override
+        public int getLoginTimeout() {
+            return 0;
+        }
+        
+        @Override
+        public Logger getParentLogger() {
+            return Logger.getGlobal();
+        }
     }
 }

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProviderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProviderTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.sql.DataSource;
+import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -42,12 +43,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class MySQLIdentifierCaseRuleProviderTest {
-    
-    private static final String QUERY_LOWER_CASE_TABLE_NAMES = "SELECT @@lower_case_table_names";
     
     private static final DatabaseType DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "MySQL");
     
@@ -67,6 +64,14 @@ class MySQLIdentifierCaseRuleProviderTest {
         assertLookupMode(actual, QuoteCharacter.BACK_QUOTE, expectedQuotedLookupMode);
         assertLookupMode(actual, QuoteCharacter.NONE, expectedUnquotedLookupMode);
         assertMatch(actual, expectedMatch);
+    }
+    
+    @Test
+    void assertProvideWithQuotedTableName() throws SQLException {
+        IdentifierCaseRule actual = provider.provide(new IdentifierCaseRuleProviderContext(DATABASE_TYPE, mockDataSource(true, 1)))
+                .map(ruleSet -> ruleSet.getRule(IdentifierScope.TABLE)).orElseThrow(AssertionError::new);
+        assertThat(actual.getLookupMode(QuoteCharacter.BACK_QUOTE), is(LookupMode.NORMALIZED));
+        assertThat(actual.matches("t_mask", "T_MASK", QuoteCharacter.BACK_QUOTE), is(Boolean.TRUE));
     }
     
     private void assertMatch(final IdentifierCaseRule actual, final Boolean expected) {
@@ -98,21 +103,125 @@ class MySQLIdentifierCaseRuleProviderTest {
     }
     
     private static DataSource mockDataSource(final boolean hasResultSetRow, final int lowerCaseTableNames) throws SQLException {
-        DataSource result = mock(DataSource.class);
-        Connection connection = mock(Connection.class);
-        PreparedStatement preparedStatement = mock(PreparedStatement.class);
-        ResultSet resultSet = mock(ResultSet.class);
-        when(result.getConnection()).thenReturn(connection);
-        when(connection.prepareStatement(QUERY_LOWER_CASE_TABLE_NAMES)).thenReturn(preparedStatement);
-        when(preparedStatement.executeQuery()).thenReturn(resultSet);
-        when(resultSet.next()).thenReturn(hasResultSetRow);
-        when(resultSet.getInt(1)).thenReturn(lowerCaseTableNames);
-        return result;
+        return (DataSource) Proxy.newProxyInstance(DataSource.class.getClassLoader(), new Class[]{DataSource.class},
+                (proxy, method, args) -> handleDataSourceMethod(method.getName(), method.getReturnType(), hasResultSetRow, lowerCaseTableNames));
     }
     
     private static DataSource mockFailingDataSource() throws SQLException {
-        DataSource result = mock(DataSource.class);
-        when(result.getConnection()).thenThrow(new SQLException("expected"));
-        return result;
+        return (DataSource) Proxy.newProxyInstance(DataSource.class.getClassLoader(), new Class[]{DataSource.class},
+                (proxy, method, args) -> handleFailingDataSourceMethod(method.getName(), method.getReturnType()));
+    }
+    
+    private static Connection createConnection(final boolean hasResultSetRow, final int lowerCaseTableNames) {
+        return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class[]{Connection.class},
+                (proxy, method, args) -> handleConnectionMethod(method.getName(), method.getReturnType(), hasResultSetRow, lowerCaseTableNames));
+    }
+    
+    private static PreparedStatement createPreparedStatement(final boolean hasResultSetRow, final int lowerCaseTableNames) {
+        return (PreparedStatement) Proxy.newProxyInstance(PreparedStatement.class.getClassLoader(), new Class[]{PreparedStatement.class},
+                (proxy, method, args) -> handlePreparedStatementMethod(method.getName(), method.getReturnType(), hasResultSetRow, lowerCaseTableNames));
+    }
+    
+    private static ResultSet createResultSet(final boolean hasResultSetRow, final int lowerCaseTableNames) {
+        boolean[] nextInvoked = new boolean[1];
+        return (ResultSet) Proxy.newProxyInstance(ResultSet.class.getClassLoader(), new Class[]{ResultSet.class},
+                (proxy, method, args) -> handleResultSetMethod(method.getName(), method.getReturnType(), hasResultSetRow, lowerCaseTableNames, nextInvoked));
+    }
+    
+    private static Object handleDataSourceMethod(final String methodName, final Class<?> returnType, final boolean hasResultSetRow,
+                                                 final int lowerCaseTableNames) {
+        switch (methodName) {
+            case "getConnection":
+                return createConnection(hasResultSetRow, lowerCaseTableNames);
+            case "unwrap":
+                return null;
+            case "isWrapperFor":
+                return false;
+            default:
+                return getDefaultValue(returnType);
+        }
+    }
+    
+    private static Object handleFailingDataSourceMethod(final String methodName, final Class<?> returnType) throws SQLException {
+        if ("getConnection".equals(methodName)) {
+            throw new SQLException("expected");
+        }
+        return "isWrapperFor".equals(methodName) ? false : getDefaultValue(returnType);
+    }
+    
+    private static Object handleConnectionMethod(final String methodName, final Class<?> returnType, final boolean hasResultSetRow, final int lowerCaseTableNames) {
+        switch (methodName) {
+            case "prepareStatement":
+                return createPreparedStatement(hasResultSetRow, lowerCaseTableNames);
+            case "close":
+                return null;
+            case "isWrapperFor":
+                return false;
+            default:
+                return getDefaultValue(returnType);
+        }
+    }
+    
+    private static Object handlePreparedStatementMethod(final String methodName, final Class<?> returnType,
+                                                        final boolean hasResultSetRow, final int lowerCaseTableNames) {
+        switch (methodName) {
+            case "executeQuery":
+                return createResultSet(hasResultSetRow, lowerCaseTableNames);
+            case "close":
+                return null;
+            case "isWrapperFor":
+                return false;
+            default:
+                return getDefaultValue(returnType);
+        }
+    }
+    
+    private static Object handleResultSetMethod(final String methodName, final Class<?> returnType, final boolean hasResultSetRow,
+                                                final int lowerCaseTableNames, final boolean[] nextInvoked) {
+        switch (methodName) {
+            case "next":
+                boolean result = hasResultSetRow && !nextInvoked[0];
+                nextInvoked[0] = true;
+                return result;
+            case "getInt":
+                return lowerCaseTableNames;
+            case "close":
+                return null;
+            case "isWrapperFor":
+                return false;
+            default:
+                return getDefaultValue(returnType);
+        }
+    }
+    
+    private static Object getDefaultValue(final Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (boolean.class == returnType) {
+            return false;
+        }
+        if (byte.class == returnType) {
+            return (byte) 0;
+        }
+        if (short.class == returnType) {
+            return (short) 0;
+        }
+        if (int.class == returnType) {
+            return 0;
+        }
+        if (long.class == returnType) {
+            return 0L;
+        }
+        if (float.class == returnType) {
+            return 0F;
+        }
+        if (double.class == returnType) {
+            return 0D;
+        }
+        if (char.class == returnType) {
+            return '\0';
+        }
+        return null;
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -25,6 +25,8 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.config.props.MetadataIdentifierCaseSensitivity;
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
 import org.apache.shardingsphere.infra.metadata.database.resource.node.StorageNode;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
@@ -32,12 +34,14 @@ import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePo
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.infra.util.props.PropertiesBuilder;
 import org.apache.shardingsphere.infra.util.props.PropertiesBuilder.Property;
+import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.sql.DataSource;
+import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -45,6 +49,8 @@ import java.util.Properties;
 import java.util.stream.Stream;
 import java.io.PrintWriter;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.logging.Logger;
@@ -152,6 +158,16 @@ class DatabaseIdentifierContextFactoryTest {
         assertTrue(actualRule.matches("foo_db", "FOO_DB", QuoteCharacter.NONE));
     }
     
+    @Test
+    void assertCreateContainsQuotedTableWithMySQLInsensitiveStorageRule() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE,
+                createResourceMetaDataWithMySQLLowerCaseTableNames(1), new ConfigurationProperties(new Properties()));
+        ShardingSphereTable table = new ShardingSphereTable("t_mask", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        ShardingSphereSchema schema = new ShardingSphereSchema("foo_db", MYSQL_DATABASE_TYPE, Collections.singleton(table), Collections.emptyList());
+        schema.refreshIdentifierContext(actual);
+        assertTrue(schema.containsTable(new IdentifierValue("`T_MASK`")));
+    }
+    
     private static Stream<Arguments> createWithProtocolTypeAndPropsArguments() {
         return Stream.of(
                 Arguments.of("null protocol type and null props use insensitive rules", null, null, LookupMode.NORMALIZED, "Foo", "foo", true),
@@ -210,6 +226,12 @@ class DatabaseIdentifierContextFactoryTest {
         return createResourceMetaDataWithStorageUrls("jdbc:mysql://localhost:3306/foo_db");
     }
     
+    private static ResourceMetaData createResourceMetaDataWithMySQLLowerCaseTableNames(final int lowerCaseTableNames) {
+        Map<String, StorageUnit> storageUnits = new LinkedHashMap<>(1, 1F);
+        storageUnits.put("ds_0", createStorageUnit("ds_0", "jdbc:mysql://localhost:3306/foo_db", new LowerCaseTableNamesDataSource(lowerCaseTableNames)));
+        return new ResourceMetaData(Collections.emptyMap(), storageUnits);
+    }
+    
     private static ResourceMetaData createResourceMetaDataWithStorageUrls(final String... urls) {
         Map<String, StorageUnit> storageUnits = new LinkedHashMap<>(urls.length, 1F);
         for (int i = 0; i < urls.length; i++) {
@@ -219,10 +241,14 @@ class DatabaseIdentifierContextFactoryTest {
     }
     
     private static StorageUnit createStorageUnit(final String name, final String url) {
+        return createStorageUnit(name, url, new FixtureDataSource());
+    }
+    
+    private static StorageUnit createStorageUnit(final String name, final String url, final DataSource dataSource) {
         Map<String, Object> props = new LinkedHashMap<>(2, 1F);
         props.put("url", url);
         props.put("username", "root");
-        return new StorageUnit(new StorageNode(name), new DataSourcePoolProperties("com.zaxxer.hikari.HikariDataSource", props), new FixtureDataSource());
+        return new StorageUnit(new StorageNode(name), new DataSourcePoolProperties("com.zaxxer.hikari.HikariDataSource", props), dataSource);
     }
     
     private static final class FixtureDataSource implements DataSource {
@@ -263,6 +289,107 @@ class DatabaseIdentifierContextFactoryTest {
         @Override
         public <T> T unwrap(final Class<T> iface) throws SQLException {
             throw new SQLFeatureNotSupportedException("Not supported in fixture.");
+        }
+        
+        @Override
+        public boolean isWrapperFor(final Class<?> iface) {
+            return false;
+        }
+    }
+    
+    private static final class LowerCaseTableNamesDataSource implements DataSource {
+        
+        private final int lowerCaseTableNames;
+        
+        private LowerCaseTableNamesDataSource(final int lowerCaseTableNames) {
+            this.lowerCaseTableNames = lowerCaseTableNames;
+        }
+        
+        @Override
+        public Connection getConnection() {
+            return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class[]{Connection.class},
+                    (proxy, method, args) -> "prepareStatement".equals(method.getName()) ? createPreparedStatement(lowerCaseTableNames) : getDefaultValue(method.getReturnType()));
+        }
+        
+        @Override
+        public Connection getConnection(final String username, final String password) {
+            return getConnection();
+        }
+        
+        private PreparedStatement createPreparedStatement(final int lowerCaseTableNames) {
+            return (PreparedStatement) Proxy.newProxyInstance(PreparedStatement.class.getClassLoader(), new Class[]{PreparedStatement.class},
+                    (proxy, method, args) -> "executeQuery".equals(method.getName()) ? createResultSet(lowerCaseTableNames) : getDefaultValue(method.getReturnType()));
+        }
+        
+        private ResultSet createResultSet(final int lowerCaseTableNames) {
+            boolean[] nextInvoked = new boolean[1];
+            return (ResultSet) Proxy.newProxyInstance(ResultSet.class.getClassLoader(), new Class[]{ResultSet.class}, (proxy, method, args) -> {
+                if ("next".equals(method.getName())) {
+                    boolean result = !nextInvoked[0];
+                    nextInvoked[0] = true;
+                    return result;
+                }
+                return "getInt".equals(method.getName()) ? lowerCaseTableNames : getDefaultValue(method.getReturnType());
+            });
+        }
+        
+        private Object getDefaultValue(final Class<?> returnType) {
+            if (!returnType.isPrimitive()) {
+                return null;
+            }
+            if (boolean.class == returnType) {
+                return false;
+            }
+            if (int.class == returnType) {
+                return 0;
+            }
+            if (long.class == returnType) {
+                return 0L;
+            }
+            if (float.class == returnType) {
+                return 0F;
+            }
+            if (double.class == returnType) {
+                return 0D;
+            }
+            if (byte.class == returnType) {
+                return (byte) 0;
+            }
+            if (short.class == returnType) {
+                return (short) 0;
+            }
+            if (char.class == returnType) {
+                return '\0';
+            }
+            return null;
+        }
+        
+        @Override
+        public PrintWriter getLogWriter() {
+            return null;
+        }
+        
+        @Override
+        public void setLogWriter(final PrintWriter out) {
+        }
+        
+        @Override
+        public void setLoginTimeout(final int seconds) {
+        }
+        
+        @Override
+        public int getLoginTimeout() {
+            return 0;
+        }
+        
+        @Override
+        public Logger getParentLogger() {
+            return Logger.getGlobal();
+        }
+        
+        @Override
+        public <T> T unwrap(final Class<T> iface) {
+            return null;
         }
         
         @Override

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierIndexTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierIndexTest.java
@@ -113,11 +113,11 @@ class IdentifierIndexTest {
     }
     
     @Test
-    void assertFindWithQuotedNormalizedLookupReturnsEmptyWhenActualNameDiffers() {
+    void assertFindWithQuotedNormalizedLookup() {
         IdentifierIndex<String> index = new IdentifierIndex<>(new DatabaseIdentifierContext(new IdentifierCaseRuleSet(createMySQLInsensitiveRule())), IdentifierScope.TABLE);
-        index.rebuild(createSingleValueMap("Foo", "value_1"));
-        Optional<String> actualValue = index.find(new IdentifierValue("\"FOO\""));
-        assertThat(actualValue, is(Optional.empty()));
+        index.rebuild(createSingleValueMap("t_mask", "value_1"));
+        Optional<String> actualValue = index.find(new IdentifierValue("`T_MASK`"));
+        assertThat(actualValue, is(Optional.of("value_1")));
     }
     
     @Test


### PR DESCRIPTION


Changes proposed in this pull request:
 This PR fixes a regression in StandardIdentifierCaseRule.matches(...) introduced while aligning quoted normalized lookup behavior.

The previous change correctly enabled quoted NORMALIZED matching for cases like MySQL with lower_case_table_names=1/2, but it accidentally removed the existing null guard in matches(...). As a result, StandardIdentifierCaseRuleTest could throw NullPointerException when either storedName or actualIdentifier was null.

- Root Cause

StandardIdentifierCaseRule.matches(...) now supports two quoted paths:

LookupMode.EXACT: compare stored and actual identifiers directly
LookupMode.NORMALIZED: compare normalized identifiers
During that refactor, the original null handling was dropped.
For unquoted matching, the method still evaluates:

unquotedStoredNamePredicate.test(storedName)
So when storedName or actualIdentifier is null, the predicate/normalizer path can fail before any equality check.

- Fix

Restore the null-safe guard at the start of matches(...):

if either storedName or actualIdentifier is null
return Objects.equals(storedName, actualIdentifier)
This preserves the quoted normalized matching fix and restores the original null-safe behavior.

- Tests

Updated StandardIdentifierCaseRuleTest to cover:

quoted normalized match
quoted null names
quoted null actual identifier
existing unquoted null scenarios

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
