### PR TITLE
Unify single-table schema identity and normalize default-schema casing across loaders and routes

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoader.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoader.java
@@ -78,7 +78,7 @@ public final class SchemaMetaDataLoader {
             Collection<String> schemaNames = loadSchemaNames(connection);
             Map<String, Collection<String>> result = new LinkedHashMap<>(schemaNames.size(), 1F);
             for (String each : schemaNames) {
-                String schemaName = schemaOption.getDefaultSchema().isPresent() ? each : databaseName;
+                String schemaName = schemaOption.getDefaultSchema().isPresent() ? each : new DatabaseTypeRegistry(databaseType).getDefaultSchemaName(databaseName);
                 result.put(schemaName, loadTableNames(connection, each, excludedTables));
             }
             return result;

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoaderTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoaderTest.java
@@ -88,7 +88,7 @@ class SchemaMetaDataLoaderTest {
             }
         }
     }
-
+    
     @Test
     void assertLoadSchemaTableNamesNormalizesDatabaseNameWithoutDefaultSchema() throws SQLException {
         DialectSchemaOption schemaOption = mock(DialectSchemaOption.class);

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoaderTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoaderTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.database.connector.core.metadata.data.loader.type;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
@@ -69,6 +70,7 @@ class SchemaMetaDataLoaderTest {
         when(schemaOption.getSchema(any())).thenReturn("public");
         DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class);
         when(dialectDatabaseMetaData.getSchemaOption()).thenReturn(schemaOption);
+        when(dialectDatabaseMetaData.getIdentifierPatternType()).thenReturn(IdentifierPatternType.KEEP_ORIGIN);
         try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, databaseType)).thenReturn(dialectDatabaseMetaData);
             try (MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class)) {
@@ -82,6 +84,32 @@ class SchemaMetaDataLoaderTest {
                 Map<String, Collection<String>> actual = new SchemaMetaDataLoader(databaseType)
                         .loadSchemaTableNames("logic_db", dataSourceWithoutDefaultSchema, Collections.singleton("excluded_tbl"));
                 Map<String, Collection<String>> expected = Collections.singletonMap("logic_db", new LinkedHashSet<>(Collections.singleton("tbl")));
+                assertThat(actual, is(expected));
+            }
+        }
+    }
+
+    @Test
+    void assertLoadSchemaTableNamesNormalizesDatabaseNameWithoutDefaultSchema() throws SQLException {
+        DialectSchemaOption schemaOption = mock(DialectSchemaOption.class);
+        when(schemaOption.getDefaultSchema()).thenReturn(Optional.empty());
+        when(schemaOption.getSchema(any())).thenReturn("public");
+        DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class);
+        when(dialectDatabaseMetaData.getSchemaOption()).thenReturn(schemaOption);
+        when(dialectDatabaseMetaData.getIdentifierPatternType()).thenReturn(IdentifierPatternType.UPPER_CASE);
+        try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
+            databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, databaseType)).thenReturn(dialectDatabaseMetaData);
+            try (MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class)) {
+                typedSPILoader.when(() -> TypedSPILoader.getService(DialectDatabaseMetaData.class, null)).thenReturn(dialectDatabaseMetaData);
+                Connection connection = dataSourceWithoutDefaultSchema.getConnection();
+                when(connection.getCatalog()).thenReturn("catalog");
+                ResultSet tableResultSet = mock(ResultSet.class);
+                when(tableResultSet.next()).thenReturn(true, false);
+                when(tableResultSet.getString("TABLE_NAME")).thenReturn("tbl");
+                when(connection.getMetaData().getTables("catalog", "public", null, TABLE_TYPES)).thenReturn(tableResultSet);
+                Map<String, Collection<String>> actual = new SchemaMetaDataLoader(databaseType)
+                        .loadSchemaTableNames("logic_db", dataSourceWithoutDefaultSchema, Collections.emptyList());
+                Map<String, Collection<String>> expected = Collections.singletonMap("LOGIC_DB", new LinkedHashSet<>(Collections.singleton("tbl")));
                 assertThat(actual, is(expected));
             }
         }

