### PR TITLE
Fix MySQL JSON literal decoding in pipeline migration

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,6 +17,7 @@
 1. Proxy: Resolve openGauss batch bind parameter types before reading values - [#38390](https://github.com/apache/shardingsphere/pull/38390)
 1. Proxy: Fix primary key metadata loss for aliased columns in mysql prepare probe path - [#38517](https://github.com/apache/shardingsphere/pull/38517)
 1. Sharding: Fix incorrect routing when irrelevant sharding conditions are present - [#38527](https://github.com/apache/shardingsphere/pull/38527)
+1. Pipeline: Fix MySQL JSON literal decoding in migration - [#38622](https://github.com/apache/shardingsphere/pull/38622)
 
 ### Enhancements
 

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/string/MySQLJsonValueDecoder.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/string/MySQLJsonValueDecoder.java
@@ -89,6 +89,9 @@ public final class MySQLJsonValueDecoder {
                 case JsonValueTypes.STRING:
                     outputString(decodeString(byteBuf.slice()), stringBuilder);
                     break;
+                case JsonValueTypes.LITERAL:
+                    outputLiteral(byteBuf.readUnsignedByte(), stringBuilder);
+                    break;
                 default:
                     throw new UnsupportedSQLOperationException(String.valueOf(type));
             }

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/string/MySQLJsonValueDecoderTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/string/MySQLJsonValueDecoderTest.java
@@ -275,6 +275,9 @@ class MySQLJsonValueDecoderTest {
     
     private static Stream<Arguments> decodeTopLevelScalarArguments() {
         return Stream.of(
+                Arguments.of("decode top-level literal null", mockTopLevelLiteralByteBuf(JsonValueTypes.LITERAL_NULL), "null"),
+                Arguments.of("decode top-level literal true", mockTopLevelLiteralByteBuf(JsonValueTypes.LITERAL_TRUE), "true"),
+                Arguments.of("decode top-level literal false", mockTopLevelLiteralByteBuf(JsonValueTypes.LITERAL_FALSE), "false"),
                 Arguments.of("decode int16 top-level", mockTopLevelInt16ByteBuf(), "-32768"),
                 Arguments.of("decode uint16 top-level", mockTopLevelUInt16ByteBuf(), "65535"),
                 Arguments.of("decode string with escaped chars", mockTopLevelStringByteBuf(), "\"a\\\"\\\\b\""));
@@ -333,7 +336,14 @@ class MySQLJsonValueDecoderTest {
         result.writeShortLE(32768);
         return result;
     }
-    
+
+    private static ByteBuf mockTopLevelLiteralByteBuf(final byte value) {
+        ByteBuf result = Unpooled.buffer();
+        result.writeByte(JsonValueTypes.LITERAL);
+        result.writeByte(value);
+        return result;
+    }
+
     private static ByteBuf mockTopLevelUInt16ByteBuf() {
         ByteBuf result = Unpooled.buffer();
         result.writeByte(JsonValueTypes.UINT16);

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/string/MySQLJsonValueDecoderTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/string/MySQLJsonValueDecoderTest.java
@@ -278,9 +278,12 @@ class MySQLJsonValueDecoderTest {
                 Arguments.of("decode top-level literal null", mockTopLevelLiteralByteBuf(JsonValueTypes.LITERAL_NULL), "null"),
                 Arguments.of("decode top-level literal true", mockTopLevelLiteralByteBuf(JsonValueTypes.LITERAL_TRUE), "true"),
                 Arguments.of("decode top-level literal false", mockTopLevelLiteralByteBuf(JsonValueTypes.LITERAL_FALSE), "false"),
+                Arguments.of("decode top-level string", mockTopLevelStringByteBuf("hello"), "\"hello\""),
+                Arguments.of("decode top-level string with escaped chars", mockTopLevelStringByteBuf("a\"\\b"), "\"a\\\"\\\\b\""),
+                Arguments.of("decode top-level int32", mockTopLevelInt32ByteBuf(123), "123"),
+                Arguments.of("decode top-level double", mockTopLevelDoubleByteBuf(45.6D), "45.6"),
                 Arguments.of("decode int16 top-level", mockTopLevelInt16ByteBuf(), "-32768"),
-                Arguments.of("decode uint16 top-level", mockTopLevelUInt16ByteBuf(), "65535"),
-                Arguments.of("decode string with escaped chars", mockTopLevelStringByteBuf(), "\"a\\\"\\\\b\""));
+                Arguments.of("decode uint16 top-level", mockTopLevelUInt16ByteBuf(), "65535"));
     }
     
     private static Stream<Arguments> decodeUnsupportedArguments() {
@@ -336,14 +339,21 @@ class MySQLJsonValueDecoderTest {
         result.writeShortLE(32768);
         return result;
     }
-
+    
     private static ByteBuf mockTopLevelLiteralByteBuf(final byte value) {
         ByteBuf result = Unpooled.buffer();
         result.writeByte(JsonValueTypes.LITERAL);
         result.writeByte(value);
         return result;
     }
-
+    
+    private static ByteBuf mockTopLevelInt32ByteBuf(final int value) {
+        ByteBuf result = Unpooled.buffer();
+        result.writeByte(JsonValueTypes.INT32);
+        result.writeIntLE(value);
+        return result;
+    }
+    
     private static ByteBuf mockTopLevelUInt16ByteBuf() {
         ByteBuf result = Unpooled.buffer();
         result.writeByte(JsonValueTypes.UINT16);
@@ -351,11 +361,18 @@ class MySQLJsonValueDecoderTest {
         return result;
     }
     
-    private static ByteBuf mockTopLevelStringByteBuf() {
+    private static ByteBuf mockTopLevelDoubleByteBuf(final double value) {
+        ByteBuf result = Unpooled.buffer();
+        result.writeByte(JsonValueTypes.DOUBLE);
+        result.writeDoubleLE(value);
+        return result;
+    }
+    
+    private static ByteBuf mockTopLevelStringByteBuf(final String value) {
         ByteBuf result = Unpooled.buffer();
         result.writeByte(JsonValueTypes.STRING);
-        result.writeByte("a\"\\b".length());
-        result.writeBytes("a\"\\b".getBytes());
+        result.writeByte(value.length());
+        result.writeBytes(value.getBytes());
         return result;
     }
     

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/cases/task/E2EIncrementalTask.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/cases/task/E2EIncrementalTask.java
@@ -47,6 +47,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.ThreadLocalRandom;
 
 @RequiredArgsConstructor
@@ -74,6 +75,8 @@ public final class E2EIncrementalTask implements Runnable {
     private final DatabaseType databaseType;
     
     private final int loopCount;
+    
+    private final AtomicBoolean generatedJsonLiteralNullForUpdate = new AtomicBoolean(false);
     
     @Override
     public void run() {
@@ -152,7 +155,7 @@ public final class E2EIncrementalTask implements Runnable {
             Object[] parameters = {"中文测试", randomInt, randomInt, randomInt, randomUnsignedInt, randomUnsignedInt, randomUnsignedInt,
                     randomUnsignedInt, 1.0F, 1.0, new BigDecimal("999"), now, now, now.toLocalDate(), now.toLocalTime(), Year.now().getValue() + 1,
                     new byte[]{-1, 0, 1}, new byte[]{1, 2, -1, -3},
-                    "D".getBytes(), "A".getBytes(), "T".getBytes(), "E", "text", "mediumText", "3", "3", PipelineCaseHelper.generateJsonLiteralNull(), orderId};
+                    "D".getBytes(), "A".getBytes(), "T".getBytes(), "E", "text", "mediumText", "3", "3", generateMySQLJsonValue(), orderId};
             log.info("update sql: {}, params: {}", sql, parameters);
             DataSourceExecuteUtils.execute(dataSource, sql, parameters);
             return;
@@ -178,6 +181,10 @@ public final class E2EIncrementalTask implements Runnable {
             log.info("update sql: {}, params: {}", sql, parameters);
             DataSourceExecuteUtils.execute(dataSource, sql, parameters);
         }
+    }
+    
+    private String generateMySQLJsonValue() {
+        return generatedJsonLiteralNullForUpdate.compareAndSet(false, true) ? PipelineCaseHelper.generateJsonLiteralNull() : PipelineCaseHelper.generateJsonString(32, true);
     }
     
     private List<String> ignoreShardingColumns(final List<String> columnNames) {

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/cases/task/E2EIncrementalTask.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/cases/task/E2EIncrementalTask.java
@@ -152,7 +152,7 @@ public final class E2EIncrementalTask implements Runnable {
             Object[] parameters = {"中文测试", randomInt, randomInt, randomInt, randomUnsignedInt, randomUnsignedInt, randomUnsignedInt,
                     randomUnsignedInt, 1.0F, 1.0, new BigDecimal("999"), now, now, now.toLocalDate(), now.toLocalTime(), Year.now().getValue() + 1,
                     new byte[]{-1, 0, 1}, new byte[]{1, 2, -1, -3},
-                    "D".getBytes(), "A".getBytes(), "T".getBytes(), "E", "text", "mediumText", "3", "3", PipelineCaseHelper.generateJsonString(32, true), orderId};
+                    "D".getBytes(), "A".getBytes(), "T".getBytes(), "E", "text", "mediumText", "3", "3", PipelineCaseHelper.generateJsonLiteralNull(), orderId};
             log.info("update sql: {}, params: {}", sql, parameters);
             DataSourceExecuteUtils.execute(dataSource, sql, parameters);
             return;

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/dao/order/large/sqlbuilder/MySQLIntPkLargeOrderSQLBuilder.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/dao/order/large/sqlbuilder/MySQLIntPkLargeOrderSQLBuilder.java
@@ -103,7 +103,7 @@ public final class MySQLIntPkLargeOrderSQLBuilder implements IntPkLargeOrderSQLB
                     "1", "t", "e", "s", "t",
                     PipelineCaseHelper.generateString(2), "☠️x☺️x✋x☹️", PipelineCaseHelper.generateString(1),
                     "1", "2",
-                    PipelineCaseHelper.generateJsonLiteralNull()
+                    0 == i ? PipelineCaseHelper.generateJsonLiteralNull() : PipelineCaseHelper.generateJsonString(32, false)
             };
             result.add(params);
         }

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/dao/order/large/sqlbuilder/MySQLIntPkLargeOrderSQLBuilder.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/dao/order/large/sqlbuilder/MySQLIntPkLargeOrderSQLBuilder.java
@@ -103,7 +103,7 @@ public final class MySQLIntPkLargeOrderSQLBuilder implements IntPkLargeOrderSQLB
                     "1", "t", "e", "s", "t",
                     PipelineCaseHelper.generateString(2), "☠️x☺️x✋x☹️", PipelineCaseHelper.generateString(1),
                     "1", "2",
-                    PipelineCaseHelper.generateJsonString(32, false)
+                    PipelineCaseHelper.generateJsonLiteralNull()
             };
             result.add(params);
         }

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/framework/helper/PipelineCaseHelper.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/framework/helper/PipelineCaseHelper.java
@@ -29,7 +29,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.mockito.Mockito.mock;
@@ -37,8 +36,6 @@ import static org.mockito.Mockito.mock;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
 public final class PipelineCaseHelper {
-    
-    private static final AtomicInteger GENERATED_JSON_LITERAL_NULL_COUNT = new AtomicInteger();
     
     /**
      * Generate a pseudorandom integer in the specified range.
@@ -69,9 +66,6 @@ public final class PipelineCaseHelper {
      * @return json string
      */
     public static String generateJsonString(final int length, final boolean useUnicodeCharacter) {
-        if (shouldGenerateTopLevelJsonLiteralNull(length)) {
-            return "null";
-        }
         String value;
         if (useUnicodeCharacter) {
             value = Strings.repeat("{''中 } A'", Math.max(1, length / 10));
@@ -81,8 +75,13 @@ public final class PipelineCaseHelper {
         return String.format("{\"test\":\"%s\"}", value);
     }
     
-    private static boolean shouldGenerateTopLevelJsonLiteralNull(final int length) {
-        return 32 == length && GENERATED_JSON_LITERAL_NULL_COUNT.getAndIncrement() < 2;
+    /**
+     * Generate json literal null.
+     *
+     * @return json literal null
+     */
+    public static String generateJsonLiteralNull() {
+        return "null";
     }
     
     /**

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/framework/helper/PipelineCaseHelper.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/framework/helper/PipelineCaseHelper.java
@@ -29,6 +29,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.mockito.Mockito.mock;
@@ -36,6 +37,12 @@ import static org.mockito.Mockito.mock;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
 public final class PipelineCaseHelper {
+
+    private static final int MYSQL_JSON_LITERAL_LENGTH = 32;
+
+    private static final AtomicBoolean GENERATED_ASCII_JSON_LITERAL_NULL = new AtomicBoolean(false);
+
+    private static final AtomicBoolean GENERATED_UNICODE_JSON_LITERAL_NULL = new AtomicBoolean(false);
     
     /**
      * Generate a pseudorandom integer in the specified range.
@@ -66,6 +73,9 @@ public final class PipelineCaseHelper {
      * @return json string
      */
     public static String generateJsonString(final int length, final boolean useUnicodeCharacter) {
+        if (shouldGenerateTopLevelJsonLiteralNull(length, useUnicodeCharacter)) {
+            return "null";
+        }
         String value;
         if (useUnicodeCharacter) {
             value = Strings.repeat("{''中 } A'", Math.max(1, length / 10));
@@ -73,6 +83,13 @@ public final class PipelineCaseHelper {
             value = generateString(length);
         }
         return String.format("{\"test\":\"%s\"}", value);
+    }
+
+    private static boolean shouldGenerateTopLevelJsonLiteralNull(final int length, final boolean useUnicodeCharacter) {
+        if (MYSQL_JSON_LITERAL_LENGTH != length) {
+            return false;
+        }
+        return useUnicodeCharacter ? GENERATED_UNICODE_JSON_LITERAL_NULL.compareAndSet(false, true) : GENERATED_ASCII_JSON_LITERAL_NULL.compareAndSet(false, true);
     }
     
     /**

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/framework/helper/PipelineCaseHelper.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/framework/helper/PipelineCaseHelper.java
@@ -29,7 +29,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.mockito.Mockito.mock;
@@ -37,12 +37,8 @@ import static org.mockito.Mockito.mock;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
 public final class PipelineCaseHelper {
-
-    private static final int MYSQL_JSON_LITERAL_LENGTH = 32;
-
-    private static final AtomicBoolean GENERATED_ASCII_JSON_LITERAL_NULL = new AtomicBoolean(false);
-
-    private static final AtomicBoolean GENERATED_UNICODE_JSON_LITERAL_NULL = new AtomicBoolean(false);
+    
+    private static final AtomicInteger GENERATED_JSON_LITERAL_NULL_COUNT = new AtomicInteger();
     
     /**
      * Generate a pseudorandom integer in the specified range.
@@ -73,7 +69,7 @@ public final class PipelineCaseHelper {
      * @return json string
      */
     public static String generateJsonString(final int length, final boolean useUnicodeCharacter) {
-        if (shouldGenerateTopLevelJsonLiteralNull(length, useUnicodeCharacter)) {
+        if (shouldGenerateTopLevelJsonLiteralNull(length)) {
             return "null";
         }
         String value;
@@ -84,12 +80,9 @@ public final class PipelineCaseHelper {
         }
         return String.format("{\"test\":\"%s\"}", value);
     }
-
-    private static boolean shouldGenerateTopLevelJsonLiteralNull(final int length, final boolean useUnicodeCharacter) {
-        if (MYSQL_JSON_LITERAL_LENGTH != length) {
-            return false;
-        }
-        return useUnicodeCharacter ? GENERATED_UNICODE_JSON_LITERAL_NULL.compareAndSet(false, true) : GENERATED_ASCII_JSON_LITERAL_NULL.compareAndSet(false, true);
+    
+    private static boolean shouldGenerateTopLevelJsonLiteralNull(final int length) {
+        return 32 == length && GENERATED_JSON_LITERAL_NULL_COUNT.getAndIncrement() < 2;
     }
     
     /**


### PR DESCRIPTION
Fixes #35529.

Changes proposed in this pull request:
  - Fix MySQL JSON literal decoding in pipeline migration

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
