### PR TITLE
Fix wrong parameter index parse in MySQL, Doris

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 1. SQL Parser: Preserve unary NOT as NotExpression for scalar-subquery table extraction in PostgreSQL - [#38187](https://github.com/apache/shardingsphere/pull/38187)
+1. SQL Parser: Fix wrong parameter index parse in MySQL, Doris - [#38624](https://github.com/apache/shardingsphere/pull/38624)
 1. SQL Binder: Add DialectFunctionOption to handle wrong skip column bind in ColumnSegmentBinder - [#38350](https://github.com/apache/shardingsphere/pull/38350)
 1. SQL Binder: Fix wrong bind info when order by refer column from with temporary table - [#38353](https://github.com/apache/shardingsphere/pull/38353)
 1. JDBC: Fix stale generated values leaking into prepared statement executeBatch calls without pending batches - [#38160](https://github.com/apache/shardingsphere/pull/38160)

--- a/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/DorisStatementVisitor.java
+++ b/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/DorisStatementVisitor.java
@@ -755,6 +755,7 @@ public abstract class DorisStatementVisitor extends DorisStatementBaseVisitor<AS
     
     @Override
     public ASTNode visitQueryExpression(final QueryExpressionContext ctx) {
+        WithSegment with = null == ctx.withClause() ? null : (WithSegment) visit(ctx.withClause());
         SelectStatement result;
         if (null != ctx.queryExpressionBody()) {
             result = (SelectStatement) visit(ctx.queryExpressionBody());
@@ -762,14 +763,14 @@ public abstract class DorisStatementVisitor extends DorisStatementBaseVisitor<AS
             result = (SelectStatement) visit(ctx.queryExpressionParens());
         }
         SelectStatement.SelectStatementBuilder selectStatementBuilder = createSelectStatementBuilder(result);
+        if (null != with) {
+            selectStatementBuilder.with(with);
+        }
         if (null != ctx.orderByClause()) {
             selectStatementBuilder.orderBy((OrderBySegment) visit(ctx.orderByClause()));
         }
         if (null != ctx.limitClause()) {
             selectStatementBuilder.limit((LimitSegment) visit(ctx.limitClause()));
-        }
-        if (null != ctx.withClause()) {
-            selectStatementBuilder.with((WithSegment) visit(ctx.withClause()));
         }
         return selectStatementBuilder.build();
     }

--- a/parser/sql/engine/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/engine/mysql/visitor/statement/MySQLStatementVisitor.java
+++ b/parser/sql/engine/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/engine/mysql/visitor/statement/MySQLStatementVisitor.java
@@ -755,6 +755,7 @@ public abstract class MySQLStatementVisitor extends MySQLStatementBaseVisitor<AS
     
     @Override
     public ASTNode visitQueryExpression(final QueryExpressionContext ctx) {
+        WithSegment with = null == ctx.withClause() ? null : (WithSegment) visit(ctx.withClause());
         SelectStatement result;
         if (null != ctx.queryExpressionBody()) {
             result = (SelectStatement) visit(ctx.queryExpressionBody());
@@ -762,8 +763,8 @@ public abstract class MySQLStatementVisitor extends MySQLStatementBaseVisitor<AS
             result = (SelectStatement) visit(ctx.queryExpressionParens());
         }
         SelectStatement.SelectStatementBuilder selectStatementBuilder = createSelectStatementBuilder(result);
-        if (null != ctx.withClause()) {
-            selectStatementBuilder.with((WithSegment) visit(ctx.withClause()));
+        if (null != with) {
+            selectStatementBuilder.with(with);
         }
         if (null != ctx.orderByClause()) {
             selectStatementBuilder.orderBy((OrderBySegment) visit(ctx.orderByClause()));

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/projection/ProjectionAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/projection/ProjectionAssert.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.Colu
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ExpressionProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionsSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ShorthandProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.SubqueryProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.rownum.NumberLiteralRowNumberValueSegment;
@@ -39,6 +40,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.ide
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.owner.OwnerAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.window.WindowClauseAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dml.standard.type.SelectStatementAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.expr.simple.ExpectedParameterMarkerExpression;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.projection.ExpectedProjection;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.projection.ExpectedProjections;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.projection.impl.aggregation.ExpectedAggregationDistinctProjection;
@@ -107,6 +109,9 @@ public final class ProjectionAssert {
         } else if (actual instanceof ExpressionProjectionSegment) {
             assertThat(assertContext.getText("Projection type assertion error: "), expected, isA(ExpectedExpressionProjection.class));
             assertExpressionProjection(assertContext, (ExpressionProjectionSegment) actual, (ExpectedExpressionProjection) expected);
+        } else if (actual instanceof ParameterMarkerExpressionSegment) {
+            assertThat(assertContext.getText("Projection type assertion error: "), expected, isA(ExpectedParameterMarkerExpression.class));
+            ExpressionAssert.assertParameterMarkerExpression(assertContext, (ParameterMarkerExpressionSegment) actual, (ExpectedParameterMarkerExpression) expected);
         } else if (actual instanceof TopProjectionSegment) {
             assertThat(assertContext.getText("Projection type assertion error: "), expected, isA(ExpectedTopProjection.class));
             assertTopProjection(assertContext, (TopProjectionSegment) actual, (ExpectedTopProjection) expected);

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/expr/simple/ExpectedParameterMarkerExpression.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/expr/simple/ExpectedParameterMarkerExpression.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.projection.ExpectedProjection;
 
 import javax.xml.bind.annotation.XmlAttribute;
 
@@ -27,7 +28,7 @@ import javax.xml.bind.annotation.XmlAttribute;
  */
 @Getter
 @Setter
-public final class ExpectedParameterMarkerExpression extends ExpectedBaseSimpleExpression {
+public final class ExpectedParameterMarkerExpression extends ExpectedBaseSimpleExpression implements ExpectedProjection {
     
     @XmlAttribute(name = "parameter-index")
     private int parameterIndex;

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/projection/ExpectedProjections.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/projection/ExpectedProjections.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.AbstractExpectedSQLSegment;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.ExpectedSQLSegment;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.expr.simple.ExpectedParameterMarkerExpression;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.projection.impl.aggregation.ExpectedAggregationDistinctProjection;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.projection.impl.aggregation.ExpectedAggregationProjection;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.projection.impl.column.ExpectedColumnProjection;
@@ -64,6 +65,9 @@ public final class ExpectedProjections extends AbstractExpectedSQLSegment {
     @XmlElement(name = "subquery-projection")
     private final Collection<ExpectedSubqueryProjection> subqueryProjections = new LinkedList<>();
     
+    @XmlElement(name = "parameter-marker-expression")
+    private final Collection<ExpectedParameterMarkerExpression> parameterMarkerExpressions = new LinkedList<>();
+    
     /**
      * Get size.
      *
@@ -71,7 +75,7 @@ public final class ExpectedProjections extends AbstractExpectedSQLSegment {
      */
     public int getSize() {
         return shorthandProjections.size() + columnProjections.size() + aggregationProjections.size() + aggregationDistinctProjections.size()
-                + expressionProjections.size() + topProjections.size() + subqueryProjections.size();
+                + expressionProjections.size() + topProjections.size() + subqueryProjections.size() + parameterMarkerExpressions.size();
     }
     
     /**
@@ -88,6 +92,7 @@ public final class ExpectedProjections extends AbstractExpectedSQLSegment {
         result.addAll(expressionProjections);
         result.addAll(topProjections);
         result.addAll(subqueryProjections);
+        result.addAll(parameterMarkerExpressions);
         result.sort(Comparator.comparingInt(ExpectedSQLSegment::getStartIndex));
         return result;
     }

--- a/test/it/parser/src/main/resources/case/dml/clickhouse.xml
+++ b/test/it/parser/src/main/resources/case/dml/clickhouse.xml
@@ -521,12 +521,7 @@
     
     <select sql-case-id="clickhouse_select_param_projection" parameters="1">
         <projections start-index="7" stop-index="22">
-            <expression-projection alias="param_alias" text="?" start-index="7" stop-index="22">
-                <expr>
-                    <parameter-marker-expression parameter-index="0" start-index="7" stop-index="7" />
-                    <literal-expression value="1" start-index="7" stop-index="7" />
-                </expr>
-            </expression-projection>
+            <parameter-marker-expression parameter-index="0" start-index="7" stop-index="22" />
         </projections>
     </select>
     
@@ -1116,12 +1111,7 @@
                     <common-expression text="X'1A'" start-index="25" stop-index="29" />
                 </expr>
             </expression-projection>
-            <expression-projection text="?" start-index="32" stop-index="32">
-                <expr>
-                    <parameter-marker-expression parameter-index="0" start-index="32" stop-index="32" />
-                    <literal-expression value="1" start-index="32" stop-index="32" />
-                </expr>
-            </expression-projection>
+            <parameter-marker-expression parameter-index="0" start-index="32" stop-index="32" />
         </projections>
         <from>
             <simple-table name="t_order" start-index="39" stop-index="45" />

--- a/test/it/parser/src/main/resources/case/dml/merge.xml
+++ b/test/it/parser/src/main/resources/case/dml/merge.xml
@@ -342,14 +342,8 @@
                 <subquery>
                     <select>
                         <projections start-index="92" stop-index="116">
-                            <expression-projection text="1" start-index="92" stop-index="102" alias="userId">
-                                <parameter-marker-expression parameter-index="0" start-index="92" stop-index="92" />
-                                <literal-expression value="1" start-index="92" stop-index="92" />
-                            </expression-projection>
-                            <expression-projection text="1" start-index="105" stop-index="116" alias="orderId">
-                                <parameter-marker-expression parameter-index="1" start-index="105" stop-index="105" />
-                                <literal-expression value="1" start-index="105" stop-index="105" />
-                            </expression-projection>
+                            <parameter-marker-expression parameter-index="0" start-index="92" stop-index="102" />
+                            <parameter-marker-expression parameter-index="1" start-index="105" stop-index="116" />
                         </projections>
                         <from>
                             <simple-table name="DUAL" start-index="186" stop-index="189" />

--- a/test/it/parser/src/main/resources/case/dml/presto.xml
+++ b/test/it/parser/src/main/resources/case/dml/presto.xml
@@ -1125,12 +1125,7 @@
 
     <select sql-case-id="presto_select_parameter_marker" parameters="1">
         <projections start-index="7" stop-index="7">
-            <expression-projection text="1" start-index="7" stop-index="7">
-                <expr>
-                    <literal-expression value="1" start-index="7" stop-index="7" />
-                    <parameter-marker-expression parameter-index="0" start-index="7" stop-index="7" />
-                </expr>
-            </expression-projection>
+            <parameter-marker-expression parameter-index="0" start-index="7" stop-index="7" />
         </projections>
     </select>
 

--- a/test/it/parser/src/main/resources/case/dml/select-with.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-with.xml
@@ -871,5 +871,145 @@
             <simple-table name="t" start-index="50" stop-index="50" />
         </from>
     </select>
+    
+    <select sql-case-id="select_with_projection_parameter_mysql">
+        <with start-index="0" stop-index="146">
+            <common-table-expression name="combined_users" start-index="5" stop-index="146">
+                <subquery-expression start-index="23" stop-index="145">
+                    <select>
+                        <projections start-index="31" stop-index="37">
+                            <column-projection name="user_id" start-index="31" stop-index="37" />
+                        </projections>
+                        <from>
+                            <simple-table name="t_user" start-index="44" stop-index="49" />
+                        </from>
+                        <where start-index="51" stop-index="67">
+                            <expr>
+                                <binary-operation-expression start-index="57" stop-index="67">
+                                    <left>
+                                        <column name="user_id" start-index="57" stop-index="63" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <parameter-marker-expression parameter-index="0" start-index="67" stop-index="67" />
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
+                        </where>
+                        <combine combine-type="UNION_ALL" start-index="24" stop-index="145">
+                            <left>
+                                <projections start-index="31" stop-index="37">
+                                    <column-projection name="user_id" start-index="31" stop-index="37" />
+                                </projections>
+                                <from>
+                                    <simple-table name="t_user" start-index="44" stop-index="49" />
+                                </from>
+                                <where start-index="51" stop-index="67">
+                                    <expr>
+                                        <binary-operation-expression start-index="57" stop-index="67">
+                                            <left>
+                                                <column name="user_id" start-index="57" stop-index="63" />
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
+                                                <parameter-marker-expression parameter-index="0" start-index="67" stop-index="67" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </expr>
+                                </where>
+                            </left>
+                            <right>
+                                <projections start-index="86" stop-index="107">
+                                    <column-projection name="merchant_id" alias="user_id" start-index="86" stop-index="107" />
+                                </projections>
+                                <from>
+                                    <simple-table name="t_merchant" start-index="114" stop-index="123" />
+                                </from>
+                                <where start-index="125" stop-index="145">
+                                    <expr>
+                                        <binary-operation-expression start-index="131" stop-index="145">
+                                            <left>
+                                                <column name="merchant_id" start-index="131" stop-index="141" />
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
+                                                <parameter-marker-expression parameter-index="1" start-index="145" stop-index="145" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </expr>
+                                </where>
+                            </right>
+                        </combine>
+                    </select>
+                </subquery-expression>
+            </common-table-expression>
+        </with>
+        <projections start-index="155" stop-index="264">
+            <expression-projection text="t_order.order_id + 5000" start-index="155" stop-index="177">
+                <expr>
+                    <binary-operation-expression start-index="155" stop-index="177">
+                        <left>
+                            <column name="order_id" start-index="155" stop-index="170">
+                                <owner name="t_order" start-index="155" stop-index="161" />
+                            </column>
+                        </left>
+                        <operator>+</operator>
+                        <right>
+                            <literal-expression value="5000" start-index="174" stop-index="177" />
+                        </right>
+                    </binary-operation-expression>
+                </expr>
+            </expression-projection>
+            <column-projection name="user_id" start-index="180" stop-index="201">
+                <owner name="combined_users" start-index="180" stop-index="193" />
+            </column-projection>
+            <parameter-marker-expression parameter-index="2" start-index="204" stop-index="204" />
+            <column-projection name="merchant_id" start-index="207" stop-index="225">
+                <owner name="t_order" start-index="207" stop-index="213" />
+            </column-projection>
+            <column-projection name="remark" start-index="228" stop-index="241">
+                <owner name="t_order" start-index="228" stop-index="234" />
+            </column-projection>
+            <column-projection name="creation_date" start-index="244" stop-index="264">
+                <owner name="t_order" start-index="244" stop-index="250" />
+            </column-projection>
+        </projections>
+        <from>
+            <join-table join-type="INNER">
+                <left>
+                    <simple-table name="t_order" start-index="271" stop-index="277" />
+                </left>
+                <right>
+                    <simple-table name="combined_users" start-index="284" stop-index="297" />
+                </right>
+                <on-condition>
+                    <binary-operation-expression start-index="302" stop-index="341">
+                        <left>
+                            <column name="user_id" start-index="302" stop-index="316">
+                                <owner name="t_order" start-index="302" stop-index="308" />
+                            </column>
+                        </left>
+                        <operator>=</operator>
+                        <right>
+                            <column name="user_id" start-index="320" stop-index="341">
+                                <owner name="combined_users" start-index="320" stop-index="333" />
+                            </column>
+                        </right>
+                    </binary-operation-expression>
+                </on-condition>
+            </join-table>
+        </from>
+        <order-by>
+            <column-item name="user_id" order-direction="ASC" start-index="352" stop-index="377">
+                <owner name="combined_users" start-index="352" stop-index="365" />
+            </column-item>
+            <column-item name="order_id" order-direction="ASC" start-index="380" stop-index="399">
+                <owner name="t_order" start-index="380" stop-index="386" />
+            </column-item>
+        </order-by>
+        <limit start-index="401" stop-index="407">
+            <row-count value="1" parameter-index="3" start-index="407" stop-index="407" />
+        </limit>
+    </select>
 
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -6495,11 +6495,7 @@
                     <literal-expression value="1" start-index="7" stop-index="7" />
                 </expr>
             </expression-projection>
-            <expression-projection text="OK" start-index="16" stop-index="26" literal-stop-index="29" alias="status">
-                <expr>
-                    <literal-expression value="OK" start-index="16" stop-index="19" />
-                </expr>
-            </expression-projection>
+            <parameter-marker-expression parameter-index="0" start-index="16" stop-index="26" literal-stop-index="29" />
             <column-projection name="SYSDATE" start-index="29" stop-index="50" literal-start-index="32" literal-stop-index="53" alias="create_time" />
             <expression-projection text="TRUNC(SYSDATE)" start-index="53" stop-index="81" literal-start-index="56" literal-stop-index="84" alias="create_date">
                 <expr>
@@ -13218,12 +13214,7 @@
 
     <select sql-case-id="select_all_param_alias_schema_sql92" parameters="1">
         <projections start-index="11" stop-index="20">
-            <expression-projection text="1" start-index="11" stop-index="20" alias="aid">
-                <expr>
-                    <literal-expression value="1" start-index="11" stop-index="11" />
-                    <parameter-marker-expression parameter-index="0" start-index="11" stop-index="11" />
-                </expr>
-            </expression-projection>
+            <parameter-marker-expression parameter-index="0" start-index="11" stop-index="20" />
         </projections>
         <from>
             <simple-table name="t_order" start-index="27" stop-index="41">

--- a/test/it/parser/src/main/resources/sql/supported/dml/merge.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/merge.xml
@@ -33,7 +33,7 @@
                                                             UPDATE
                                                             SET merchant_id = ?,
                                                                 remark      = ?,
-                                                                status      = ?;"  db-types="Oracle" />
+                                                                status      = ?;"  db-types="Oracle" case-types="PLACEHOLDER" />
     <sql-case id="merge_insert_then_update" value="MERGE INTO bonuses D USING employees S ON (D.id = S.id) WHEN NOT MATCHED THEN INSERT (id) VALUES (S.id) WHEN MATCHED THEN UPDATE SET D.id = S.id" db-types="Oracle" />
     <sql-case id="merge_into_select" value="MERGE INTO (SELECT * FROM bonuses WHERE department_id = 80) D USING (SELECT employee_id, salary, department_id FROM employees WHERE department_id = 80) S ON (D.employee_id = S.employee_id) WHEN MATCHED THEN UPDATE SET D.bonus = D.bonus + S.salary*.01 DELETE WHERE (S.salary > 8000)" db-types="Oracle" />
     <sql-case id="merge_output_with_aaterisk" value="MERGE INTO people_target pt USING people_source ps ON (pt.person_id = ps.person_id) WHEN MATCHED THEN UPDATE SET first_name = ps.first_name, pt.last_name = ps.last_name, pt.title = ps.title OUTPUT deleted.*, $action, inserted.*" db-types="SQLServer" />

--- a/test/it/parser/src/main/resources/sql/supported/dml/presto.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/presto.xml
@@ -58,7 +58,7 @@
     <sql-case id="presto_select_limit_comma" value="SELECT * FROM t_order LIMIT 2, 5" db-types="Presto,Doris" />
     <sql-case id="presto_select_join_natural_left" value="SELECT * FROM t_order NATURAL LEFT JOIN t_order_item" db-types="Presto" />
     <sql-case id="presto_select_system_variable" value="SELECT @@global.time_zone" db-types="Presto" />
-    <sql-case id="presto_select_parameter_marker" value="SELECT ?" db-types="Presto,Hive" />
+    <sql-case id="presto_select_parameter_marker" value="SELECT ?" db-types="Presto,Hive" case-types="PLACEHOLDER" />
     <sql-case id="presto_select_all_qualified_shorthand" value="SELECT ALL t_order.* FROM t_order" db-types="Presto" />
     <sql-case id="presto_select_two_level_order_expr" value="SELECT t_order.order_id FROM t_order ORDER BY order_id + 1" db-types="Presto" />
     <sql-case id="presto_select_current_time_trim" value="SELECT CURRENT_TIME, TRIM(LEADING 'x' FROM status), TRIM(TRAILING 'y' FROM status) FROM t_order" db-types="Presto" />

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-with.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-with.xml
@@ -30,5 +30,6 @@
     <sql-case id="select_with_oracle_recursive_union_all1" value="WITH DirectoryCTE as (SELECT table1.col1, table1.col2 FROM table1 WHERE id = 1 AND project_id = 2 UNION ALL SELECT t.col1, t.col2 FROM project_file_catalog t INNER JOIN DirectoryCTE cte ON t.project_id = cte.project_id AND t.parent_id = cte.id) SELECT DirectoryCTE.col1, DirectoryCTE.col2 FROM DirectoryCTE ORDER BY level" db-types="Oracle" />
     <sql-case id="select_with_recursive_union_all2" value="WITH cte AS (SELECT 1 AS col1, 2 AS col2 UNION ALL SELECT 3, 4) SELECT col1, col2 FROM cte" db-types="MySQL" />
     <sql-case id="select_with_columns_cte" value="WITH cte(a,b) AS (SELECT 1,2) SELECT * FROM cte" db-types="MySQL" />
+    <sql-case id="select_with_projection_parameter_mysql" value="WITH combined_users AS (SELECT user_id FROM t_user WHERE user_id = ? UNION ALL SELECT merchant_id AS user_id FROM t_merchant WHERE merchant_id = ?) SELECT t_order.order_id + 5000, combined_users.user_id, ?, t_order.merchant_id, t_order.remark, t_order.creation_date FROM t_order JOIN combined_users ON t_order.user_id = combined_users.user_id ORDER BY combined_users.user_id ASC, t_order.order_id ASC LIMIT ?" case-types="PLACEHOLDER" db-types="MySQL" />
     <sql-case id="select_with_recursive_firebird" value="WITH RECURSIVE t(id) AS (SELECT 1) SELECT id FROM t" db-types="Firebird" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -214,7 +214,7 @@
     <sql-case id="select_positional_parameter_type_cast_money" value="SELECT $1::money" db-types="PostgreSQL,openGauss" case-types="Placeholder" />
     <sql-case id="select_string_constant_type_cast" value="SELECT int4 '1', money '2'" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_constant_with_nested_type_cast" value="SELECT CAST(MONEY '1' AS VARCHAR)::CHAR(10)::VARCHAR::CHAR(4)" db-types="PostgreSQL,openGauss"  />
-    <sql-case id="select_projection_with_parameter" value="SELECT 1 AS id, ? AS status, SYSDATE AS create_time, TRUNC(SYSDATE) AS create_date FROM DUAL" db-types="Oracle,Firebird"  />
+    <sql-case id="select_projection_with_parameter" value="SELECT 1 AS id, ? AS status, SYSDATE AS create_time, TRUNC(SYSDATE) AS create_date FROM DUAL" db-types="Oracle,Firebird" case-types="PLACEHOLDER" />
     <sql-case id="select_with_chinese_comma" value="SELECT 1， 2，3 FROM DUAL" db-types="Oracle"  />
     <sql-case id="select_with_chinese_whitespace" value="SELECT 1， 2，3 FROM　DUAL" db-types="Oracle"  />
     <sql-case id="select_with_auto_keyword" value="SELECT * FROM t_auto WHERE auto = ?" db-types="MySQL"/>
@@ -452,7 +452,7 @@
     <sql-case id="select_distinct_with_count_sql92" value="SELECT COUNT(DISTINCT order_id) c FROM t_order WHERE order_id &lt; 1100" db-types="SQL92" />
     <sql-case id="select_having_sql92" value="SELECT user_id, COUNT(*) AS cnt FROM t_order GROUP BY user_id HAVING COUNT(*) &gt; 1" db-types="SQL92" />
     <sql-case id="select_cast_int_sql92" value="SELECT CAST(user_id AS INT) FROM t_order" db-types="SQL92" />
-    <sql-case id="select_all_param_alias_schema_sql92" value="SELECT ALL ? AS &quot;aid&quot; FROM schema1.t_order WHERE (order_id = 1) OR active IS NULL" db-types="SQL92" />
+    <sql-case id="select_all_param_alias_schema_sql92" value="SELECT ALL ? AS &quot;aid&quot; FROM schema1.t_order WHERE (order_id = 1) OR active IS NULL" db-types="SQL92" case-types="PLACEHOLDER" />
     <sql-case id="select_like_between_and_sql92" value="SELECT status FROM t_order WHERE status LIKE '1%' AND order_id BETWEEN 1 AND 10" db-types="SQL92" />
     <sql-case id="select_where_is_null_sql92" value="SELECT * FROM t_order WHERE status IS NULL" db-types="SQL92" />
     <sql-case id="select_safe_eq_sql92" value="SELECT order_id FROM t_order WHERE order_id &lt;=&gt; 1" db-types="SQL92" />


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix wrong parameter index parse in MySQL, Doris

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