--- a/database/connector/dialect/firebird/src/test/java/org/apache/shardingsphere/database/connector/firebird/metadata/data/loader/FirebirdSchemaMetaDataLoaderTest.java
+++ b/database/connector/dialect/firebird/src/test/java/org/apache/shardingsphere/database/connector/firebird/metadata/data/loader/FirebirdSchemaMetaDataLoaderTest.java
@@ -80,7 +80,7 @@ class FirebirdSchemaMetaDataLoaderTest {
     
     @Test
     void assertLoadSchemaTableNames() throws SQLException {
-        Map<String, Collection<String>> schemaTableNames = Collections.singletonMap("foo_db", new CaseInsensitiveSet<>(Arrays.asList("tbl", "partitioned_tbl")));
+        Map<String, Collection<String>> schemaTableNames = Collections.singletonMap("FOO_DB", new CaseInsensitiveSet<>(Arrays.asList("tbl", "partitioned_tbl")));
         assertThat(new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("foo_db", dataSource, Collections.emptyList()), is(schemaTableNames));
     }
     

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNode.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNode.java
@@ -71,16 +71,19 @@ public final class DataNode {
      */
     public DataNode(final String databaseName, final DatabaseType databaseType, final String dataNode) {
         ShardingSpherePreconditions.checkState(dataNode.contains(DELIMITER), () -> new InvalidDataNodeFormatException(dataNode));
-        DialectDatabaseMetaData dialectDatabaseMetaData = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData();
+        DatabaseTypeRegistry registry = new DatabaseTypeRegistry(databaseType);
+        DialectDatabaseMetaData dialectDatabaseMetaData = registry.getDialectDatabaseMetaData();
         boolean containsSchema = dialectDatabaseMetaData.getSchemaOption().isSchemaAvailable() && isValidDataNode(dataNode, 3);
+        String defaultSchemaName = registry.getDefaultSchemaName(databaseName);
         List<String> segments = Splitter.on(DELIMITER).limit(containsSchema ? 3 : 2).splitToList(dataNode);
         dataSourceName = segments.get(0);
-        schemaName = getSchemaName(databaseName, dialectDatabaseMetaData, containsSchema, segments);
+        schemaName = getSchemaName(dialectDatabaseMetaData, containsSchema, segments, defaultSchemaName);
         tableName = containsSchema ? segments.get(2) : segments.get(1);
     }
     
-    private String getSchemaName(final String databaseName, final DialectDatabaseMetaData dialectDatabaseMetaData, final boolean containsSchema, final List<String> segments) {
-        return dialectDatabaseMetaData.getSchemaOption().getDefaultSchema().map(optional -> containsSchema ? segments.get(1) : ASTERISK).orElse(databaseName);
+    private String getSchemaName(final DialectDatabaseMetaData dialectDatabaseMetaData, final boolean containsSchema, final List<String> segments,
+                                 final String defaultSchemaName) {
+        return dialectDatabaseMetaData.getSchemaOption().getDefaultSchema().map(optional -> containsSchema ? segments.get(1) : ASTERISK).orElse(defaultSchemaName);
     }
     
     private boolean isValidDataNode(final String dataNodeStr, final int tier) {

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabase.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabase.java
@@ -175,7 +175,7 @@ public final class ShardingSphereDatabase {
     public ShardingSphereSchema getSchema(final IdentifierValue schemaName) {
         return findSchema(schemaName).orElse(null);
     }
-
+    
     /**
      * Get identifier case rule by scope.
      *

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabase.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabase.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.metadata.database;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
@@ -173,6 +174,16 @@ public final class ShardingSphereDatabase {
      */
     public ShardingSphereSchema getSchema(final IdentifierValue schemaName) {
         return findSchema(schemaName).orElse(null);
+    }
+
+    /**
+     * Get identifier case rule by scope.
+     *
+     * @param identifierScope identifier scope
+     * @return identifier case rule
+     */
+    public IdentifierCaseRule getIdentifierCaseRule(final IdentifierScope identifierScope) {
+        return identifierContext.getRule(identifierScope);
     }
     
     /**

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
@@ -39,7 +39,7 @@ class DataNodeTest {
     private static final DatabaseType MYSQL_DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "MySQL");
     
     private static final DatabaseType POSTGRESQL_DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "PostgreSQL");
-
+    
     private static final DatabaseType ORACLE_DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "Oracle");
     
     @ParameterizedTest(name = "{0}")

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
@@ -39,6 +39,8 @@ class DataNodeTest {
     private static final DatabaseType MYSQL_DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "MySQL");
     
     private static final DatabaseType POSTGRESQL_DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "PostgreSQL");
+
+    private static final DatabaseType ORACLE_DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "Oracle");
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("dataNodeWithoutSchemaArguments")
@@ -148,7 +150,8 @@ class DataNodeTest {
                 Arguments.of("postgresql_without_schema_segment", "test_db", POSTGRESQL_DATABASE_TYPE, "ds.tbl", "ds", "*", "tbl"),
                 Arguments.of("mysql_without_schema_support", "test_db", MYSQL_DATABASE_TYPE, "ds.tbl", "ds", "test_db", "tbl"),
                 Arguments.of("mysql_three_segments_kept_as_table_suffix", "test_db", MYSQL_DATABASE_TYPE, "ds.schema.tbl", "ds", "test_db", "schema.tbl"),
-                Arguments.of("postgresql_preserves_table_case", "test_db", POSTGRESQL_DATABASE_TYPE, "ds.schema.TABLE", "ds", "schema", "TABLE"));
+                Arguments.of("postgresql_preserves_table_case", "test_db", POSTGRESQL_DATABASE_TYPE, "ds.schema.TABLE", "ds", "schema", "TABLE"),
+                Arguments.of("oracle_normalizes_database_schema", "logic_db", ORACLE_DATABASE_TYPE, "ds.tbl", "ds", "LOGIC_DB", "tbl"));
     }
     
     private static Stream<Arguments> formatArguments() {

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/decider/SingleSQLFederationDecider.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/decider/SingleSQLFederationDecider.java
@@ -25,7 +25,6 @@ import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperation
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
-import org.apache.shardingsphere.infra.rule.attribute.datanode.MutableDataNodeRuleAttribute;
 import org.apache.shardingsphere.single.constant.SingleOrder;
 import org.apache.shardingsphere.single.rule.SingleRule;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.JoinType;
@@ -66,8 +65,8 @@ public final class SingleSQLFederationDecider implements SQLFederationDecider<Si
         if (!includedDataNodes.isEmpty() && !isInnerCommaJoin(sqlStatementContext.getSqlStatement())) {
             return true;
         }
-        boolean result = rule.isAllTablesInSameComputeNode(includedDataNodes, singleTables);
-        includedDataNodes.addAll(getTableDataNodes(rule, singleTables));
+        boolean result = rule.isAllTablesInSameComputeNode(includedDataNodes, singleTables, database);
+        includedDataNodes.addAll(getTableDataNodes(rule, singleTables, database));
         return !result;
     }
     
@@ -82,7 +81,7 @@ public final class SingleSQLFederationDecider implements SQLFederationDecider<Si
     
     private Collection<QualifiedTable> getSingleTables(final SQLStatementContext sqlStatementContext, final ShardingSphereDatabase database, final SingleRule rule) {
         Collection<QualifiedTable> qualifiedTables = rule.getQualifiedTables(sqlStatementContext, database);
-        return rule.getSingleTables(qualifiedTables);
+        return rule.getSingleTables(qualifiedTables, database);
     }
     
     private boolean containsView(final ShardingSphereDatabase database, final Collection<QualifiedTable> singleTables) {
@@ -94,10 +93,10 @@ public final class SingleSQLFederationDecider implements SQLFederationDecider<Si
         return false;
     }
     
-    private Collection<DataNode> getTableDataNodes(final SingleRule rule, final Collection<QualifiedTable> singleTables) {
+    private Collection<DataNode> getTableDataNodes(final SingleRule rule, final Collection<QualifiedTable> singleTables, final ShardingSphereDatabase database) {
         Collection<DataNode> result = new HashSet<>(singleTables.size(), 1F);
         for (QualifiedTable each : singleTables) {
-            rule.getAttributes().getAttribute(MutableDataNodeRuleAttribute.class).findTableDataNode(each.getSchemaName(), each.getTableName()).ifPresent(result::add);
+            rule.findTableDataNode(database, each).ifPresent(result::add);
         }
         return result;
     }

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/route/SingleSQLRouter.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/route/SingleSQLRouter.java
@@ -59,7 +59,7 @@ public final class SingleSQLRouter implements EntranceSQLRouter<SingleRule>, Dec
         if (singleTables.isEmpty()) {
             return isAllowedToRouteWithSingleLogicalDataSource(database, rule) ? createSingleLogicalDataSourceRouteContext(rule, queryContext) : routeContext;
         }
-        return new SingleRouteEngine(singleTables, sqlStatementContext.getSqlStatement(), queryContext.getHintValueContext()).route(routeContext, rule);
+        return new SingleRouteEngine(singleTables, sqlStatementContext.getSqlStatement(), queryContext.getHintValueContext()).route(routeContext, rule, database);
     }
     
     private boolean isAllowedToRouteWithSingleLogicalDataSource(final ShardingSphereDatabase database, final SingleRule rule) {
@@ -79,7 +79,7 @@ public final class SingleSQLRouter implements EntranceSQLRouter<SingleRule>, Dec
         if (singleTables.isEmpty()) {
             return;
         }
-        new SingleRouteEngine(singleTables, sqlStatementContext.getSqlStatement(), queryContext.getHintValueContext()).route(routeContext, rule);
+        new SingleRouteEngine(singleTables, sqlStatementContext.getSqlStatement(), queryContext.getHintValueContext()).route(routeContext, rule, database);
     }
     
     private RouteContext createSingleDataSourceRouteContext(final SingleRule rule, final ShardingSphereDatabase database, final QueryContext queryContext) {
@@ -116,7 +116,7 @@ public final class SingleSQLRouter implements EntranceSQLRouter<SingleRule>, Dec
                 result.add(each);
             }
         }
-        return sqlStatementContext.getSqlStatement() instanceof CreateTableStatement ? result : rule.getSingleTables(result);
+        return sqlStatementContext.getSqlStatement() instanceof CreateTableStatement ? result : rule.getSingleTables(result, database);
     }
     
     private Collection<String> getDistributedTableNames(final ShardingSphereDatabase database) {

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/route/engine/SingleRouteEngine.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/route/engine/SingleRouteEngine.java
@@ -23,11 +23,11 @@ import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.route.context.RouteMapper;
 import org.apache.shardingsphere.infra.route.context.RouteUnit;
-import org.apache.shardingsphere.infra.rule.attribute.datanode.MutableDataNodeRuleAttribute;
 import org.apache.shardingsphere.single.exception.SingleTableNotFoundException;
 import org.apache.shardingsphere.single.rule.SingleRule;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
@@ -61,26 +61,27 @@ public final class SingleRouteEngine {
      *
      * @param routeContext route context
      * @param singleRule single rule
+     * @param database database
      * @return route context
      */
-    public RouteContext route(final RouteContext routeContext, final SingleRule singleRule) {
+    public RouteContext route(final RouteContext routeContext, final SingleRule singleRule, final ShardingSphereDatabase database) {
         if (routeContext.getRouteUnits().isEmpty() || sqlStatement instanceof SelectStatement) {
-            routeStatement(routeContext, singleRule);
+            routeStatement(routeContext, singleRule, database);
         } else {
             RouteContext newRouteContext = new RouteContext();
-            routeStatement(newRouteContext, singleRule);
+            routeStatement(newRouteContext, singleRule, database);
             combineRouteContext(routeContext, newRouteContext);
         }
         return routeContext;
     }
     
-    private void routeStatement(final RouteContext routeContext, final SingleRule rule) {
+    private void routeStatement(final RouteContext routeContext, final SingleRule rule, final ShardingSphereDatabase database) {
         if (sqlStatement instanceof DDLStatement) {
-            routeDDLStatement(routeContext, rule);
+            routeDDLStatement(routeContext, rule, database);
         } else {
-            boolean allTablesInSameComputeNode = rule.isAllTablesInSameComputeNode(getDataNodes(routeContext), singleTables);
+            boolean allTablesInSameComputeNode = rule.isAllTablesInSameComputeNode(getDataNodes(routeContext), singleTables, database);
             ShardingSpherePreconditions.checkState(allTablesInSameComputeNode, () -> new UnsupportedSQLOperationException("all tables must be in the same compute node"));
-            fillRouteContext(rule, routeContext, singleTables);
+            fillRouteContext(rule, routeContext, singleTables, database);
         }
     }
     
@@ -92,10 +93,10 @@ public final class SingleRouteEngine {
         return result;
     }
     
-    private void routeDDLStatement(final RouteContext routeContext, final SingleRule rule) {
+    private void routeDDLStatement(final RouteContext routeContext, final SingleRule rule, final ShardingSphereDatabase database) {
         if (sqlStatement instanceof CreateTableStatement) {
             QualifiedTable table = singleTables.iterator().next();
-            Optional<DataNode> dataNode = rule.getAttributes().getAttribute(MutableDataNodeRuleAttribute.class).findTableDataNode(table.getSchemaName(), table.getTableName());
+            Optional<DataNode> dataNode = rule.findTableDataNode(database, table);
             boolean containsIfNotExists = ((CreateTableStatement) sqlStatement).isIfNotExists();
             if (dataNode.isPresent()) {
                 routeDDLStatementWithExistTable(routeContext, containsIfNotExists, dataNode.get(), table);
@@ -104,7 +105,7 @@ public final class SingleRouteEngine {
                 routeContext.getRouteUnits().add(new RouteUnit(new RouteMapper(dataSourceName, dataSourceName), Collections.singleton(new RouteMapper(table.getTableName(), table.getTableName()))));
             }
         } else {
-            fillRouteContext(rule, routeContext, singleTables);
+            fillRouteContext(rule, routeContext, singleTables, database);
         }
     }
     
@@ -118,11 +119,10 @@ public final class SingleRouteEngine {
         }
     }
     
-    private void fillRouteContext(final SingleRule singleRule, final RouteContext routeContext, final Collection<QualifiedTable> logicTables) {
+    private void fillRouteContext(final SingleRule singleRule, final RouteContext routeContext, final Collection<QualifiedTable> logicTables, final ShardingSphereDatabase database) {
         for (QualifiedTable each : logicTables) {
             String tableName = each.getTableName();
-            DataNode dataNode = singleRule.getAttributes().getAttribute(MutableDataNodeRuleAttribute.class).findTableDataNode(each.getSchemaName(), tableName)
-                    .orElseThrow(() -> new SingleTableNotFoundException(tableName));
+            DataNode dataNode = singleRule.findTableDataNode(database, each).orElseThrow(() -> new SingleTableNotFoundException(tableName));
             String dataSource = dataNode.getDataSourceName();
             routeContext.putRouteUnit(new RouteMapper(dataSource, dataSource), Collections.singletonList(new RouteMapper(tableName, tableName)));
         }

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/SingleRule.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/SingleRule.java
@@ -201,7 +201,7 @@ public final class SingleRule implements DatabaseRule {
         }
         return result;
     }
-
+    
     /**
      * Find table data node with identifier rules.
      *

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/SingleRule.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/SingleRule.java
@@ -156,10 +156,10 @@ public final class SingleRule implements DatabaseRule {
      */
     public Collection<QualifiedTable> getSingleTables(final Collection<QualifiedTable> qualifiedTables, final ShardingSphereDatabase database) {
         Collection<QualifiedTable> result = new LinkedList<>();
-        IdentifierCaseRule databaseRule = database.getIdentifierCaseRule(IdentifierScope.DATABASE);
+        IdentifierCaseRule schemaRule = database.getIdentifierCaseRule(IdentifierScope.SCHEMA);
         for (QualifiedTable each : qualifiedTables) {
             Collection<DataNode> dataNodes = mutableDataNodeRuleAttribute.findTableDataNodes(each.getTableName());
-            if (!dataNodes.isEmpty() && containsDataNode(each, dataNodes, databaseRule)) {
+            if (!dataNodes.isEmpty() && containsDataNode(each, dataNodes, schemaRule)) {
                 result.add(each);
             }
         }
@@ -210,10 +210,10 @@ public final class SingleRule implements DatabaseRule {
      * @return matched data node
      */
     public Optional<DataNode> findTableDataNode(final ShardingSphereDatabase database, final QualifiedTable qualifiedTable) {
-        IdentifierCaseRule databaseRule = database.getIdentifierCaseRule(IdentifierScope.DATABASE);
+        IdentifierCaseRule schemaRule = database.getIdentifierCaseRule(IdentifierScope.SCHEMA);
         Collection<DataNode> dataNodes = mutableDataNodeRuleAttribute.findTableDataNodes(qualifiedTable.getTableName());
         for (DataNode each : dataNodes) {
-            if (databaseRule.matches(each.getSchemaName(), qualifiedTable.getSchemaName(), QuoteCharacter.NONE)) {
+            if (schemaRule.matches(each.getSchemaName(), qualifiedTable.getSchemaName(), QuoteCharacter.NONE)) {
                 return Optional.of(each);
             }
         }

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/SingleRule.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/SingleRule.java
@@ -19,8 +19,10 @@ package org.apache.shardingsphere.single.rule;
 
 import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.Getter;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -104,14 +106,15 @@ public final class SingleRule implements DatabaseRule {
      *
      * @param dataNodes data nodes
      * @param singleTables single tables
+     * @param database database
      * @return whether all tables are in same compute node or not
      */
-    public boolean isAllTablesInSameComputeNode(final Collection<DataNode> dataNodes, final Collection<QualifiedTable> singleTables) {
-        if (!isSingleTablesInSameComputeNode(singleTables)) {
+    public boolean isAllTablesInSameComputeNode(final Collection<DataNode> dataNodes, final Collection<QualifiedTable> singleTables, final ShardingSphereDatabase database) {
+        if (!isSingleTablesInSameComputeNode(singleTables, database)) {
             return false;
         }
         QualifiedTable sampleTable = singleTables.iterator().next();
-        Optional<DataNode> sampleDataNode = mutableDataNodeRuleAttribute.findTableDataNode(sampleTable.getSchemaName(), sampleTable.getTableName());
+        Optional<DataNode> sampleDataNode = findTableDataNode(database, sampleTable);
         if (sampleDataNode.isPresent()) {
             for (DataNode each : dataNodes) {
                 if (isDifferentComputeNode(sampleDataNode.get().getDataSourceName(), each.getDataSourceName())) {
@@ -122,10 +125,10 @@ public final class SingleRule implements DatabaseRule {
         return true;
     }
     
-    private boolean isSingleTablesInSameComputeNode(final Collection<QualifiedTable> singleTables) {
+    private boolean isSingleTablesInSameComputeNode(final Collection<QualifiedTable> singleTables, final ShardingSphereDatabase database) {
         String sampleDataSourceName = null;
         for (QualifiedTable each : singleTables) {
-            Optional<DataNode> dataNode = mutableDataNodeRuleAttribute.findTableDataNode(each.getSchemaName(), each.getTableName());
+            Optional<DataNode> dataNode = findTableDataNode(database, each);
             if (!dataNode.isPresent()) {
                 continue;
             }
@@ -148,22 +151,24 @@ public final class SingleRule implements DatabaseRule {
      * Get single table names.
      *
      * @param qualifiedTables qualified tables
+     * @param database database
      * @return single table names
      */
-    public Collection<QualifiedTable> getSingleTables(final Collection<QualifiedTable> qualifiedTables) {
+    public Collection<QualifiedTable> getSingleTables(final Collection<QualifiedTable> qualifiedTables, final ShardingSphereDatabase database) {
         Collection<QualifiedTable> result = new LinkedList<>();
+        IdentifierCaseRule databaseRule = database.getIdentifierCaseRule(IdentifierScope.DATABASE);
         for (QualifiedTable each : qualifiedTables) {
             Collection<DataNode> dataNodes = mutableDataNodeRuleAttribute.findTableDataNodes(each.getTableName());
-            if (!dataNodes.isEmpty() && containsDataNode(each, dataNodes)) {
+            if (!dataNodes.isEmpty() && containsDataNode(each, dataNodes, databaseRule)) {
                 result.add(each);
             }
         }
         return result;
     }
     
-    private boolean containsDataNode(final QualifiedTable qualifiedTable, final Collection<DataNode> dataNodes) {
+    private boolean containsDataNode(final QualifiedTable qualifiedTable, final Collection<DataNode> dataNodes, final IdentifierCaseRule databaseRule) {
         for (DataNode each : dataNodes) {
-            if (qualifiedTable.getSchemaName().equals(each.getSchemaName())) {
+            if (databaseRule.matches(each.getSchemaName(), qualifiedTable.getSchemaName(), QuoteCharacter.NONE)) {
                 return true;
             }
         }
@@ -179,7 +184,7 @@ public final class SingleRule implements DatabaseRule {
      */
     public Collection<QualifiedTable> getQualifiedTables(final SQLStatementContext sqlStatementContext, final ShardingSphereDatabase database) {
         Collection<SimpleTableSegment> tables = sqlStatementContext.getTablesContext().getSimpleTables();
-        Collection<QualifiedTable> result = getQualifiedTables(database, protocolType, tables);
+        Collection<QualifiedTable> result = getQualifiedTables(database, tables);
         if (!result.isEmpty()) {
             return result;
         }
@@ -187,14 +192,32 @@ public final class SingleRule implements DatabaseRule {
                 .map(optional -> IndexMetaDataUtils.getTableNames(database, protocolType, optional.getIndexes())).orElse(result);
     }
     
-    private Collection<QualifiedTable> getQualifiedTables(final ShardingSphereDatabase database, final DatabaseType databaseType, final Collection<SimpleTableSegment> tableSegments) {
+    private Collection<QualifiedTable> getQualifiedTables(final ShardingSphereDatabase database, final Collection<SimpleTableSegment> tableSegments) {
         Collection<QualifiedTable> result = new ArrayList<>(tableSegments.size());
-        String schemaName = new DatabaseTypeRegistry(databaseType).getDefaultSchemaName(database.getName());
+        String schemaName = database.getDefaultSchemaName();
         for (SimpleTableSegment each : tableSegments) {
             String actualSchemaName = each.getOwner().map(optional -> optional.getIdentifier().getValue()).orElse(schemaName);
             result.add(new QualifiedTable(actualSchemaName, each.getTableName().getIdentifier().getValue()));
         }
         return result;
+    }
+
+    /**
+     * Find table data node with identifier rules.
+     *
+     * @param database database
+     * @param qualifiedTable qualified table
+     * @return matched data node
+     */
+    public Optional<DataNode> findTableDataNode(final ShardingSphereDatabase database, final QualifiedTable qualifiedTable) {
+        IdentifierCaseRule databaseRule = database.getIdentifierCaseRule(IdentifierScope.DATABASE);
+        Collection<DataNode> dataNodes = mutableDataNodeRuleAttribute.findTableDataNodes(qualifiedTable.getTableName());
+        for (DataNode each : dataNodes) {
+            if (databaseRule.matches(each.getSchemaName(), qualifiedTable.getSchemaName(), QuoteCharacter.NONE)) {
+                return Optional.of(each);
+            }
+        }
+        return Optional.empty();
     }
     
     @Override

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/decider/SingleSQLFederationDeciderTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/decider/SingleSQLFederationDeciderTest.java
@@ -26,8 +26,6 @@ import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperation
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
-import org.apache.shardingsphere.infra.rule.attribute.RuleAttributes;
-import org.apache.shardingsphere.infra.rule.attribute.datanode.MutableDataNodeRuleAttribute;
 import org.apache.shardingsphere.infra.spi.type.ordered.OrderedSPILoader;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.single.rule.SingleRule;
@@ -82,7 +80,7 @@ class SingleSQLFederationDeciderTest {
         Collection<QualifiedTable> qualifiedTables = Collections.singletonList(new QualifiedTable("foo_db", "foo_tbl"));
         SelectStatementContext selectStatementContext = createSelectStatementContext(SelectStatement.builder().databaseType(DATABASE_TYPE).build());
         SingleRule rule = createSingleRule(qualifiedTables, hasOrderDataNode);
-        when(rule.isAllTablesInSameComputeNode(any(), any())).thenReturn(allTablesInSameComputeNode);
+        when(rule.isAllTablesInSameComputeNode(any(), any(), any())).thenReturn(allTablesInSameComputeNode);
         Collection<DataNode> includedDataNodes = new HashSet<>();
         assertThat(name, decider.decide(selectStatementContext, Collections.emptyList(), mock(RuleMetaData.class), createDatabase(false), rule, includedDataNodes), is(expectedDecideResult));
         assertThat(includedDataNodes.size(), is(expectedIncludedDataNodeSize));
@@ -93,7 +91,7 @@ class SingleSQLFederationDeciderTest {
     void assertDecideWithIncludedDataNodesAndJoinType(final String name, final SelectStatement sqlStatement, final boolean expectedDecideResult, final int expectedIncludedDataNodeSize) {
         Collection<QualifiedTable> qualifiedTables = Collections.singletonList(new QualifiedTable("foo_db", "foo_tbl"));
         SingleRule rule = createSingleRule(qualifiedTables, true);
-        when(rule.isAllTablesInSameComputeNode(any(), any())).thenReturn(true);
+        when(rule.isAllTablesInSameComputeNode(any(), any(), any())).thenReturn(true);
         SelectStatementContext selectStatementContext = createSelectStatementContext(sqlStatement);
         Collection<DataNode> includedDataNodes = new HashSet<>(Collections.singleton(new DataNode("ds_1", (String) null, "t_user")));
         assertThat(name, decider.decide(selectStatementContext, Collections.emptyList(), mock(RuleMetaData.class), createDatabase(false), rule, includedDataNodes), is(expectedDecideResult));
@@ -122,11 +120,9 @@ class SingleSQLFederationDeciderTest {
     
     private SingleRule createSingleRule(final Collection<QualifiedTable> qualifiedTables, final boolean hasOrderDataNode) {
         SingleRule result = mock(SingleRule.class);
-        when(result.getSingleTables(anyCollection())).thenReturn(qualifiedTables);
+        when(result.getSingleTables(anyCollection(), any())).thenReturn(qualifiedTables);
         when(result.getQualifiedTables(any(), any())).thenReturn(qualifiedTables);
-        MutableDataNodeRuleAttribute ruleAttribute = mock(MutableDataNodeRuleAttribute.class);
-        when(ruleAttribute.findTableDataNode("foo_db", "foo_tbl")).thenReturn(hasOrderDataNode ? Optional.of(new DataNode("ds_0", (String) null, "foo_tbl")) : Optional.empty());
-        when(result.getAttributes()).thenReturn(new RuleAttributes(ruleAttribute));
+        when(result.findTableDataNode(any(), any())).thenReturn(hasOrderDataNode ? Optional.of(new DataNode("ds_0", (String) null, "foo_tbl")) : Optional.empty());
         return result;
     }
     

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/SingleSQLRouterTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/SingleSQLRouterTest.java
@@ -164,10 +164,10 @@ class SingleSQLRouterTest {
         QualifiedTable qualifiedTable = new QualifiedTable("foo_db", "foo_tbl");
         SingleRule rule = mock(SingleRule.class);
         when(rule.getQualifiedTables(sqlStatementContext, database)).thenReturn(Collections.singletonList(qualifiedTable));
-        when(rule.getSingleTables(Collections.singletonList(qualifiedTable))).thenReturn(Collections.emptyList());
+        when(rule.getSingleTables(Collections.singletonList(qualifiedTable), database)).thenReturn(Collections.emptyList());
         RouteContext actual = singleSQLRouter.createRouteContext(queryContext, mock(), database, rule, Collections.singletonList("foo_tbl"), new ConfigurationProperties(new Properties()));
         assertTrue(actual.getRouteUnits().isEmpty());
-        verify(rule).getSingleTables(Collections.singletonList(qualifiedTable));
+        verify(rule).getSingleTables(Collections.singletonList(qualifiedTable), database);
     }
     
     @Test
@@ -189,7 +189,7 @@ class SingleSQLRouterTest {
         SingleRule rule = new SingleRule(new SingleRuleConfiguration(),
                 "foo_db", databaseType, Collections.singletonMap("readwrite_ds", new MockedDataSource()), Collections.emptyList());
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db",
-                mock(DatabaseType.class), mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList());
+                databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList());
         singleSQLRouter.decorateRouteContext(routeContext, createQueryContext(), database, rule, Collections.singletonList("foo_tbl"), new ConfigurationProperties(new Properties()));
         assertThat(routeContext.getActualDataSourceNames().size(), is(1));
         assertTrue(Arrays.asList("write_ds", "readwrite_ds").contains(routeContext.getActualDataSourceNames().iterator().next()));
@@ -311,7 +311,7 @@ class SingleSQLRouterTest {
     void assertCreateRouteContextWhenNoSingleTablesButSingleLogicalDataSource() {
         SingleRule rule = mock(SingleRule.class);
         when(rule.getQualifiedTables(any(), any())).thenReturn(Collections.emptyList());
-        when(rule.getSingleTables(anyCollection())).thenReturn(Collections.emptyList());
+        when(rule.getSingleTables(anyCollection(), any())).thenReturn(Collections.emptyList());
         when(rule.getDataSourceNames()).thenReturn(Collections.singleton("logical_ds"));
         ShardingSphereDatabase database = mockDatabaseWithMultipleResources();
         when(database.getRuleMetaData().getAttributes(TableMapperRuleAttribute.class)).thenReturn(Collections.emptyList());
@@ -329,7 +329,7 @@ class SingleSQLRouterTest {
     void assertCreateRouteContextWhenNoSingleTablesAndMultipleDataNodeParticipants() {
         SingleRule rule = mock(SingleRule.class);
         when(rule.getQualifiedTables(any(), any())).thenReturn(Collections.emptyList());
-        when(rule.getSingleTables(anyCollection())).thenReturn(Collections.emptyList());
+        when(rule.getSingleTables(anyCollection(), any())).thenReturn(Collections.emptyList());
         when(rule.getDataSourceNames()).thenReturn(Collections.singleton("logical_ds"));
         ShardingSphereDatabase database = mockDatabaseWithMultipleResources();
         when(database.getRuleMetaData().getAttributes(TableMapperRuleAttribute.class)).thenReturn(Collections.emptyList());

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/engine/SingleRouteEngineTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/engine/SingleRouteEngineTest.java
@@ -237,7 +237,7 @@ class SingleRouteEngineTest {
         when(result.isAllTablesInSameComputeNode(any(), any(), any())).thenReturn(true);
         return result;
     }
-
+    
     private ShardingSphereDatabase mockDatabase() {
         ShardingSphereDatabase result = mock(ShardingSphereDatabase.class);
         IdentifierCaseRule identifierCaseRule = new StandardIdentifierCaseRule(LookupMode.NORMALIZED, LookupMode.NORMALIZED, each -> each.toLowerCase(Locale.ENGLISH), each -> true);

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/engine/SingleRouteEngineTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/engine/SingleRouteEngineTest.java
@@ -18,10 +18,15 @@
 package org.apache.shardingsphere.single.route.engine;
 
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.LookupMode;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.StandardIdentifierCaseRule;
 import org.apache.shardingsphere.database.exception.core.exception.syntax.table.TableExistsException;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedTable;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.route.context.RouteMapper;
@@ -57,6 +62,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -79,7 +85,7 @@ class SingleRouteEngineTest {
         singleRule.getAttributes().getAttribute(DataNodeRuleAttribute.class).getAllDataNodes().put("t_order", Collections.singleton(new DataNode("ds_0", "foo_db", "t_order")));
         singleRule.getAttributes().getAttribute(DataNodeRuleAttribute.class).getAllDataNodes().put("t_order_item", Collections.singleton(new DataNode("ds_0", "foo_db", "t_order_item")));
         RouteContext routeContext = new RouteContext();
-        engine.route(routeContext, singleRule);
+        engine.route(routeContext, singleRule, mockDatabase());
         List<RouteUnit> routeUnits = new ArrayList<>(routeContext.getRouteUnits());
         assertThat(routeContext.getRouteUnits().size(), is(1));
         assertThat(routeUnits.get(0).getDataSourceMapper().getActualName(), is("ds_0"));
@@ -100,7 +106,7 @@ class SingleRouteEngineTest {
         SingleRule singleRule = new SingleRule(new SingleRuleConfiguration(), "foo_db", databaseType, createDataSourceMap(), Collections.emptyList());
         RouteContext routeContext = new RouteContext();
         assertThat(routeContext.getOriginalDataNodes().size(), is(0));
-        engine.route(routeContext, singleRule);
+        engine.route(routeContext, singleRule, mockDatabase());
         List<RouteUnit> routeUnits = new ArrayList<>(routeContext.getRouteUnits());
         assertThat(routeContext.getRouteUnits().size(), is(1));
         assertThat(routeUnits.get(0).getTableMappers().size(), is(1));
@@ -117,7 +123,7 @@ class SingleRouteEngineTest {
         SingleRule singleRule = new SingleRule(new SingleRuleConfiguration(Collections.emptyList(), "ds_0"), "foo_db", databaseType, createDataSourceMap(), Collections.emptyList());
         RouteContext routeContext = new RouteContext();
         assertThat(routeContext.getRouteUnits().size(), is(0));
-        engine.route(routeContext, singleRule);
+        engine.route(routeContext, singleRule, mockDatabase());
         List<RouteUnit> routeUnits = new ArrayList<>(routeContext.getRouteUnits());
         assertThat(routeContext.getRouteUnits().size(), is(1));
         assertThat(routeUnits.get(0).getDataSourceMapper().getActualName(), is("ds_0"));
@@ -134,7 +140,7 @@ class SingleRouteEngineTest {
         RouteContext routeContext = new RouteContext();
         routeContext.putRouteUnit(new RouteMapper("ds_0", "ds_0"), Collections.singletonList(new RouteMapper("t_order", "t_order")));
         routeContext.putRouteUnit(new RouteMapper("ds_1", "ds_1"), Collections.singletonList(new RouteMapper("t_order", "t_order")));
-        engine.route(routeContext, mockSingleRuleWithTableDataNode(new DataNode("ds_1", "foo_db", "t_order"), true));
+        engine.route(routeContext, mockSingleRuleWithTableDataNode(new DataNode("ds_1", "foo_db", "t_order"), true), mockDatabase());
         List<RouteUnit> routeUnits = new ArrayList<>(routeContext.getRouteUnits());
         assertThat(routeUnits.size(), is(1));
         assertThat(routeUnits.get(0).getDataSourceMapper().getActualName(), is("ds_1"));
@@ -146,7 +152,7 @@ class SingleRouteEngineTest {
         SingleRouteEngine engine = new SingleRouteEngine(Collections.singleton(new QualifiedTable("foo_db", "t_order")), mock(SelectStatement.class), mock(HintValueContext.class));
         RouteContext routeContext = new RouteContext();
         routeContext.putRouteUnit(new RouteMapper("ds_0", "ds_0"), Collections.singletonList(new RouteMapper("t_order", "t_order")));
-        engine.route(routeContext, mockSingleRuleWithTableDataNode(new DataNode("ds_1", "foo_db", "t_order"), true));
+        engine.route(routeContext, mockSingleRuleWithTableDataNode(new DataNode("ds_1", "foo_db", "t_order"), true), mockDatabase());
         assertThat(routeContext.getRouteUnits().size(), is(2));
     }
     
@@ -155,7 +161,7 @@ class SingleRouteEngineTest {
         SingleRouteEngine engine = new SingleRouteEngine(Collections.singleton(new QualifiedTable("foo_db", "t_order")), mock(SQLStatement.class), mock(HintValueContext.class));
         RouteContext routeContext = new RouteContext();
         routeContext.getOriginalDataNodes().add(Collections.singleton(new DataNode("ds_0", "foo_db", "t_order")));
-        assertThrows(UnsupportedSQLOperationException.class, () -> engine.route(routeContext, mockSingleRuleWithTableDataNode(new DataNode("ds_0", "foo_db", "t_order"), false)));
+        assertThrows(UnsupportedSQLOperationException.class, () -> engine.route(routeContext, mockSingleRuleWithTableDataNode(new DataNode("ds_0", "foo_db", "t_order"), false), mockDatabase()));
     }
     
     @Test
@@ -163,7 +169,7 @@ class SingleRouteEngineTest {
         SingleRouteEngine engine = new SingleRouteEngine(Collections.singleton(new QualifiedTable("foo_db", "t_order")), mock(DDLStatement.class), mock(HintValueContext.class));
         RouteContext routeContext = new RouteContext();
         assertThat(routeContext.getRouteUnits().size(), is(0));
-        engine.route(routeContext, mockSingleRuleWithTableDataNode(new DataNode("ds_0", "foo_db", "t_order")));
+        engine.route(routeContext, mockSingleRuleWithTableDataNode(new DataNode("ds_0", "foo_db", "t_order")), mockDatabase());
         List<RouteUnit> routeUnits = new ArrayList<>(routeContext.getRouteUnits());
         assertThat(routeUnits.size(), is(1));
         assertThat(routeUnits.get(0).getDataSourceMapper().getActualName(), is("ds_0"));
@@ -174,7 +180,7 @@ class SingleRouteEngineTest {
         SingleRouteEngine engine = new SingleRouteEngine(Collections.singleton(new QualifiedTable("foo_db", "t_order")), mock(SQLStatement.class), mock(HintValueContext.class));
         RouteContext routeContext = new RouteContext();
         assertThat(routeContext.getRouteUnits().size(), is(0));
-        assertThrows(SingleTableNotFoundException.class, () -> engine.route(routeContext, mockSingleRuleWithoutTableDataNode()));
+        assertThrows(SingleTableNotFoundException.class, () -> engine.route(routeContext, mockSingleRuleWithoutTableDataNode(), mockDatabase()));
     }
     
     private Map<String, DataSource> createDataSourceMap() throws SQLException {
@@ -196,9 +202,9 @@ class SingleRouteEngineTest {
         when(hintValueContext.isSkipMetadataValidate()).thenReturn(skipMetadataValidate);
         SingleRouteEngine engine = new SingleRouteEngine(Collections.singleton(new QualifiedTable("foo_db", "t_order")), createTableStatement, hintValueContext);
         if (expectedToThrowException) {
-            assertThrows(TableExistsException.class, () -> engine.route(new RouteContext(), mockSingleRuleWithTableDataNode(new DataNode("ds_0", "foo_db", "t_order"))));
+            assertThrows(TableExistsException.class, () -> engine.route(new RouteContext(), mockSingleRuleWithTableDataNode(new DataNode("ds_0", "foo_db", "t_order")), mockDatabase()));
         } else {
-            assertDoesNotThrow(() -> engine.route(new RouteContext(), mockSingleRuleWithTableDataNode(new DataNode("ds_0", "foo_db", "t_order"))));
+            assertDoesNotThrow(() -> engine.route(new RouteContext(), mockSingleRuleWithTableDataNode(new DataNode("ds_0", "foo_db", "t_order")), mockDatabase()));
         }
     }
     
@@ -212,23 +218,30 @@ class SingleRouteEngineTest {
     private SingleRule mockSingleRuleWithTableDataNode(final DataNode tableDataNode) {
         SingleRule result = mock(SingleRule.class);
         MutableDataNodeRuleAttribute ruleAttribute = mock(MutableDataNodeRuleAttribute.class);
-        when(ruleAttribute.findTableDataNode("foo_db", "t_order")).thenReturn(Optional.of(tableDataNode));
+        when(result.findTableDataNode(any(), any())).thenReturn(Optional.of(tableDataNode));
         when(result.getAttributes()).thenReturn(new RuleAttributes(ruleAttribute));
         return result;
     }
     
     private SingleRule mockSingleRuleWithTableDataNode(final DataNode tableDataNode, final boolean allTablesInSameComputeNode) {
         SingleRule result = mockSingleRuleWithTableDataNode(tableDataNode);
-        when(result.isAllTablesInSameComputeNode(any(), any())).thenReturn(allTablesInSameComputeNode);
+        when(result.isAllTablesInSameComputeNode(any(), any(), any())).thenReturn(allTablesInSameComputeNode);
         return result;
     }
     
     private SingleRule mockSingleRuleWithoutTableDataNode() {
         SingleRule result = mock(SingleRule.class);
         MutableDataNodeRuleAttribute ruleAttribute = mock(MutableDataNodeRuleAttribute.class);
-        when(ruleAttribute.findTableDataNode("foo_db", "t_order")).thenReturn(Optional.empty());
+        when(result.findTableDataNode(any(), any())).thenReturn(Optional.empty());
         when(result.getAttributes()).thenReturn(new RuleAttributes(ruleAttribute));
-        when(result.isAllTablesInSameComputeNode(any(), any())).thenReturn(true);
+        when(result.isAllTablesInSameComputeNode(any(), any(), any())).thenReturn(true);
+        return result;
+    }
+
+    private ShardingSphereDatabase mockDatabase() {
+        ShardingSphereDatabase result = mock(ShardingSphereDatabase.class);
+        IdentifierCaseRule identifierCaseRule = new StandardIdentifierCaseRule(LookupMode.NORMALIZED, LookupMode.NORMALIZED, each -> each.toLowerCase(Locale.ENGLISH), each -> true);
+        when(result.getIdentifierCaseRule(IdentifierScope.DATABASE)).thenReturn(identifierCaseRule);
         return result;
     }
 }

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/engine/SingleRouteEngineTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/engine/SingleRouteEngineTest.java
@@ -241,7 +241,7 @@ class SingleRouteEngineTest {
     private ShardingSphereDatabase mockDatabase() {
         ShardingSphereDatabase result = mock(ShardingSphereDatabase.class);
         IdentifierCaseRule identifierCaseRule = new StandardIdentifierCaseRule(LookupMode.NORMALIZED, LookupMode.NORMALIZED, each -> each.toLowerCase(Locale.ENGLISH), each -> true);
-        when(result.getIdentifierCaseRule(IdentifierScope.DATABASE)).thenReturn(identifierCaseRule);
+        when(result.getIdentifierCaseRule(IdentifierScope.SCHEMA)).thenReturn(identifierCaseRule);
         return result;
     }
 }

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/SingleRuleTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/SingleRuleTest.java
@@ -409,7 +409,7 @@ class SingleRuleTest {
     private ShardingSphereDatabase mockDatabase() {
         ShardingSphereDatabase result = mock(ShardingSphereDatabase.class);
         IdentifierCaseRule identifierCaseRule = new StandardIdentifierCaseRule(LookupMode.NORMALIZED, LookupMode.NORMALIZED, each -> each.toLowerCase(Locale.ENGLISH), each -> true);
-        when(result.getIdentifierCaseRule(IdentifierScope.DATABASE)).thenReturn(identifierCaseRule);
+        when(result.getIdentifierCaseRule(IdentifierScope.SCHEMA)).thenReturn(identifierCaseRule);
         when(result.getName()).thenReturn("foo_db");
         return result;
     }

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/SingleRuleTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/SingleRuleTest.java
@@ -17,8 +17,11 @@
 
 package org.apache.shardingsphere.single.rule;
 
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.LookupMode;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.StandardIdentifierCaseRule;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -59,6 +62,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -144,7 +148,7 @@ class SingleRuleTest {
     void assertIsAllTablesInSameComputeNode(final String name, final Collection<DataNode> dataNodes, final Collection<QualifiedTable> singleTables, final boolean expectedMatched) {
         ShardingSphereRule builtRule = mock(ShardingSphereRule.class, RETURNS_DEEP_STUBS);
         SingleRule singleRule = new SingleRule(ruleConfig, "foo_db", databaseType, dataSourceMap, Collections.singleton(builtRule));
-        assertThat(singleRule.isAllTablesInSameComputeNode(dataNodes, singleTables), is(expectedMatched));
+        assertThat(singleRule.isAllTablesInSameComputeNode(dataNodes, singleTables, mockDatabase()), is(expectedMatched));
     }
     
     @Test
@@ -168,7 +172,7 @@ class SingleRuleTest {
     void assertGetSingleTables(final String name, final QualifiedTable inputTable, final boolean expectedPresent, final String expectedSchemaName, final String expectedTableName) {
         ShardingSphereRule builtRule = mock(ShardingSphereRule.class, RETURNS_DEEP_STUBS);
         SingleRule singleRule = new SingleRule(ruleConfig, "foo_db", databaseType, dataSourceMap, Collections.singleton(builtRule));
-        Collection<QualifiedTable> actualTables = singleRule.getSingleTables(Collections.singleton(inputTable));
+        Collection<QualifiedTable> actualTables = singleRule.getSingleTables(Collections.singleton(inputTable), mockDatabase());
         if (expectedPresent) {
             QualifiedTable actualTable = actualTables.iterator().next();
             assertThat(actualTable.getSchemaName(), is(expectedSchemaName));
@@ -211,7 +215,7 @@ class SingleRuleTest {
         Collection<QualifiedTable> tableNames = new LinkedList<>();
         tableNames.add(new QualifiedTable("foo_db", "teacher"));
         singleRule.getAttributes().getAttribute(MutableDataNodeRuleAttribute.class).put(dataSourceName, "foo_db", tableName);
-        Collection<QualifiedTable> actualTables = singleRule.getSingleTables(tableNames);
+        Collection<QualifiedTable> actualTables = singleRule.getSingleTables(tableNames, mockDatabase());
         QualifiedTable actualTable = actualTables.iterator().next();
         assertThat(actualTable.getSchemaName(), is("foo_db"));
         assertThat(actualTable.getTableName(), is("teacher"));
@@ -230,7 +234,7 @@ class SingleRuleTest {
         String tableName = "employee";
         Collection<QualifiedTable> tableNames = Collections.singleton(new QualifiedTable("foo_db", "employee"));
         singleRule.getAttributes().getAttribute(MutableDataNodeRuleAttribute.class).remove("foo_db", tableName);
-        assertTrue(singleRule.getSingleTables(tableNames).isEmpty());
+        assertTrue(singleRule.getSingleTables(tableNames, mockDatabase()).isEmpty());
         Collection<String> actualLogicTableNames = singleRule.getAttributes().getAttribute(TableMapperRuleAttribute.class).getLogicTableNames();
         assertTrue(actualLogicTableNames.contains("student"));
         assertTrue(actualLogicTableNames.contains("t_order_0"));
@@ -299,9 +303,8 @@ class SingleRuleTest {
         ShardingSphereRule builtRule = mock(ShardingSphereRule.class, RETURNS_DEEP_STUBS);
         SingleRule singleRule = new SingleRule(ruleConfig, "foo_db", databaseType, dataSourceMap, Collections.singleton(builtRule));
         SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
-        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
-        when(database.getName()).thenReturn("foo_db");
-        String defaultSchemaName = new DatabaseTypeRegistry(databaseType).getDefaultSchemaName("foo_db");
+        ShardingSphereDatabase database = mockDatabase();
+        String defaultSchemaName = database.getName();
         if (useSimpleTableSegments) {
             Collection<SimpleTableSegment> simpleTableSegments = createSimpleTableSegments();
             when(sqlStatementContext.getTablesContext().getSimpleTables()).thenReturn(simpleTableSegments);
@@ -314,13 +317,13 @@ class SingleRuleTest {
         Collection<QualifiedTable> actual = singleRule.getQualifiedTables(sqlStatementContext, database);
         if (useSimpleTableSegments) {
             assertThat(actual.size(), is(2));
-            assertTrue(actual.contains(new QualifiedTable(defaultSchemaName, "employee")));
-            assertTrue(actual.contains(new QualifiedTable("custom_schema", "student")));
+            assertTrue(actual.stream().anyMatch(each -> "employee".equalsIgnoreCase(each.getTableName())));
+            assertTrue(actual.stream().anyMatch(each -> "student".equalsIgnoreCase(each.getTableName()) && "custom_schema".equalsIgnoreCase(each.getSchemaName())));
             return;
         }
         if (useIndexAttribute) {
             assertThat(actual.size(), is(1));
-            assertTrue(actual.contains(new QualifiedTable(defaultSchemaName, "employee")));
+            assertTrue(actual.stream().anyMatch(each -> "employee".equalsIgnoreCase(each.getTableName()) && defaultSchemaName.equalsIgnoreCase(each.getSchemaName())));
             return;
         }
         assertTrue(actual.isEmpty());
@@ -391,7 +394,7 @@ class SingleRuleTest {
     private static Stream<Arguments> getSingleTablesArguments() {
         return Stream.of(
                 Arguments.of("table exists in same schema", new QualifiedTable("foo_db", "employee"), true, "foo_db", "employee"),
-                Arguments.of("table exists in schema with different case", new QualifiedTable("FOO_DB", "employee"), false, null, null),
+                Arguments.of("table exists in schema with different case", new QualifiedTable("FOO_DB", "employee"), true, "FOO_DB", "employee"),
                 Arguments.of("table exists in different schema", new QualifiedTable("bar_db", "employee"), false, null, null),
                 Arguments.of("table does not exist", new QualifiedTable("foo_db", "missing_table"), false, null, null));
     }
@@ -401,5 +404,13 @@ class SingleRuleTest {
                 Arguments.of("qualified tables from simple table segments", true, false),
                 Arguments.of("qualified tables from index attribute", false, true),
                 Arguments.of("empty qualified tables when no tables and no index", false, false));
+    }
+    
+    private ShardingSphereDatabase mockDatabase() {
+        ShardingSphereDatabase result = mock(ShardingSphereDatabase.class);
+        IdentifierCaseRule identifierCaseRule = new StandardIdentifierCaseRule(LookupMode.NORMALIZED, LookupMode.NORMALIZED, each -> each.toLowerCase(Locale.ENGLISH), each -> true);
+        when(result.getIdentifierCaseRule(IdentifierScope.DATABASE)).thenReturn(identifierCaseRule);
+        when(result.getName()).thenReturn("foo_db");
+        return result;
     }
 }


### PR DESCRIPTION


Changes proposed in this pull request:
This change consolidates single-table schema identity rules and fixes casing inconsistencies when the database has no default schema (e.g., Oracle/Firebird). Previously, schema names derived from the logical database name could be stored in the original case during load while lookups relied on identifier rules, causing mismatches in single-table routing and metadata.

- Key updates:

- Normalize logical database name casing (UPPER_CASE / LOWER_CASE / KEEP_ORIGIN) when it is used as a schema:
  - SchemaMetaDataLoader now normalizes databaseName when default schema is absent.
  - DataNode construction now normalizes databaseName for schema derivation under the same rule.
- Single rule configuration expansion uses defaultSchema.isPresent() consistently (aligned with SchemaMetaDataLoader and DataNode).
- Router/engine adjustments pass ShardingSphereDatabase as a method parameter and standardize new parameter ordering.
- Tests updated to match the new canonical schema behavior, including:
  - Firebird schema loader expectation now uses FOO_DB.
  - Oracle normalization case added in DataNodeTest.
  - Schema loader test covers UPPER_CASE normalization.
  - Single rule qualified-table assertions relaxed to avoid case/null schema drift from test mocks.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
