### PR TITLE
Optimize SingleTableDataNodeLoader#loadSchemaTableNames

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoader.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoader.java
@@ -40,6 +40,8 @@ import java.util.Map;
  */
 public final class SchemaMetaDataLoader {
     
+    private static final String WILDCARD = "*";
+    
     private static final String TABLE_TYPE = "TABLE";
     
     private static final String PARTITIONED_TABLE_TYPE = "PARTITIONED TABLE";
@@ -69,17 +71,19 @@ public final class SchemaMetaDataLoader {
      *
      * @param databaseName database name
      * @param dataSource data source
+     * @param includedTables included tables
      * @param excludedTables excluded tables
      * @return loaded schema table names
      * @throws SQLException SQL exception
      */
-    public Map<String, Collection<String>> loadSchemaTableNames(final String databaseName, final DataSource dataSource, final Collection<String> excludedTables) throws SQLException {
+    public Map<String, Collection<String>> loadSchemaTableNames(final String databaseName, final DataSource dataSource, final Collection<String> includedTables,
+                                                                final Collection<String> excludedTables) throws SQLException {
         try (MetaDataLoaderConnection connection = new MetaDataLoaderConnection(databaseType, dataSource.getConnection())) {
             Collection<String> schemaNames = loadSchemaNames(connection);
             Map<String, Collection<String>> result = new LinkedHashMap<>(schemaNames.size(), 1F);
             for (String each : schemaNames) {
                 String schemaName = schemaOption.getDefaultSchema().isPresent() ? each : new DatabaseTypeRegistry(databaseType).getDefaultSchemaName(databaseName);
-                result.put(schemaName, loadTableNames(connection, each, excludedTables));
+                result.put(schemaName, loadTableNames(connection, each, includedTables, excludedTables));
             }
             return result;
         }
@@ -109,18 +113,27 @@ public final class SchemaMetaDataLoader {
         return result.isEmpty() ? Collections.singletonList(connection.getSchema()) : result;
     }
     
-    private Collection<String> loadTableNames(final Connection connection, final String schemaName, final Collection<String> excludedTables) throws SQLException {
+    private Collection<String> loadTableNames(final Connection connection, final String schemaName, final Collection<String> includedTables,
+                                              final Collection<String> excludedTables) throws SQLException {
         Collection<String> result = new LinkedHashSet<>();
         String[] tableTypes = new String[]{TABLE_TYPE, PARTITIONED_TABLE_TYPE, VIEW_TYPE, SYSTEM_TABLE_TYPE, SYSTEM_VIEW_TYPE};
         try (ResultSet resultSet = connection.getMetaData().getTables(connection.getCatalog(), schemaName, null, tableTypes)) {
             while (resultSet.next()) {
-                String table = resultSet.getString(TABLE_NAME);
-                if (!isSystemTable(table) && !excludedTables.contains(table)) {
-                    result.add(table);
+                String tableName = resultSet.getString(TABLE_NAME);
+                if (isSystemTable(tableName) || excludedTables.contains(tableName)) {
+                    continue;
                 }
+                if (!includedTables.isEmpty() && !isIncludedTable(tableName, includedTables)) {
+                    continue;
+                }
+                result.add(tableName);
             }
         }
         return result;
+    }
+    
+    private boolean isIncludedTable(final String tableName, final Collection<String> includedTables) {
+        return includedTables.contains(WILDCARD) || includedTables.contains(tableName);
     }
     
     private boolean isSystemTable(final String table) {

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoaderTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoaderTest.java
@@ -116,6 +116,58 @@ class SchemaMetaDataLoaderTest {
     }
     
     @Test
+    void assertLoadSchemaTableNamesWithIncludedTables() throws SQLException {
+        DialectSchemaOption schemaOption = mock(DialectSchemaOption.class);
+        when(schemaOption.getDefaultSchema()).thenReturn(Optional.empty());
+        when(schemaOption.getSchema(any())).thenReturn("public");
+        DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class);
+        when(dialectDatabaseMetaData.getSchemaOption()).thenReturn(schemaOption);
+        when(dialectDatabaseMetaData.getIdentifierPatternType()).thenReturn(IdentifierPatternType.KEEP_ORIGIN);
+        try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
+            databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, databaseType)).thenReturn(dialectDatabaseMetaData);
+            try (MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class)) {
+                typedSPILoader.when(() -> TypedSPILoader.getService(DialectDatabaseMetaData.class, null)).thenReturn(dialectDatabaseMetaData);
+                Connection connection = dataSourceWithoutDefaultSchema.getConnection();
+                when(connection.getCatalog()).thenReturn("catalog");
+                ResultSet tableResultSet = mock(ResultSet.class);
+                when(tableResultSet.next()).thenReturn(true, true, false);
+                when(tableResultSet.getString("TABLE_NAME")).thenReturn("tbl_1", "tbl_2");
+                when(connection.getMetaData().getTables("catalog", "public", null, TABLE_TYPES)).thenReturn(tableResultSet);
+                Map<String, Collection<String>> actual =
+                        new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("logic_db", dataSourceWithoutDefaultSchema, Collections.singleton("tbl_1"), Collections.emptySet());
+                Map<String, Collection<String>> expected = Collections.singletonMap("logic_db", new LinkedHashSet<>(Collections.singleton("tbl_1")));
+                assertThat(actual, is(expected));
+            }
+        }
+    }
+    
+    @Test
+    void assertLoadSchemaTableNamesWithWildcardIncludedTables() throws SQLException {
+        DialectSchemaOption schemaOption = mock(DialectSchemaOption.class);
+        when(schemaOption.getDefaultSchema()).thenReturn(Optional.empty());
+        when(schemaOption.getSchema(any())).thenReturn("public");
+        DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class);
+        when(dialectDatabaseMetaData.getSchemaOption()).thenReturn(schemaOption);
+        when(dialectDatabaseMetaData.getIdentifierPatternType()).thenReturn(IdentifierPatternType.KEEP_ORIGIN);
+        try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
+            databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, databaseType)).thenReturn(dialectDatabaseMetaData);
+            try (MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class)) {
+                typedSPILoader.when(() -> TypedSPILoader.getService(DialectDatabaseMetaData.class, null)).thenReturn(dialectDatabaseMetaData);
+                Connection connection = dataSourceWithoutDefaultSchema.getConnection();
+                when(connection.getCatalog()).thenReturn("catalog");
+                ResultSet tableResultSet = mock(ResultSet.class);
+                when(tableResultSet.next()).thenReturn(true, true, false);
+                when(tableResultSet.getString("TABLE_NAME")).thenReturn("tbl_1", "tbl_2");
+                when(connection.getMetaData().getTables("catalog", "public", null, TABLE_TYPES)).thenReturn(tableResultSet);
+                Map<String, Collection<String>> actual =
+                        new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("logic_db", dataSourceWithoutDefaultSchema, Collections.singleton("*"), Collections.singleton("tbl_2"));
+                Map<String, Collection<String>> expected = Collections.singletonMap("logic_db", new LinkedHashSet<>(Collections.singleton("tbl_1")));
+                assertThat(actual, is(expected));
+            }
+        }
+    }
+    
+    @Test
     void assertLoadSchemaTableNamesWithDefaultSchema() throws SQLException {
         DialectSchemaOption schemaOption = mock(DialectSchemaOption.class);
         when(schemaOption.getDefaultSchema()).thenReturn(Optional.of("public"));

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoaderTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoaderTest.java
@@ -82,7 +82,7 @@ class SchemaMetaDataLoaderTest {
                 when(tableResultSet.getString("TABLE_NAME")).thenReturn("tbl", "$tbl", "/tbl", "##tbl", "excluded_tbl");
                 when(connection.getMetaData().getTables("catalog", "public", null, TABLE_TYPES)).thenReturn(tableResultSet);
                 Map<String, Collection<String>> actual = new SchemaMetaDataLoader(databaseType)
-                        .loadSchemaTableNames("logic_db", dataSourceWithoutDefaultSchema, Collections.singleton("excluded_tbl"));
+                        .loadSchemaTableNames("logic_db", dataSourceWithoutDefaultSchema, Collections.emptySet(), Collections.singleton("excluded_tbl"));
                 Map<String, Collection<String>> expected = Collections.singletonMap("logic_db", new LinkedHashSet<>(Collections.singleton("tbl")));
                 assertThat(actual, is(expected));
             }
@@ -108,7 +108,7 @@ class SchemaMetaDataLoaderTest {
                 when(tableResultSet.getString("TABLE_NAME")).thenReturn("tbl");
                 when(connection.getMetaData().getTables("catalog", "public", null, TABLE_TYPES)).thenReturn(tableResultSet);
                 Map<String, Collection<String>> actual = new SchemaMetaDataLoader(databaseType)
-                        .loadSchemaTableNames("logic_db", dataSourceWithoutDefaultSchema, Collections.emptyList());
+                        .loadSchemaTableNames("logic_db", dataSourceWithoutDefaultSchema, Collections.emptySet(), Collections.emptySet());
                 Map<String, Collection<String>> expected = Collections.singletonMap("LOGIC_DB", new LinkedHashSet<>(Collections.singleton("tbl")));
                 assertThat(actual, is(expected));
             }
@@ -138,7 +138,8 @@ class SchemaMetaDataLoaderTest {
                 when(tableResultSet.next()).thenReturn(true, false);
                 when(tableResultSet.getString("TABLE_NAME")).thenReturn("tbl_visible");
                 when(connection.getMetaData().getTables("catalog_2", "user_schema", null, TABLE_TYPES)).thenReturn(tableResultSet);
-                Map<String, Collection<String>> actual = new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("logic_db_2", dataSourceWithDefaultSchema, Collections.emptyList());
+                Map<String, Collection<String>> actual =
+                        new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("logic_db_2", dataSourceWithDefaultSchema, Collections.emptySet(), Collections.emptySet());
                 Map<String, Collection<String>> expected = Collections.singletonMap("user_schema", new LinkedHashSet<>(Collections.singleton("tbl_visible")));
                 assertThat(actual, is(expected));
             }
@@ -168,7 +169,8 @@ class SchemaMetaDataLoaderTest {
                 when(tableResultSet.next()).thenReturn(true, true, false);
                 when(tableResultSet.getString("TABLE_NAME")).thenReturn("Test3", "test3");
                 when(connection.getMetaData().getTables("catalog_3", "public", null, TABLE_TYPES)).thenReturn(tableResultSet);
-                Map<String, Collection<String>> actual = new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("logic_db_3", dataSourceWithDefaultSchema, Collections.emptyList());
+                Map<String, Collection<String>> actual =
+                        new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("logic_db_3", dataSourceWithDefaultSchema, Collections.emptySet(), Collections.emptySet());
                 assertThat(actual.get("public"), is(new LinkedHashSet<>(Arrays.asList("Test3", "test3"))));
             }
         }

