### PR TITLE
Remove the useless constructor of ShardingSphereDatabase

### DIFF
--- a/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/exporter/impl/jdbc/JDBCMetaDataInfoExporterTest.java
+++ b/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/exporter/impl/jdbc/JDBCMetaDataInfoExporterTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.agent.plugin.metrics.core.exporter.impl.jdbc;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.agent.plugin.core.context.ShardingSphereDataSourceContext;
 import org.apache.shardingsphere.agent.plugin.core.holder.ShardingSphereDataSourceContextHolder;
 import org.apache.shardingsphere.agent.plugin.metrics.core.collector.MetricsCollectorRegistry;
@@ -24,9 +26,11 @@ import org.apache.shardingsphere.agent.plugin.metrics.core.collector.type.GaugeM
 import org.apache.shardingsphere.agent.plugin.metrics.core.config.MetricCollectorType;
 import org.apache.shardingsphere.agent.plugin.metrics.core.config.MetricConfiguration;
 import org.apache.shardingsphere.agent.plugin.metrics.core.fixture.collector.MetricsCollectorFixture;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
+import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -60,9 +65,15 @@ class JDBCMetaDataInfoExporterTest {
     
     private ContextManager mockContextManager(final String instanceId, final String databaseName) {
         ResourceMetaData resourceMetaData = mock(ResourceMetaData.class);
-        when(resourceMetaData.getStorageUnits()).thenReturn(Collections.singletonMap("ds_0", mock(StorageUnit.class)));
+        DatabaseType databaseType = mock(DatabaseType.class);
+        StorageUnit storageUnit = mock(StorageUnit.class);
+        when(storageUnit.getStorageType()).thenReturn(databaseType);
+        when(resourceMetaData.getStorageUnits()).thenReturn(Collections.singletonMap("ds_0", storageUnit));
         ContextManager result = mock(ContextManager.class, RETURNS_DEEP_STUBS);
-        when(result.getDatabase(databaseName)).thenReturn(new ShardingSphereDatabase(databaseName, mock(), resourceMetaData, mock(), Collections.emptyList()));
+        RuleMetaData ruleMetaData = mock(RuleMetaData.class);
+        ShardingSphereDatabase database = new ShardingSphereDatabase(databaseName, databaseType, resourceMetaData, ruleMetaData,
+                Collections.emptyList(), new ConfigurationProperties(new Properties()));
+        when(result.getDatabase(databaseName)).thenReturn(database);
         when(result.getComputeNodeInstanceContext().getInstance().getMetaData().getId()).thenReturn(instanceId);
         return result;
     }

--- a/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/exporter/impl/jdbc/JDBCStateExporterTest.java
+++ b/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/exporter/impl/jdbc/JDBCStateExporterTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.agent.plugin.metrics.core.exporter.impl.jdbc;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.agent.plugin.core.context.ShardingSphereDataSourceContext;
 import org.apache.shardingsphere.agent.plugin.core.holder.ShardingSphereDataSourceContextHolder;
 import org.apache.shardingsphere.agent.plugin.metrics.core.collector.MetricsCollectorRegistry;
@@ -34,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -58,7 +61,7 @@ class JDBCStateExporterTest {
     
     private ContextManager mockContextManager(final String instanceId, final String databaseName) {
         ContextManager result = mock(ContextManager.class, RETURNS_DEEP_STUBS);
-        ShardingSphereDatabase database = new ShardingSphereDatabase(databaseName, mock(), mock(), mock(), Collections.emptyList());
+        ShardingSphereDatabase database = new ShardingSphereDatabase(databaseName, mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         when(result.getDatabase(databaseName)).thenReturn(database);
         when(result.getComputeNodeInstanceContext().getInstance().getMetaData().getId()).thenReturn(instanceId);
         when(result.getComputeNodeInstanceContext().getInstance().getState().getCurrentState().ordinal()).thenReturn(InstanceState.OK.ordinal());

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResultTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResultTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.encrypt.merge.dql;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.encrypt.exception.data.DecryptFailedException;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.column.EncryptColumn;
@@ -48,6 +50,7 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.apache.shardingsphere.test.infra.framework.matcher.ShardingSphereArgumentVerifyMatchers.deepEq;
 import static org.hamcrest.Matchers.is;
@@ -87,7 +90,8 @@ class EncryptMergedResultTest {
         ColumnSegmentBoundInfo columnSegmentBoundInfo = new ColumnSegmentBoundInfo(new IdentifierValue("foo_col"));
         when(selectStatementContext.findColumnBoundInfo(1)).thenReturn(Optional.of(columnSegmentBoundInfo));
         EncryptRule rule = mockRule(mock(EncryptAlgorithm.class));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         when(mergedResult.getValue(1, String.class)).thenReturn("foo_value");
         assertThat(new EncryptMergedResult(database, mock(), selectStatementContext, mergedResult).getValue(1, String.class), is("foo_value"));
     }
@@ -97,7 +101,8 @@ class EncryptMergedResultTest {
         ColumnSegmentBoundInfo columnSegmentBoundInfo = new ColumnSegmentBoundInfo(new IdentifierValue("bar_col"));
         when(selectStatementContext.findColumnBoundInfo(1)).thenReturn(Optional.of(columnSegmentBoundInfo));
         EncryptRule rule = mockRule(mock(EncryptAlgorithm.class));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         when(mergedResult.getValue(1, String.class)).thenReturn("foo_value");
         assertThat(new EncryptMergedResult(database, mock(), selectStatementContext, mergedResult).getValue(1, String.class), is("foo_value"));
     }
@@ -112,7 +117,8 @@ class EncryptMergedResultTest {
         EncryptAlgorithm encryptAlgorithm = mock(EncryptAlgorithm.class);
         when(encryptAlgorithm.decrypt(eq("foo_value"), deepEq(new AlgorithmSQLContext("foo_db", "foo_schema", "foo_tbl", "foo_col")))).thenReturn("foo_decrypted_value");
         EncryptRule rule = mockRule(encryptAlgorithm);
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock());
         when(mergedResult.getValue(1, Object.class)).thenReturn("foo_value");
         assertThat(new EncryptMergedResult(database, metaData, selectStatementContext, mergedResult).getValue(1, String.class), is("foo_decrypted_value"));
@@ -128,7 +134,8 @@ class EncryptMergedResultTest {
         EncryptAlgorithm encryptAlgorithm = mock(EncryptAlgorithm.class);
         when(encryptAlgorithm.decrypt(eq("foo_value"), deepEq(new AlgorithmSQLContext("foo_db", "foo_schema", "foo_tbl", "foo_col")))).thenThrow(new RuntimeException("Test failed"));
         EncryptRule rule = mockRule(encryptAlgorithm);
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock());
         when(mergedResult.getValue(1, Object.class)).thenReturn("foo_value");
         assertThrows(DecryptFailedException.class, () -> new EncryptMergedResult(database, metaData, selectStatementContext, mergedResult).getValue(1, String.class));

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/insert/EncryptInsertValuesTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/insert/EncryptInsertValuesTokenGeneratorTest.java
@@ -57,7 +57,8 @@ class EncryptInsertValuesTokenGeneratorTest {
     
     @BeforeEach
     void setup() {
-        generator = new EncryptInsertValuesTokenGenerator(EncryptGeneratorFixtureBuilder.createEncryptRule(), new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()));
+        generator = new EncryptInsertValuesTokenGenerator(EncryptGeneratorFixtureBuilder.createEncryptRule(),
+                new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())));
     }
     
     @Test

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateValueTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateValueTokenGeneratorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.token.generator.predicate;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.encrypt.rewrite.condition.EncryptCondition;
 import org.apache.shardingsphere.encrypt.rewrite.condition.EncryptConditionEngine;
 import org.apache.shardingsphere.encrypt.rewrite.token.generator.fixture.EncryptGeneratorFixtureBuilder;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -40,7 +43,7 @@ class EncryptPredicateValueTokenGeneratorTest {
         UpdateStatementContext updateStatementContext = EncryptGeneratorFixtureBuilder.createUpdateStatementContext();
         Collection<EncryptCondition> encryptConditions = getEncryptConditions(updateStatementContext);
         EncryptPredicateValueTokenGenerator generator = new EncryptPredicateValueTokenGenerator(EncryptGeneratorFixtureBuilder.createEncryptRule(),
-                new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), encryptConditions);
+                new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())), encryptConditions);
         assertTrue(generator.isGenerateSQLToken(updateStatementContext));
     }
     
@@ -48,7 +51,7 @@ class EncryptPredicateValueTokenGeneratorTest {
     void assertGenerateSQLTokenFromGenerateNewSQLToken() {
         UpdateStatementContext updateStatementContext = EncryptGeneratorFixtureBuilder.createUpdateStatementContext();
         EncryptPredicateValueTokenGenerator generator = new EncryptPredicateValueTokenGenerator(EncryptGeneratorFixtureBuilder.createEncryptRule(),
-                new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), getEncryptConditions(updateStatementContext));
+                new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())), getEncryptConditions(updateStatementContext));
         Collection<SQLToken> sqlTokens = generator.generateSQLTokens(updateStatementContext);
         assertThat(sqlTokens.size(), is(1));
         assertThat(sqlTokens.iterator().next().toString(), is("'assistedEncryptValue'"));

--- a/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleExecutorTest.java
+++ b/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.encrypt.distsql.handler.update;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine;
 import org.apache.shardingsphere.distsql.segment.AlgorithmSegment;
 import org.apache.shardingsphere.encrypt.config.EncryptRuleConfiguration;
@@ -29,6 +31,7 @@ import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.InvalidRuleConfigurationException;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.MissingRequiredRuleException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.mode.persist.service.MetaDataManagerPersistService;
@@ -109,7 +112,12 @@ class AlterEncryptRuleExecutorTest {
     
     private ContextManager mockContextManager(final EncryptRule rule) {
         ContextManager result = mock(ContextManager.class, RETURNS_DEEP_STUBS);
-        when(result.getDatabase("foo_db")).thenReturn(new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList()));
+        DatabaseType databaseType = mock(DatabaseType.class);
+        ResourceMetaData resourceMetaData = mock(ResourceMetaData.class);
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, new RuleMetaData(Collections.singleton(rule)), Collections.emptyList(),
+                        new ConfigurationProperties(new Properties()));
+        when(result.getDatabase("foo_db")).thenReturn(database);
         return result;
     }
     

--- a/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/DropEncryptRuleExecutorTest.java
+++ b/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/DropEncryptRuleExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.encrypt.distsql.handler.update;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine;
 import org.apache.shardingsphere.encrypt.config.EncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.config.rule.EncryptColumnItemRuleConfiguration;
