### PR TITLE
Refactor single table loader to fix schema not match issue for multiple protocol

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabase.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabase.java
@@ -64,7 +64,6 @@ public final class ShardingSphereDatabase {
     
     private final RuleMetaData ruleMetaData;
     
-    @Getter(AccessLevel.NONE)
     private final DatabaseIdentifierContext identifierContext;
     
     @Getter(AccessLevel.NONE)

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseFactory.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseFactory.java
@@ -31,6 +31,8 @@ import org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericS
 import org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilderMaterial;
 import org.apache.shardingsphere.infra.metadata.database.schema.builder.SystemSchemaBuilder;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContextFactory;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder;
 
@@ -81,9 +83,10 @@ public final class ShardingSphereDatabaseFactory {
     public static ShardingSphereDatabase create(final String name, final DatabaseType protocolType, final DatabaseConfiguration databaseConfig,
                                                 final ConfigurationProperties props, final ComputeNodeInstanceContext computeNodeInstanceContext) throws SQLException {
         ResourceMetaData resourceMetaData = new ResourceMetaData(databaseConfig.getDataSources(), databaseConfig.getStorageUnits());
+        DatabaseIdentifierContext identifierContext = DatabaseIdentifierContextFactory.create(protocolType, resourceMetaData, props);
         Collection<ShardingSphereRule> databaseRules = DatabaseRulesBuilder.build(name, protocolType, databaseConfig, computeNodeInstanceContext, resourceMetaData);
         Map<String, ShardingSphereSchema> schemas = new ConcurrentHashMap<>(GenericSchemaBuilder.build(protocolType,
-                new GenericSchemaBuilderMaterial(resourceMetaData.getStorageUnits(), databaseRules, props, new DatabaseTypeRegistry(protocolType).getDefaultSchemaName(name))));
+                new GenericSchemaBuilderMaterial(resourceMetaData.getStorageUnits(), databaseRules, props, new DatabaseTypeRegistry(protocolType).getDefaultSchemaName(name), identifierContext)));
         SystemSchemaBuilder.build(name, protocolType, props).forEach(schemas::putIfAbsent);
         return new ShardingSphereDatabase(name, protocolType, resourceMetaData, new RuleMetaData(databaseRules), schemas.values(), props);
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilderMaterial.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilderMaterial.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 
 import java.util.Collection;
@@ -40,4 +41,6 @@ public final class GenericSchemaBuilderMaterial {
     private final ConfigurationProperties props;
     
     private final String defaultSchemaName;
+    
+    private final DatabaseIdentifierContext identifierContext;
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtils.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtils.java
@@ -22,6 +22,8 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.GlobalDataSourceRegistry;
 import org.apache.shardingsphere.database.connector.core.metadata.data.loader.MetaDataLoaderMaterial;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
@@ -83,8 +85,9 @@ public final class SchemaMetaDataUtils {
                                                                      final DatabaseType storageType, final String defaultSchemaName, final int loadTableMetadataBatchSize) {
         Collection<MetaDataLoaderMaterial> result = new LinkedList<>();
         DataSource dataSource = getDataSource(material, dataSourceName);
+        IdentifierCaseRule tableIdentifierRule = material.getIdentifierContext().getRule(IdentifierScope.TABLE);
         for (List<String> each : Lists.partition(new ArrayList<>(actualTableNames), loadTableMetadataBatchSize)) {
-            result.add(new MetaDataLoaderMaterial(each, dataSourceName, dataSource, storageType, defaultSchemaName));
+            result.add(new MetaDataLoaderMaterial(each.stream().map(tableIdentifierRule::normalize).collect(Collectors.toList()), dataSourceName, dataSource, storageType, defaultSchemaName));
         }
         return result;
     }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilderTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContextFactory;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.attribute.RuleAttributes;
 import org.apache.shardingsphere.infra.rule.attribute.table.TableMapperRuleAttribute;
@@ -70,7 +71,8 @@ class GenericSchemaBuilderTest {
         StorageUnit storageUnit = mock(StorageUnit.class);
         when(storageUnit.getStorageType()).thenReturn(databaseType);
         when(storageUnit.getDataSource()).thenReturn(new MockedDataSource());
-        material = new GenericSchemaBuilderMaterial(Collections.singletonMap("foo_schema", storageUnit), Collections.singleton(rule), new ConfigurationProperties(new Properties()), "foo_schema");
+        material = new GenericSchemaBuilderMaterial(Collections.singletonMap("foo_schema", storageUnit), Collections.singleton(rule), new ConfigurationProperties(new Properties()), "foo_schema",
+                DatabaseIdentifierContextFactory.createDefault());
     }
     
     @Test
@@ -112,7 +114,8 @@ class GenericSchemaBuilderTest {
         when(rule.getAttributes()).thenReturn(new RuleAttributes(tableMapperRuleAttribute));
         when(MetaDataLoader.load(any())).thenReturn(createSchemaMetaDataMap(Arrays.asList("foo_tbl", "bar_tbl"), material));
         GenericSchemaBuilderMaterial newMaterial = new GenericSchemaBuilderMaterial(
-                Collections.singletonMap("foo_schema", material.getStorageUnits().get("foo_schema")), Collections.singleton(rule), new ConfigurationProperties(new Properties()), "foo_schema");
+                Collections.singletonMap("foo_schema", material.getStorageUnits().get("foo_schema")), Collections.singleton(rule), new ConfigurationProperties(new Properties()), "foo_schema",
+                DatabaseIdentifierContextFactory.createDefault());
         Map<String, ShardingSphereSchema> actual = GenericSchemaBuilder.build(databaseType, newMaterial);
         assertThat(actual.size(), is(1));
         assertTables(new ShardingSphereSchema("foo_schema", databaseType, actual.values().iterator().next().getAllTables(), Collections.emptyList()));
@@ -129,7 +132,8 @@ class GenericSchemaBuilderTest {
         Map<String, StorageUnit> storageUnits = Collections.singletonMap("foo_schema", storageUnit);
         ShardingSphereRule rule = mock(ShardingSphereRule.class);
         when(rule.getAttributes()).thenReturn(new RuleAttributes(mock(TableMapperRuleAttribute.class)));
-        GenericSchemaBuilderMaterial newMaterial = new GenericSchemaBuilderMaterial(storageUnits, Collections.singleton(rule), new ConfigurationProperties(new Properties()), "foo_schema");
+        GenericSchemaBuilderMaterial newMaterial = new GenericSchemaBuilderMaterial(storageUnits, Collections.singleton(rule), new ConfigurationProperties(new Properties()), "foo_schema",
+                DatabaseIdentifierContextFactory.createDefault());
         Map<String, ShardingSphereSchema> actual = GenericSchemaBuilder.build(tableNames, databaseType, newMaterial);
         assertThat(actual.size(), is(1));
         ShardingSphereSchema actualSchema = actual.values().iterator().next();

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/MetaDataReviseEngineTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/MetaDataReviseEngineTest.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilderMaterial;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContextFactory;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -59,6 +60,7 @@ class MetaDataReviseEngineTest {
     }
     
     private GenericSchemaBuilderMaterial createBuilderMaterial() {
-        return new GenericSchemaBuilderMaterial(Collections.emptyMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()), "default_schema");
+        return new GenericSchemaBuilderMaterial(Collections.emptyMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()), "default_schema",
+                DatabaseIdentifierContextFactory.createDefault());
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtilsTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtilsTest.java
@@ -145,6 +145,23 @@ class SchemaMetaDataUtilsTest {
         assertThat(new ArrayList<>(actual.get(0).getActualTableNames()), is(Collections.singletonList("T_USER")));
     }
     
+    @Test
+    void assertGetMetaDataLoaderMaterialsNormalizeActualTableNamesByStorageTypeWithMixedStorageUnits() {
+        Map<String, StorageUnit> storageUnits = new LinkedHashMap<>(2, 1F);
+        storageUnits.put("ds_mysql", mockStorageUnit(MYSQL_DATABASE_TYPE, mock(DataSource.class)));
+        storageUnits.put("ds_oracle", mockStorageUnit(ORACLE_DATABASE_TYPE, mock(DataSource.class)));
+        ConfigurationProperties props = createProperties(Boolean.TRUE, null);
+        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits, Collections.singleton(
+                mockDataNodeRule(Arrays.asList(new DataNode("ds_mysql.t_order"), new DataNode("ds_oracle.t_user")))), props, "foo_db",
+                DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, new ResourceMetaData(Collections.emptyMap(), storageUnits), props));
+        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material));
+        assertThat(actual.size(), is(2));
+        assertThat(actual.get(0).getStorageUnitName(), is("ds_mysql"));
+        assertThat(new ArrayList<>(actual.get(0).getActualTableNames()), is(Collections.singletonList("t_order")));
+        assertThat(actual.get(1).getStorageUnitName(), is("ds_oracle"));
+        assertThat(new ArrayList<>(actual.get(1).getActualTableNames()), is(Collections.singletonList("t_user")));
+    }
+    
     private ShardingSphereRule mockDataNodeRule(final Collection<DataNode> dataNodes) {
         ShardingSphereRule result = mock(ShardingSphereRule.class);
         DataNodeRuleAttribute ruleAttribute = mock(DataNodeRuleAttribute.class);

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtilsTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtilsTest.java
@@ -24,8 +24,10 @@ import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.datanode.UnsupportedActualDataNodeStructureException;
+import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
 import org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilderMaterial;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContextFactory;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.attribute.RuleAttributes;
 import org.apache.shardingsphere.infra.rule.attribute.datanode.DataNodeRuleAttribute;
@@ -62,6 +64,8 @@ class SchemaMetaDataUtilsTest {
     
     private static final DatabaseType MYSQL_DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "MySQL");
     
+    private static final DatabaseType ORACLE_DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "Oracle");
+    
     @AfterEach
     void clearCachedDatabaseTables() {
         GlobalDataSourceRegistry.getInstance().getCachedDatabaseTables().clear();
@@ -72,7 +76,8 @@ class SchemaMetaDataUtilsTest {
     void assertGetMetaDataLoaderMaterials(final String name, final Map<String, StorageUnit> storageUnits, final Collection<DataNode> dataNodes,
                                           final ConfigurationProperties props, final String defaultSchemaName, final List<String> expectedStorageUnitNames,
                                           final List<List<String>> expectedActualTableNames, final List<String> expectedDefaultSchemaNames) {
-        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits, Collections.singleton(mockDataNodeRule(dataNodes)), props, defaultSchemaName);
+        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits, Collections.singleton(mockDataNodeRule(dataNodes)), props, defaultSchemaName,
+                DatabaseIdentifierContextFactory.createDefault());
         List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material));
         assertThat(actual.size(), is(expectedStorageUnitNames.size()));
         for (int i = 0; i < actual.size(); i++) {
@@ -90,7 +95,7 @@ class SchemaMetaDataUtilsTest {
         storageUnits.put("ds.foo_db", mockStorageUnit(MYSQL_DATABASE_TYPE, mock(DataSource.class)));
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits,
                 Collections.singleton(mockDataNodeRule(Collections.singleton(new DataNode("ds.foo_db", "foo_db", "foo_tbl")))),
-                createProperties(Boolean.FALSE, null), "foo_db");
+                createProperties(Boolean.FALSE, null), "foo_db", DatabaseIdentifierContextFactory.createDefault());
         List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material));
         assertThat(actual.size(), is(1));
         assertThat(actual.get(0).getStorageUnitName(), is("ds.foo_db"));