--- a/database/connector/dialect/firebird/src/test/java/org/apache/shardingsphere/database/connector/firebird/metadata/data/loader/FirebirdSchemaMetaDataLoaderTest.java
+++ b/database/connector/dialect/firebird/src/test/java/org/apache/shardingsphere/database/connector/firebird/metadata/data/loader/FirebirdSchemaMetaDataLoaderTest.java
@@ -81,7 +81,7 @@ class FirebirdSchemaMetaDataLoaderTest {
     @Test
     void assertLoadSchemaTableNames() throws SQLException {
         Map<String, Collection<String>> schemaTableNames = Collections.singletonMap("FOO_DB", new CaseInsensitiveSet<>(Arrays.asList("tbl", "partitioned_tbl")));
-        assertThat(new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("foo_db", dataSource, Collections.emptyList()), is(schemaTableNames));
+        assertThat(new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("foo_db", dataSource, Collections.emptySet(), Collections.emptySet()), is(schemaTableNames));
     }
     
     @Test

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLSchemaMetaDataLoaderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLSchemaMetaDataLoaderTest.java
@@ -81,7 +81,7 @@ class MySQLSchemaMetaDataLoaderTest {
     @Test
     void assertLoadSchemaTableNames() throws SQLException {
         Map<String, Collection<String>> schemaTableNames = Collections.singletonMap("foo_db", new CaseInsensitiveSet<>(Arrays.asList("tbl", "partitioned_tbl")));
-        assertThat(new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("foo_db", dataSource, Collections.emptyList()), is(schemaTableNames));
+        assertThat(new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("foo_db", dataSource, Collections.emptySet(), Collections.emptySet()), is(schemaTableNames));
     }
     
     @Test

--- a/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/data/loader/OpenGaussSchemaMetaDataLoaderTest.java
+++ b/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/data/loader/OpenGaussSchemaMetaDataLoaderTest.java
@@ -81,7 +81,7 @@ class OpenGaussSchemaMetaDataLoaderTest {
     
     @Test
     void assertLoadSchemaTableNames() throws SQLException {
-        assertThat(new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("foo_db", dataSource, Collections.emptyList()), is(createSchemaTableNames()));
+        assertThat(new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("foo_db", dataSource, Collections.emptySet(), Collections.emptySet()), is(createSchemaTableNames()));
     }
     
     private Map<String, Collection<String>> createSchemaTableNames() {

--- a/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/data/loader/PostgreSQLSchemaMetaDataLoaderTest.java
+++ b/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/data/loader/PostgreSQLSchemaMetaDataLoaderTest.java
@@ -81,7 +81,7 @@ class PostgreSQLSchemaMetaDataLoaderTest {
     
     @Test
     void assertLoadSchemaTableNames() throws SQLException {
-        assertThat(new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("foo_db", dataSource, Collections.emptyList()), is(createSchemaTableNames()));
+        assertThat(new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("foo_db", dataSource, Collections.emptySet(), Collections.emptySet()), is(createSchemaTableNames()));
     }
     
     private Map<String, Collection<String>> createSchemaTableNames() {

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
@@ -71,7 +71,7 @@ public final class SingleTableDataNodeLoader {
         }
         Collection<DataNode> configuredDataNodes = getConfiguredDataNodes(splitTables);
         Collection<String> configuredDataSources = getConfiguredDataSources(configuredDataNodes);
-        Collection<String> includedTables = getIncludedTables(configuredDataNodes, featureRequiredSingleTables);
+        Collection<String> includedTables = getIncludedTables(dataSourceMap, configuredDataNodes, featureRequiredSingleTables);
         Map<String, DataSource> validDataSources = dataSourceMap.entrySet().stream().filter(entry -> configuredDataSources.contains(entry.getKey()))
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
         Map<String, Collection<DataNode>> actualDataNodes = load(databaseName, validDataSources, includedTables, excludedTables);
@@ -130,14 +130,16 @@ public final class SingleTableDataNodeLoader {
         return result;
     }
     
-    private static Collection<String> getIncludedTables(final Collection<DataNode> configuredDataNodes, final Collection<String> featureRequiredSingleTables) {
-        if (!featureRequiredSingleTables.isEmpty() || !isSafeToFilterBeforeLoad(configuredDataNodes)) {
+    private static Collection<String> getIncludedTables(final Map<String, DataSource> dataSourceMap, final Collection<DataNode> configuredDataNodes,
+                                                        final Collection<String> featureRequiredSingleTables) {
+        if (!isSafeToFilterBeforeLoad(configuredDataNodes) || !isSingleDataSource(dataSourceMap) && !featureRequiredSingleTables.isEmpty()) {
             return Collections.emptySet();
         }
-        Collection<String> result = new CaseInsensitiveSet<>(configuredDataNodes.size(), 1F);
+        Collection<String> result = new CaseInsensitiveSet<>(configuredDataNodes.size() + featureRequiredSingleTables.size(), 1F);
         for (DataNode each : configuredDataNodes) {
             result.add(each.getTableName());
         }
+        result.addAll(featureRequiredSingleTables);
         return result;
     }
     
@@ -148,6 +150,10 @@ public final class SingleTableDataNodeLoader {
             }
         }
         return true;
+    }
+    
+    private static boolean isSingleDataSource(final Map<String, DataSource> dataSourceMap) {
+        return 1 == dataSourceMap.size();
     }
     
     private static Map<String, Collection<DataNode>> loadSpecifiedDataNodes(final Map<String, Collection<DataNode>> actualDataNodes, final Collection<String> featureRequiredSingleTables,

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
@@ -17,8 +17,10 @@
 
 package org.apache.shardingsphere.single.datanode;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.database.connector.core.metadata.data.loader.type.SchemaMetaDataLoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.DatabaseTypeEngine;
@@ -32,6 +34,7 @@ import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -43,6 +46,7 @@ import java.util.stream.Collectors;
 /**
  * Single table data node loader.
  */
+@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class SingleTableDataNodeLoader {
     
@@ -65,12 +69,19 @@ public final class SingleTableDataNodeLoader {
         Collection<String> excludedTables = SingleTableLoadUtils.getExcludedTables(builtRules);
         Collection<String> splitTables = SingleTableLoadUtils.splitTableLines(configuredTables);
         if (splitTables.contains(SingleTableConstants.ALL_TABLES) || splitTables.contains(SingleTableConstants.ALL_SCHEMA_TABLES)) {
-            return load(databaseName, dataSourceMap, excludedTables);
+            return load(databaseName, dataSourceMap, Collections.emptySet(), excludedTables);
         }
-        Collection<String> configuredDataSources = configuredTables.stream().map(DataNode::new).map(DataNode::getDataSourceName).collect(Collectors.toSet());
-        Map<String, DataSource> configuredDataSourceMap = dataSourceMap.entrySet().stream().filter(entry -> configuredDataSources.contains(entry.getKey()))
+        Collection<String> configuredDataSources = new HashSet<>();
+        Collection<String> includedTables = new CaseInsensitiveSet<>(splitTables.size(), 1F);
+        for (String each : splitTables) {
+            DataNode configuredDataNode = new DataNode(each);
+            configuredDataSources.add(configuredDataNode.getDataSourceName());
+            includedTables.add(configuredDataNode.getTableName());
+        }
+        includedTables.addAll(featureRequiredSingleTables);
+        Map<String, DataSource> validDataSources = dataSourceMap.entrySet().stream().filter(entry -> configuredDataSources.contains(entry.getKey()))
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-        Map<String, Collection<DataNode>> actualDataNodes = load(databaseName, configuredDataSourceMap, excludedTables);
+        Map<String, Collection<DataNode>> actualDataNodes = load(databaseName, validDataSources, includedTables, excludedTables);
         Map<String, Map<String, Collection<String>>> configuredTableMap = getConfiguredTableMap(databaseName, protocolType, splitTables);
         return loadSpecifiedDataNodes(actualDataNodes, featureRequiredSingleTables, configuredTableMap);
     }
@@ -80,13 +91,16 @@ public final class SingleTableDataNodeLoader {
      *
      * @param databaseName database name
      * @param dataSourceMap data source map
+     * @param includedTables included tables
      * @param excludedTables excluded tables
      * @return single table data node map
      */
-    public static Map<String, Collection<DataNode>> load(final String databaseName, final Map<String, DataSource> dataSourceMap, final Collection<String> excludedTables) {
+    public static Map<String, Collection<DataNode>> load(final String databaseName, final Map<String, DataSource> dataSourceMap, final Collection<String> includedTables,
+                                                         final Collection<String> excludedTables) {
         Map<String, Collection<DataNode>> result = new LinkedHashMap<>(dataSourceMap.size(), 1F);
         for (Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
-            Map<String, Collection<DataNode>> dataNodeMap = load(databaseName, DatabaseTypeEngine.getStorageType(entry.getValue()), entry.getKey(), entry.getValue(), excludedTables);
+            Map<String, Collection<DataNode>> dataNodeMap =
+                    load(databaseName, DatabaseTypeEngine.getStorageType(entry.getValue()), entry.getKey(), entry.getValue(), includedTables, excludedTables);
             for (Entry<String, Collection<DataNode>> each : dataNodeMap.entrySet()) {
                 Collection<DataNode> addedDataNodes = each.getValue();
                 Collection<DataNode> existDataNodes = result.getOrDefault(each.getKey(), new LinkedHashSet<>(addedDataNodes.size(), 1F));
@@ -98,8 +112,8 @@ public final class SingleTableDataNodeLoader {
     }
     
     private static Map<String, Collection<DataNode>> load(final String databaseName, final DatabaseType storageType, final String dataSourceName,
-                                                          final DataSource dataSource, final Collection<String> excludedTables) {
-        Map<String, Collection<String>> schemaTableNames = loadSchemaTableNames(databaseName, storageType, dataSource, dataSourceName, excludedTables);
+                                                          final DataSource dataSource, final Collection<String> includedTables, final Collection<String> excludedTables) {
+        Map<String, Collection<String>> schemaTableNames = loadSchemaTableNames(databaseName, storageType, dataSource, dataSourceName, includedTables, excludedTables);
         Map<String, Collection<DataNode>> result = new LinkedHashMap<>(schemaTableNames.size(), 1F);
         for (Entry<String, Collection<String>> entry : schemaTableNames.entrySet()) {
             for (String each : entry.getValue()) {
@@ -173,14 +187,15 @@ public final class SingleTableDataNodeLoader {
      * @param storageType storage type
      * @param dataSource data source
      * @param dataSourceName data source name
+     * @param includedTables included tables
      * @param excludedTables excluded tables
      * @return schema table names
      * @throws SingleTablesLoadingException Single tables loading exception
      */
-    public static Map<String, Collection<String>> loadSchemaTableNames(final String databaseName, final DatabaseType storageType,
-                                                                       final DataSource dataSource, final String dataSourceName, final Collection<String> excludedTables) {
+    public static Map<String, Collection<String>> loadSchemaTableNames(final String databaseName, final DatabaseType storageType, final DataSource dataSource, final String dataSourceName,
+                                                                       final Collection<String> includedTables, final Collection<String> excludedTables) {
         try {
-            return new SchemaMetaDataLoader(storageType).loadSchemaTableNames(databaseName, dataSource, excludedTables);
+            return new SchemaMetaDataLoader(storageType).loadSchemaTableNames(databaseName, dataSource, includedTables, excludedTables);
         } catch (final SQLException ex) {
             throw new SingleTablesLoadingException(databaseName, dataSourceName, ex);
         }

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.single.datanode;
 import com.cedarsoftware.util.CaseInsensitiveSet;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.database.connector.core.metadata.data.loader.type.SchemaMetaDataLoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.DatabaseTypeEngine;
@@ -46,7 +45,6 @@ import java.util.stream.Collectors;
 /**
  * Single table data node loader.
  */
-@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class SingleTableDataNodeLoader {
     

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
@@ -69,14 +69,9 @@ public final class SingleTableDataNodeLoader {
         if (splitTables.contains(SingleTableConstants.ALL_TABLES) || splitTables.contains(SingleTableConstants.ALL_SCHEMA_TABLES)) {
             return load(databaseName, dataSourceMap, Collections.emptySet(), excludedTables);
         }
-        Collection<String> configuredDataSources = new HashSet<>();
-        Collection<String> includedTables = new CaseInsensitiveSet<>(splitTables.size(), 1F);
-        for (String each : splitTables) {
-            DataNode configuredDataNode = new DataNode(each);
-            configuredDataSources.add(configuredDataNode.getDataSourceName());
-            includedTables.add(configuredDataNode.getTableName());
-        }
-        includedTables.addAll(featureRequiredSingleTables);
+        Collection<DataNode> configuredDataNodes = getConfiguredDataNodes(splitTables);
+        Collection<String> configuredDataSources = getConfiguredDataSources(configuredDataNodes);
+        Collection<String> includedTables = getIncludedTables(configuredDataNodes, featureRequiredSingleTables);
         Map<String, DataSource> validDataSources = dataSourceMap.entrySet().stream().filter(entry -> configuredDataSources.contains(entry.getKey()))
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
         Map<String, Collection<DataNode>> actualDataNodes = load(databaseName, validDataSources, includedTables, excludedTables);
@@ -121,6 +116,38 @@ public final class SingleTableDataNodeLoader {
             }
         }
         return result;
+    }
+    
+    private static Collection<DataNode> getConfiguredDataNodes(final Collection<String> splitTables) {
+        return splitTables.stream().map(DataNode::new).collect(Collectors.toList());
+    }
+    
+    private static Collection<String> getConfiguredDataSources(final Collection<DataNode> configuredDataNodes) {
+        Collection<String> result = new HashSet<>(configuredDataNodes.size(), 1F);
+        for (DataNode each : configuredDataNodes) {
+            result.add(each.getDataSourceName());
+        }
+        return result;
+    }
+    
+    private static Collection<String> getIncludedTables(final Collection<DataNode> configuredDataNodes, final Collection<String> featureRequiredSingleTables) {
+        if (!featureRequiredSingleTables.isEmpty() || !isSafeToFilterBeforeLoad(configuredDataNodes)) {
+            return Collections.emptySet();
+        }
+        Collection<String> result = new CaseInsensitiveSet<>(configuredDataNodes.size(), 1F);
+        for (DataNode each : configuredDataNodes) {
+            result.add(each.getTableName());
+        }
+        return result;
+    }
+    
+    private static boolean isSafeToFilterBeforeLoad(final Collection<DataNode> configuredDataNodes) {
+        for (DataNode each : configuredDataNodes) {
+            if (null != each.getSchemaName() && !SingleTableConstants.ASTERISK.equals(each.getSchemaName())) {
+                return false;
+            }
+        }
+        return true;
     }
     
     private static Map<String, Collection<DataNode>> loadSpecifiedDataNodes(final Map<String, Collection<DataNode>> actualDataNodes, final Collection<String> featureRequiredSingleTables,

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/decorator/SingleRuleConfigurationDecorator.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/decorator/SingleRuleConfigurationDecorator.java
@@ -69,7 +69,7 @@ public final class SingleRuleConfigurationDecorator implements RuleConfiguration
         Map<String, DataSource> aggregatedDataSources = PhysicalDataSourceAggregator.getAggregatedDataSources(dataSources, builtRules);
         DatabaseType databaseType = dataSources.isEmpty() ? DatabaseTypeEngine.getDefaultStorageType() : DatabaseTypeEngine.getStorageType(dataSources.values().iterator().next());
         Collection<String> excludedTables = SingleTableLoadUtils.getExcludedTables(builtRules);
-        Map<String, Collection<DataNode>> actualDataNodes = SingleTableDataNodeLoader.load(databaseName, aggregatedDataSources, excludedTables);
+        Map<String, Collection<DataNode>> actualDataNodes = SingleTableDataNodeLoader.load(databaseName, aggregatedDataSources, Collections.emptySet(), excludedTables);
         boolean isSchemaAvailable = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getSchemaOption().isSchemaAvailable();
         if (splitTables.contains(SingleTableConstants.ALL_TABLES) || splitTables.contains(SingleTableConstants.ALL_SCHEMA_TABLES)) {
             return loadAllTables(isSchemaAvailable, actualDataNodes);

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
@@ -104,12 +104,12 @@ class SingleTableDataNodeLoaderTest {
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("loadWithConfiguredTableMapRuleArguments")
-    void assertLoadWithConfiguredTableMapRules(final String name, final Collection<String> splitTables,
+    void assertLoadWithConfiguredTableMapRules(final String name, final Collection<String> configuredTables, final Collection<String> splitTables,
                                                final Collection<DataNode> configuredDataNodes, final Map<String, Collection<String>> expectedTableDataSources) {
         try (MockedStatic<SingleTableLoadUtils> mockedSingleTableLoadUtils = mockStatic(SingleTableLoadUtils.class, Answers.CALLS_REAL_METHODS)) {
-            mockedSingleTableLoadUtils.when(() -> SingleTableLoadUtils.splitTableLines(Collections.singleton("foo_ds.foo_tbl2"))).thenReturn(splitTables);
+            mockedSingleTableLoadUtils.when(() -> SingleTableLoadUtils.splitTableLines(configuredTables)).thenReturn(splitTables);
             mockedSingleTableLoadUtils.when(() -> SingleTableLoadUtils.convertToDataNodes("foo_db", databaseType, splitTables)).thenReturn(configuredDataNodes);
-            Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", databaseType, dataSourceMap, Collections.emptyList(), Collections.singleton("foo_ds.foo_tbl2"));
+            Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", databaseType, dataSourceMap, Collections.emptyList(), configuredTables);
             assertThat(new TreeSet<>(actual.keySet()), is(new TreeSet<>(expectedTableDataSources.keySet())));
             assertTableDataSources(actual, expectedTableDataSources);
         }
@@ -213,19 +213,26 @@ class SingleTableDataNodeLoaderTest {
     }
     
     private static Stream<Arguments> loadWithConfiguredTableMapRuleArguments() {
-        Map<String, Collection<String>> wildcardExpectedDataSources = new LinkedHashMap<>(1, 1F);
-        wildcardExpectedDataSources.put("foo_tbl2", Collections.singleton("foo_ds"));
+        Map<String, Collection<String>> schemaWildcardExpectedDataSources = new LinkedHashMap<>(1, 1F);
+        schemaWildcardExpectedDataSources.put("foo_tbl2", Collections.singleton("foo_ds"));
+        Map<String, Collection<String>> tableWildcardExpectedDataSources = new LinkedHashMap<>(2, 1F);
+        tableWildcardExpectedDataSources.put("foo_tbl1", Collections.singleton("foo_ds"));
+        tableWildcardExpectedDataSources.put("foo_tbl2", Collections.singleton("foo_ds"));
         return Stream.of(
-                Arguments.arguments("configured data source not found", new LinkedHashSet<>(Collections.singleton("other_ds.foo_tbl2")),
+                Arguments.arguments("configured data source not found", Collections.singleton("other_ds.foo_tbl2"),
+                        new LinkedHashSet<>(Collections.singleton("other_ds.foo_tbl2")),
                         Collections.singleton(new DataNode("other_ds", "foo_db", "foo_tbl2")), Collections.emptyMap()),
-                Arguments.arguments("configured wildcard schema", new LinkedHashSet<>(Collections.singleton("foo_ds.*.foo_tbl2")),
+                Arguments.arguments("configured wildcard schema", Collections.singleton("foo_ds.*.foo_tbl2"),
+                        new LinkedHashSet<>(Collections.singleton("foo_ds.*.foo_tbl2")),
                         Collections.singleton(new DataNode("foo_ds", "*", "foo_tbl2")),
-                        createExpectedTableDataSources(wildcardExpectedDataSources)),
-                Arguments.arguments("configured schema not matched", new LinkedHashSet<>(Collections.singleton("foo_ds.foo_tbl2")),
+                        createExpectedTableDataSources(schemaWildcardExpectedDataSources)),
+                Arguments.arguments("configured schema not matched", Collections.singleton("foo_ds.other_schema.foo_tbl2"),
+                        new LinkedHashSet<>(Collections.singleton("foo_ds.other_schema.foo_tbl2")),
                         Collections.singleton(new DataNode("foo_ds", "other_schema", "foo_tbl2")), Collections.emptyMap()),
-                Arguments.arguments("configured table wildcard", new LinkedHashSet<>(Collections.singleton("foo_ds.foo_tbl2")),
+                Arguments.arguments("configured table wildcard", Collections.singleton("foo_ds.foo_db.*"),
+                        new LinkedHashSet<>(Collections.singleton("foo_ds.foo_db.*")),
                         Collections.singleton(new DataNode("foo_ds", "foo_db", "*")),
-                        createExpectedTableDataSources(wildcardExpectedDataSources)));
+                        createExpectedTableDataSources(tableWildcardExpectedDataSources)));
     }
     
     private static Map<String, Collection<String>> createExpectedTableDataSources(final Map<String, Collection<String>> tableDataSources) {

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
@@ -134,6 +134,18 @@ class SingleTableDataNodeLoaderTest {
     }
     
     @Test
+    void assertLoadWithFeatureRequiredSingleTablesAndSingleDataSource() {
+        Map<String, DataSource> localDataSourceMap = new LinkedHashMap<>(1, 1F);
+        localDataSourceMap.put("foo_ds", dataSourceMap.get("foo_ds"));
+        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load(
+                "foo_db", databaseType, localDataSourceMap, Collections.singleton(createRule(Collections.emptyList(), Collections.singleton("foo_tbl1"))), Collections.singleton("foo_ds.foo_tbl2"));
+        assertTrue(actual.containsKey("foo_tbl1"));
+        assertTrue(actual.containsKey("foo_tbl2"));
+        assertThat(actual.get("foo_tbl1").iterator().next().getDataSourceName(), is("foo_ds"));
+        assertThat(actual.get("foo_tbl2").iterator().next().getDataSourceName(), is("foo_ds"));
+    }
+    
+    @Test
     void assertLoadWithEmptyConfiguredTablesAndFeatureRequiredSingleTables() {
         assertTrue(SingleTableDataNodeLoader.load(
                 "foo_db", databaseType, dataSourceMap, Collections.singleton(createRule(Collections.emptyList(), Collections.singleton("foo_tbl1"))), Collections.emptyList()).isEmpty());

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
@@ -146,6 +146,26 @@ class SingleTableDataNodeLoaderTest {
     }
     
     @Test
+    void assertLoadWithSameTableInDifferentSchemas() {
+        Map<String, Collection<String>> schemaTableNames = new LinkedHashMap<>(2, 1F);
+        schemaTableNames.put("target_schema", Collections.singleton("same_tbl"));
+        schemaTableNames.put("other_schema", Collections.singleton("same_tbl"));
+        Collection<String> configuredTables = Collections.singleton("foo_ds.target_schema.same_tbl");
+        Collection<DataNode> configuredDataNodes = Collections.singleton(new DataNode("foo_ds", "target_schema", "same_tbl"));
+        try (
+                MockedStatic<SingleTableLoadUtils> mockedSingleTableLoadUtils = mockStatic(SingleTableLoadUtils.class, Answers.CALLS_REAL_METHODS);
+                MockedStatic<SingleTableDataNodeLoader> mockedSingleTableDataNodeLoader = mockStatic(SingleTableDataNodeLoader.class, Answers.CALLS_REAL_METHODS)) {
+            mockedSingleTableLoadUtils.when(() -> SingleTableLoadUtils.convertToDataNodes("foo_db", databaseType, configuredTables)).thenReturn(configuredDataNodes);
+            mockedSingleTableDataNodeLoader.when(() -> SingleTableDataNodeLoader.loadSchemaTableNames(
+                    "foo_db", databaseType, dataSourceMap.get("foo_ds"), "foo_ds", Collections.emptySet(), Collections.emptySet())).thenReturn(schemaTableNames);
+            Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", databaseType, dataSourceMap, Collections.emptyList(), configuredTables);
+            assertThat(actual.keySet(), is(Collections.singleton("same_tbl")));
+            assertThat(actual.get("same_tbl").size(), is(1));
+            assertThat(actual.get("same_tbl").iterator().next(), is(new DataNode("foo_ds", "target_schema", "same_tbl")));
+        }
+    }
+    
+    @Test
     void assertLoadWithEmptyConfiguredTablesAndFeatureRequiredSingleTables() {
         assertTrue(SingleTableDataNodeLoader.load(
                 "foo_db", databaseType, dataSourceMap, Collections.singleton(createRule(Collections.emptyList(), Collections.singleton("foo_tbl1"))), Collections.emptyList()).isEmpty());

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
@@ -141,7 +141,7 @@ class SingleTableDataNodeLoaderTest {
     
     @Test
     void assertLoadWithDataSourceMap() {
-        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", dataSourceMap, Collections.singleton("foo_tbl2"));
+        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", dataSourceMap, Collections.emptySet(), Collections.singleton("foo_tbl2"));
         assertThat(new TreeSet<>(actual.keySet()), is(new TreeSet<>(Arrays.asList("foo_tbl1", "bar_tbl1", "bar_tbl2"))));
         assertThat(new TreeSet<>(actual.get("bar_tbl1").stream().map(DataNode::getDataSourceName).collect(Collectors.toList())), is(new TreeSet<>(Collections.singleton("bar_ds"))));
     }
@@ -150,7 +150,7 @@ class SingleTableDataNodeLoaderTest {
     void assertLoadWithDataSourceMapPreservesCaseSensitiveTableNames() throws SQLException {
         Map<String, DataSource> localDataSourceMap = new LinkedHashMap<>(1, 1F);
         localDataSourceMap.put("foo_ds", mockDataSource("foo_ds", Arrays.asList("Test3", "test3")));
-        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", localDataSourceMap, Collections.emptyList());
+        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", localDataSourceMap, Collections.emptySet(), Collections.emptySet());
         assertTrue(actual.containsKey("Test3"));
         assertTrue(actual.containsKey("test3"));
         assertThat(actual.get("Test3").iterator().next().getTableName(), is("Test3"));
@@ -162,7 +162,7 @@ class SingleTableDataNodeLoaderTest {
         Map<String, DataSource> localDataSourceMap = new LinkedHashMap<>(2, 1F);
         localDataSourceMap.put("foo_ds", mockDataSource("foo_ds", Collections.singletonList("foo_tbl")));
         localDataSourceMap.put("FOO_DS", mockDataSource("FOO_DS", Collections.singletonList("foo_tbl")));
-        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", localDataSourceMap, Collections.emptyList());
+        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", localDataSourceMap, Collections.emptySet(), Collections.emptySet());
         assertThat(actual.get("foo_tbl").size(), is(2));
         assertThat(actual.get("foo_tbl").stream().map(DataNode::getDataSourceName).collect(Collectors.toCollection(LinkedHashSet::new)),
                 is(new LinkedHashSet<>(Arrays.asList("foo_ds", "FOO_DS"))));
@@ -170,7 +170,8 @@ class SingleTableDataNodeLoaderTest {
     
     @Test
     void assertLoadSchemaTableNames() {
-        Map<String, Collection<String>> actual = SingleTableDataNodeLoader.loadSchemaTableNames("foo_db", databaseType, dataSourceMap.get("foo_ds"), "foo_ds", Collections.singleton("foo_tbl2"));
+        Map<String, Collection<String>> actual = SingleTableDataNodeLoader.loadSchemaTableNames("foo_db", databaseType, dataSourceMap.get("foo_ds"), "foo_ds",
+                Collections.emptySet(), Collections.singleton("foo_tbl2"));
         assertThat(new TreeSet<>(actual.keySet()), is(new TreeSet<>(Collections.singleton("foo_db"))));
         assertThat(new TreeSet<>(actual.get("foo_db")), is(new TreeSet<>(Collections.singleton("foo_tbl1"))));
     }
@@ -181,7 +182,7 @@ class SingleTableDataNodeLoaderTest {
         DataSource dataSource = mock(DataSource.class);
         when(dataSource.getConnection()).thenThrow(expected);
         SingleTablesLoadingException actual = assertThrows(SingleTablesLoadingException.class,
-                () -> SingleTableDataNodeLoader.loadSchemaTableNames("foo_db", databaseType, dataSource, "foo_ds", Collections.emptyList()));
+                () -> SingleTableDataNodeLoader.loadSchemaTableNames("foo_db", databaseType, dataSource, "foo_ds", Collections.emptySet(), Collections.emptySet()));
         assertThat(actual.getCause(), is(expected));
     }
     
@@ -212,13 +213,12 @@ class SingleTableDataNodeLoaderTest {
     }
     
     private static Stream<Arguments> loadWithConfiguredTableMapRuleArguments() {
-        Map<String, Collection<String>> wildcardExpectedDataSources = new LinkedHashMap<>(2, 1F);
-        wildcardExpectedDataSources.put("foo_tbl1", Collections.singleton("foo_ds"));
+        Map<String, Collection<String>> wildcardExpectedDataSources = new LinkedHashMap<>(1, 1F);
         wildcardExpectedDataSources.put("foo_tbl2", Collections.singleton("foo_ds"));
         return Stream.of(
                 Arguments.arguments("configured data source not found", new LinkedHashSet<>(Collections.singleton("other_ds.foo_tbl2")),
                         Collections.singleton(new DataNode("other_ds", "foo_db", "foo_tbl2")), Collections.emptyMap()),
-                Arguments.arguments("configured wildcard schema", new LinkedHashSet<>(Collections.singleton("foo_ds.foo_tbl2")),
+                Arguments.arguments("configured wildcard schema", new LinkedHashSet<>(Collections.singleton("foo_ds.*.foo_tbl2")),
                         Collections.singleton(new DataNode("foo_ds", "*", "foo_tbl2")),
                         createExpectedTableDataSources(wildcardExpectedDataSources)),
                 Arguments.arguments("configured schema not matched", new LinkedHashSet<>(Collections.singleton("foo_ds.foo_tbl2")),

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/decorator/SingleRuleConfigurationDecoratorTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/decorator/SingleRuleConfigurationDecoratorTest.java
@@ -89,7 +89,7 @@ class SingleRuleConfigurationDecoratorTest {
     @Test
     void assertDecorateLoadsTablesWhenRulesPresentButConfigEmpty() {
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap("t_order", Collections.singleton(new DataNode("foo_ds", "foo_schema", "t_order")));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
         mockSplitAndConvert(Collections.singleton(SingleTableConstants.ALL_TABLES), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         Map<String, DataSource> dataSources = Collections.singletonMap("foo_ds", mock(DataSource.class));
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration(Collections.emptyList(), null);
@@ -107,7 +107,7 @@ class SingleRuleConfigurationDecoratorTest {
     @Test
     void assertDecorateLoadsAllSchemaTablesWhenSchemaSupported() {
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap("t_order", Collections.singleton(new DataNode("foo_ds", "public", "t_order")));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
         mockSplitAndConvert(Collections.singleton(SingleTableConstants.ALL_SCHEMA_TABLES), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         Map<String, DataSource> dataSources = Collections.singletonMap("foo_ds", mock(DataSource.class));
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration(Collections.singleton(SingleTableConstants.ALL_SCHEMA_TABLES), null);
@@ -122,7 +122,7 @@ class SingleRuleConfigurationDecoratorTest {
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap(dataNode.getTableName(), Collections.singleton(dataNode));
         Collection<String> splitTables = Collections.singleton("*.foo_schema.t_order");
         Collection<DataNode> configuredDataNodes = Collections.singleton(new DataNode("foo_ds", "foo_schema", "t_order"));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
         mockSplitAndConvert(splitTables, configuredDataNodes, Collections.emptyList(), Collections.emptyList());
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration(Collections.singleton("*.foo_schema.t_order"), null);
         try (MockedConstruction<DatabaseTypeRegistry> ignored = mockSchemaRegistry(true)) {
@@ -137,7 +137,7 @@ class SingleRuleConfigurationDecoratorTest {
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap(dataNode.getTableName(), Collections.singleton(dataNode));
         Collection<String> splitTables = Arrays.asList("*.foo_schema.t_order");
         Collection<DataNode> configuredDataNodes = Collections.singleton(new DataNode("foo_ds", "foo_schema", "t_order"));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
         mockSplitAndConvert(splitTables, configuredDataNodes, Collections.emptyList(), Collections.emptyList());
         Map<String, DataSource> dataSources = Collections.singletonMap("foo_ds", mock(DataSource.class));
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration(Arrays.asList("*.foo_schema.t_order"), null);
@@ -151,7 +151,7 @@ class SingleRuleConfigurationDecoratorTest {
         actualDataNodes.put("feature_tbl", Collections.singleton(new DataNode("skip_ds", "foo_schema", "feature_tbl")));
         actualDataNodes.put("expanded_tbl", Collections.singleton(new DataNode("expand_ds", "foo_schema", "expanded_tbl")));
         actualDataNodes.put("matched_tbl", Collections.singleton(new DataNode("bar_ds", "foo_schema", "matched_tbl")));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
         Collection<String> splitTables = Arrays.asList("expand_ds.*", "bar_ds.bar_tbl");
         Collection<DataNode> configuredDataNodes = Arrays.asList(
                 new DataNode("expand_ds", "foo_schema", SingleTableConstants.ASTERISK),
@@ -169,7 +169,7 @@ class SingleRuleConfigurationDecoratorTest {
         actualDataNodes.put("expanded_tbl", Collections.singleton(new DataNode("expand_ds", "foo_schema", "expanded_tbl")));
         actualDataNodes.put("ignored_tbl", Collections.singleton(new DataNode("ignored_ds", "foo_schema", "ignored_tbl")));
         actualDataNodes.put("matched_tbl", Collections.singleton(new DataNode("bar_ds", "foo_schema", "matched_tbl")));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
         Collection<String> splitTables = Arrays.asList("expand_ds.*", "bar_ds.bar_tbl");
         Collection<DataNode> configuredDataNodes = Arrays.asList(
                 new DataNode("expand_ds", "foo_schema", SingleTableConstants.ASTERISK),
@@ -185,7 +185,7 @@ class SingleRuleConfigurationDecoratorTest {
     void assertDecorateThrowsWhenExpandedNodeMismatch() {
         Collection<String> emptyTables = Collections.emptySet();
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap("t_order", Collections.singleton(new DataNode("other_ds", "foo_schema", "t_order")));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
         Collection<String> splitTables = Arrays.asList("expand_ds.*", "expand_ds.t_order");
         Collection<DataNode> configuredDataNodes = Arrays.asList(
                 new DataNode("expand_ds", "foo_schema", SingleTableConstants.ASTERISK),
@@ -203,7 +203,7 @@ class SingleRuleConfigurationDecoratorTest {
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap(dataNode.getTableName(), Collections.singleton(dataNode));
         Collection<String> splitTables = Collections.singleton("expand_ds.*.*");
         Collection<DataNode> configuredDataNodes = Collections.singleton(new DataNode("expand_ds", SingleTableConstants.ASTERISK, SingleTableConstants.ASTERISK));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
         mockSplitAndConvert(splitTables, configuredDataNodes, Collections.emptyList(), Collections.emptyList());
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration(Collections.singleton("expand_ds.*.*"), null);
         Map<String, DataSource> dataSources = Collections.singletonMap("foo_ds", mock(DataSource.class));
@@ -217,7 +217,7 @@ class SingleRuleConfigurationDecoratorTest {
     void assertDecorateSkipsSchemaExpandWhenSchemaNotMatched() {
         final DataNode dataNode = new DataNode("schema_ds", "bar_schema", "ignored_tbl");
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap(dataNode.getTableName(), Collections.singleton(dataNode));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
         Collection<String> splitTables = Collections.singleton("schema_ds.foo_schema.*");
         Collection<DataNode> configuredDataNodes = Collections.singleton(new DataNode("schema_ds", "foo_schema", SingleTableConstants.ASTERISK));
         mockSplitAndConvert(splitTables, configuredDataNodes, Collections.emptyList(), Collections.emptyList());
@@ -230,7 +230,7 @@ class SingleRuleConfigurationDecoratorTest {
     void assertDecorateThrowsWhenSpecifiedTableNotFound() {
         final DataNode dataNode = new DataNode("foo_ds", "foo_schema", "t_order");
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap(dataNode.getTableName(), Collections.singleton(dataNode));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
         Collection<String> splitTables = Collections.singleton("*.foo_schema.missing_tbl");
         Collection<DataNode> configuredDataNodes = Collections.singleton(new DataNode("foo_ds", "foo_schema", "missing_tbl"));
         mockSplitAndConvert(splitTables, configuredDataNodes, Collections.emptyList(), Collections.emptyList());

--- a/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutor.java
+++ b/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutor.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.single.util.SingleTableLoadUtils;
 import javax.sql.DataSource;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -89,7 +90,7 @@ public final class ShowUnloadedSingleTablesExecutor implements DistSQLQueryExecu
                         .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().getDataSource(), (oldValue, currentValue) -> oldValue, LinkedHashMap::new)),
                 database.getRuleMetaData().getRules());
         Collection<String> excludedTables = SingleTableLoadUtils.getExcludedTables(database.getRuleMetaData().getRules());
-        return SingleTableDataNodeLoader.load(database.getName(), aggregateDataSourceMap, excludedTables);
+        return SingleTableDataNodeLoader.load(database.getName(), aggregateDataSourceMap, Collections.emptySet(), excludedTables);
     }
     
     @Override

--- a/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/update/LoadSingleTableExecutor.java
+++ b/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/update/LoadSingleTableExecutor.java
@@ -123,8 +123,8 @@ public final class LoadSingleTableExecutor implements DatabaseRuleCreateExecutor
         Map<String, Map<String, Collection<String>>> result = new LinkedHashMap<>(storageUnitNames.size(), 1F);
         for (String each : storageUnitNames) {
             DataSource dataSource = aggregatedDataSourceMap.get(each);
-            Map<String, Collection<String>> schemaTableNames =
-                    SingleTableDataNodeLoader.loadSchemaTableNames(database.getName(), DatabaseTypeEngine.getStorageType(dataSource), dataSource, each, Collections.emptyList());
+            Map<String, Collection<String>> schemaTableNames = SingleTableDataNodeLoader.loadSchemaTableNames(database.getName(), DatabaseTypeEngine.getStorageType(dataSource),
+                    dataSource, each, Collections.emptySet(), Collections.emptySet());
             if (!schemaTableNames.isEmpty()) {
                 result.put(each, schemaTableNames);
             }

--- a/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutorTest.java
+++ b/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutorTest.java
@@ -60,6 +60,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -137,7 +138,7 @@ class ShowUnloadedSingleTablesExecutorTest {
         when(storageUnit.getDataSource()).thenReturn(dataSource);
         when(PhysicalDataSourceAggregator.getAggregatedDataSources(any(), any())).thenReturn(Collections.singletonMap("ds_0", dataSource));
         when(SingleTableLoadUtils.getExcludedTables(Collections.emptyList())).thenReturn(Collections.emptySet());
-        when(SingleTableDataNodeLoader.load(eq("foo_db"), any(), any())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(eq("foo_db"), any(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
     }
     
     private void assertRows(final List<List<String>> expectedRows) {

--- a/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/update/LoadSingleTableExecutorTest.java
+++ b/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/update/LoadSingleTableExecutorTest.java
@@ -177,7 +177,7 @@ class LoadSingleTableExecutorTest {
         prepareSchema(false, "foo_db");
         when(PhysicalDataSourceAggregator.getAggregatedDataSources(any(), any())).thenReturn(aggregatedDataSources);
         if (aggregatedDataSources.containsKey("foo_ds")) {
-            when(SingleTableDataNodeLoader.loadSchemaTableNames(eq("foo_db"), any(), any(), eq("foo_ds"), eq(Collections.emptyList()))).thenReturn(schemaTableNames);
+            when(SingleTableDataNodeLoader.loadSchemaTableNames(eq("foo_db"), any(), any(), eq("foo_ds"), eq(Collections.emptySet()), eq(Collections.emptySet()))).thenReturn(schemaTableNames);
         }
     }
     


### PR DESCRIPTION
Changes proposed in this pull request:
  - Only retrieve tables configured in the single rule configuration


## Summary

  This PR optimizes single table loading to avoid retrieving and constructing unnecessary table data nodes when the single rule configuration only targets a subset of tables.

  ## Problem

  Previously, `SingleTableDataNodeLoader` loaded all candidate tables from the matched data source/schema first, and then filtered them afterwards in `loadSpecifiedDataNode`.

  This caused extra object creation and filtering overhead:

  1. when `LOAD SINGLE TABLE` or single rule configuration only specifies a small subset of tables, unrelated tables in the same data source/schema were still fetched and converted into `DataNode` collections.

  2.  the loader built `Collection<DataNode>` for tables that would eventually be discarded, which added avoidable work during single table loading.

  ## Optimization

  This PR pushes the filtering logic forward to the metadata loading stage.

  ### Main changes

  - Extend SchemaMetaDataLoader.loadSchemaTableNames(...) to accept includedTables in addition to excludedTables.
  - Optimize SchemaMetaDataLoader#loadTableNames(...) so that it only keeps:
      - non-system tables
      - tables not excluded by rules
      - tables explicitly included by the current single table configuration
  - Adjust SingleTableDataNodeLoader to pass the configured included table set when loading schema table names.
  - Keep feature-required single table handling compatible while avoiding unnecessary table loading.
  - Update related caller signatures accordingly in single rule decorators and DistSQL executors.

  ## Result

  After this change, only tables that are actually required by the single rule configuration are retrieved and converted into data nodes.

  Compared with the previous behavior, this optimization brings:

  - less metadata scanning work
  - fewer temporary DataNode objects created
  - smaller intermediate collections during single table loading
  - more direct and predictable loading behavior

### Example
For single tables configuration: `- ds_1.t_single_1_0`, there is only one expected table.

- Before
<img width="2962" height="1544" alt="image" src="https://github.com/user-attachments/assets/7dbceef9-1475-485e-ad04-d0c73aab1eeb" />

- After
<img width="2726" height="1746" alt="image" src="https://github.com/user-attachments/assets/8724a5af-60e1-4a64-90f2-9ee258aa01aa" />


  ## Tests

  This PR updates and improves the related tests to cover the new loading behavior:

  - SchemaMetaDataLoaderTest
      - updated to verify includedTables + excludedTables behavior together
      - keeps coverage for default schema / non-default schema / case-sensitive table names
  - SingleTableDataNodeLoaderTest
      - updated to verify that only configured tables are loaded into the result
      - keeps coverage for feature-required single tables
      - adjusts wildcard-related expectations to reflect the optimized loading path
  - Related caller tests were also updated to align with the new method signature:
      - SingleRuleConfigurationDecoratorTest
      - LoadSingleTableExecutorTest
      - ShowUnloadedSingleTablesExecutorTest
      - dialect-specific SchemaMetaDataLoader tests

  ## Impact

  This change is an internal optimization and does not introduce new configuration items or change external SQL syntax.
  It improves the efficiency of single table loading while preserving the expected loading result.