@@ -138,7 +140,8 @@ class DropEncryptRuleExecutorTest {
     
     private ContextManager mockContextManager(final EncryptRule rule) {
         ContextManager result = mock(ContextManager.class, RETURNS_DEEP_STUBS);
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         when(result.getDatabase("foo_db")).thenReturn(database);
         return result;
     }

--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/DropMaskRuleExecutorTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/update/DropMaskRuleExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mask.distsql.handler.update;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecuteEngine;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.MissingRequiredRuleException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -34,6 +36,7 @@ import org.mockito.ArgumentMatchers;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -99,7 +102,8 @@ class DropMaskRuleExecutorTest {
     }
     
     private ContextManager mockContextManager(final MaskRule rule) {
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", mock(), mock(), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         ContextManager result = mock(ContextManager.class, RETURNS_DEEP_STUBS);
         when(result.getDatabase("foo_db")).thenReturn(database);
         return result;

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/route/ReadwriteSplittingSQLRouterTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/route/ReadwriteSplittingSQLRouterTest.java
@@ -82,7 +82,8 @@ class ReadwriteSplittingSQLRouterTest {
         RouteContext routeContext = mockRouteContext();
         QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(staticRule));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(), mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", mock(), mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         sqlRouter.decorateRouteContext(routeContext, queryContext, database, staticRule, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         List<String> routedDataSourceNames = new ArrayList<>(routeContext.getActualDataSourceNames());
         assertThat(routedDataSourceNames.get(0), is("noneReadwriteSplittingDataSource"));
@@ -98,7 +99,8 @@ class ReadwriteSplittingSQLRouterTest {
         when(connectionContext.getTransactionContext()).thenReturn(mock(TransactionConnectionContext.class));
         QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), connectionContext, mock(ShardingSphereMetaData.class));
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(staticRule));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(), mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", mock(), mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         RouteContext routeContext = mockRouteContext();
         sqlRouter.decorateRouteContext(routeContext, queryContext, database, staticRule, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         assertThat(routeContext.getActualDataSourceNames(), is(new HashSet<>(Arrays.asList("noneReadwriteSplittingDataSource", "read"))));
@@ -112,7 +114,8 @@ class ReadwriteSplittingSQLRouterTest {
         when(sqlStatementContext.getSqlStatement()).thenReturn(selectStatement);
         QueryContext queryContext = new QueryContext(sqlStatementContext, "", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(staticRule));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(), mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", mock(), mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         sqlRouter.decorateRouteContext(routeContext, queryContext, database, staticRule, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         List<String> routedDataSourceNames = new ArrayList<>(routeContext.getActualDataSourceNames());
         assertThat(routedDataSourceNames.get(0), is("noneReadwriteSplittingDataSource"));

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/cache/checker/ShardingRouteCacheableCheckerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/cache/checker/ShardingRouteCacheableCheckerTest.java
@@ -147,7 +147,8 @@ class ShardingRouteCacheableCheckerTest {
                 new ShardingSphereColumn("id", Types.INTEGER, false, false, false, true, false, false)),
                 Collections.emptyList(), Collections.emptyList()));
         return new ShardingSphereDatabase(DATABASE_NAME, databaseType,
-                new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Arrays.asList(shardingRule, timestampServiceRule)), Collections.singleton(schema));
+                new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Arrays.asList(shardingRule, timestampServiceRule)), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
     }
     
     private QueryContext createQueryContext(final ShardingSphereDatabase database, final String sql, final List<Object> params) {

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.sharding.merge.dql;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
@@ -66,6 +68,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
@@ -491,13 +494,15 @@ class ShardingDQLResultMergerTest {
     
     private ShardingSphereDatabase createDatabase() {
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_db", mysqlDatabaseType, Collections.singleton(createTable()), Collections.emptyList());
-        return new ShardingSphereDatabase("foo_db", mysqlDatabaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.singleton(schema));
+        return new ShardingSphereDatabase("foo_db", mysqlDatabaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
     }
     
     private ShardingSphereDatabase createSQLServerDatabase() {
         ShardingSphereSchema schema = new ShardingSphereSchema("dbo", sqlserverDatabaseType, Collections.singleton(createTable()), Collections.emptyList());
         return new ShardingSphereDatabase(
-                "foo_db", TypedSPILoader.getService(DatabaseType.class, "SQLServer"), mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.singleton(schema));
+                "foo_db", TypedSPILoader.getService(DatabaseType.class, "SQLServer"), mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
     }
     
     private ShardingSphereTable createTable() {

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResultTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResultTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.sharding.merge.dql.groupby;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
@@ -51,6 +53,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -187,7 +190,7 @@ class GroupByStreamMergedResultTest {
         ShardingSphereColumn column3 = new ShardingSphereColumn("col3", 0, false, false, false, true, false, false);
         ShardingSphereTable table = new ShardingSphereTable("tbl", Arrays.asList(column1, column2, column3), Collections.emptyList(), Collections.emptyList());
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_db", databaseType, Collections.singleton(table), Collections.emptyList());
-        return new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.singleton(schema));
+        return new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.singleton(schema), new ConfigurationProperties(new Properties()));
     }
     
     private QueryResult mockQueryResult() throws SQLException {

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/orderby/OrderByStreamMergedResultTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/orderby/OrderByStreamMergedResultTest.java
@@ -49,6 +49,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -208,6 +209,6 @@ class OrderByStreamMergedResultTest {
         ShardingSphereColumn column2 = new ShardingSphereColumn("col2", 0, false, false, false, true, false, false);
         ShardingSphereTable table = new ShardingSphereTable("tbl", Arrays.asList(column1, column2), Collections.emptyList(), Collections.emptyList());
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_db", databaseType, Collections.singleton(table), Collections.emptyList());
-        return new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.singleton(schema));
+        return new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.singleton(schema), new ConfigurationProperties(new Properties()));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRouteEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRouteEngineTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.sharding.route.engine.type.broadcast;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.groovy.util.Maps;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstanceContext;
@@ -44,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -90,7 +93,8 @@ class ShardingTableBroadcastRouteEngineTest {
         when(schema.getTable(anyString()).containsIndex(anyString())).thenReturn(true);
         IndexSegment segment = new IndexSegment(0, 0, new IndexNameSegment(0, 0, indexName));
         DropIndexStatement sqlStatement = DropIndexStatement.builder().databaseType(databaseType).indexes(Collections.singleton(segment)).build();
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.singleton(schema));
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
         ShardingTableBroadcastRouteEngine shardingTableBroadcastRouteEngine = new ShardingTableBroadcastRouteEngine(database, sqlStatement, Collections.emptyList());
         RouteContext routeContext = shardingTableBroadcastRouteEngine.route(createShardingRule());
         assertThat(routeContext.getActualDataSourceNames().size(), is(2));
@@ -107,7 +111,8 @@ class ShardingTableBroadcastRouteEngineTest {
         when(schema.getName()).thenReturn("foo_db");
         when(schema.getTable(anyString()).containsIndex(anyString())).thenReturn(false);
         DropIndexStatement sqlStatement = DropIndexStatement.builder().databaseType(databaseType).build();
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.singleton(schema));
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
         ShardingTableBroadcastRouteEngine shardingTableBroadcastRouteEngine = new ShardingTableBroadcastRouteEngine(database, sqlStatement, Collections.emptyList());
         RouteContext routeContext = shardingTableBroadcastRouteEngine.route(createShardingRule());
         assertRouteUnitWithoutTables(routeContext);

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/assertion/ShardingRouteAssert.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/assertion/ShardingRouteAssert.java
@@ -85,7 +85,8 @@ public final class ShardingRouteAssert {
         when(ruleAttribute.getDistributedTableNames()).thenReturn(Collections.singleton("t_product"));
         when(broadcastRule.getAttributes().findAttribute(TableMapperRuleAttribute.class)).thenReturn(Optional.of(ruleAttribute));
         RuleMetaData ruleMetaData = new RuleMetaData(Arrays.asList(shardingRule, broadcastRule, singleRule, timestampServiceRule));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, buildSchemas());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, buildSchemas(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock());
         SQLStatementContext sqlStatementContext = new SQLBindEngine(metaData, "foo_db", new HintValueContext()).bind(sqlParserEngine.parse(sql, false));
         ConnectionContext connectionContext = new ConnectionContext(Collections::emptySet);
@@ -114,7 +115,8 @@ public final class ShardingRouteAssert {
         when(ruleAttribute.getDistributedTableNames()).thenReturn(Collections.singleton("t_product"));
         when(broadcastRule.getAttributes().findAttribute(TableMapperRuleAttribute.class)).thenReturn(Optional.of(ruleAttribute));
         RuleMetaData ruleMetaData = new RuleMetaData(Arrays.asList(shardingRule, broadcastRule, singleRule, timestampServiceRule));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, buildSchemas());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), ruleMetaData, buildSchemas(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock());
         SQLStatementContext sqlStatementContext = new SQLBindEngine(metaData, "foo_db", new HintValueContext()).bind(sqlParserEngine.parse(sql, false));
         ConnectionContext connectionContext = new ConnectionContext(Collections::emptySet);

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/pagination/PaginationContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/pagination/PaginationContextTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.infra.binder.context.segment.select.pagination;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
@@ -38,6 +40,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -151,7 +154,7 @@ class PaginationContextTest {
     @Test
     void assertGetRevisedRowCount() {
         SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0)).build();
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList());
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock());
         SelectStatementContext selectStatementContext = new SelectStatementContext(selectStatement, metaData, "foo_db", Collections.emptyList());
         assertThat(new PaginationContext(getOffsetSegment(), getRowCountSegment(), getParameters()).getRevisedRowCount(selectStatementContext), is(50L));