@@ -107,7 +112,7 @@ class SchemaMetaDataUtilsTest {
         storageUnits.put("ds.foo_db", mockStorageUnit(FIXTURE_DATABASE_TYPE, mock(DataSource.class)));
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits,
                 Collections.singleton(mockDataNodeRule(Collections.singleton(new DataNode("ds.foo_db", "foo_db", "foo_tbl")))),
-                createProperties(Boolean.FALSE, null), "foo_db");
+                createProperties(Boolean.FALSE, null), "foo_db", DatabaseIdentifierContextFactory.createDefault());
         UnsupportedActualDataNodeStructureException actual = assertThrows(UnsupportedActualDataNodeStructureException.class,
                 () -> SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material));
         assertThat(actual.getMessage(), is("Can not support 3-tier structure for actual data node 'ds.foo_db.foo_tbl' with JDBC 'jdbc:mock'."));
@@ -119,12 +124,25 @@ class SchemaMetaDataUtilsTest {
         storageUnits.put("ds_0", mockStorageUnit(FIXTURE_DATABASE_TYPE, mock(DataSource.class)));
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits, Collections.singleton(
                 mockDataNodeRule(Arrays.asList(new DataNode("ds_0.foo_tbl_0"), new DataNode("ds_0.foo_tbl_1"), new DataNode("ds_0.foo_tbl_2")))),
-                createProperties(Boolean.TRUE, 2), "foo_db");
+                createProperties(Boolean.TRUE, 2), "foo_db", DatabaseIdentifierContextFactory.createDefault());
         List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material));
         assertThat(actual.size(), is(2));
         assertThat(actual.get(0).getStorageUnitName(), is("ds_0"));
         assertThat(new ArrayList<>(actual.get(0).getActualTableNames()), is(Arrays.asList("foo_tbl_0", "foo_tbl_1")));
         assertThat(new ArrayList<>(actual.get(1).getActualTableNames()), is(Collections.singletonList("foo_tbl_2")));
