### PR TITLE
Fix nativeTest under GraalVM Native Image that failed due to keyGenerateStrategy being removed

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -15,64 +15,63 @@
 # limitations under the License.
 #
 
-# TODO Fix me
-#name: NativeTest CI - GraalVM Native Image
-#
-## Only execute CI when changes involving GraalVM Reachability Metadata and nativeTest are involved. Because most Contributors don't use GraalVM CE.
-#on:
-#  pull_request:
-#    branches: [ master ]
-#    paths:
-#      - '.github/workflows/graalvm.yml'
-#      - 'infra/reachability-metadata/src/**'
-#      - 'test/native/native-image-filter/**'
-#      - 'test/native/src/**'
-#  workflow_dispatch:
-#
-#concurrency:
-#  group: graalvm-${{ github.workflow }}-${{ github.ref }}
-#  cancel-in-progress: true
-#
-#permissions:
-#  contents: read
-#
-#jobs:
-#  global-environment:
-#    name: Import Global Environment
-#    uses: ./.github/workflows/required-reusable.yml
-#  nativetest:
-#    if: github.repository == 'apache/shardingsphere'
-#    needs: global-environment
-#    name: GraalVM - GraalVM CE for JDK ${{ matrix.java-version }} on ${{ matrix.os }}
-#    runs-on: ${{ matrix.os }}
-#    timeout-minutes: 90
-#    strategy:
-#      max-parallel: 15
-#      fail-fast: false
-#      matrix:
-#        os: [ 'ubuntu-latest', 'windows-latest' ]
-#        java-version: [ '24.0.2' ]
-#    steps:
-#      - uses: actions/checkout@v6.0.1
-#      - name: Free Disk Space on Ubuntu
-#        if: matrix.os == 'ubuntu-latest'
-#        run: ./test/native/src/test/resources/test-native/sh/free-disk-space.sh
-#      - name: Setup Rancher Desktop without GUI on Windows Server
-#        if: matrix.os == 'windows-latest'
-#        run: |
-#          ./test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
-#          "PATH=$env:PATH" >> $env:GITHUB_ENV
-#      - uses: ./.github/workflows/resources/actions/setup-build-environment
-#        with:
-#          java-version: ${{ matrix.java-version }}
-#          distribution: 'graalvm'
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          cache-prefix: ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}
-#          cache-suffix: 'native-test'
-#      # TODO Remove this workaround after. The graalvm native image built with windows server is missing some GRMs for testcontainers
-#      - name: Run test with GraalVM CE
-#        if: matrix.os == 'windows-latest'
-#        run: ./mvnw -PgenerateMetadata -e -T 1C clean verify
-#      - name: Run nativeTest with GraalVM CE for ${{ matrix.java-version }}
-#        if: matrix.os == 'ubuntu-latest'
-#        run: ./mvnw -PnativeTestInShardingSphere -e "-DjvmArgs=-XX:MaxRAMPercentage=85.0" clean verify
+name: NativeTest CI - GraalVM Native Image
+
+# Only execute CI when changes involving GraalVM Reachability Metadata and nativeTest are involved. Because most Contributors don't use GraalVM CE.
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '.github/workflows/graalvm.yml'
+      - 'infra/reachability-metadata/src/**'
+      - 'test/native/native-image-filter/**'
+      - 'test/native/src/**'
+  workflow_dispatch:
+
+concurrency:
+  group: graalvm-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  global-environment:
+    name: Import Global Environment
+    uses: ./.github/workflows/required-reusable.yml
+  nativetest:
+    if: github.repository == 'apache/shardingsphere'
+    needs: global-environment
+    name: GraalVM - GraalVM CE for JDK ${{ matrix.java-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      max-parallel: 15
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest', 'windows-latest' ]
+        java-version: [ '24.0.2' ]
+    steps:
+      - uses: actions/checkout@v6.0.1
+      - name: Free Disk Space on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: ./test/native/src/test/resources/test-native/sh/free-disk-space.sh
+      - name: Setup Rancher Desktop without GUI on Windows Server
+        if: matrix.os == 'windows-latest'
+        run: |
+          ./test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
+          "PATH=$env:PATH" >> $env:GITHUB_ENV
+      - uses: ./.github/workflows/resources/actions/setup-build-environment
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-prefix: ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}
+          cache-suffix: 'native-test'
+      # TODO Remove this workaround after. The graalvm native image built with windows server is missing some GRMs for testcontainers
+      - name: Run test with GraalVM CE
+        if: matrix.os == 'windows-latest'
+        run: ./mvnw -PgenerateMetadata -e -T 1C clean verify
+      - name: Run nativeTest with GraalVM CE for ${{ matrix.java-version }}
+        if: matrix.os == 'ubuntu-latest'
+        run: ./mvnw -PnativeTestInShardingSphere -e "-DjvmArgs=-XX:MaxRAMPercentage=85.0" clean verify

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
@@ -335,13 +335,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.DatabaseMetaDataPersistFacade"
-      },
-      "type": "java.lang.Object",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
       "type": "java.lang.Object"
@@ -4123,13 +4116,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.DatabaseMetaDataPersistFacade"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
@@ -5440,12 +5426,6 @@
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.DatabaseMetaDataPersistFacade"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
     },
@@ -8888,10 +8868,6 @@
           "parameterTypes": []
         },
         {
-          "name": "getKeyGenerateStrategy",
-          "parameterTypes": []
-        },
-        {
           "name": "getLogicTable",
           "parameterTypes": []
         },
@@ -8953,7 +8929,33 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyRuleConfiguration",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyRuleConfiguration",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyRuleConfiguration"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyRuleConfiguration"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.rule.tuple.YamlRuleNodeTupleSwapperEngine"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyRuleConfiguration",
       "methods": [
@@ -9031,23 +9033,10 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
-      "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
+      "allDeclaredFields": true,
       "methods": [
         {
           "name": "getComplex",
@@ -9069,7 +9058,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
+        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
       "methods": [
@@ -11565,7 +11554,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.executor.kernel.ExecutorEngine"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.infra.executor.sql.hook.SQLExecutionHook"
     },


### PR DESCRIPTION
Fixes #38616 .

Changes proposed in this pull request:
  - Fix nativeTest under GraalVM Native Image that failed due to keyGenerateStrategy being removed. See https://github.com/apache/shardingsphere/pull/38609 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