@@ -162,7 +165,7 @@ class PaginationContextTest {
         SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(new ProjectionsSegment(0, 0))
                 .groupBy(new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.ASC, NullsOrderType.LAST))))
                 .orderBy(new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 1, OrderDirection.DESC, NullsOrderType.LAST)))).build();
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList());
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock());
         SelectStatementContext selectStatementContext = new SelectStatementContext(selectStatement, metaData, "foo_db", Collections.emptyList());
         assertThat(new PaginationContext(getOffsetSegment(), getRowCountSegment(), getParameters()).getRevisedRowCount(selectStatementContext), is((long) Integer.MAX_VALUE));

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/InsertStatementContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/InsertStatementContextTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.infra.binder.context.statement.type.dml;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -51,6 +53,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -86,7 +89,7 @@ class InsertStatementContextTest {
         ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
         when(schema.getName()).thenReturn("foo_db");
         when(schema.getVisibleColumnNames(new IdentifierValue("tbl"))).thenReturn(Arrays.asList("id", "name", "status"));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.singleton(schema));
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.singleton(schema), new ConfigurationProperties(new Properties()));
         return new InsertStatementContext(insertStatement, new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock()), "foo_db");
     }
     

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabase.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabase.java
@@ -70,24 +70,6 @@ public final class ShardingSphereDatabase {
     private final IdentifierIndex<ShardingSphereSchema> schemaIndex;
     
     /**
-     * Construct database through the legacy compatibility path.
-     *
-     * <p>This constructor keeps existing callers and tests working until all database creation paths pass protocol-aware identifier rules explicitly.</p>
-     *
-     * <p>TODO(haoran): Remove this constructor after all metadata builders and tests migrate to the protocol-aware constructor.</p>
-     *
-     * @param name database name
-     * @param protocolType protocol type
-     * @param resourceMetaData resource meta data
-     * @param ruleMetaData rule meta data
-     * @param schemas schemas
-     */
-    public ShardingSphereDatabase(final String name, final DatabaseType protocolType, final ResourceMetaData resourceMetaData,
-                                  final RuleMetaData ruleMetaData, final Collection<ShardingSphereSchema> schemas) {
-        this(name, protocolType, resourceMetaData, ruleMetaData, schemas, DatabaseIdentifierContextFactory.createDefault());
-    }
-    
-    /**
      * Construct database with protocol-aware identifier rules.
      *
      * @param name database name

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseIdentifierTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseIdentifierTest.java
@@ -115,9 +115,9 @@ class ShardingSphereDatabaseIdentifierTest {
     }
     
     @Test
-    void assertLegacyConstructorUsesInsensitiveLookup() {
+    void assertDefaultPropsUseInsensitiveLookup() {
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", postgreSQLDatabaseType, createResourceMetaData(),
-                new RuleMetaData(Collections.emptyList()), Collections.singleton(createSchema("foo_schema", postgreSQLDatabaseType)));
+                new RuleMetaData(Collections.emptyList()), Collections.singleton(createSchema("foo_schema", postgreSQLDatabaseType)), new ConfigurationProperties(new Properties()));
         assertTrue(database.containsSchema("FOO_SCHEMA"));
     }
     

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
+import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -83,7 +84,8 @@ class ShardingSphereDatabaseTest {
     @Test
     void assertGetAllSchemas() {
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.singleton(new ShardingSphereSchema("foo_schema", databaseType)));
+                "foo_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.singleton(new ShardingSphereSchema("foo_schema", databaseType)),
+                new ConfigurationProperties(new Properties()));
         List<ShardingSphereSchema> actualSchemas = new LinkedList<>(database.getAllSchemas());
         assertThat(actualSchemas.size(), is(1));
         assertThat(actualSchemas.get(0).getName(), is("foo_schema"));
@@ -93,7 +95,8 @@ class ShardingSphereDatabaseTest {
     @MethodSource("containsSchemaArguments")
     void assertContainsSchema(final String name, final String schemaName, final boolean expectedContainsSchema) {
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.singleton(new ShardingSphereSchema("foo_schema", databaseType)));
+                "foo_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.singleton(new ShardingSphereSchema("foo_schema", databaseType)),
+                new ConfigurationProperties(new Properties()));
         assertThat(database.containsSchema(schemaName), is(expectedContainsSchema));
     }
     
@@ -101,7 +104,8 @@ class ShardingSphereDatabaseTest {
     @MethodSource("getSchemaArguments")
     void assertGetSchema(final String name, final String schemaName, final String expectedSchemaName) {
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.singleton(new ShardingSphereSchema("foo_schema", databaseType)));
+                "foo_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.singleton(new ShardingSphereSchema("foo_schema", databaseType)),
+                new ConfigurationProperties(new Properties()));
         ShardingSphereSchema actualSchema = database.getSchema(schemaName);
         if (null == expectedSchemaName) {
             assertNull(actualSchema);
@@ -112,7 +116,8 @@ class ShardingSphereDatabaseTest {
     
     @Test
     void assertAddSchema() {
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         ShardingSphereSchema schema = new ShardingSphereSchema("new_schema", databaseType);
         database.addSchema(schema);
         assertThat(database.getAllSchemas().size(), is(1));
@@ -123,7 +128,8 @@ class ShardingSphereDatabaseTest {
     @MethodSource("dropSchemaArguments")
     void assertDropSchema(final String name, final String schemaName, final boolean expectedSchemaRetained) {
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.singleton(new ShardingSphereSchema("foo_schema", databaseType)));
+                "foo_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.singleton(new ShardingSphereSchema("foo_schema", databaseType)),
+                new ConfigurationProperties(new Properties()));
         database.dropSchema(schemaName);
         assertThat(database.containsSchema("foo_schema"), is(expectedSchemaRetained));
     }
@@ -131,7 +137,7 @@ class ShardingSphereDatabaseTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("isCompleteArguments")
     void assertIsComplete(final String name, final ResourceMetaData resourceMetaData, final RuleMetaData ruleMetaData, final boolean expectedComplete) {
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, ruleMetaData, Collections.emptyList());
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, ruleMetaData, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         assertThat(database.isComplete(), is(expectedComplete));
     }
     
@@ -139,7 +145,8 @@ class ShardingSphereDatabaseTest {
     @MethodSource("containsDataSourceArguments")
     void assertContainsDataSource(final String name, final ResourceMetaData resourceMetaData, final boolean expectedContainsDataSource) {
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, resourceMetaData, new RuleMetaData(Collections.singleton(mock(ShardingSphereRule.class))), Collections.emptyList());
+                "foo_db", databaseType, resourceMetaData, new RuleMetaData(Collections.singleton(mock(ShardingSphereRule.class))), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         assertThat(database.containsDataSource(), is(expectedContainsDataSource));
     }
     
@@ -153,7 +160,8 @@ class ShardingSphereDatabaseTest {
         when(ruleAttribute.reloadRule(eq(ruleConfig), eq("foo_db"), anyMap(), anyCollection())).thenReturn(reloadedRule);
         RuleMetaData ruleMetaData = new RuleMetaData(Arrays.asList(mutableRule, immutableRule));
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource())), ruleMetaData, Collections.emptyList());
+                "foo_db", databaseType, new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource())), ruleMetaData, Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         database.reloadRules();
         Collection<ShardingSphereRule> actualRules = database.getRuleMetaData().getRules();
         assertThat(actualRules.size(), is(2));
@@ -168,7 +176,8 @@ class ShardingSphereDatabaseTest {
         ShardingSphereRule otherRule = createRule(mock(RuleConfiguration.class), new RuleAttributes());
         RuleMetaData ruleMetaData = new RuleMetaData(Arrays.asList(rule, otherRule));
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource())), ruleMetaData, Collections.emptyList());
+                "foo_db", databaseType, new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource())), ruleMetaData, Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         database.reloadRules();
         Collection<ShardingSphereRule> actualRules = database.getRuleMetaData().getRules();
         assertThat(actualRules.size(), is(2));
@@ -181,7 +190,8 @@ class ShardingSphereDatabaseTest {
         DataSourceMapperRuleAttribute ruleAttribute = mock(DataSourceMapperRuleAttribute.class);
         when(ruleAttribute.getDataSourceMapper()).thenReturn(Collections.singletonMap("logic_ds", Collections.singleton("actual_ds")));
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), createRuleMetaData(ruleAttribute), Collections.emptyList());
+                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), createRuleMetaData(ruleAttribute), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         assertDoesNotThrow(() -> database.checkStorageUnitsExisted(Collections.singleton("logic_ds")));
     }
     
@@ -190,7 +200,8 @@ class ShardingSphereDatabaseTest {
         DataSourceMapperRuleAttribute ruleAttribute = mock(DataSourceMapperRuleAttribute.class);
         when(ruleAttribute.getDataSourceMapper()).thenReturn(Collections.singletonMap("logic_ds", Collections.singleton("actual_ds")));
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), createRuleMetaData(ruleAttribute), Collections.emptyList());
+                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), createRuleMetaData(ruleAttribute), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         MissingRequiredStorageUnitsException ex = assertThrows(MissingRequiredStorageUnitsException.class, () -> database.checkStorageUnitsExisted(Collections.singleton("missing_ds")));
         assertThat(ex.getMessage(), is("Storage units 'missing_ds' do not exist in database 'foo_db'."));
     }
@@ -207,7 +218,8 @@ class ShardingSphereDatabaseTest {
     void assertRefreshIdentifierContext() {
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_schema", databaseType);
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema));
+                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
         database.refreshIdentifierContext(new ConfigurationProperties(
                 PropertiesBuilder.build(new Property(ConfigurationPropertyKey.METADATA_IDENTIFIER_CASE_SENSITIVITY.getKey(), MetadataIdentifierCaseSensitivity.SENSITIVE.name()))));
         DatabaseIdentifierContext actualIdentifierContext = getIdentifierContext(database);
@@ -229,7 +241,8 @@ class ShardingSphereDatabaseTest {
     void assertDecorateRuleConfiguration() {
         RuleConfiguration ruleConfig = mock(RuleConfiguration.class);
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.singleton(mock())), Collections.emptyList());
+                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.singleton(mock())), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         try (MockedStatic<TypedSPILoader> mockedTypedSPILoader = mockStatic(TypedSPILoader.class)) {
             mockedTypedSPILoader.when(() -> TypedSPILoader.findService(RuleConfigurationDecorator.class, ruleConfig.getClass())).thenReturn(Optional.empty());
             RuleConfiguration actualRuleConfig = database.decorateRuleConfiguration(ruleConfig);
@@ -245,7 +258,8 @@ class ShardingSphereDatabaseTest {
         RuleConfiguration decoratedRuleConfig = mock(RuleConfiguration.class);
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(mock(ShardingSphereRule.class)));
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource())), ruleMetaData, Collections.emptyList());
+                "foo_db", databaseType, new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource())), ruleMetaData, Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         try (MockedStatic<TypedSPILoader> mockedTypedSPILoader = mockStatic(TypedSPILoader.class)) {
             mockedTypedSPILoader.when(() -> TypedSPILoader.findService(RuleConfigurationDecorator.class, ruleConfig.getClass())).thenReturn(Optional.of(decorator));
             when(decorator.decorate(eq("foo_db"), anyMap(), eq(ruleMetaData.getRules()), eq(ruleConfig))).thenReturn(decoratedRuleConfig);
@@ -257,7 +271,8 @@ class ShardingSphereDatabaseTest {
     @Test
     void assertGetDefaultSchemaName() {
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         try (
                 MockedConstruction<DatabaseTypeRegistry> mockedConstruction = mockConstruction(DatabaseTypeRegistry.class,
                         (mock, context) -> when(mock.getDefaultSchemaName("foo_db")).thenReturn("foo_schema"))) {

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/IndexMetaDataUtilsTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/IndexMetaDataUtilsTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.infra.metadata.database.schema.util;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
@@ -33,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -78,6 +81,6 @@ class IndexMetaDataUtilsTest {
         ShardingSphereTable table = new ShardingSphereTable(
                 "foo_tbl", Collections.emptyList(), Collections.singleton(new ShardingSphereIndex("foo_idx", Collections.emptyList(), false)), Collections.emptyList());
         Collection<ShardingSphereSchema> schemas = Collections.singleton(new ShardingSphereSchema("foo_db", mock(DatabaseType.class), Collections.singleton(table), Collections.emptyList()));
-        return new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), mock(ResourceMetaData.class), mock(RuleMetaData.class), schemas);
+        return new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), mock(ResourceMetaData.class), mock(RuleMetaData.class), schemas, new ConfigurationProperties(new Properties()));
     }
 }

--- a/infra/context/src/test/java/org/apache/shardingsphere/infra/connection/kernel/KernelProcessorTest.java
+++ b/infra/context/src/test/java/org/apache/shardingsphere/infra/connection/kernel/KernelProcessorTest.java
@@ -121,7 +121,8 @@ class KernelProcessorTest {
         when(resourceMetaData.getStorageUnits()).thenReturn(Collections.singletonMap("ds_0", mock(StorageUnit.class, RETURNS_DEEP_STUBS)));
         when(metaData.containsDatabase("foo_db")).thenReturn(true);
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, resourceMetaData, new RuleMetaData(Arrays.asList(mockSQLTranslatorRule(), mockAggregatedDataSourceRule())), Collections.emptyList());
+                "foo_db", databaseType, resourceMetaData, new RuleMetaData(Arrays.asList(mockSQLTranslatorRule(), mockAggregatedDataSourceRule())), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         when(metaData.getDatabase("foo_db")).thenReturn(database);
         when(metaData.getProps()).thenReturn(new ConfigurationProperties(new Properties()));
         SQLStatementContext sqlStatementContext = new CommonSQLStatementContext(SelectStatement.builder().databaseType(databaseType).build());

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/context/ExecutionContextBuilderTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/context/ExecutionContextBuilderTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.infra.executor.sql.context;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -41,6 +43,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -67,7 +70,7 @@ class ExecutionContextBuilderTest {
         String firstDataSourceName = "firstDataSourceName";
         when(resourceMetaData.getAllInstanceDataSourceNames()).thenReturn(Arrays.asList(firstDataSourceName, "lastDataSourceName"));
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.emptyList());
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, buildSchemas());
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, buildSchemas(), new ConfigurationProperties(new Properties()));
         SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getTablesContext().getDatabaseNames()).thenReturn(Collections.emptyList());
         Collection<ExecutionUnit> actual = ExecutionContextBuilder.build(database, genericSQLRewriteResult, sqlStatementContext);
@@ -83,7 +86,7 @@ class ExecutionContextBuilderTest {
         String firstDataSourceName = "firstDataSourceName";
         when(resourceMetaData.getAllInstanceDataSourceNames()).thenReturn(Arrays.asList(firstDataSourceName, "lastDataSourceName"));
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.emptyList());
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, buildSchemas());
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, buildSchemas(), new ConfigurationProperties(new Properties()));
         SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
         Collection<ExecutionUnit> actual = ExecutionContextBuilder.build(database, genericSQLRewriteResult, sqlStatementContext);
         Collection<ExecutionUnit> expected = Collections.singletonList(new ExecutionUnit(firstDataSourceName, new SQLUnit(sql, Collections.singletonList("foo_param"))));
@@ -94,7 +97,7 @@ class ExecutionContextBuilderTest {
     void assertBuildRouteSQLRewriteResult() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.emptyMap());
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.emptyList());
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, buildSchemas());
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, buildSchemas(), new ConfigurationProperties(new Properties()));
         Collection<ExecutionUnit> actual = ExecutionContextBuilder.build(database, new RouteSQLRewriteResult(createRouteUnitSQLRewriteUnitMap()), mock(SQLStatementContext.class));
         ExecutionUnit expectedUnit1 = new ExecutionUnit("actual_db_1", new SQLUnit("sql1", Collections.singletonList("parameter1")));
         ExecutionUnit expectedUnit2 = new ExecutionUnit("actual_db_2", new SQLUnit("sql2", Collections.singletonList("parameter2")));
@@ -123,7 +126,8 @@ class ExecutionContextBuilderTest {
         sqlRewriteUnits.put(routeUnit2, sqlRewriteUnit2);
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.emptyMap());
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.emptyList());
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, buildSchemasWithoutPrimaryKey());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, ruleMetaData, buildSchemasWithoutPrimaryKey(), new ConfigurationProperties(new Properties()));
         Collection<ExecutionUnit> actual = ExecutionContextBuilder.build(database, new RouteSQLRewriteResult(sqlRewriteUnits), mock(SQLStatementContext.class));
         ExecutionUnit expectedUnit2 = new ExecutionUnit("actualName2", new SQLUnit("sql2", Collections.singletonList("parameter2")));
         assertThat(actual, is(Collections.singleton(expectedUnit2)));

--- a/infra/rewrite/core/src/test/java/org/apache/shardingsphere/infra/rewrite/SQLRewriteEntryTest.java
+++ b/infra/rewrite/core/src/test/java/org/apache/shardingsphere/infra/rewrite/SQLRewriteEntryTest.java
@@ -61,7 +61,7 @@ class SQLRewriteEntryTest {
     @Test
     void assertRewriteForGenericSQLRewriteResult() {
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mockResourceMetaData(),
-                mock(RuleMetaData.class), Collections.singleton(new ShardingSphereSchema("test", mock(DatabaseType.class))));
+                mock(RuleMetaData.class), Collections.singleton(new ShardingSphereSchema("test", mock(DatabaseType.class))), new ConfigurationProperties(new Properties()));
         SQLRewriteEntry sqlRewriteEntry = new SQLRewriteEntry(
                 database, new RuleMetaData(Collections.singleton(new SQLTranslatorRule(new DefaultSQLTranslatorRuleConfigurationBuilder().build()))), new ConfigurationProperties(new Properties()));
         RouteContext routeContext = new RouteContext();
@@ -89,7 +89,8 @@ class SQLRewriteEntryTest {
     @Test
     void assertRewriteForRouteSQLRewriteResult() {
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, mockResourceMetaData(), mock(RuleMetaData.class), Collections.singleton(new ShardingSphereSchema("test", mock(DatabaseType.class))));
+                "foo_db", databaseType, mockResourceMetaData(), mock(RuleMetaData.class), Collections.singleton(new ShardingSphereSchema("test", mock(DatabaseType.class))),
+                new ConfigurationProperties(new Properties()));
         SQLTranslatorRule sqlTranslatorRule = mock(SQLTranslatorRule.class);
         when(sqlTranslatorRule.translate(any(), any(), any(), any(), any(), any())).thenReturn(Optional.of(new SQLTranslatorContext("", Collections.emptyList())));
         SQLRewriteEntry sqlRewriteEntry = new SQLRewriteEntry(database, new RuleMetaData(Collections.singleton(sqlTranslatorRule)), new ConfigurationProperties(new Properties()));

--- a/infra/rewrite/core/src/test/java/org/apache/shardingsphere/infra/rewrite/engine/GenericSQLRewriteEngineTest.java
+++ b/infra/rewrite/core/src/test/java/org/apache/shardingsphere/infra/rewrite/engine/GenericSQLRewriteEngineTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.infra.rewrite.engine;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
@@ -34,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -73,7 +76,7 @@ class GenericSQLRewriteEngineTest {
     void assertRewriteStorageTypeIsEmpty() {
         SQLTranslatorRule rule = new SQLTranslatorRule(new DefaultSQLTranslatorRuleConfigurationBuilder().build());
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(), new ResourceMetaData(Collections.emptyMap()), mock(),
-                Collections.singleton(new ShardingSphereSchema("test", mock(DatabaseType.class))));
+                Collections.singleton(new ShardingSphereSchema("test", mock(DatabaseType.class))), new ConfigurationProperties(new Properties()));
         SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getTablesContext().getDatabaseNames()).thenReturn(Collections.emptyList());
         DatabaseType databaseType = mock(DatabaseType.class);

--- a/kernel/data-pipeline/scenario/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/CDCSchemaTableUtilsTest.java
+++ b/kernel/data-pipeline/scenario/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/CDCSchemaTableUtilsTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.data.pipeline.cdc.util;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.SchemaTable;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.TableNotFoundException;
@@ -35,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -51,7 +54,8 @@ class CDCSchemaTableUtilsTest {
         ShardingSphereSchema publicSchema = mockSchema("public", "t_order", "t_order_item");
         ShardingSphereSchema testSchema = mockSchema("test", "t_test");
         ShardingSphereSchema systemSchema = mockSchema("pg_catalog", "t_pg");
-        ShardingSphereDatabase database = new ShardingSphereDatabase("sharding_db", databaseType, null, null, Arrays.asList(publicSchema, testSchema, systemSchema));
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("sharding_db", databaseType, null, null, Arrays.asList(publicSchema, testSchema, systemSchema), new ConfigurationProperties(new Properties()));
         List<SchemaTable> schemaTables = Collections.singletonList(SchemaTable.newBuilder().setSchema("*").setTable("*").build());
         Map<String, Set<String>> actualResult = CDCSchemaTableUtils.parseTableExpressionWithSchema(database, schemaTables);
         Map<String, Set<String>> expectedResult = new HashMap<>(2, 1F);
@@ -65,7 +69,8 @@ class CDCSchemaTableUtilsTest {
         ShardingSphereSchema analyticsSchema = mockSchema("analytics", "t_shared");
         ShardingSphereSchema auditSchema = mockSchema("audit", "t_other");
         ShardingSphereSchema systemSchema = mockSchema("pg_catalog", "t_shared");
-        ShardingSphereDatabase database = new ShardingSphereDatabase("sharding_db", databaseType, null, null, Arrays.asList(analyticsSchema, auditSchema, systemSchema));
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("sharding_db", databaseType, null, null, Arrays.asList(analyticsSchema, auditSchema, systemSchema), new ConfigurationProperties(new Properties()));
         List<SchemaTable> schemaTables = Collections.singletonList(SchemaTable.newBuilder().setSchema("*").setTable("t_shared").build());
         Map<String, Set<String>> actualResult = CDCSchemaTableUtils.parseTableExpressionWithSchema(database, schemaTables);
         Map<String, Set<String>> expectedResult = Collections.singletonMap("analytics", Collections.singleton("t_shared"));
@@ -75,7 +80,7 @@ class CDCSchemaTableUtilsTest {
     @Test
     void assertParseTableExpressionWithAllTablesInSchema() {
         ShardingSphereSchema publicSchema = mockSchema("public", "t_order", "t_order_item");
-        ShardingSphereDatabase database = new ShardingSphereDatabase("sharding_db", databaseType, null, null, Collections.singleton(publicSchema));
+        ShardingSphereDatabase database = new ShardingSphereDatabase("sharding_db", databaseType, null, null, Collections.singleton(publicSchema), new ConfigurationProperties(new Properties()));
         List<SchemaTable> schemaTables = Collections.singletonList(SchemaTable.newBuilder().setSchema("public").setTable("*").build());
         Map<String, Set<String>> actualResult = CDCSchemaTableUtils.parseTableExpressionWithSchema(database, schemaTables);
         Map<String, Set<String>> expectedResult = Collections.singletonMap("public", new HashSet<>(Arrays.asList("t_order", "t_order_item")));
@@ -85,7 +90,7 @@ class CDCSchemaTableUtilsTest {
     @Test
     void assertParseTableExpressionFillDefaultSchema() {
         ShardingSphereSchema publicSchema = mockSchema("public", "t_order");
-        ShardingSphereDatabase database = new ShardingSphereDatabase("sharding_db", databaseType, null, null, Collections.singleton(publicSchema));
+        ShardingSphereDatabase database = new ShardingSphereDatabase("sharding_db", databaseType, null, null, Collections.singleton(publicSchema), new ConfigurationProperties(new Properties()));
         List<SchemaTable> schemaTables = Collections.singletonList(SchemaTable.newBuilder().setTable("t_order").build());
         Map<String, Set<String>> actualResult = CDCSchemaTableUtils.parseTableExpressionWithSchema(database, schemaTables);
         Map<String, Set<String>> expectedResult = Collections.singletonMap("public", Collections.singleton("t_order"));
@@ -95,7 +100,7 @@ class CDCSchemaTableUtilsTest {
     @Test
     void assertParseTableExpressionWithMissingTable() {
         ShardingSphereSchema publicSchema = mockSchema("public", "t_exist");
-        ShardingSphereDatabase database = new ShardingSphereDatabase("sharding_db", databaseType, null, null, Collections.singleton(publicSchema));
+        ShardingSphereDatabase database = new ShardingSphereDatabase("sharding_db", databaseType, null, null, Collections.singleton(publicSchema), new ConfigurationProperties(new Properties()));
         List<SchemaTable> schemaTables = Collections.singletonList(SchemaTable.newBuilder().setSchema("public").setTable("t_missing").build());
         assertThrows(TableNotFoundException.class, () -> CDCSchemaTableUtils.parseTableExpressionWithSchema(database, schemaTables));
     }
@@ -103,12 +108,14 @@ class CDCSchemaTableUtilsTest {
     @Test
     void assertParseTableExpressionWithoutSchema() {
         ShardingSphereSchema publicSchema = mockSchema("public", "t_order", "t_order2");
-        ShardingSphereDatabase database = new ShardingSphereDatabase("public", TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), null, null, Collections.singleton(publicSchema));
+        ShardingSphereDatabase database = new ShardingSphereDatabase("public", TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), null, null, Collections.singleton(publicSchema),
+                new ConfigurationProperties(new Properties()));
         List<String> tableNames = Collections.singletonList("*");
         Collection<String> actualWildcardTable = CDCSchemaTableUtils.parseTableExpressionWithoutSchema(database, tableNames);
         Set<String> expectedWildcardTable = new HashSet<>(Arrays.asList("t_order", "t_order2"));
         assertThat(actualWildcardTable, is(expectedWildcardTable));
-        ShardingSphereDatabase databaseWithoutSchema = new ShardingSphereDatabase("missing", TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), null, null, Collections.emptyList());
+        ShardingSphereDatabase databaseWithoutSchema =
+                new ShardingSphereDatabase("missing", TypedSPILoader.getService(DatabaseType.class, "FIXTURE"), null, null, Collections.emptyList(), new ConfigurationProperties(new Properties()));
         List<String> singleTable = Collections.singletonList("t_order");
         Collection<String> actualTableNames = CDCSchemaTableUtils.parseTableExpressionWithoutSchema(databaseWithoutSchema, singleTable);
         Set<String> expectedTableNames = new HashSet<>(singleTable);

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/SingleSQLRouterTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/route/SingleSQLRouterTest.java
@@ -189,7 +189,7 @@ class SingleSQLRouterTest {
         SingleRule rule = new SingleRule(new SingleRuleConfiguration(),
                 "foo_db", databaseType, Collections.singletonMap("readwrite_ds", new MockedDataSource()), Collections.emptyList());
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db",
-                databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList());
+                databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), new RuleMetaData(Collections.singleton(rule)), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         singleSQLRouter.decorateRouteContext(routeContext, createQueryContext(), database, rule, Collections.singletonList("foo_tbl"), new ConfigurationProperties(new Properties()));
         assertThat(routeContext.getActualDataSourceNames().size(), is(1));
         assertTrue(Arrays.asList("write_ds", "readwrite_ds").contains(routeContext.getActualDataSourceNames().iterator().next()));

--- a/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/ShowSingleTablesExecutorTest.java
+++ b/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/ShowSingleTablesExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.single.distsql.handler.query;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.distsql.handler.engine.query.DistSQLQueryExecutor;
@@ -41,6 +43,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -58,7 +61,8 @@ class ShowSingleTablesExecutorTest {
     @Test
     void assertGetColumnNamesWithoutSchema() {
         executor.setDatabase(new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList()));
+                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                new ConfigurationProperties(new Properties())));
         assertThat(executor.getColumnNames(new ShowSingleTablesStatement(null, null)), is(Arrays.asList("table_name", "storage_unit_name")));
     }
     
@@ -68,7 +72,8 @@ class ShowSingleTablesExecutorTest {
                 MockedConstruction<DatabaseTypeRegistry> ignored = mockConstruction(DatabaseTypeRegistry.class, withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS),
                         (mock, context) -> when(mock.getDialectDatabaseMetaData().getSchemaOption().isSchemaAvailable()).thenReturn(true))) {
             executor.setDatabase(new ShardingSphereDatabase(
-                    "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList()));
+                    "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                    new ConfigurationProperties(new Properties())));
             assertThat(executor.getColumnNames(new ShowSingleTablesStatement(null, null)), is(Arrays.asList("table_name", "storage_unit_name", "schema_name")));
         }
     }
@@ -76,7 +81,8 @@ class ShowSingleTablesExecutorTest {
     @Test
     void assertGetRowsWithoutLikePattern() {
         executor.setDatabase(new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList()));
+                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                new ConfigurationProperties(new Properties())));
         Map<String, Collection<DataNode>> singleTableDataNodeMap = new HashMap<>(2, 1F);
         singleTableDataNodeMap.put("t_order_item", Collections.singleton(new DataNode("ds_2", (String) null, "t_order_item")));
         singleTableDataNodeMap.put("t_order", Collections.singleton(new DataNode("ds_1", (String) null, "t_order")));
@@ -95,7 +101,8 @@ class ShowSingleTablesExecutorTest {
                 MockedConstruction<DatabaseTypeRegistry> ignored = mockConstruction(DatabaseTypeRegistry.class, withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS),
                         (mock, context) -> when(mock.getDialectDatabaseMetaData().getSchemaOption().isSchemaAvailable()).thenReturn(true))) {
             executor.setDatabase(new ShardingSphereDatabase(
-                    "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList()));
+                    "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                    new ConfigurationProperties(new Properties())));
             Map<String, Collection<DataNode>> singleTableDataNodeMap = new HashMap<>(2, 1F);
             singleTableDataNodeMap.put("t_order", Collections.singleton(new DataNode("ds_1", "public", "t_order")));
             singleTableDataNodeMap.put("t_order_item", Collections.singleton(new DataNode("ds_2", "public", "t_order_item")));

--- a/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/context/schema/CalciteSchemaBuilderTest.java
+++ b/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/context/schema/CalciteSchemaBuilderTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.sqlfederation.compiler.context.schema;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
@@ -35,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
@@ -54,7 +57,7 @@ class CalciteSchemaBuilderTest {
     void assertBuildWithoutSchemas() {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
         ShardingSphereDatabase databaseWithoutSchemas = new ShardingSphereDatabase(
-                "empty_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+                "empty_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         CalciteSchemaBuilder.build(Collections.emptyList());
         CalciteSchema actual = CalciteSchemaBuilder.build(Collections.singleton(databaseWithoutSchemas));
         assertFalse(actual.getSubSchemaMap().containsKey("empty_db"));
@@ -65,7 +68,8 @@ class CalciteSchemaBuilderTest {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "PostgreSQL");
         Collection<ShardingSphereSchema> schemas = Arrays.asList(new ShardingSphereSchema("public", mock(DatabaseType.class)),
                 new ShardingSphereSchema("other", mock(DatabaseType.class)));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("pg_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), schemas);
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("pg_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), schemas, new ConfigurationProperties(new Properties()));
         DialectSQLFederationFunctionRegister functionRegister = mock(DialectSQLFederationFunctionRegister.class);
         try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class, CALLS_REAL_METHODS)) {
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(DialectSQLFederationFunctionRegister.class, databaseType))
@@ -85,7 +89,7 @@ class CalciteSchemaBuilderTest {
     void assertBuildWithoutDefaultSchemaRegistersFunctions() {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
         ShardingSphereDatabase database = new ShardingSphereDatabase("mysql_db", databaseType, mock(ResourceMetaData.class),
-                new RuleMetaData(Collections.emptyList()), Collections.singletonList(new ShardingSphereSchema("foo_schema", mock(DatabaseType.class))));
+                new RuleMetaData(Collections.emptyList()), Collections.singletonList(new ShardingSphereSchema("foo_schema", mock(DatabaseType.class))), new ConfigurationProperties(new Properties()));
         try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class, CALLS_REAL_METHODS)) {
             DialectSQLFederationFunctionRegister functionRegister = mock(DialectSQLFederationFunctionRegister.class);
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(DialectSQLFederationFunctionRegister.class, databaseType))

--- a/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/metadata/schema/SQLFederationDatabaseTest.java
+++ b/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/metadata/schema/SQLFederationDatabaseTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.sqlfederation.compiler.metadata.schema;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.Types;
 import java.util.Collections;
+import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -42,7 +45,8 @@ class SQLFederationDatabaseTest {
     @Test
     void assertNew() {
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_schema", databaseType, Collections.singleton(createTable()), Collections.emptyList());
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema));
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
         SQLFederationDatabase actual = new SQLFederationDatabase(database, databaseType);
         assertThat(actual.getName(), is("foo_db"));
         assertNotNull(actual.getSubSchemaMap().get("foo_schema"));

--- a/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/engine/SQLFederationEngineTest.java
+++ b/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/engine/SQLFederationEngineTest.java
@@ -150,7 +150,10 @@ class SQLFederationEngineTest {
         when(selectStatementContext.getTablesContext().getDatabaseNames()).thenReturn(Collections.singleton("foo_db"));
         QueryContext queryContext = mock(QueryContext.class);
         when(queryContext.getSqlStatementContext()).thenReturn(selectStatementContext);
-        when(queryContext.getUsedDatabase()).thenReturn(new ShardingSphereDatabase("foo_db", databaseType, mock(), new RuleMetaData(databaseRules), Collections.emptyList()));
+        ResourceMetaData resourceMetaData = mock(ResourceMetaData.class);
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, new RuleMetaData(databaseRules), Collections.emptyList(), new ConfigurationProperties(new Properties()));
+        when(queryContext.getUsedDatabase()).thenReturn(database);
         try (SQLFederationEngine engine = createSQLFederationEngine(globalRules, databaseRules)) {
             assertFalse(engine.decide(queryContext, new RuleMetaData(globalRules)));
         }
@@ -164,7 +167,10 @@ class SQLFederationEngineTest {
         when(selectStatementContext.getTablesContext().getDatabaseNames()).thenReturn(Collections.singleton("foo_db"));
         QueryContext queryContext = mock(QueryContext.class);
         when(queryContext.getSqlStatementContext()).thenReturn(selectStatementContext);
-        when(queryContext.getUsedDatabase()).thenReturn(new ShardingSphereDatabase("foo_db", databaseType, mock(), new RuleMetaData(databaseRules), Collections.emptyList()));
+        ResourceMetaData resourceMetaData = mock(ResourceMetaData.class);
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, new RuleMetaData(databaseRules), Collections.emptyList(), new ConfigurationProperties(new Properties()));
+        when(queryContext.getUsedDatabase()).thenReturn(database);
         try (SQLFederationEngine engine = createSQLFederationEngine(globalRules, databaseRules)) {
             assertTrue(engine.decide(queryContext, new RuleMetaData(globalRules)));
         }
@@ -492,7 +498,8 @@ class SQLFederationEngineTest {
     private ShardingSphereMetaData createMetaData(final Collection<ShardingSphereTable> tables, final Properties props) {
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_schema", databaseType, tables, Collections.emptyList());
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema));
+                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
         SQLFederationRuleConfiguration ruleConfig = new SQLFederationRuleConfiguration(true, false, cacheOption);
         Collection<ShardingSphereRule> globalRules = Collections.singleton(new SQLFederationRule(ruleConfig, Collections.singleton(database)));
         return new ShardingSphereMetaData(Collections.singleton(database), new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(globalRules), new ConfigurationProperties(props));

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/manager/ContextManagerTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/manager/ContextManagerTest.java
@@ -149,7 +149,8 @@ class ContextManagerTest {
     @Test
     void assertGetDatabaseType() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap());
-        ShardingSphereDatabase emptyDatabase = new ShardingSphereDatabase("bar_db", databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList());
+        ShardingSphereDatabase emptyDatabase =
+                new ShardingSphereDatabase("bar_db", databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         when(metaDataContexts.getMetaData().getAllDatabases()).thenReturn(Collections.singleton(emptyDatabase));
         assertThat(contextManager.getDatabaseType(), is(DatabaseTypeEngine.getDefaultStorageType()));
     }
@@ -177,7 +178,8 @@ class ContextManagerTest {
     @Test
     void assertGetStorageUnits() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource()));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, mock(RuleMetaData.class), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resourceMetaData, mock(RuleMetaData.class), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         when(metaDataContexts.getMetaData().getDatabase("foo_db")).thenReturn(database);
         when(metaDataContexts.getMetaData().containsDatabase("foo_db")).thenReturn(true);
         assertThat(contextManager.getStorageUnits("foo_db").size(), is(1));
@@ -310,7 +312,8 @@ class ContextManagerTest {
     @Test
     void assertGetPreSelectedDatabaseNameWithJDBC() {
         when(computeNodeInstanceContext.getInstance()).thenReturn(new ComputeNodeInstance(new JDBCInstanceMetaData("foo_id", "foo_db"), Collections.emptyList()));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         when(metaDataContexts.getMetaData().getAllDatabases()).thenReturn(Collections.singleton(database));
         assertThat(contextManager.getPreSelectedDatabaseName(), is("foo_db"));
     }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/MetaDataContextsTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/MetaDataContextsTest.java
@@ -87,7 +87,8 @@ class MetaDataContextsTest {
     private ShardingSphereMetaData createMetaData(final String databaseName) {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                databaseName, databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+                databaseName, databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         return new ShardingSphereMetaData(
                 Collections.singleton(database), new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()));
     }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/factory/MetaDataContextsFactoryTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/factory/MetaDataContextsFactoryTest.java
@@ -104,7 +104,8 @@ class MetaDataContextsFactoryTest {
     @BeforeEach
     void setUp() throws SQLException {
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db",
-                databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+                databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         when(ShardingSphereDatabasesFactory.create(anyMap(), anyMap(), any(), any(), any())).thenReturn(Collections.singleton(database));
         when(ShardingSphereDatabasesFactory.create(anyMap(), any(ConfigurationProperties.class), any(ComputeNodeInstanceContext.class),
                 any(DatabaseType.class))).thenReturn(Collections.singleton(database));
@@ -122,7 +123,8 @@ class MetaDataContextsFactoryTest {
     private ShardingSphereDatabase createDatabaseFromConfiguration(final String databaseName, final DatabaseType protocolType,
                                                                    final DatabaseConfiguration databaseConfiguration, final Collection<ShardingSphereSchema> schemas) {
         return new ShardingSphereDatabase(databaseName, protocolType,
-                new ResourceMetaData(databaseConfiguration.getDataSources(), databaseConfiguration.getStorageUnits()), new RuleMetaData(Collections.emptyList()), schemas);
+                new ResourceMetaData(databaseConfiguration.getDataSources(), databaseConfiguration.getStorageUnits()), new RuleMetaData(Collections.emptyList()), schemas,
+                new ConfigurationProperties(new Properties()));
     }
     
     @Test
@@ -160,7 +162,8 @@ class MetaDataContextsFactoryTest {
         currentStorageUnits.put("stale_ds", createStorageUnit("stale_ds"));
         currentStorageUnits.put("active_ds", createStorageUnit("active_ds"));
         ResourceMetaData resourceMetaData = new ResourceMetaData(currentStorageNodes, currentStorageUnits);
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, new RuleMetaData(Collections.emptyList()), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database),
                 new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()));
         MetaDataContexts originalMetaDataContexts = new MetaDataContexts(metaData, new ShardingSphereStatistics());
@@ -180,7 +183,8 @@ class MetaDataContextsFactoryTest {
     @Test
     void assertCreateBySwitchResourceKeepsExistingNodesWhenNoNewDataSources() throws SQLException {
         ResourceMetaData resourceMetaData = createResourceMetaDataWithSingleUnit();
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, new RuleMetaData(Collections.emptyList()), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database),
                 new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()));
         MetaDataContexts originalMetaDataContexts = new MetaDataContexts(metaData, new ShardingSphereStatistics());
@@ -197,7 +201,7 @@ class MetaDataContextsFactoryTest {
         when(metaDataPersistFacade.getDatabaseMetaDataFacade().getSchema().load(eq("foo_db"), any())).thenReturn(loadedSchemas);
         ShardingSphereSchema originSchema = createSchemaWithTable("foo_schema", "origin_table");
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, createResourceMetaDataWithSingleUnit(),
-                new RuleMetaData(Collections.emptyList()), Collections.singleton(originSchema));
+                new RuleMetaData(Collections.emptyList()), Collections.singleton(originSchema), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(
                 Collections.singleton(database), new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()),
                 new ConfigurationProperties(PropertiesBuilder.build(new Property(ConfigurationPropertyKey.PERSIST_SCHEMAS_TO_REPOSITORY_ENABLED.getKey(), Boolean.FALSE.toString()))));
@@ -214,7 +218,7 @@ class MetaDataContextsFactoryTest {
     @Test
     void assertCreateByAlterRuleKeepsPersistedSchemasWhenEnabled() throws SQLException {
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, createResourceMetaDataWithSingleUnit(), new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+                "foo_db", databaseType, createResourceMetaDataWithSingleUnit(), new RuleMetaData(Collections.emptyList()), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(
                 Collections.singleton(database), new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()),
                 new ConfigurationProperties(PropertiesBuilder.build(new Property(ConfigurationPropertyKey.PERSIST_SCHEMAS_TO_REPOSITORY_ENABLED.getKey(), Boolean.TRUE.toString()))));

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/factory/init/type/LocalConfigurationMetaDataContextsInitFactoryTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/factory/init/type/LocalConfigurationMetaDataContextsInitFactoryTest.java
@@ -136,7 +136,8 @@ class LocalConfigurationMetaDataContextsInitFactoryTest {
     
     private ShardingSphereDatabase createDatabase(final String databaseName, final Collection<ShardingSphereSchema> schemas,
                                                   final Map<String, StorageUnit> storageUnits, final Collection<ShardingSphereRule> rules) {
-        return new ShardingSphereDatabase(databaseName, mock(DatabaseType.class), new ResourceMetaData(Collections.emptyMap(), storageUnits), new RuleMetaData(rules), schemas);
+        return new ShardingSphereDatabase(databaseName, mock(DatabaseType.class), new ResourceMetaData(Collections.emptyMap(), storageUnits), new RuleMetaData(rules), schemas,
+                new ConfigurationProperties(new Properties()));
     }
     
     private ShardingSphereStatistics createStatistics(final String databaseName, final String schemaName) {

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/factory/init/type/RegisterCenterMetaDataContextsInitFactoryTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/factory/init/type/RegisterCenterMetaDataContextsInitFactoryTest.java
@@ -180,7 +180,7 @@ class RegisterCenterMetaDataContextsInitFactoryTest {
     
     private ShardingSphereDatabase createDatabase(final String databaseName, final Collection<ShardingSphereSchema> schemas) {
         return new ShardingSphereDatabase(databaseName,
-                databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), schemas);
+                databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), schemas, new ConfigurationProperties(new Properties()));
     }
     
     private ContextManagerBuilderParameter createContextManagerBuilderParameter(final Map<String, DatabaseConfiguration> databaseConfigs) {

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/MetaDataContextManagerTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/MetaDataContextManagerTest.java
@@ -129,7 +129,8 @@ class MetaDataContextManagerTest {
         props.setProperty(ConfigurationPropertyKey.PERSIST_SCHEMAS_TO_REPOSITORY_ENABLED.getKey(), "true");
         ConfigurationProperties configurationProps = new ConfigurationProperties(props);
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "test_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+                "test_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(
                 Collections.singleton(database), new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), configurationProps);
         return new MetaDataContexts(metaData, new ShardingSphereStatistics());

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/statistics/StatisticsManagerTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/statistics/StatisticsManagerTest.java
@@ -350,14 +350,16 @@ class StatisticsManagerTest {
                 new ShardingSphereColumn("name", Types.VARCHAR, false, false, false, true, false, true)), Collections.emptyList(), Collections.emptyList());
         ShardingSphereSchema schema = new ShardingSphereSchema(SCHEMA, databaseType, Collections.singleton(table), Collections.emptyList());
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                DATABASE, databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema));
+                DATABASE, databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
         return new ShardingSphereMetaData(
                 Collections.singleton(database), new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()));
     }
     
     private ShardingSphereMetaData createMetaDataWithDatabaseOnly() {
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                DATABASE, databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+                DATABASE, databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         return new ShardingSphereMetaData(
                 Collections.singleton(database), new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()));
     }
@@ -365,7 +367,8 @@ class StatisticsManagerTest {
     private ShardingSphereMetaData createMetaDataWithSchemaWithoutTable() {
         ShardingSphereSchema schema = new ShardingSphereSchema(SCHEMA, mock(DatabaseType.class));
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                DATABASE, databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema));
+                DATABASE, databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
         return new ShardingSphereMetaData(
                 Collections.singleton(database), new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()));
     }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/metadata/DatabaseMetaDataPersistFacadeTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/metadata/DatabaseMetaDataPersistFacadeTest.java
@@ -220,7 +220,7 @@ class DatabaseMetaDataPersistFacadeTest {
     
     private ShardingSphereDatabase createDatabase(final String databaseName, final Collection<ShardingSphereSchema> schemas) {
         return new ShardingSphereDatabase(databaseName, databaseType,
-                new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), schemas);
+                new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), schemas, new ConfigurationProperties(new Properties()));
     }
     
     private DialectDatabaseMetaData createDialectDatabaseMetaData() {

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/PushDownMetaDataRefreshEngineIdentifierTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/PushDownMetaDataRefreshEngineIdentifierTest.java
@@ -65,6 +65,6 @@ class PushDownMetaDataRefreshEngineIdentifierTest {
                 Collections.singletonList(new ShardingSphereTable("Foo_Tbl", Collections.emptyList(), Collections.emptyList(), Collections.emptyList())),
                 Collections.emptyList());
         return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()),
-                new RuleMetaData(Collections.emptyList()), Collections.singletonList(schema));
+                new RuleMetaData(Collections.emptyList()), Collections.singletonList(schema), new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/index/AlterIndexPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/index/AlterIndexPushDownMetaDataRefresherTest.java
@@ -87,6 +87,7 @@ class AlterIndexPushDownMetaDataRefresherTest {
     }
     
     private ShardingSphereDatabase createDatabase(final java.util.Collection<ShardingSphereSchema> schemas) {
-        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), schemas);
+        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), schemas,
+                new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/index/CreateIndexPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/index/CreateIndexPushDownMetaDataRefresherTest.java
@@ -88,6 +88,7 @@ class CreateIndexPushDownMetaDataRefresherTest {
     }
     
     private ShardingSphereDatabase createDatabase(final Collection<ShardingSphereSchema> schemas) {
-        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), schemas);
+        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), schemas,
+                new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/index/DropIndexPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/index/DropIndexPushDownMetaDataRefresherTest.java
@@ -99,6 +99,7 @@ class DropIndexPushDownMetaDataRefresherTest {
     }
     
     private ShardingSphereDatabase createDatabase(final Collection<ShardingSphereSchema> schemas) {
-        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), schemas);
+        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), schemas,
+                new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/AlterSchemaPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/AlterSchemaPushDownMetaDataRefresherTest.java
@@ -77,6 +77,6 @@ class AlterSchemaPushDownMetaDataRefresherTest {
     
     private ShardingSphereDatabase createDatabase() {
         return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()),
-                Collections.singletonList(new ShardingSphereSchema("FOO_SCHEMA", databaseType)));
+                Collections.singletonList(new ShardingSphereSchema("FOO_SCHEMA", databaseType)), new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/CreateSchemaPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/CreateSchemaPushDownMetaDataRefresherTest.java
@@ -68,6 +68,7 @@ class CreateSchemaPushDownMetaDataRefresherTest {
     }
     
     private ShardingSphereDatabase createDatabase() {
-        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/DropSchemaPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/schema/DropSchemaPushDownMetaDataRefresherTest.java
@@ -48,7 +48,7 @@ class DropSchemaPushDownMetaDataRefresherTest {
         DropSchemaStatement sqlStatement = new DropSchemaStatement(databaseType);
         sqlStatement.getSchemaNames().addAll(Arrays.asList(new IdentifierValue("FOO_SCHEMA"), new IdentifierValue("BAR_SCHEMA")));
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()),
-                Arrays.asList(new ShardingSphereSchema("foo_schema", databaseType), new ShardingSphereSchema("bar_schema", databaseType)));
+                Arrays.asList(new ShardingSphereSchema("foo_schema", databaseType), new ShardingSphereSchema("bar_schema", databaseType)), new ConfigurationProperties(new Properties()));
         refresher.refresh(persistService, database, "logic_ds", "foo_schema", databaseType, sqlStatement, new ConfigurationProperties(new Properties()));
         assertThat(persistService.getDroppedSchemaNames(), contains("foo_schema", "bar_schema"));
     }
@@ -59,7 +59,7 @@ class DropSchemaPushDownMetaDataRefresherTest {
         DropSchemaStatement sqlStatement = new DropSchemaStatement(databaseType);
         sqlStatement.getSchemaNames().addAll(Arrays.asList(new IdentifierValue("Foo_Schema"), new IdentifierValue("Bar_Schema")));
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()),
-                Arrays.asList(new ShardingSphereSchema("Foo_Schema", databaseType), new ShardingSphereSchema("Bar_Schema", databaseType)));
+                Arrays.asList(new ShardingSphereSchema("Foo_Schema", databaseType), new ShardingSphereSchema("Bar_Schema", databaseType)), new ConfigurationProperties(new Properties()));
         Properties props = new Properties();
         props.setProperty("metadata-identifier-case-sensitivity", "SENSITIVE");
         refresher.refresh(persistService, database, "logic_ds", "foo_schema", databaseType, sqlStatement, new ConfigurationProperties(props));

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/AlterTablePushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/AlterTablePushDownMetaDataRefresherTest.java
@@ -87,7 +87,7 @@ class AlterTablePushDownMetaDataRefresherTest {
         ShardingSphereSchema schema = new ShardingSphereSchema(SCHEMA_NAME, databaseType,
                 Collections.singleton(new ShardingSphereTable(currentTableName, Collections.emptyList(), Collections.emptyList(), Collections.emptyList())), Collections.emptyList());
         return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.singletonMap(LOGIC_DATA_SOURCE_NAME, dataSource)),
-                new RuleMetaData(Collections.emptyList()), Collections.singleton(schema));
+                new RuleMetaData(Collections.emptyList()), Collections.singleton(schema), new ConfigurationProperties(new Properties()));
     }
     
     private JdbcDataSource createDataSource(final String databaseName) {

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/CreateTablePushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/CreateTablePushDownMetaDataRefresherTest.java
@@ -66,7 +66,7 @@ class CreateTablePushDownMetaDataRefresherTest {
     
     private ShardingSphereDatabase createDatabase(final JdbcDataSource dataSource) {
         return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.singletonMap(LOGIC_DATA_SOURCE_NAME, dataSource)),
-                new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+                new RuleMetaData(Collections.emptyList()), Collections.emptyList(), new ConfigurationProperties(new Properties()));
     }
     
     private JdbcDataSource createDataSource(final String databaseName) {

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/DropTablePushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/DropTablePushDownMetaDataRefresherTest.java
@@ -77,6 +77,7 @@ class DropTablePushDownMetaDataRefresherTest {
                 Arrays.asList(new ShardingSphereTable("Foo_Tbl", Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
                         new ShardingSphereTable("Bar_Tbl", Collections.emptyList(), Collections.emptyList(), Collections.emptyList())),
                 Collections.emptyList());
-        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singletonList(schema));
+        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singletonList(schema),
+                new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/RenameTablePushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/RenameTablePushDownMetaDataRefresherTest.java
@@ -86,6 +86,7 @@ class RenameTablePushDownMetaDataRefresherTest {
     private ShardingSphereDatabase createDatabase() {
         ShardingSphereTable table = new ShardingSphereTable("Foo_Tbl", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         ShardingSphereSchema schema = new ShardingSphereSchema("Foo_Schema", databaseType, Collections.singleton(table), Collections.emptyList());
-        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema));
+        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/AlterViewPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/AlterViewPushDownMetaDataRefresherTest.java
@@ -96,7 +96,7 @@ class AlterViewPushDownMetaDataRefresherTest {
         ShardingSphereSchema schema = new ShardingSphereSchema(SCHEMA_NAME, databaseType, Collections.emptyList(),
                 Collections.singleton(new ShardingSphereView(currentViewName, "SELECT 1")));
         return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.singletonMap(LOGIC_DATA_SOURCE_NAME, dataSource)),
-                new RuleMetaData(Collections.emptyList()), Collections.singleton(schema));
+                new RuleMetaData(Collections.emptyList()), Collections.singleton(schema), new ConfigurationProperties(new Properties()));
     }
     
     private JdbcDataSource createDataSource(final String databaseName) {

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/CreateViewPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/CreateViewPushDownMetaDataRefresherTest.java
@@ -113,7 +113,7 @@ class CreateViewPushDownMetaDataRefresherTest {
     
     private ShardingSphereDatabase createDatabase(final JdbcDataSource dataSource, final RuleMetaData ruleMetaData) {
         return new ShardingSphereDatabase("foo_db", databaseType,
-                new ResourceMetaData(Collections.singletonMap(LOGIC_DATA_SOURCE_NAME, dataSource)), ruleMetaData, Collections.emptyList());
+                new ResourceMetaData(Collections.singletonMap(LOGIC_DATA_SOURCE_NAME, dataSource)), ruleMetaData, Collections.emptyList(), new ConfigurationProperties(new Properties()));
     }
     
     private JdbcDataSource createDataSource(final String databaseName) {

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/DropViewPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/DropViewPushDownMetaDataRefresherTest.java
@@ -79,6 +79,7 @@ class DropViewPushDownMetaDataRefresherTest {
     private ShardingSphereDatabase createDatabase() {
         ShardingSphereSchema schema = new ShardingSphereSchema("Foo_Schema", databaseType, Collections.emptyList(),
                 Arrays.asList(new ShardingSphereView("Foo_View", "SELECT 1"), new ShardingSphereView("Bar_View", "SELECT 1")));
-        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singletonList(schema));
+        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singletonList(schema),
+                new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/SchemaRefreshUtilsTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/SchemaRefreshUtilsTest.java
@@ -58,7 +58,7 @@ class SchemaRefreshUtilsTest {
     @Test
     void assertGetActualSchemaNameWithSensitiveProps() {
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()),
-                new RuleMetaData(Collections.emptyList()), Collections.singletonList(new ShardingSphereSchema("Foo_Schema", databaseType)));
+                new RuleMetaData(Collections.emptyList()), Collections.singletonList(new ShardingSphereSchema("Foo_Schema", databaseType)), new ConfigurationProperties(new Properties()));
         Properties props = new Properties();
         props.setProperty("metadata-identifier-case-sensitivity", "SENSITIVE");
         assertThat(SchemaRefreshUtils.getActualSchemaName(database, new IdentifierValue("Foo_Schema", QuoteCharacter.QUOTE), new ConfigurationProperties(props)), is("Foo_Schema"));
@@ -70,7 +70,8 @@ class SchemaRefreshUtilsTest {
     }
     
     private ShardingSphereDatabase createDatabase() {
-        return new ShardingSphereDatabase("FOO_DB", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList());
+        return new ShardingSphereDatabase("FOO_DB", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
     }
     
     private SQLStatementContext createSQLStatementContextWithSchema(final String schemaName) {

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtilsIdentifierTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtilsIdentifierTest.java
@@ -136,6 +136,6 @@ class TableRefreshUtilsIdentifierTest {
                         new ShardingSphereTable("Bar_Tbl", Collections.emptyList(), Collections.emptyList(), Collections.emptyList())),
                 Arrays.asList(new ShardingSphereView("Foo_View", "SELECT 1"), new ShardingSphereView("Bar_View", "SELECT 1")));
         return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()),
-                new RuleMetaData(Collections.emptyList()), Collections.singletonList(schema));
+                new RuleMetaData(Collections.emptyList()), Collections.singletonList(schema), new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtilsTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtilsTest.java
@@ -270,6 +270,6 @@ class TableRefreshUtilsTest {
                         new ShardingSphereTable("Bar_Tbl", Collections.emptyList(), Collections.emptyList(), Collections.emptyList())),
                 Arrays.asList(new ShardingSphereView("Foo_View", "SELECT 1"), new ShardingSphereView("Bar_View", "SELECT 1")));
         return new ShardingSphereDatabase("foo_db", fixtureDatabaseType, new ResourceMetaData(Collections.emptyMap()),
-                new RuleMetaData(Collections.emptyList()), Collections.singletonList(schema));
+                new RuleMetaData(Collections.emptyList()), Collections.singletonList(schema), new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistServiceTest.java
+++ b/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistServiceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mode.manager.cluster.persist.service;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -82,14 +84,14 @@ class ClusterMetaDataManagerPersistServiceTest {
     
     @Test
     void assertDropDatabase() {
-        metaDataManagerPersistService.dropDatabase(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()));
+        metaDataManagerPersistService.dropDatabase(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())));
         verify(clusterDatabaseListenerPersistCoordinator).persist("foo_db", ClusterDatabaseListenerCoordinatorType.DROP);
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade().getDatabase()).drop("foo_db");
     }
     
     @Test
     void assertCreateSchema() {
-        metaDataManagerPersistService.createSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), "foo_schema");
+        metaDataManagerPersistService.createSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())), "foo_schema");
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade().getSchema()).add("foo_db", "foo_schema");
     }
     
@@ -97,13 +99,15 @@ class ClusterMetaDataManagerPersistServiceTest {
     void assertRenameSchema() {
         ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
         when(metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase("foo_db").getSchema("foo_schema")).thenReturn(schema);
-        metaDataManagerPersistService.renameSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), "foo_schema", "bar_schema");
+        metaDataManagerPersistService.renameSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())), "foo_schema",
+                "bar_schema");
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).renameSchema(any(), any(), eq("foo_schema"), eq("bar_schema"));
     }
     
     @Test
     void assertDropSchema() {
-        metaDataManagerPersistService.dropSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), Collections.singleton("foo_schema"));
+        metaDataManagerPersistService.dropSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
+                Collections.singleton("foo_schema"));
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade().getSchema()).drop("foo_db", "foo_schema");
     }
     
@@ -114,13 +118,15 @@ class ClusterMetaDataManagerPersistServiceTest {
         when(singleRule.getConfiguration()).thenReturn(singleRuleConfig);
         when(metaDataPersistFacade.getDatabaseRuleService().persist("foo_db", Collections.singleton(singleRuleConfig))).thenReturn(Collections.emptyList());
         metaDataManagerPersistService.alterSingleRuleConfiguration(
-                new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), new RuleMetaData(Collections.singleton(singleRule)));
+                new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
+                new RuleMetaData(Collections.singleton(singleRule)));
         verify(metaDataPersistFacade.getDatabaseRuleService()).persist("foo_db", Collections.singleton(singleRuleConfig));
     }
     
     @Test
     void assertAlterNullRuleConfiguration() {
-        metaDataManagerPersistService.alterRuleConfiguration(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), null);
+        metaDataManagerPersistService.alterRuleConfiguration(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
+                null);
         verify(metaDataPersistFacade.getDatabaseRuleService(), never()).persist(eq("foo_db"), any());
     }
     
@@ -137,7 +143,8 @@ class ClusterMetaDataManagerPersistServiceTest {
     
     @Test
     void assertRemoveNullRuleConfigurationItem() {
-        metaDataManagerPersistService.removeRuleConfigurationItem(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), null);
+        metaDataManagerPersistService.removeRuleConfigurationItem(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
+                null);
         verify(metaDataPersistFacade.getDatabaseRuleService(), never()).delete(eq("foo_db"), anyCollection());
     }
     
@@ -157,7 +164,8 @@ class ClusterMetaDataManagerPersistServiceTest {
     
     @Test
     void assertRemoveRuleConfiguration() {
-        metaDataManagerPersistService.removeRuleConfiguration(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), mock(RuleConfiguration.class), "fixtureRule");
+        metaDataManagerPersistService.removeRuleConfiguration(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
+                mock(RuleConfiguration.class), "fixtureRule");
         verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", "fixtureRule");
     }
     
@@ -178,14 +186,15 @@ class ClusterMetaDataManagerPersistServiceTest {
     @Test
     void assertCreateTable() {
         ShardingSphereTable table = mock(ShardingSphereTable.class);
-        metaDataManagerPersistService.createTable(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), "foo_schema", table);
+        metaDataManagerPersistService.createTable(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())), "foo_schema",
+                table);
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade().getTable()).persist("foo_db", "foo_schema", Collections.singleton(table));
     }
     
     @Test
     void assertDropTables() {
         metaDataManagerPersistService.dropTables(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(),
-                Collections.emptyList()), "foo_schema", Collections.singleton("foo_tbl"));
+                Collections.emptyList(), new ConfigurationProperties(new Properties())), "foo_schema", Collections.singleton("foo_tbl"));
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade().getTable()).drop("foo_db", "foo_schema", "foo_tbl");
     }
 }

--- a/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
+++ b/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
@@ -86,14 +86,14 @@ class StandaloneMetaDataManagerPersistServiceTest {
     
     @Test
     void assertDropDatabase() {
-        metaDataManagerPersistService.dropDatabase(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()));
+        metaDataManagerPersistService.dropDatabase(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())));
         verify(metaDataContextManager.getDatabaseMetaDataManager()).dropDatabase("foo_db");
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade().getDatabase()).drop("foo_db");
     }
     
     @Test
     void assertCreateSchema() {
-        metaDataManagerPersistService.createSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), "foo_schema");
+        metaDataManagerPersistService.createSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())), "foo_schema");
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade().getSchema()).add("foo_db", "foo_schema");
     }
     
@@ -105,7 +105,8 @@ class StandaloneMetaDataManagerPersistServiceTest {
         when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
         DatabaseMetaDataPersistFacade databaseMetaDataFacade = mock(DatabaseMetaDataPersistFacade.class, RETURNS_DEEP_STUBS);
         when(metaDataPersistFacade.getDatabaseMetaDataFacade()).thenReturn(databaseMetaDataFacade);
-        metaDataManagerPersistService.renameSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), "foo_schema", "bar_schema");
+        metaDataManagerPersistService.renameSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())), "foo_schema",
+                "bar_schema");
         verify(databaseMetaDataFacade.getSchema(), never()).add("foo_db", "bar_schema");
         verify(databaseMetaDataFacade).renameSchema(any(), any(), eq("foo_schema"), eq("bar_schema"));
     }
@@ -120,7 +121,8 @@ class StandaloneMetaDataManagerPersistServiceTest {
         when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
         DatabaseMetaDataPersistFacade databaseMetaDataFacade = mock(DatabaseMetaDataPersistFacade.class, RETURNS_DEEP_STUBS);
         when(metaDataPersistFacade.getDatabaseMetaDataFacade()).thenReturn(databaseMetaDataFacade);
-        metaDataManagerPersistService.renameSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), "foo_schema", "bar_schema");
+        metaDataManagerPersistService.renameSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())), "foo_schema",
+                "bar_schema");
         verify(databaseMetaDataFacade).renameSchema(any(), any(), eq("foo_schema"), eq("bar_schema"));
     }
     
@@ -131,7 +133,8 @@ class StandaloneMetaDataManagerPersistServiceTest {
         when(database.getSchema("foo_schema")).thenReturn(new ShardingSphereSchema("foo_schema", mock(DatabaseType.class)));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
         when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
-        metaDataManagerPersistService.dropSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), Collections.singleton("foo_schema"));
+        metaDataManagerPersistService.dropSchema(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
+                Collections.singleton("foo_schema"));
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade().getSchema()).drop("foo_db", "foo_schema");
         verify(metaDataContextManager.getDatabaseMetaDataManager()).dropSchema("foo_db", "foo_schema");
     }
@@ -142,13 +145,15 @@ class StandaloneMetaDataManagerPersistServiceTest {
         SingleRule singleRule = mock(SingleRule.class);
         when(singleRule.getConfiguration()).thenReturn(singleRuleConfig);
         metaDataManagerPersistService.alterSingleRuleConfiguration(
-                new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), new RuleMetaData(Collections.singleton(singleRule)));
+                new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
+                new RuleMetaData(Collections.singleton(singleRule)));
         verify(metaDataContextManager.getDatabaseRuleConfigurationManager()).refresh("foo_db", singleRuleConfig);
     }
     
     @Test
     void assertAlterNullRuleConfiguration() {
-        metaDataManagerPersistService.alterRuleConfiguration(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), null);
+        metaDataManagerPersistService.alterRuleConfiguration(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
+                null);
         verify(metaDataPersistFacade, never()).getVersionService();
     }
     
@@ -171,7 +176,8 @@ class StandaloneMetaDataManagerPersistServiceTest {
     
     @Test
     void assertRemoveNullRuleConfigurationItem() {
-        metaDataManagerPersistService.removeRuleConfigurationItem(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), null);
+        metaDataManagerPersistService.removeRuleConfigurationItem(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
+                null);
         verify(metaDataPersistFacade, never()).getVersionService();
     }
     
@@ -193,7 +199,7 @@ class StandaloneMetaDataManagerPersistServiceTest {
     
     @Test
     void assertRemoveRuleConfiguration() {
-        metaDataManagerPersistService.removeRuleConfiguration(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()),
+        metaDataManagerPersistService.removeRuleConfiguration(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
                 mock(RuleConfiguration.class), "foo_rule");
         verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", "foo_rule");
     }
@@ -217,14 +223,15 @@ class StandaloneMetaDataManagerPersistServiceTest {
     @Test
     void assertCreateTable() {
         ShardingSphereTable table = new ShardingSphereTable("foo_tbl", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), TableType.TABLE);
-        metaDataManagerPersistService.createTable(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList()), "foo_schema", table);
+        metaDataManagerPersistService.createTable(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())), "foo_schema",
+                table);
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade().getTable()).persist("foo_db", "foo_schema", Collections.singleton(table));
     }
     
     @Test
     void assertDropTables() {
         metaDataManagerPersistService.dropTables(new ShardingSphereDatabase(
-                "foo_db", mock(), mock(), mock(), Collections.emptyList()), "foo_schema", Collections.singleton("foo_tbl"));
+                "foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())), "foo_schema", Collections.singleton("foo_tbl"));
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade().getTable()).drop("foo_db", "foo_schema", "foo_tbl");
     }
 }

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/ProxyBackendHandlerFactoryTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/ProxyBackendHandlerFactoryTest.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.infra.executor.checker.SQLExecutionChecker;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.infra.metadata.user.Grantee;
 import org.apache.shardingsphere.infra.session.connection.ConnectionContext;
@@ -135,9 +136,16 @@ class ProxyBackendHandlerFactoryTest {
     
     private ContextManager mockContextManager() {
         MetaDataContexts metaDataContexts = mock(MetaDataContexts.class, RETURNS_DEEP_STUBS);
-        when(metaDataContexts.getMetaData().getDatabase("db")).thenReturn(new ShardingSphereDatabase("db", mock(), mock(), new RuleMetaData(Collections.emptyList()), Collections.emptyList()));
-        when(metaDataContexts.getMetaData().getDatabase("information_schema"))
-                .thenReturn(new ShardingSphereDatabase("information_schema", mock(), mock(), new RuleMetaData(Collections.emptyList()), Collections.emptyList()));
+        DatabaseType dbProtocolType = mock(DatabaseType.class);
+        ResourceMetaData dbResourceMetaData = mock(ResourceMetaData.class);
+        ShardingSphereDatabase database = new ShardingSphereDatabase("db", dbProtocolType, dbResourceMetaData,
+                new RuleMetaData(Collections.emptyList()), Collections.emptyList(), new ConfigurationProperties(new Properties()));
+        DatabaseType informationSchemaProtocolType = mock(DatabaseType.class);
+        ResourceMetaData informationSchemaResourceMetaData = mock(ResourceMetaData.class);
+        ShardingSphereDatabase informationSchemaDatabase = new ShardingSphereDatabase("information_schema", informationSchemaProtocolType, informationSchemaResourceMetaData,
+                new RuleMetaData(Collections.emptyList()), Collections.emptyList(), new ConfigurationProperties(new Properties()));
+        when(metaDataContexts.getMetaData().getDatabase("db")).thenReturn(database);
+        when(metaDataContexts.getMetaData().getDatabase("information_schema")).thenReturn(informationSchemaDatabase);
         when(metaDataContexts.getMetaData().containsDatabase("db")).thenReturn(true);
         when(metaDataContexts.getMetaData().containsDatabase("information_schema")).thenReturn(true);
         ContextManager result = mock(ContextManager.class, RETURNS_DEEP_STUBS);

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/admin/DatabaseAdminQueryProxyBackendHandlerTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/admin/DatabaseAdminQueryProxyBackendHandlerTest.java
@@ -71,7 +71,7 @@ class DatabaseAdminQueryProxyBackendHandlerTest {
     }
     
     private ContextManager mockContextManager() {
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList());
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
         ComputeNodeInstanceContext computeNodeInstanceContext = mock(ComputeNodeInstanceContext.class, RETURNS_DEEP_STUBS);
         return new ContextManager(new MetaDataContexts(metaData, ShardingSphereStatisticsFactory.create(metaData, new ShardingSphereStatistics())), computeNodeInstanceContext, mock(), mock());

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/admin/executor/DatabaseMetaDataExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/admin/executor/DatabaseMetaDataExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.proxy.backend.handler.admin.executor;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.authority.provider.database.DatabasePermittedPrivileges;
 import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
@@ -47,6 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -86,7 +89,8 @@ class DatabaseMetaDataExecutorTest {
         expectedResultSetMap.put("DEFAULT_CHARACTER_SET_NAME", "utf8mb4");
         String sql = "SELECT SCHEMA_NAME AS sn, DEFAULT_CHARACTER_SET_NAME FROM information_schema.SCHEMATA";
         ShardingSphereDatabase database = new ShardingSphereDatabase("auth_db", databaseType,
-                new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource(mockConnection(expectedResultSetMap)))), mock(), Collections.emptyList());
+                new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource(mockConnection(expectedResultSetMap)))), mock(), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         DatabaseMetaDataExecutor executor = new DatabaseMetaDataExecutor(sql, Collections.emptyList());
         executor.execute(connectionSession, mockMetaData(database, Collections.singleton("auth_db")));
         assertThat(executor.getRows().get(0).get("sn"), is("foo_ds"));
@@ -97,7 +101,8 @@ class DatabaseMetaDataExecutorTest {
     void assertExecuteWithDefaultValue() throws SQLException {
         String sql = "SELECT COUNT(*) AS support_ndb FROM information_schema.ENGINES WHERE Engine = 'ndbcluster'";
         ShardingSphereDatabase database = new ShardingSphereDatabase("auth_db", databaseType,
-                new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource(mockConnection(Collections.singletonMap("support_ndb", "0"))))), mock(), Collections.emptyList());
+                new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource(mockConnection(Collections.singletonMap("support_ndb", "0"))))), mock(), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         DatabaseMetaDataExecutor executor = new DatabaseMetaDataExecutor(sql, Collections.emptyList());
         executor.execute(connectionSession, mockMetaData(database, Collections.singleton("auth_db")));
         assertThat(executor.getQueryResultMetaData().getColumnCount(), is(1));
@@ -110,7 +115,8 @@ class DatabaseMetaDataExecutorTest {
     void assertExecuteWithPreparedStatement() throws SQLException {
         String sql = "SELECT COUNT(*) AS support_ndb FROM information_schema.ENGINES WHERE Engine = ?";
         ShardingSphereDatabase database = new ShardingSphereDatabase("auth_db", databaseType,
-                new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource(mockConnection(Collections.singletonMap("support_ndb", "0"))))), mock(), Collections.emptyList());
+                new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource(mockConnection(Collections.singletonMap("support_ndb", "0"))))), mock(), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         DatabaseMetaDataExecutor executor = new DatabaseMetaDataExecutor(sql, Collections.singletonList("ndbcluster"));
         executor.execute(connectionSession, mockMetaData(database, Collections.singleton("auth_db")));
         assertThat(executor.getQueryResultMetaData().getColumnCount(), is(1));
@@ -123,7 +129,8 @@ class DatabaseMetaDataExecutorTest {
     void assertGetDatabasesWithAuthorizedFromAllDatabases() {
         when(connectionSession.getCurrentDatabaseName()).thenReturn("foo_db");
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "auth_db", databaseType, new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource())), mock(), Collections.emptyList());
+                "auth_db", databaseType, new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource())), mock(), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         DatabaseMetaDataExecutor executor = new DatabaseMetaDataExecutor("SELECT 1", Collections.emptyList());
         Collection<ShardingSphereDatabase> actual = executor.getDatabases(connectionSession, mockMetaData(database, Collections.singleton("auth_db")));
         assertFalse(actual.isEmpty());
@@ -134,7 +141,8 @@ class DatabaseMetaDataExecutorTest {
     void assertGetDatabasesReturnEmptyWhenUnauthorized() {
         when(connectionSession.getCurrentDatabaseName()).thenReturn("foo_db");
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "auth_db", databaseType, new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource())), mock(), Collections.emptyList());
+                "auth_db", databaseType, new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource())), mock(), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         DatabaseMetaDataExecutor executor = new DatabaseMetaDataExecutor("SELECT 1", Collections.emptyList());
         assertTrue(executor.getDatabases(connectionSession, mockMetaData(database, Collections.emptySet())).isEmpty());
     }
@@ -142,7 +150,8 @@ class DatabaseMetaDataExecutorTest {
     @Test
     void assertExecuteSkipLoadMetaDataWithoutStorageUnit() throws SQLException {
         ShardingSphereDatabase database =
-                new ShardingSphereDatabase("empty_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), mock(RuleMetaData.class), Collections.emptyList());
+                new ShardingSphereDatabase("empty_db", databaseType, new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), mock(RuleMetaData.class), Collections.emptyList(),
+                        new ConfigurationProperties(new Properties()));
         DatabaseMetaDataExecutor executor = mock(DatabaseMetaDataExecutor.class, withSettings().useConstructor("SELECT 1", Collections.emptyList()).defaultAnswer(CALLS_REAL_METHODS));
         doReturn(Collections.singleton(database)).when(executor).getDatabases(any(ConnectionSession.class), any(ShardingSphereMetaData.class));
         assertThat(connectionSession.getCurrentDatabaseName(), is("auth_db"));
@@ -156,7 +165,8 @@ class DatabaseMetaDataExecutorTest {
     void assertExecuteFillLabelsWhenRowsFilteredOut() throws SQLException {
         Map<String, String> expectedResultSetMap = Collections.singletonMap("foo_column", "foo_value");
         ShardingSphereDatabase database = new ShardingSphereDatabase("auth_db",
-                databaseType, new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource(mockConnection(expectedResultSetMap)))), mock(), Collections.emptyList());
+                databaseType, new ResourceMetaData(Collections.singletonMap("foo_ds", new MockedDataSource(mockConnection(expectedResultSetMap)))), mock(), Collections.emptyList(),
+                new ConfigurationProperties(new Properties()));
         DatabaseMetaDataExecutor executor = mock(DatabaseMetaDataExecutor.class, withSettings().useConstructor(
                 "SELECT foo_column FROM foo_table", Collections.emptyList()).defaultAnswer(CALLS_REAL_METHODS));
         doAnswer(invocation -> {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/data/type/UnicastDatabaseProxyBackendHandlerTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/data/type/UnicastDatabaseProxyBackendHandlerTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.proxy.backend.handler.data.type;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.authority.model.ShardingSpherePrivileges;
 import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
@@ -57,6 +59,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -95,7 +98,8 @@ class UnicastDatabaseProxyBackendHandlerTest {
     
     private ContextManager mockContextManager() {
         ContextManager result = mock(ContextManager.class, RETURNS_DEEP_STUBS);
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), mock(), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class, RETURNS_DEEP_STUBS), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock());
         when(result.getMetaDataContexts()).thenReturn(new MetaDataContexts(metaData, ShardingSphereStatisticsFactory.create(metaData, new ShardingSphereStatistics())));
         when(result.getDatabase("foo_db")).thenReturn(Collections.singleton(database).iterator().next());

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/DistSQLQueryProxyBackendHandlerTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/DistSQLQueryProxyBackendHandlerTest.java
@@ -103,7 +103,8 @@ class DistSQLQueryProxyBackendHandlerTest {
     @Test
     void assertExecute() {
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, mock(), mock(), Collections.singleton(new ShardingSphereSchema("foo_db", databaseType, createTables(), Collections.emptyList())));
+                "foo_db", databaseType, mock(), mock(), Collections.singleton(new ShardingSphereSchema("foo_db", databaseType, createTables(), Collections.emptyList())),
+                new ConfigurationProperties(new Properties()));
         ContextManager contextManager = mock(ContextManager.class);
         when(contextManager.getDatabase("foo_db")).thenReturn(database);
         assertDoesNotThrow(() -> new DistSQLQueryProxyBackendHandler(createSqlStatement(), mock(), mock(ConnectionSession.class, RETURNS_DEEP_STUBS), contextManager).execute());

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/DistSQLUpdateProxyBackendHandlerTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/DistSQLUpdateProxyBackendHandlerTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.proxy.backend.handler.distsql;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.distsql.statement.type.ral.updatable.RefreshTableMetaDataStatement;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.SchemaNotFoundException;
@@ -26,6 +28,7 @@ import org.apache.shardingsphere.infra.exception.kernel.metadata.resource.storag
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
+import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
@@ -40,6 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
@@ -59,7 +63,11 @@ class DistSQLUpdateProxyBackendHandlerTest {
     
     @Test
     void assertEmptyStorageUnit() {
-        when(contextManager.getDatabase("foo_db")).thenReturn(new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList()));
+        ResourceMetaData resourceMetaData = mock(ResourceMetaData.class);
+        RuleMetaData ruleMetaData = mock(RuleMetaData.class);
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, ruleMetaData,
+                Collections.emptyList(), new ConfigurationProperties(new Properties()));
+        when(contextManager.getDatabase("foo_db")).thenReturn(database);
         RefreshTableMetaDataStatement sqlStatement = new RefreshTableMetaDataStatement();
         DistSQLUpdateProxyBackendHandler backendHandler = new DistSQLUpdateProxyBackendHandler(sqlStatement, mockQueryContext(), mockConnectionSession(), contextManager);
         assertThrows(EmptyStorageUnitException.class, backendHandler::execute);
@@ -68,8 +76,13 @@ class DistSQLUpdateProxyBackendHandlerTest {
     @Test
     void assertMissingRequiredStorageUnit() {
         ResourceMetaData resourceMetaData = mock(ResourceMetaData.class);
-        when(resourceMetaData.getStorageUnits()).thenReturn(Collections.singletonMap("ds_0", mock(StorageUnit.class)));
-        when(contextManager.getDatabase("foo_db")).thenReturn(new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, mock(), Collections.emptyList()));
+        StorageUnit storageUnit = mock(StorageUnit.class);
+        when(storageUnit.getStorageType()).thenReturn(databaseType);
+        when(resourceMetaData.getStorageUnits()).thenReturn(Collections.singletonMap("ds_0", storageUnit));
+        RuleMetaData ruleMetaData = mock(RuleMetaData.class);
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, ruleMetaData,
+                Collections.emptyList(), new ConfigurationProperties(new Properties()));
+        when(contextManager.getDatabase("foo_db")).thenReturn(database);
         RefreshTableMetaDataStatement sqlStatement = new RefreshTableMetaDataStatement("t_order", "ds_1", null);
         DistSQLUpdateProxyBackendHandler backendHandler = new DistSQLUpdateProxyBackendHandler(sqlStatement, mockQueryContext(), mockConnectionSession(), contextManager);
         assertThrows(MissingRequiredStorageUnitsException.class, backendHandler::execute);
@@ -78,8 +91,13 @@ class DistSQLUpdateProxyBackendHandlerTest {
     @Test
     void assertSchemaNotFound() {
         ResourceMetaData resourceMetaData = mock(ResourceMetaData.class);
-        when(resourceMetaData.getStorageUnits()).thenReturn(Collections.singletonMap("ds_0", mock(StorageUnit.class)));
-        when(contextManager.getDatabase("foo_db")).thenReturn(new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, mock(), Collections.emptyList()));
+        StorageUnit storageUnit = mock(StorageUnit.class);
+        when(storageUnit.getStorageType()).thenReturn(databaseType);
+        when(resourceMetaData.getStorageUnits()).thenReturn(Collections.singletonMap("ds_0", storageUnit));
+        RuleMetaData ruleMetaData = mock(RuleMetaData.class);
+        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", databaseType, resourceMetaData, ruleMetaData,
+                Collections.emptyList(), new ConfigurationProperties(new Properties()));
+        when(contextManager.getDatabase("foo_db")).thenReturn(database);
         RefreshTableMetaDataStatement sqlStatement = new RefreshTableMetaDataStatement("t_order", "ds_0", "bar_db");
         DistSQLUpdateProxyBackendHandler backendHandler = new DistSQLUpdateProxyBackendHandler(sqlStatement, mockQueryContext(), mockConnectionSession(), contextManager);
         assertThrows(SchemaNotFoundException.class, backendHandler::execute);

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/MySQLAdminExecutorCreatorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/MySQLAdminExecutorCreatorTest.java
@@ -288,7 +288,8 @@ class MySQLAdminExecutorCreatorTest {
     @Test
     void assertCreateWithOtherSelectStatementForDatabaseName() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource()));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("db_0", databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("db_0", databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         initProxyContext(Collections.singleton(database));
         when(ProxyContext.getInstance().getContextManager().getAllDatabaseNames()).thenReturn(Collections.singleton("db_0"));
         when(ProxyContext.getInstance().getContextManager().getDatabase("db_0")).thenReturn(database);
@@ -306,7 +307,8 @@ class MySQLAdminExecutorCreatorTest {
     @Test
     void assertCreateWithOtherSelectStatementForNullDatabaseName() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds_0", new MockedDataSource()));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("db_0", databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("db_0", databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         initProxyContext(Collections.singleton(database));
         when(ProxyContext.getInstance().getContextManager().getAllDatabaseNames()).thenReturn(Collections.singleton("db_0"));
         when(ProxyContext.getInstance().getContextManager().getDatabase("db_0")).thenReturn(database);
@@ -419,7 +421,8 @@ class MySQLAdminExecutorCreatorTest {
     @Test
     void assertCreateWithNoFromAndMultiProjectionsSkipsAdmin() {
         ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds_0", new MockedDataSource()));
-        ShardingSphereDatabase database = new ShardingSphereDatabase("db_0", databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("db_0", databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         initProxyContext(Collections.singleton(database));
         
         SelectStatement selectStatement = mock(SelectStatement.class);

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLUseDatabaseExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLUseDatabaseExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.exception.core.exception.syntax.database.UnknownDatabaseException;
@@ -33,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -76,6 +79,7 @@ class MySQLUseDatabaseExecutorTest {
     private ShardingSphereMetaData mockMetaData() {
         AuthorityRule rule = mock(AuthorityRule.class);
         return new ShardingSphereMetaData(
-                Collections.singleton(new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList())), mock(), new RuleMetaData(Collections.singleton(rule)), mock());
+                Collections.singleton(new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties()))), mock(),
+                new RuleMetaData(Collections.singleton(rule)), mock());
     }
 }

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/select/SelectInformationSchemataExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/select/SelectInformationSchemataExecutorTest.java
@@ -169,7 +169,7 @@ class SelectInformationSchemataExecutorTest {
     }
     
     private ShardingSphereDatabase createDatabase(final String databaseName, final ResourceMetaData resourceMetaData) {
-        return new ShardingSphereDatabase(databaseName, databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList());
+        return new ShardingSphereDatabase(databaseName, databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList(), new ConfigurationProperties(new Properties()));
     }
     
     private ShardingSphereDatabase createDatabase(final String databaseName) {

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowCreateDatabaseExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowCreateDatabaseExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.show;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.exception.core.exception.syntax.database.UnknownDatabaseException;
@@ -34,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -81,6 +84,7 @@ class MySQLShowCreateDatabaseExecutorTest {
     private ShardingSphereMetaData mockMetaData() {
         AuthorityRule rule = mock(AuthorityRule.class);
         return new ShardingSphereMetaData(
-                Collections.singleton(new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList())), mock(), new RuleMetaData(Collections.singleton(rule)), mock());
+                Collections.singleton(new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties()))), mock(),
+                new RuleMetaData(Collections.singleton(rule)), mock());
     }
 }

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowDatabasesExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowDatabasesExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.show;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.authority.model.ShardingSpherePrivileges;
 import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
@@ -44,6 +46,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -172,7 +175,9 @@ class MySQLShowDatabasesExecutorTest {
     
     private Collection<ShardingSphereDatabase> createDatabases() {
         return IntStream.range(0, 10)
-                .mapToObj(each -> new ShardingSphereDatabase(String.format(DATABASE_PATTERN, each), databaseType, mock(), mock(), Collections.emptyList())).collect(Collectors.toList());
+                .mapToObj(
+                        each -> new ShardingSphereDatabase(String.format(DATABASE_PATTERN, each), databaseType, mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())))
+                .collect(Collectors.toList());
     }
     
     private ConnectionSession mockConnectionSession() {

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowFunctionStatusExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowFunctionStatusExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.show;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -32,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -53,6 +56,8 @@ class MySQLShowFunctionStatusExecutorTest {
     
     private Collection<ShardingSphereDatabase> createDatabases() {
         return IntStream.range(0, 10)
-                .mapToObj(each -> new ShardingSphereDatabase(String.format(DATABASE_PATTERN, each), databaseType, mock(), mock(), Collections.emptyList())).collect(Collectors.toList());
+                .mapToObj(
+                        each -> new ShardingSphereDatabase(String.format(DATABASE_PATTERN, each), databaseType, mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())))
+                .collect(Collectors.toList());
     }
 }

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowProcedureStatusExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowProcedureStatusExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.show;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -32,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -53,6 +56,8 @@ class MySQLShowProcedureStatusExecutorTest {
     
     private Collection<ShardingSphereDatabase> createDatabases() {
         return IntStream.range(0, 10)
-                .mapToObj(each -> new ShardingSphereDatabase(String.format(DATABASE_PATTERN, each), databaseType, mock(), mock(), Collections.emptyList())).collect(Collectors.toList());
+                .mapToObj(
+                        each -> new ShardingSphereDatabase(String.format(DATABASE_PATTERN, each), databaseType, mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())))
+                .collect(Collectors.toList());
     }
 }

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowTablesExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/show/MySQLShowTablesExecutorTest.java
@@ -173,7 +173,7 @@ class MySQLShowTablesExecutorTest {
         when(database.getProtocolType()).thenReturn(databaseType);
         when(database.isComplete()).thenReturn(true);
         when(database.getSchema(String.format(DATABASE_PATTERN, 0))).thenReturn(schema);
-        return Arrays.asList(database, new ShardingSphereDatabase("uncompleted", mock(), mock(), mock(), Collections.emptyList()));
+        return Arrays.asList(database, new ShardingSphereDatabase("uncompleted", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())));
     }
     
     private ConnectionSession mockConnectionSession() {

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutorTest.java
@@ -107,7 +107,8 @@ class FirebirdPrepareStatementCommandExecutorTest {
         ShardingSphereTable table = new ShardingSphereTable("foo_tbl", Collections.singleton(column), Collections.emptyList(), Collections.emptyList());
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_db", databaseType, Collections.singleton(table), Collections.emptyList());
         ShardingSphereDatabase database = new ShardingSphereDatabase(
-                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema));
+                "foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(
                 Collections.singleton(database), new ResourceMetaData(Collections.emptyMap()), globalRuleMetaData, new ConfigurationProperties(new Properties()));
         return new MetaDataContexts(metaData, new ShardingSphereStatistics());

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/MySQLAuthenticationEngineTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/MySQLAuthenticationEngineTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.proxy.frontend.mysql.authentication;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -75,6 +77,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -338,7 +341,8 @@ class MySQLAuthenticationEngineTest {
     
     private ContextManager mockContextManager(final AuthorityRule rule) {
         ContextManager result = mock(ContextManager.class, RETURNS_DEEP_STUBS);
-        ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", TypedSPILoader.getService(DatabaseType.class, "MySQL"), mock(), mock(), Collections.emptyList());
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase("foo_db", TypedSPILoader.getService(DatabaseType.class, "MySQL"), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), new RuleMetaData(Collections.singleton(rule)), mock());
         MetaDataContexts metaDataContexts = new MetaDataContexts(metaData, ShardingSphereStatisticsFactory.create(metaData, new ShardingSphereStatistics()));
         when(result.getMetaDataContexts()).thenReturn(metaDataContexts);

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.proxy.frontend.mysql.command.query.binary.prepare;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
@@ -75,6 +77,7 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -345,6 +348,7 @@ class MySQLComStmtPrepareExecutorTest {
                 new ShardingSphereColumn("name", Types.VARCHAR, false, false, false, false, false, false),
                 new ShardingSphereColumn("age", Types.SMALLINT, false, false, false, false, true, false)), Collections.emptyList(), Collections.emptyList());
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_db", databaseType, Collections.singleton(table), Collections.emptyList());
-        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema));
+        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
     }
 }

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareParameterMarkerExtractorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareParameterMarkerExtractorTest.java
@@ -310,7 +310,8 @@ class MySQLComStmtPrepareParameterMarkerExtractorTest {
     
     private ShardingSphereMetaData createMetaData() {
         return new ShardingSphereMetaData(Collections.singleton(
-                new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.singleton(schema))), mock(), mock(), new ConfigurationProperties(new Properties()));
+                new ShardingSphereDatabase("foo_db", databaseType, mock(), mock(), Collections.singleton(schema), new ConfigurationProperties(new Properties()))), mock(), mock(),
+                new ConfigurationProperties(new Properties()));
     }
     
     private JoinTableSegment createJoinTableSegment() {

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutorTest.java
@@ -181,7 +181,8 @@ class MySQLComQueryPacketExecutorTest {
         ShardingSphereTable table = new ShardingSphereTable("t", Arrays.asList(new ShardingSphereColumn("id", Types.BIGINT, true, false, false, false, true, false),
                 new ShardingSphereColumn("v", Types.INTEGER, false, false, false, false, true, false)), Collections.emptyList(), Collections.emptyList());
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_db", databaseType, Collections.singleton(table), Collections.emptyList());
-        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema));
+        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema),
+                new ConfigurationProperties(new Properties()));
     }
     
     @Test

--- a/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/parse/PostgreSQLComParseExecutorTest.java
+++ b/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/parse/PostgreSQLComParseExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.extended.PostgreSQLBinaryColumnType;
@@ -59,6 +61,7 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -191,7 +194,8 @@ class PostgreSQLComParseExecutorTest {
         when(result.getMetaDataContexts().getMetaData().getGlobalRuleMetaData())
                 .thenReturn(new RuleMetaData(Collections.singleton(new SQLParserRule(new DefaultSQLParserRuleConfigurationBuilder().build()))));
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db",
-                databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(createSchema()));
+                databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(createSchema()),
+                new ConfigurationProperties(new Properties()));
         when(result.getMetaDataContexts().getMetaData().getDatabase("foo_db")).thenReturn(database);
         when(result.getMetaDataContexts().getMetaData().getDatabase(new IdentifierValue("foo_db"))).thenReturn(database);
         when(result.getMetaDataContexts().getMetaData().containsDatabase("foo_db")).thenReturn(true);

--- a/test/it/binder/src/test/java/org/apache/shardingsphere/test/it/sql/binder/HavingCorrelatedSubqueryBinderIT.java
+++ b/test/it/binder/src/test/java/org/apache/shardingsphere/test/it/sql/binder/HavingCorrelatedSubqueryBinderIT.java
@@ -88,7 +88,8 @@ class HavingCorrelatedSubqueryBinderIT {
     
     private ShardingSphereMetaData mockMetaData(final DatabaseType databaseType) {
         Collection<ShardingSphereDatabase> databases = new LinkedList<>();
-        databases.add(new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), mockSchemas(databaseType)));
+        databases.add(
+                new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), mockSchemas(databaseType), new ConfigurationProperties(new Properties())));
         return new ShardingSphereMetaData(databases, mock(ResourceMetaData.class), mock(RuleMetaData.class), new ConfigurationProperties(new Properties()));
     }
     

--- a/test/it/binder/src/test/java/org/apache/shardingsphere/test/it/sql/binder/SQLBinderIT.java
+++ b/test/it/binder/src/test/java/org/apache/shardingsphere/test/it/sql/binder/SQLBinderIT.java
@@ -22,6 +22,8 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.binder.engine.SQLBindEngine;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.config.props.MetadataIdentifierCaseSensitivity;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.hint.SQLHintUtils;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
@@ -46,6 +48,8 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.SQLPar
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.sql.SQLCases;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.sql.type.SQLCaseType;
+import org.apache.shardingsphere.infra.util.props.PropertiesBuilder;
+import org.apache.shardingsphere.infra.util.props.PropertiesBuilder.Property;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -60,7 +64,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -71,6 +74,9 @@ public abstract class SQLBinderIT {
     private static final SQLCases SQL_CASES = SQLBinderCasesRegistry.getInstance().getCases();
     
     private static final SQLParserTestCases SQL_BINDER_TEST_CASES = SQLBinderTestCasesRegistry.getInstance().getCases();
+    
+    private static final ConfigurationProperties IDENTIFIER_INSENSITIVE_PROPS = new ConfigurationProperties(
+            PropertiesBuilder.build(new Property(ConfigurationPropertyKey.METADATA_IDENTIFIER_CASE_SENSITIVITY.getKey(), MetadataIdentifierCaseSensitivity.INSENSITIVE.name())));
     
     @ParameterizedTest(name = "{0} ({1}) -> {2}")
     @ArgumentsSource(TestCaseArgumentsProvider.class)
@@ -89,9 +95,11 @@ public abstract class SQLBinderIT {
     
     private ShardingSphereMetaData mockMetaData(final DatabaseType databaseType) {
         Collection<ShardingSphereDatabase> databases = new LinkedList<>();
-        databases.add(new ShardingSphereDatabase("foo_db_1", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), mockSchemas(databaseType, "foo_db_1")));
-        databases.add(new ShardingSphereDatabase("foo_db_2", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), mockSchemas(databaseType, "foo_db_2")));
-        return new ShardingSphereMetaData(databases, mock(ResourceMetaData.class), mock(RuleMetaData.class), new ConfigurationProperties(new Properties()));
+        databases.add(new ShardingSphereDatabase("foo_db_1", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), mockSchemas(databaseType, "foo_db_1"),
+                IDENTIFIER_INSENSITIVE_PROPS));
+        databases.add(new ShardingSphereDatabase("foo_db_2", databaseType, mock(ResourceMetaData.class), mock(RuleMetaData.class), mockSchemas(databaseType, "foo_db_2"),
+                IDENTIFIER_INSENSITIVE_PROPS));
+        return new ShardingSphereMetaData(databases, mock(ResourceMetaData.class), mock(RuleMetaData.class), IDENTIFIER_INSENSITIVE_PROPS);
     }
     
     private Collection<ShardingSphereSchema> mockSchemas(final DatabaseType databaseType, final String databaseName) {

--- a/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewriter/engine/SQLRewriterIT.java
+++ b/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewriter/engine/SQLRewriterIT.java
@@ -109,7 +109,8 @@ public abstract class SQLRewriterIT {
         SQLParserEngine sqlParserEngine = new SQLParserRule(new DefaultSQLParserRuleConfigurationBuilder().build()).getSQLParserEngine(databaseType);
         SQLStatement sqlStatement = sqlParserEngine.parse(sql, false);
         Collection<ShardingSphereRule> rules = createDatabaseRules(databaseConfig, schemaName, sqlStatement, databaseType);
-        ShardingSphereDatabase database = new ShardingSphereDatabase(databaseName, databaseType, resourceMetaData, new RuleMetaData(rules), mockSchemas(schemaName));
+        ShardingSphereDatabase database =
+                new ShardingSphereDatabase(databaseName, databaseType, resourceMetaData, new RuleMetaData(rules), mockSchemas(schemaName), new ConfigurationProperties(new Properties()));
         RuleMetaData globalRuleMetaData = new RuleMetaData(GlobalRulesBuilder.buildRules(Collections.emptyList(), Collections.emptyList(), new ConfigurationProperties(new Properties())));
         ConfigurationProperties props = new ConfigurationProperties(rootConfig.getProps());
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), globalRuleMetaData, props);


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