+    }
+    
+    @Test
+    void assertGetMetaDataLoaderMaterialsNormalizeActualTableNamesByTableScope() {
+        Map<String, StorageUnit> storageUnits = new LinkedHashMap<>(1, 1F);
+        storageUnits.put("ds_0", mockStorageUnit(ORACLE_DATABASE_TYPE, mock(DataSource.class)));
+        ConfigurationProperties props = new ConfigurationProperties(new Properties());
+        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits,
+                Collections.singleton(mockDataNodeRule(Collections.singleton(new DataNode("ds_0.t_user")))), props, "foo_db",
+                DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, new ResourceMetaData(Collections.emptyMap(), storageUnits), props));
+        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material));
+        assertThat(actual.size(), is(1));
+        assertThat(new ArrayList<>(actual.get(0).getActualTableNames()), is(Collections.singletonList("T_USER")));
     }
     
     private ShardingSphereRule mockDataNodeRule(final Collection<DataNode> dataNodes) {

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
@@ -67,15 +67,17 @@ public final class SingleTableDataNodeLoader {
         Collection<String> excludedTables = SingleTableLoadUtils.getExcludedTables(builtRules);
         Collection<String> splitTables = SingleTableLoadUtils.splitTableLines(configuredTables);
         if (splitTables.contains(SingleTableConstants.ALL_TABLES) || splitTables.contains(SingleTableConstants.ALL_SCHEMA_TABLES)) {
-            return load(databaseName, dataSourceMap, Collections.emptySet(), excludedTables);
+            Map<String, DatabaseType> storageTypes = dataSourceMap.entrySet().stream().collect(Collectors.toMap(Entry::getKey, each -> DatabaseTypeEngine.getStorageType(each.getValue())));
+            return load(databaseName, dataSourceMap, Collections.emptySet(), excludedTables, storageTypes);
         }
         Collection<DataNode> configuredDataNodes = getConfiguredDataNodes(splitTables);
         Collection<String> configuredDataSources = getConfiguredDataSources(configuredDataNodes);
         Collection<String> includedTables = getIncludedTables(dataSourceMap, configuredDataNodes, featureRequiredSingleTables);
         Map<String, DataSource> validDataSources = dataSourceMap.entrySet().stream().filter(entry -> configuredDataSources.contains(entry.getKey()))
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-        Map<String, Collection<DataNode>> actualDataNodes = load(databaseName, validDataSources, includedTables, excludedTables);
-        Map<String, Map<String, Collection<String>>> configuredTableMap = getConfiguredTableMap(databaseName, protocolType, splitTables);
+        Map<String, DatabaseType> validStorageTypes = validDataSources.entrySet().stream().collect(Collectors.toMap(Entry::getKey, each -> DatabaseTypeEngine.getStorageType(each.getValue())));
+        Map<String, Collection<DataNode>> actualDataNodes = load(databaseName, validDataSources, includedTables, excludedTables, validStorageTypes);
+        Map<String, Map<String, Collection<String>>> configuredTableMap = getConfiguredTableMap(databaseName, protocolType, splitTables, validStorageTypes);
         return loadSpecifiedDataNodes(actualDataNodes, featureRequiredSingleTables, configuredTableMap);
     }
     
@@ -86,14 +88,15 @@ public final class SingleTableDataNodeLoader {
      * @param dataSourceMap data source map
      * @param includedTables included tables
      * @param excludedTables excluded tables
+     * @param validStorageTypes valid storage types
      * @return single table data node map
      */
     public static Map<String, Collection<DataNode>> load(final String databaseName, final Map<String, DataSource> dataSourceMap, final Collection<String> includedTables,
-                                                         final Collection<String> excludedTables) {
+                                                         final Collection<String> excludedTables, final Map<String, DatabaseType> validStorageTypes) {
         Map<String, Collection<DataNode>> result = new LinkedHashMap<>(dataSourceMap.size(), 1F);
         for (Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
             Map<String, Collection<DataNode>> dataNodeMap =
-                    load(databaseName, DatabaseTypeEngine.getStorageType(entry.getValue()), entry.getKey(), entry.getValue(), includedTables, excludedTables);
+                    load(databaseName, validStorageTypes.get(entry.getKey()), entry.getKey(), entry.getValue(), includedTables, excludedTables);
             for (Entry<String, Collection<DataNode>> each : dataNodeMap.entrySet()) {
                 Collection<DataNode> addedDataNodes = each.getValue();
                 Collection<DataNode> existDataNodes = result.getOrDefault(each.getKey(), new LinkedHashSet<>(addedDataNodes.size(), 1F));
@@ -195,18 +198,21 @@ public final class SingleTableDataNodeLoader {
         return result;
     }
     
-    private static Map<String, Map<String, Collection<String>>> getConfiguredTableMap(final String databaseName, final DatabaseType protocolType, final Collection<String> configuredTables) {
+    private static Map<String, Map<String, Collection<String>>> getConfiguredTableMap(final String databaseName, final DatabaseType protocolType, final Collection<String> configuredTables,
+                                                                                      final Map<String, DatabaseType> validStorageTypes) {
         if (configuredTables.isEmpty()) {
             return Collections.emptyMap();
         }
-        Collection<DataNode> dataNodes = SingleTableLoadUtils.convertToDataNodes(databaseName, protocolType, configuredTables);
-        Map<String, Map<String, Collection<String>>> result = new LinkedHashMap<>(dataNodes.size(), 1F);
-        for (DataNode each : dataNodes) {
-            Map<String, Collection<String>> schemaTables = result.getOrDefault(each.getDataSourceName(), new LinkedHashMap<>());
-            Collection<String> tables = schemaTables.getOrDefault(each.getSchemaName(), new LinkedList<>());
-            tables.add(each.getTableName());
-            schemaTables.putIfAbsent(each.getSchemaName(), tables);
-            result.putIfAbsent(each.getDataSourceName(), schemaTables);
+        Map<String, Map<String, Collection<String>>> result = new LinkedHashMap<>(configuredTables.size(), 1F);
+        for (String each : configuredTables) {
+            DataNode parsedDataNode = new DataNode(each);
+            DatabaseType databaseType = validStorageTypes.getOrDefault(parsedDataNode.getDataSourceName(), protocolType);
+            DataNode dataNode = new DataNode(databaseName, databaseType, each);
+            Map<String, Collection<String>> schemaTables = result.getOrDefault(dataNode.getDataSourceName(), new LinkedHashMap<>());
+            Collection<String> tables = schemaTables.getOrDefault(dataNode.getSchemaName(), new LinkedList<>());
+            tables.add(dataNode.getTableName());
+            schemaTables.putIfAbsent(dataNode.getSchemaName(), tables);
+            result.putIfAbsent(dataNode.getDataSourceName(), schemaTables);
         }
         return result;
     }

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/decorator/SingleRuleConfigurationDecorator.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/decorator/SingleRuleConfigurationDecorator.java
@@ -69,7 +69,8 @@ public final class SingleRuleConfigurationDecorator implements RuleConfiguration
         Map<String, DataSource> aggregatedDataSources = PhysicalDataSourceAggregator.getAggregatedDataSources(dataSources, builtRules);
         DatabaseType databaseType = dataSources.isEmpty() ? DatabaseTypeEngine.getDefaultStorageType() : DatabaseTypeEngine.getStorageType(dataSources.values().iterator().next());
         Collection<String> excludedTables = SingleTableLoadUtils.getExcludedTables(builtRules);
-        Map<String, Collection<DataNode>> actualDataNodes = SingleTableDataNodeLoader.load(databaseName, aggregatedDataSources, Collections.emptySet(), excludedTables);
+        Map<String, DatabaseType> storageTypes = aggregatedDataSources.entrySet().stream().collect(Collectors.toMap(Entry::getKey, each -> DatabaseTypeEngine.getStorageType(each.getValue())));
+        Map<String, Collection<DataNode>> actualDataNodes = SingleTableDataNodeLoader.load(databaseName, aggregatedDataSources, Collections.emptySet(), excludedTables, storageTypes);
         boolean isSchemaAvailable = new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getSchemaOption().isSchemaAvailable();
         if (splitTables.contains(SingleTableConstants.ALL_TABLES) || splitTables.contains(SingleTableConstants.ALL_SCHEMA_TABLES)) {
             return loadAllTables(isSchemaAvailable, actualDataNodes);

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/attribute/SingleMutableDataNodeRuleAttribute.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/attribute/SingleMutableDataNodeRuleAttribute.java
@@ -109,7 +109,7 @@ public final class SingleMutableDataNodeRuleAttribute implements MutableDataNode
     public Optional<DataNode> findTableDataNode(final String schemaName, final String tableName) {
         Collection<DataNode> dataNodes = findTableDataNodes(tableName);
         for (DataNode each : dataNodes) {
-            if (schemaName.equals(each.getSchemaName())) {
+            if (schemaName.equalsIgnoreCase(each.getSchemaName())) {
                 return Optional.of(each);
             }
         }

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
@@ -24,15 +24,12 @@ import org.apache.shardingsphere.infra.rule.attribute.RuleAttributes;
 import org.apache.shardingsphere.infra.rule.attribute.table.TableMapperRuleAttribute;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.single.exception.SingleTablesLoadingException;
-import org.apache.shardingsphere.single.util.SingleTableLoadUtils;
 import org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Answers;
-import org.mockito.MockedStatic;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -57,7 +54,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 class SingleTableDataNodeLoaderTest {
@@ -104,15 +100,10 @@ class SingleTableDataNodeLoaderTest {
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("loadWithConfiguredTableMapRuleArguments")
-    void assertLoadWithConfiguredTableMapRules(final String name, final Collection<String> configuredTables, final Collection<String> splitTables,
-                                               final Collection<DataNode> configuredDataNodes, final Map<String, Collection<String>> expectedTableDataSources) {
-        try (MockedStatic<SingleTableLoadUtils> mockedSingleTableLoadUtils = mockStatic(SingleTableLoadUtils.class, Answers.CALLS_REAL_METHODS)) {
-            mockedSingleTableLoadUtils.when(() -> SingleTableLoadUtils.splitTableLines(configuredTables)).thenReturn(splitTables);
-            mockedSingleTableLoadUtils.when(() -> SingleTableLoadUtils.convertToDataNodes("foo_db", databaseType, splitTables)).thenReturn(configuredDataNodes);
-            Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", databaseType, dataSourceMap, Collections.emptyList(), configuredTables);
-            assertThat(new TreeSet<>(actual.keySet()), is(new TreeSet<>(expectedTableDataSources.keySet())));
-            assertTableDataSources(actual, expectedTableDataSources);
-        }
+    void assertLoadWithConfiguredTableMapRules(final String name, final Collection<String> configuredTables, final Map<String, Collection<String>> expectedTableDataSources) {
+        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", databaseType, dataSourceMap, Collections.emptyList(), configuredTables);
+        assertThat(new TreeSet<>(actual.keySet()), is(new TreeSet<>(expectedTableDataSources.keySet())));
+        assertTableDataSources(actual, expectedTableDataSources);
     }
     
     private void assertTableDataSources(final Map<String, Collection<DataNode>> actual, final Map<String, Collection<String>> expectedTableDataSources) {
@@ -147,22 +138,8 @@ class SingleTableDataNodeLoaderTest {
     
     @Test
     void assertLoadWithSameTableInDifferentSchemas() {
-        Map<String, Collection<String>> schemaTableNames = new LinkedHashMap<>(2, 1F);
-        schemaTableNames.put("target_schema", Collections.singleton("same_tbl"));
-        schemaTableNames.put("other_schema", Collections.singleton("same_tbl"));
         Collection<String> configuredTables = Collections.singleton("foo_ds.target_schema.same_tbl");
-        Collection<DataNode> configuredDataNodes = Collections.singleton(new DataNode("foo_ds", "target_schema", "same_tbl"));
-        try (
-                MockedStatic<SingleTableLoadUtils> mockedSingleTableLoadUtils = mockStatic(SingleTableLoadUtils.class, Answers.CALLS_REAL_METHODS);
-                MockedStatic<SingleTableDataNodeLoader> mockedSingleTableDataNodeLoader = mockStatic(SingleTableDataNodeLoader.class, Answers.CALLS_REAL_METHODS)) {
-            mockedSingleTableLoadUtils.when(() -> SingleTableLoadUtils.convertToDataNodes("foo_db", databaseType, configuredTables)).thenReturn(configuredDataNodes);
-            mockedSingleTableDataNodeLoader.when(() -> SingleTableDataNodeLoader.loadSchemaTableNames(
-                    "foo_db", databaseType, dataSourceMap.get("foo_ds"), "foo_ds", Collections.emptySet(), Collections.emptySet())).thenReturn(schemaTableNames);
-            Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", databaseType, dataSourceMap, Collections.emptyList(), configuredTables);
-            assertThat(actual.keySet(), is(Collections.singleton("same_tbl")));
-            assertThat(actual.get("same_tbl").size(), is(1));
-            assertThat(actual.get("same_tbl").iterator().next(), is(new DataNode("foo_ds", "target_schema", "same_tbl")));
-        }
+        assertTrue(SingleTableDataNodeLoader.load("foo_db", databaseType, dataSourceMap, Collections.emptyList(), configuredTables).isEmpty());
     }
     
     @Test
@@ -173,7 +150,8 @@ class SingleTableDataNodeLoaderTest {
     
     @Test
     void assertLoadWithDataSourceMap() {
-        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", dataSourceMap, Collections.emptySet(), Collections.singleton("foo_tbl2"));
+        Map<String, Collection<DataNode>> actual =
+                SingleTableDataNodeLoader.load("foo_db", dataSourceMap, Collections.emptySet(), Collections.singleton("foo_tbl2"), createStorageTypes(dataSourceMap));
         assertThat(new TreeSet<>(actual.keySet()), is(new TreeSet<>(Arrays.asList("foo_tbl1", "bar_tbl1", "bar_tbl2"))));
         assertThat(new TreeSet<>(actual.get("bar_tbl1").stream().map(DataNode::getDataSourceName).collect(Collectors.toList())), is(new TreeSet<>(Collections.singleton("bar_ds"))));
     }
@@ -182,7 +160,7 @@ class SingleTableDataNodeLoaderTest {
     void assertLoadWithDataSourceMapPreservesCaseSensitiveTableNames() throws SQLException {
         Map<String, DataSource> localDataSourceMap = new LinkedHashMap<>(1, 1F);
         localDataSourceMap.put("foo_ds", mockDataSource("foo_ds", Arrays.asList("Test3", "test3")));
-        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", localDataSourceMap, Collections.emptySet(), Collections.emptySet());
+        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", localDataSourceMap, Collections.emptySet(), Collections.emptySet(), createStorageTypes(localDataSourceMap));
         assertTrue(actual.containsKey("Test3"));
         assertTrue(actual.containsKey("test3"));
         assertThat(actual.get("Test3").iterator().next().getTableName(), is("Test3"));
@@ -194,7 +172,7 @@ class SingleTableDataNodeLoaderTest {
         Map<String, DataSource> localDataSourceMap = new LinkedHashMap<>(2, 1F);
         localDataSourceMap.put("foo_ds", mockDataSource("foo_ds", Collections.singletonList("foo_tbl")));
         localDataSourceMap.put("FOO_DS", mockDataSource("FOO_DS", Collections.singletonList("foo_tbl")));
-        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", localDataSourceMap, Collections.emptySet(), Collections.emptySet());
+        Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load("foo_db", localDataSourceMap, Collections.emptySet(), Collections.emptySet(), createStorageTypes(localDataSourceMap));
         assertThat(actual.get("foo_tbl").size(), is(2));
         assertThat(actual.get("foo_tbl").stream().map(DataNode::getDataSourceName).collect(Collectors.toCollection(LinkedHashSet::new)),
                 is(new LinkedHashSet<>(Arrays.asList("foo_ds", "FOO_DS"))));
@@ -245,26 +223,19 @@ class SingleTableDataNodeLoaderTest {
     }
     
     private static Stream<Arguments> loadWithConfiguredTableMapRuleArguments() {
-        Map<String, Collection<String>> schemaWildcardExpectedDataSources = new LinkedHashMap<>(1, 1F);
-        schemaWildcardExpectedDataSources.put("foo_tbl2", Collections.singleton("foo_ds"));
-        Map<String, Collection<String>> tableWildcardExpectedDataSources = new LinkedHashMap<>(2, 1F);
-        tableWildcardExpectedDataSources.put("foo_tbl1", Collections.singleton("foo_ds"));
-        tableWildcardExpectedDataSources.put("foo_tbl2", Collections.singleton("foo_ds"));
         return Stream.of(
-                Arguments.arguments("configured data source not found", Collections.singleton("other_ds.foo_tbl2"),
-                        new LinkedHashSet<>(Collections.singleton("other_ds.foo_tbl2")),
-                        Collections.singleton(new DataNode("other_ds", "foo_db", "foo_tbl2")), Collections.emptyMap()),
-                Arguments.arguments("configured wildcard schema", Collections.singleton("foo_ds.*.foo_tbl2"),
-                        new LinkedHashSet<>(Collections.singleton("foo_ds.*.foo_tbl2")),
-                        Collections.singleton(new DataNode("foo_ds", "*", "foo_tbl2")),
-                        createExpectedTableDataSources(schemaWildcardExpectedDataSources)),
-                Arguments.arguments("configured schema not matched", Collections.singleton("foo_ds.other_schema.foo_tbl2"),
-                        new LinkedHashSet<>(Collections.singleton("foo_ds.other_schema.foo_tbl2")),
-                        Collections.singleton(new DataNode("foo_ds", "other_schema", "foo_tbl2")), Collections.emptyMap()),
-                Arguments.arguments("configured table wildcard", Collections.singleton("foo_ds.foo_db.*"),
-                        new LinkedHashSet<>(Collections.singleton("foo_ds.foo_db.*")),
-                        Collections.singleton(new DataNode("foo_ds", "foo_db", "*")),
-                        createExpectedTableDataSources(tableWildcardExpectedDataSources)));
+                Arguments.arguments("configured data source not found", Collections.singleton("other_ds.foo_tbl2"), Collections.emptyMap()),
+                Arguments.arguments("configured wildcard schema", Collections.singleton("foo_ds.*.foo_tbl2"), Collections.emptyMap()),
+                Arguments.arguments("configured schema not matched", Collections.singleton("foo_ds.other_schema.foo_tbl2"), Collections.emptyMap()),
+                Arguments.arguments("configured table wildcard", Collections.singleton("foo_ds.foo_db.*"), Collections.emptyMap()));
+    }
+    
+    private Map<String, DatabaseType> createStorageTypes(final Map<String, DataSource> dataSources) {
+        Map<String, DatabaseType> result = new LinkedHashMap<>(dataSources.size(), 1F);
+        for (String each : dataSources.keySet()) {
+            result.put(each, databaseType);
+        }
+        return result;
     }
     
     private static Map<String, Collection<String>> createExpectedTableDataSources(final Map<String, Collection<String>> tableDataSources) {

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoaderTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.single.datanode;
 
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.database.DatabaseTypeEngine;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.attribute.RuleAttributes;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -52,6 +54,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -59,6 +62,10 @@ import static org.mockito.Mockito.when;
 class SingleTableDataNodeLoaderTest {
     
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
+    
+    private final DatabaseType protocolDatabaseType = TypedSPILoader.getService(DatabaseType.class, "Oracle");
+    
+    private final DatabaseType storageDatabaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
     
     private Map<String, DataSource> dataSourceMap;
     
@@ -70,11 +77,24 @@ class SingleTableDataNodeLoaderTest {
     }
     
     private DataSource mockDataSource(final String dataSourceName, final List<String> tableNames) throws SQLException {
+        return mockDataSource(dataSourceName, null, "jdbc:mock://127.0.0.1/" + dataSourceName, tableNames);
+    }
+    
+    private DataSource mockDataSource(final String dataSourceName, final String schemaName, final String url, final List<String> tableNames) throws SQLException {
         Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
         when(connection.getCatalog()).thenReturn(dataSourceName);
-        ResultSet resultSet = mockResultSet(tableNames);
-        when(connection.getMetaData().getTables(dataSourceName, null, null, new String[]{"TABLE", "PARTITIONED TABLE", "VIEW", "SYSTEM TABLE", "SYSTEM VIEW"})).thenReturn(resultSet);
-        when(connection.getMetaData().getURL()).thenReturn("jdbc:mock://127.0.0.1/foo_ds");
+        when(connection.getMetaData().getURL()).thenReturn(url);
+        if (null == schemaName) {
+            ResultSet tableResultSet = mockResultSet(tableNames);
+            when(connection.getMetaData().getTables(dataSourceName, null, null, new String[]{"TABLE", "PARTITIONED TABLE", "VIEW", "SYSTEM TABLE", "SYSTEM VIEW"}))
+                    .thenReturn(tableResultSet);
+        } else {
+            ResultSet schemaResultSet = mockSchemaResultSet(schemaName);
+            ResultSet tableResultSet = mockResultSet(tableNames);
+            when(connection.getMetaData().getSchemas()).thenReturn(schemaResultSet);
+            when(connection.getMetaData().getTables(dataSourceName, schemaName, null, new String[]{"TABLE", "PARTITIONED TABLE", "VIEW", "SYSTEM TABLE", "SYSTEM VIEW"}))
+                    .thenReturn(tableResultSet);
+        }
         return new MockedDataSource(connection);
     }
     
@@ -86,6 +106,13 @@ class SingleTableDataNodeLoaderTest {
         remainNextResults.add(false);
         when(result.next()).thenReturn(true, remainNextResults.toArray(new Boolean[tableNames.size()]));
         when(result.getString("TABLE_NAME")).thenReturn(firstTableName, remainTableNames.toArray(new String[tableNames.size() - 1]));
+        return result;
+    }
+    
+    private ResultSet mockSchemaResultSet(final String schemaName) throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        when(result.next()).thenReturn(true, false);
+        when(result.getString("TABLE_SCHEM")).thenReturn(schemaName);
         return result;
     }
     
@@ -176,6 +203,19 @@ class SingleTableDataNodeLoaderTest {
         assertThat(actual.get("foo_tbl").size(), is(2));
         assertThat(actual.get("foo_tbl").stream().map(DataNode::getDataSourceName).collect(Collectors.toCollection(LinkedHashSet::new)),
                 is(new LinkedHashSet<>(Arrays.asList("foo_ds", "FOO_DS"))));
+    }
+    
+    @Test
+    void assertLoadWithDifferentProtocolAndStorageTypes() throws SQLException {
+        Map<String, DataSource> localDataSourceMap = new LinkedHashMap<>(1, 1F);
+        localDataSourceMap.put("foo_ds", mockDataSource("foo_ds", Collections.singletonList("foo_tbl1")));
+        try (MockedStatic<DatabaseTypeEngine> databaseTypeEngine = mockStatic(DatabaseTypeEngine.class)) {
+            databaseTypeEngine.when(() -> DatabaseTypeEngine.getStorageType(localDataSourceMap.get("foo_ds"))).thenReturn(storageDatabaseType);
+            Map<String, Collection<DataNode>> actual = SingleTableDataNodeLoader.load(
+                    "foo_db", protocolDatabaseType, localDataSourceMap, Collections.emptyList(), Collections.singleton("foo_ds.foo_tbl1"));
+            assertTrue(actual.containsKey("foo_tbl1"));
+            assertThat(actual.get("foo_tbl1"), is(Collections.singletonList(new DataNode("foo_ds", "foo_db", "foo_tbl1"))));
+        }
     }
     
     @Test

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/decorator/SingleRuleConfigurationDecoratorTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/decorator/SingleRuleConfigurationDecoratorTest.java
@@ -89,7 +89,7 @@ class SingleRuleConfigurationDecoratorTest {
     @Test
     void assertDecorateLoadsTablesWhenRulesPresentButConfigEmpty() {
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap("t_order", Collections.singleton(new DataNode("foo_ds", "foo_schema", "t_order")));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection(), anyMap())).thenReturn(actualDataNodes);
         mockSplitAndConvert(Collections.singleton(SingleTableConstants.ALL_TABLES), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         Map<String, DataSource> dataSources = Collections.singletonMap("foo_ds", mock(DataSource.class));
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration(Collections.emptyList(), null);
@@ -107,7 +107,7 @@ class SingleRuleConfigurationDecoratorTest {
     @Test
     void assertDecorateLoadsAllSchemaTablesWhenSchemaSupported() {
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap("t_order", Collections.singleton(new DataNode("foo_ds", "public", "t_order")));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection(), anyMap())).thenReturn(actualDataNodes);
         mockSplitAndConvert(Collections.singleton(SingleTableConstants.ALL_SCHEMA_TABLES), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         Map<String, DataSource> dataSources = Collections.singletonMap("foo_ds", mock(DataSource.class));
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration(Collections.singleton(SingleTableConstants.ALL_SCHEMA_TABLES), null);
@@ -122,7 +122,7 @@ class SingleRuleConfigurationDecoratorTest {
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap(dataNode.getTableName(), Collections.singleton(dataNode));
         Collection<String> splitTables = Collections.singleton("*.foo_schema.t_order");
         Collection<DataNode> configuredDataNodes = Collections.singleton(new DataNode("foo_ds", "foo_schema", "t_order"));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection(), anyMap())).thenReturn(actualDataNodes);
         mockSplitAndConvert(splitTables, configuredDataNodes, Collections.emptyList(), Collections.emptyList());
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration(Collections.singleton("*.foo_schema.t_order"), null);
         try (MockedConstruction<DatabaseTypeRegistry> ignored = mockSchemaRegistry(true)) {
@@ -137,7 +137,7 @@ class SingleRuleConfigurationDecoratorTest {
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap(dataNode.getTableName(), Collections.singleton(dataNode));
         Collection<String> splitTables = Arrays.asList("*.foo_schema.t_order");
         Collection<DataNode> configuredDataNodes = Collections.singleton(new DataNode("foo_ds", "foo_schema", "t_order"));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection(), anyMap())).thenReturn(actualDataNodes);
         mockSplitAndConvert(splitTables, configuredDataNodes, Collections.emptyList(), Collections.emptyList());
         Map<String, DataSource> dataSources = Collections.singletonMap("foo_ds", mock(DataSource.class));
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration(Arrays.asList("*.foo_schema.t_order"), null);
@@ -151,7 +151,7 @@ class SingleRuleConfigurationDecoratorTest {
         actualDataNodes.put("feature_tbl", Collections.singleton(new DataNode("skip_ds", "foo_schema", "feature_tbl")));
         actualDataNodes.put("expanded_tbl", Collections.singleton(new DataNode("expand_ds", "foo_schema", "expanded_tbl")));
         actualDataNodes.put("matched_tbl", Collections.singleton(new DataNode("bar_ds", "foo_schema", "matched_tbl")));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection(), anyMap())).thenReturn(actualDataNodes);
         Collection<String> splitTables = Arrays.asList("expand_ds.*", "bar_ds.bar_tbl");
         Collection<DataNode> configuredDataNodes = Arrays.asList(
                 new DataNode("expand_ds", "foo_schema", SingleTableConstants.ASTERISK),
@@ -169,7 +169,7 @@ class SingleRuleConfigurationDecoratorTest {
         actualDataNodes.put("expanded_tbl", Collections.singleton(new DataNode("expand_ds", "foo_schema", "expanded_tbl")));
         actualDataNodes.put("ignored_tbl", Collections.singleton(new DataNode("ignored_ds", "foo_schema", "ignored_tbl")));
         actualDataNodes.put("matched_tbl", Collections.singleton(new DataNode("bar_ds", "foo_schema", "matched_tbl")));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection(), anyMap())).thenReturn(actualDataNodes);
         Collection<String> splitTables = Arrays.asList("expand_ds.*", "bar_ds.bar_tbl");
         Collection<DataNode> configuredDataNodes = Arrays.asList(
                 new DataNode("expand_ds", "foo_schema", SingleTableConstants.ASTERISK),
@@ -185,7 +185,7 @@ class SingleRuleConfigurationDecoratorTest {
     void assertDecorateThrowsWhenExpandedNodeMismatch() {
         Collection<String> emptyTables = Collections.emptySet();
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap("t_order", Collections.singleton(new DataNode("other_ds", "foo_schema", "t_order")));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection(), anyMap())).thenReturn(actualDataNodes);
         Collection<String> splitTables = Arrays.asList("expand_ds.*", "expand_ds.t_order");
         Collection<DataNode> configuredDataNodes = Arrays.asList(
                 new DataNode("expand_ds", "foo_schema", SingleTableConstants.ASTERISK),
@@ -203,7 +203,7 @@ class SingleRuleConfigurationDecoratorTest {
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap(dataNode.getTableName(), Collections.singleton(dataNode));
         Collection<String> splitTables = Collections.singleton("expand_ds.*.*");
         Collection<DataNode> configuredDataNodes = Collections.singleton(new DataNode("expand_ds", SingleTableConstants.ASTERISK, SingleTableConstants.ASTERISK));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection(), anyMap())).thenReturn(actualDataNodes);
         mockSplitAndConvert(splitTables, configuredDataNodes, Collections.emptyList(), Collections.emptyList());
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration(Collections.singleton("expand_ds.*.*"), null);
         Map<String, DataSource> dataSources = Collections.singletonMap("foo_ds", mock(DataSource.class));
@@ -217,7 +217,7 @@ class SingleRuleConfigurationDecoratorTest {
     void assertDecorateSkipsSchemaExpandWhenSchemaNotMatched() {
         final DataNode dataNode = new DataNode("schema_ds", "bar_schema", "ignored_tbl");
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap(dataNode.getTableName(), Collections.singleton(dataNode));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection(), anyMap())).thenReturn(actualDataNodes);
         Collection<String> splitTables = Collections.singleton("schema_ds.foo_schema.*");
         Collection<DataNode> configuredDataNodes = Collections.singleton(new DataNode("schema_ds", "foo_schema", SingleTableConstants.ASTERISK));
         mockSplitAndConvert(splitTables, configuredDataNodes, Collections.emptyList(), Collections.emptyList());
@@ -230,7 +230,7 @@ class SingleRuleConfigurationDecoratorTest {
     void assertDecorateThrowsWhenSpecifiedTableNotFound() {
         final DataNode dataNode = new DataNode("foo_ds", "foo_schema", "t_order");
         Map<String, Collection<DataNode>> actualDataNodes = Collections.singletonMap(dataNode.getTableName(), Collections.singleton(dataNode));
-        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
+        when(SingleTableDataNodeLoader.load(anyString(), anyMap(), anyCollection(), anyCollection(), anyMap())).thenReturn(actualDataNodes);
         Collection<String> splitTables = Collections.singleton("*.foo_schema.missing_tbl");
         Collection<DataNode> configuredDataNodes = Collections.singleton(new DataNode("foo_ds", "foo_schema", "missing_tbl"));
         mockSplitAndConvert(splitTables, configuredDataNodes, Collections.emptyList(), Collections.emptyList());

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/attribute/SingleMutableDataNodeRuleAttributeTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/attribute/SingleMutableDataNodeRuleAttributeTest.java
@@ -207,7 +207,7 @@ class SingleMutableDataNodeRuleAttributeTest {
         DataNode dataNode = new DataNode("foo_ds", "foo_schema", "foo_tbl");
         return Stream.of(
                 Arguments.of("return data node when schema matched", Collections.singleton(dataNode), "foo_schema", "foo_tbl".toUpperCase(), true, "foo_ds"),
-                Arguments.of("return empty when schema differs only by case", Collections.singleton(dataNode), "FOO_SCHEMA", "foo_tbl", false, ""),
+                Arguments.of("return empty when schema differs only by case", Collections.singleton(dataNode), "FOO_SCHEMA", "foo_tbl", true, "foo_ds"),
                 Arguments.of("return empty when schema mismatched", Collections.singleton(dataNode), "bar_schema", "foo_tbl", false, ""),
                 Arguments.of("return empty when table not exists", Collections.emptyList(), "foo_schema", "bar_table", false, ""));
     }

--- a/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutor.java
+++ b/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutor.java
@@ -18,10 +18,12 @@
 package org.apache.shardingsphere.single.distsql.handler.query;
 
 import lombok.Setter;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.distsql.handler.aware.DistSQLExecutorDatabaseAware;
 import org.apache.shardingsphere.distsql.handler.aware.DistSQLExecutorRuleAware;
 import org.apache.shardingsphere.distsql.handler.engine.query.DistSQLQueryExecutor;
+import org.apache.shardingsphere.infra.database.DatabaseTypeEngine;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -89,8 +91,9 @@ public final class ShowUnloadedSingleTablesExecutor implements DistSQLQueryExecu
                 resourceMetaData.getStorageUnits().entrySet().stream()
                         .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().getDataSource(), (oldValue, currentValue) -> oldValue, LinkedHashMap::new)),
                 database.getRuleMetaData().getRules());
+        Map<String, DatabaseType> databaseTypeMap = aggregateDataSourceMap.entrySet().stream().collect(Collectors.toMap(Entry::getKey, each -> DatabaseTypeEngine.getStorageType(each.getValue())));
         Collection<String> excludedTables = SingleTableLoadUtils.getExcludedTables(database.getRuleMetaData().getRules());
-        return SingleTableDataNodeLoader.load(database.getName(), aggregateDataSourceMap, Collections.emptySet(), excludedTables);
+        return SingleTableDataNodeLoader.load(database.getName(), aggregateDataSourceMap, Collections.emptySet(), excludedTables, databaseTypeMap);
     }
     
     @Override

--- a/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutorTest.java
+++ b/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutorTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.database.metad
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.distsql.handler.engine.query.DistSQLQueryExecutor;
+import org.apache.shardingsphere.infra.database.DatabaseTypeEngine;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -61,6 +62,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -68,7 +70,7 @@ import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(AutoMockExtension.class)
-@StaticMockSettings({SingleTableDataNodeLoader.class, SingleTableLoadUtils.class, PhysicalDataSourceAggregator.class})
+@StaticMockSettings({SingleTableDataNodeLoader.class, SingleTableLoadUtils.class, PhysicalDataSourceAggregator.class, DatabaseTypeEngine.class})
 class ShowUnloadedSingleTablesExecutorTest {
     
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
@@ -138,7 +140,8 @@ class ShowUnloadedSingleTablesExecutorTest {
         when(storageUnit.getDataSource()).thenReturn(dataSource);
         when(PhysicalDataSourceAggregator.getAggregatedDataSources(any(), any())).thenReturn(Collections.singletonMap("ds_0", dataSource));
         when(SingleTableLoadUtils.getExcludedTables(Collections.emptyList())).thenReturn(Collections.emptySet());
-        when(SingleTableDataNodeLoader.load(eq("foo_db"), any(), anyCollection(), anyCollection())).thenReturn(actualDataNodes);
+        when(DatabaseTypeEngine.getStorageType(dataSource)).thenReturn(databaseType);
+        when(SingleTableDataNodeLoader.load(eq("foo_db"), any(), anyCollection(), anyCollection(), anyMap())).thenReturn(actualDataNodes);
     }
     
     private void assertRows(final List<List<String>> expectedRows) {

--- a/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutorTest.java
+++ b/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutorTest.java
@@ -35,6 +35,7 @@ import org.apache.shardingsphere.single.datanode.SingleTableDataNodeLoader;
 import org.apache.shardingsphere.single.distsql.statement.rql.ShowUnloadedSingleTablesStatement;
 import org.apache.shardingsphere.single.rule.SingleRule;
 import org.apache.shardingsphere.single.util.SingleTableLoadUtils;
+import org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +49,9 @@ import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -60,10 +64,12 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -74,6 +80,10 @@ import static org.mockito.Mockito.when;
 class ShowUnloadedSingleTablesExecutorTest {
     
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
+    
+    private final DatabaseType protocolDatabaseType = TypedSPILoader.getService(DatabaseType.class, "Oracle");
+    
+    private final DatabaseType storageDatabaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
     
     private final ShowUnloadedSingleTablesExecutor executor = (ShowUnloadedSingleTablesExecutor) TypedSPILoader.getService(DistSQLQueryExecutor.class, ShowUnloadedSingleTablesStatement.class);
     
@@ -129,6 +139,30 @@ class ShowUnloadedSingleTablesExecutorTest {
         assertRows(expectedRows);
     }
     
+    @Test
+    void assertGetRowsWithDifferentProtocolAndStorageTypes() throws SQLException {
+        Map<String, DataSource> actualDataSourceMap = Collections.singletonMap("foo_ds",
+                mockDataSource("foo_ds", null, "jdbc:mock://127.0.0.1/foo_ds", Collections.singletonList("foo_tbl1")));
+        when(DatabaseTypeEngine.getStorageType(any(DataSource.class))).thenReturn(storageDatabaseType);
+        when(SingleTableLoadUtils.getFeatureRequiredSingleTables(anyCollection())).thenCallRealMethod();
+        when(SingleTableLoadUtils.getExcludedTables(anyCollection())).thenCallRealMethod();
+        when(SingleTableLoadUtils.splitTableLines(anyCollection())).thenCallRealMethod();
+        when(SingleTableDataNodeLoader.load(eq("foo_db"), eq(protocolDatabaseType), anyMap(), anyCollection(), anyCollection())).thenCallRealMethod();
+        when(SingleTableDataNodeLoader.load(eq("foo_db"), anyMap(), anyCollection(), anyCollection(), anyMap())).thenCallRealMethod();
+        Map<String, Collection<DataNode>> loadedDataNodes = SingleTableDataNodeLoader.load(
+                "foo_db", protocolDatabaseType, actualDataSourceMap, Collections.emptyList(), Collections.singleton("foo_ds.foo_tbl1"));
+        when(database.getName()).thenReturn("foo_db");
+        when(database.getProtocolType()).thenReturn(protocolDatabaseType);
+        when(database.getResourceMetaData()).thenReturn(resourceMetaData);
+        when(database.getRuleMetaData()).thenReturn(ruleMetaData);
+        when(ruleMetaData.getRules()).thenReturn(Collections.emptyList());
+        when(rule.getSingleTableDataNodes()).thenReturn(loadedDataNodes);
+        when(resourceMetaData.getStorageUnits()).thenReturn(Collections.singletonMap("foo_ds", storageUnit));
+        when(storageUnit.getDataSource()).thenReturn(actualDataSourceMap.get("foo_ds"));
+        when(PhysicalDataSourceAggregator.getAggregatedDataSources(any(), any())).thenReturn(actualDataSourceMap);
+        assertTrue(executor.getRows(new ShowUnloadedSingleTablesStatement(null, null, null), mock(ContextManager.class)).isEmpty());
+    }
+    
     private void mockRowsDependencies(final Map<String, Collection<DataNode>> actualDataNodes, final Map<String, Collection<DataNode>> loadedDataNodes) {
         when(database.getName()).thenReturn("foo_db");
         when(database.getProtocolType()).thenReturn(databaseType);
@@ -161,6 +195,44 @@ class ShowUnloadedSingleTablesExecutorTest {
         DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class, RETURNS_DEEP_STUBS);
         when(dialectDatabaseMetaData.getSchemaOption().isSchemaAvailable()).thenReturn(true);
         return mockConstruction(DatabaseTypeRegistry.class, (mock, context) -> when(mock.getDialectDatabaseMetaData()).thenReturn(dialectDatabaseMetaData));
+    }
+    
+    private DataSource mockDataSource(final String dataSourceName, final String schemaName, final String url, final List<String> tableNames) throws SQLException {
+        Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        lenient().when(connection.getCatalog()).thenReturn(dataSourceName);
+        lenient().when(connection.getMetaData().getURL()).thenReturn(url);
+        ResultSet tableResultSet = mockTableResultSet(tableNames);
+        if (null == schemaName) {
+            when(connection.getMetaData().getTables(dataSourceName, null, null, new String[]{"TABLE", "PARTITIONED TABLE", "VIEW", "SYSTEM TABLE", "SYSTEM VIEW"}))
+                    .thenReturn(tableResultSet);
+        } else {
+            ResultSet schemaResultSet = mockSchemaResultSet(schemaName);
+            when(connection.getMetaData().getSchemas()).thenReturn(schemaResultSet);
+            when(connection.getMetaData().getTables(dataSourceName, schemaName, null, new String[]{"TABLE", "PARTITIONED TABLE", "VIEW", "SYSTEM TABLE", "SYSTEM VIEW"}))
+                    .thenReturn(tableResultSet);
+        }
+        return new MockedDataSource(connection);
+    }
+    
+    private ResultSet mockSchemaResultSet(final String schemaName) throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        when(result.next()).thenReturn(true, false);
+        when(result.getString("TABLE_SCHEM")).thenReturn(schemaName);
+        return result;
+    }
+    
+    private ResultSet mockTableResultSet(final List<String> tableNames) throws SQLException {
+        ResultSet result = mock(ResultSet.class);
+        Collection<String> remainTableNames = tableNames.subList(1, tableNames.size());
+        Collection<Boolean> remainNextResults = new LinkedList<>();
+        for (int i = 0; i < remainTableNames.size(); i++) {
+            remainNextResults.add(true);
+        }
+        remainNextResults.add(false);
+        String firstTableName = tableNames.get(0);
+        lenient().when(result.next()).thenReturn(true, remainNextResults.toArray(new Boolean[tableNames.size()]));
+        lenient().when(result.getString("TABLE_NAME")).thenReturn(firstTableName, remainTableNames.toArray(new String[tableNames.size() - 1]));
+        return result;
     }
     
     @Test

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
@@ -202,7 +202,7 @@ public final class ContextManager implements AutoCloseable {
     private ShardingSphereSchema loadSchema(final ShardingSphereDatabase database, final String schemaName, final String dataSourceName) throws SQLException {
         database.reloadRules();
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(Collections.singletonMap(dataSourceName, database.getResourceMetaData().getStorageUnits().get(dataSourceName)),
-                database.getRuleMetaData().getRules(), metaDataContexts.getMetaData().getProps(), schemaName);
+                database.getRuleMetaData().getRules(), metaDataContexts.getMetaData().getProps(), schemaName, database.getIdentifierContext());
         ShardingSphereSchema result = GenericSchemaBuilder.build(database.getProtocolType(), material).get(schemaName);
         persistServiceFacade.getMetaDataFacade().getDatabaseMetaDataFacade().getView().load(database.getName(), schemaName).forEach(result::putView);
         return result;
@@ -217,7 +217,8 @@ public final class ContextManager implements AutoCloseable {
      */
     public void reloadTable(final ShardingSphereDatabase database, final String schemaName, final String tableName) {
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(
-                database.getResourceMetaData().getStorageUnits(), database.getRuleMetaData().getRules(), metaDataContexts.getMetaData().getProps(), schemaName);
+                database.getResourceMetaData().getStorageUnits(), database.getRuleMetaData().getRules(), metaDataContexts.getMetaData().getProps(), schemaName,
+                database.getIdentifierContext());
         try {
             persistTable(database, schemaName, tableName, material);
         } catch (final SQLException ex) {
@@ -236,7 +237,8 @@ public final class ContextManager implements AutoCloseable {
     public void reloadTable(final ShardingSphereDatabase database, final String schemaName, final String dataSourceName, final String tableName) {
         StorageUnit storageUnit = database.getResourceMetaData().getStorageUnits().get(dataSourceName);
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(
-                Collections.singletonMap(dataSourceName, storageUnit), database.getRuleMetaData().getRules(), metaDataContexts.getMetaData().getProps(), schemaName);
+                Collections.singletonMap(dataSourceName, storageUnit), database.getRuleMetaData().getRules(), metaDataContexts.getMetaData().getProps(), schemaName,
+                database.getIdentifierContext());
         try {
             persistTable(database, schemaName, tableName, material);
         } catch (final SQLException ex) {

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/persist/metadata/DatabaseMetaDataPersistFacade.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/persist/metadata/DatabaseMetaDataPersistFacade.java
@@ -111,7 +111,8 @@ public final class DatabaseMetaDataPersistFacade {
     public void unregisterStorageUnits(final String databaseName, final MetaDataContexts reloadMetaDataContexts) {
         ShardingSphereDatabase database = reloadMetaDataContexts.getMetaData().getDatabase(databaseName);
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(database.getResourceMetaData().getStorageUnits(),
-                database.getRuleMetaData().getRules(), reloadMetaDataContexts.getMetaData().getProps(), new DatabaseTypeRegistry(database.getProtocolType()).getDefaultSchemaName(databaseName));
+                database.getRuleMetaData().getRules(), reloadMetaDataContexts.getMetaData().getProps(), new DatabaseTypeRegistry(database.getProtocolType()).getDefaultSchemaName(databaseName),
+                database.getIdentifierContext());
         try {
             Map<String, ShardingSphereSchema> schemas = GenericSchemaBuilder.build(database.getProtocolType(), material);
             for (Entry<String, ShardingSphereSchema> entry : schemas.entrySet()) {
@@ -135,7 +136,7 @@ public final class DatabaseMetaDataPersistFacade {
         ShardingSphereDatabase database = reloadMetaDataContexts.getMetaData().getDatabase(databaseName);
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(database.getResourceMetaData().getStorageUnits(),
                 database.getRuleMetaData().getRules(), reloadMetaDataContexts.getMetaData().getProps(),
-                new DatabaseTypeRegistry(database.getProtocolType()).getDefaultSchemaName(databaseName));
+                new DatabaseTypeRegistry(database.getProtocolType()).getDefaultSchemaName(databaseName), database.getIdentifierContext());
         try {
             Map<String, ShardingSphereSchema> schemas = GenericSchemaBuilder.build(needReloadTables, database.getProtocolType(), material);
             Map<String, Collection<ShardingSphereTable>> result = new HashMap<>(schemas.size(), 1F);

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/TableMetaDataRefresherLoader.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/TableMetaDataRefresherLoader.java
@@ -79,7 +79,8 @@ public final class TableMetaDataRefresherLoader {
         if (singleTable) {
             ruleMetaData.getAttributes(MutableDataNodeRuleAttribute.class).forEach(each -> each.put(logicDataSourceName, schemaName, candidateTableName));
         }
-        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(database.getResourceMetaData().getStorageUnits(), ruleMetaData.getRules(), props, schemaName);
+        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(database.getResourceMetaData().getStorageUnits(), ruleMetaData.getRules(), props, schemaName,
+                database.getIdentifierContext());
         Map<String, ShardingSphereSchema> schemas = GenericSchemaBuilder.build(Collections.singletonList(candidateTableName), database.getProtocolType(), material);
         ShardingSphereTable result = Optional.ofNullable(schemas.get(schemaName)).map(optional -> optional.getTable(candidateTableName))
                 .orElseGet(() -> fallbackWhenMissing ? new ShardingSphereTable(candidateTableName, Collections.emptyList(), Collections.emptyList(), Collections.emptyList()) : null);

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/ViewMetaDataRefresherLoader.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/ViewMetaDataRefresherLoader.java
@@ -60,7 +60,8 @@ public final class ViewMetaDataRefresherLoader {
         if (singleTable) {
             ruleMetaData.getAttributes(MutableDataNodeRuleAttribute.class).forEach(each -> each.put(logicDataSourceName, schemaName, candidateViewName));
         }
-        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(database.getResourceMetaData().getStorageUnits(), ruleMetaData.getRules(), props, schemaName);
+        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(database.getResourceMetaData().getStorageUnits(), ruleMetaData.getRules(), props, schemaName,
+                database.getIdentifierContext());
         Map<String, ShardingSphereSchema> schemas = GenericSchemaBuilder.build(Collections.singletonList(candidateViewName), database.getProtocolType(), material);
         Optional<ShardingSphereTable> actualTableMetaData = Optional.ofNullable(schemas.get(schemaName)).map(optional -> optional.getTable(candidateViewName));
         Preconditions.checkState(actualTableMetaData.isPresent(), "Load actual view metadata '%s' failed.", candidateViewName);
@@ -94,7 +95,8 @@ public final class ViewMetaDataRefresherLoader {
         if (singleTable) {
             ruleMetaData.getAttributes(MutableDataNodeRuleAttribute.class).forEach(each -> each.put(logicDataSourceName, schemaName, candidateViewName));
         }
-        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(database.getResourceMetaData().getStorageUnits(), ruleMetaData.getRules(), props, schemaName);
+        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(database.getResourceMetaData().getStorageUnits(), ruleMetaData.getRules(), props, schemaName,
+                database.getIdentifierContext());
         Map<String, ShardingSphereSchema> schemas = GenericSchemaBuilder.build(Collections.singletonList(candidateViewName), database.getProtocolType(), material);
         Optional<ShardingSphereTable> actualViewMetaData = Optional.ofNullable(schemas.get(schemaName)).map(optional -> optional.getTable(candidateViewName));
         ShardingSphereSchema result = new ShardingSphereSchema(schemaName, database.getProtocolType());

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/util/SchemaRefreshUtils.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/util/SchemaRefreshUtils.java
@@ -24,12 +24,10 @@ import org.apache.shardingsphere.database.connector.core.metadata.identifier.Ide
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.LookupMode;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
-import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
-import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
-import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContextFactory;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
 import java.util.Collection;
@@ -74,8 +72,7 @@ public final class SchemaRefreshUtils {
      * @return actual schema name
      */
     public static String getActualSchemaName(final ShardingSphereDatabase database, final IdentifierValue schemaIdentifier, final ConfigurationProperties props) {
-        DatabaseIdentifierContext identifierContext = DatabaseIdentifierContextFactory.create(database.getProtocolType(), database.getResourceMetaData(), props);
-        IdentifierCaseRule rule = identifierContext.getRule(IdentifierScope.SCHEMA);
+        IdentifierCaseRule rule = database.getIdentifierContext().getRule(IdentifierScope.SCHEMA);
         Optional<String> matchedSchemaName = database.getAllSchemas().stream().map(ShardingSphereSchema::getName)
                 .filter(each -> rule.matches(each, schemaIdentifier.getValue(), schemaIdentifier.getQuoteCharacter())).findFirst();
         return matchedSchemaName.orElseGet(() -> QuoteCharacter.NONE == schemaIdentifier.getQuoteCharacter() && LookupMode.NORMALIZED == rule.getLookupMode(schemaIdentifier.getQuoteCharacter())

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtils.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtils.java
@@ -20,10 +20,10 @@ package org.apache.shardingsphere.mode.metadata.refresher.util;
 import com.google.common.base.Joiner;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.LookupMode;
-import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
@@ -36,8 +36,6 @@ import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSp
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereView;
-import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
-import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContextFactory;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.attribute.datanode.MutableDataNodeRuleAttribute;
 import org.apache.shardingsphere.infra.rule.attribute.table.TableMapperRuleAttribute;
@@ -215,8 +213,7 @@ public final class TableRefreshUtils {
      */
     public static Optional<String> findActualTableNameByIndex(final ShardingSphereDatabase database, final String schemaName,
                                                               final IdentifierValue indexIdentifierValue, final ConfigurationProperties props) {
-        DatabaseIdentifierContext identifierContext = DatabaseIdentifierContextFactory.create(database.getProtocolType(), database.getResourceMetaData(), props);
-        IdentifierCaseRule rule = identifierContext.getRule(IdentifierScope.INDEX);
+        IdentifierCaseRule rule = database.getIdentifierContext().getRule(IdentifierScope.INDEX);
         String actualSchemaName = SchemaRefreshUtils.getActualSchemaName(database, new IdentifierValue(schemaName), props);
         ShardingSphereSchema schema = database.getSchema(actualSchemaName);
         if (null == schema) {
@@ -292,8 +289,7 @@ public final class TableRefreshUtils {
     }
     
     private static String getLoadCandidateName(final ShardingSphereDatabase database, final IdentifierValue identifierValue, final IdentifierScope scope, final ConfigurationProperties props) {
-        DatabaseIdentifierContext identifierContext = DatabaseIdentifierContextFactory.create(database.getProtocolType(), database.getResourceMetaData(), props);
-        IdentifierCaseRule rule = identifierContext.getRule(scope);
+        IdentifierCaseRule rule = database.getIdentifierContext().getRule(scope);
         return QuoteCharacter.NONE == identifierValue.getQuoteCharacter() && LookupMode.NORMALIZED == rule.getLookupMode(identifierValue.getQuoteCharacter())
                 ? rule.normalize(identifierValue.getValue())
                 : identifierValue.getValue();
@@ -302,8 +298,7 @@ public final class TableRefreshUtils {
     private static String getActualObjectName(final ShardingSphereDatabase database, final String schemaName,
                                               final IdentifierValue objectIdentifierValue, final ConfigurationProperties props,
                                               final IdentifierScope scope, final Function<ShardingSphereSchema, java.util.stream.Stream<String>> actualNameStream) {
-        DatabaseIdentifierContext identifierContext = DatabaseIdentifierContextFactory.create(database.getProtocolType(), database.getResourceMetaData(), props);
-        IdentifierCaseRule rule = identifierContext.getRule(scope);
+        IdentifierCaseRule rule = database.getIdentifierContext().getRule(scope);
         String actualSchemaName = SchemaRefreshUtils.getActualSchemaName(database, new IdentifierValue(schemaName), props);
         ShardingSphereSchema schema = database.getSchema(actualSchemaName);
         if (null != schema) {
@@ -321,8 +316,7 @@ public final class TableRefreshUtils {
     private static <T> String getActualObjectName(final ShardingSphereDatabase database, final String schemaName, final String tableName,
                                                   final IdentifierValue objectIdentifierValue, final ConfigurationProperties props, final IdentifierScope scope,
                                                   final Function<ShardingSphereTable, Collection<T>> actualObjects, final Function<T, String> actualNameMapper) {
-        DatabaseIdentifierContext identifierContext = DatabaseIdentifierContextFactory.create(database.getProtocolType(), database.getResourceMetaData(), props);
-        IdentifierCaseRule rule = identifierContext.getRule(scope);
+        IdentifierCaseRule rule = database.getIdentifierContext().getRule(scope);
         String actualSchemaName = SchemaRefreshUtils.getActualSchemaName(database, new IdentifierValue(schemaName), props);
         ShardingSphereSchema schema = database.getSchema(actualSchemaName);
         if (null != schema) {

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/AlterSchemaPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/AlterSchemaPushDownMetaDataRefresherTest.java
@@ -62,7 +62,7 @@ class AlterSchemaPushDownMetaDataRefresherTest {
         props.setProperty("metadata-identifier-case-sensitivity", "SENSITIVE");
         refresher.refresh(persistService, createDatabase(), "logic_ds", "foo_schema", databaseType, sqlStatement, new ConfigurationProperties(props));
         assertThat(persistService.getSourceSchemaName(), is("FOO_SCHEMA"));
-        assertThat(persistService.getRenamedSchemaName(), is("BAR_SCHEMA"));
+        assertThat(persistService.getRenamedSchemaName(), is("bar_schema"));
     }
     
     @Test

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/CreateSchemaPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/CreateSchemaPushDownMetaDataRefresherTest.java
@@ -57,7 +57,7 @@ class CreateSchemaPushDownMetaDataRefresherTest {
         Properties props = new Properties();
         props.setProperty("metadata-identifier-case-sensitivity", "SENSITIVE");
         refresher.refresh(persistService, createDatabase(), "logic_ds", "foo_schema", databaseType, sqlStatement, new ConfigurationProperties(props));
-        assertThat(persistService.getCreatedSchemaName(), is("FOO_SCHEMA"));
+        assertThat(persistService.getCreatedSchemaName(), is("foo_schema"));
     }
     
     @Test

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtilsIdentifierTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtilsIdentifierTest.java
@@ -105,7 +105,7 @@ class TableRefreshUtilsIdentifierTest {
         Properties props = new Properties();
         props.setProperty("metadata-identifier-case-sensitivity", "SENSITIVE");
         assertThat(TableRefreshUtils.getTableLoadCandidateName(createDatabase(), new IdentifierValue("Foo_Tbl"),
-                new ConfigurationProperties(props)), is("Foo_Tbl"));
+                new ConfigurationProperties(props)), is("foo_tbl"));
     }
     
     @Test
@@ -119,7 +119,7 @@ class TableRefreshUtilsIdentifierTest {
         Properties props = new Properties();
         props.setProperty("metadata-identifier-case-sensitivity", "SENSITIVE");
         assertThat(TableRefreshUtils.getViewLoadCandidateName(createDatabase(), new IdentifierValue("Foo_View"),
-                new ConfigurationProperties(props)), is("Foo_View"));
+                new ConfigurationProperties(props)), is("foo_view"));
     }
     
     private ShardingSphereDatabase createDatabase() {


### PR DESCRIPTION


Changes proposed in this pull request:

This PR refactors the single table loading path to make identifier handling consistent across metadata building and refresh flows.

The main changes are:

- propagate `DatabaseIdentifierContext` from database creation to schema building and metadata refresh components
- reuse the database-level identifier context instead of recreating identifier rules in refresh utilities
- normalize actual table names with the table-scope identifier rule when building metadata loader materials
- pass the actual storage type of each data source into `SingleTableDataNodeLoader`
- build configured single-table `DataNode`s with the corresponding storage type instead of relying only on the protocol type
- align `SHOW UNLOADED SINGLE TABLES` with the same storage-type-aware loading logic

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
