### PR TITLE
Pipeline: Fix MySQL fractional temporal binlog decoding in migration

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,7 +20,7 @@
 1. Proxy: Fix primary key metadata loss for aliased columns in mysql prepare probe path - [#38517](https://github.com/apache/shardingsphere/pull/38517)
 1. Sharding: Fix incorrect routing when irrelevant sharding conditions are present - [#38527](https://github.com/apache/shardingsphere/pull/38527)
 1. Pipeline: Fix MySQL JSON literal decoding in migration - [#38622](https://github.com/apache/shardingsphere/pull/38622)
-1. Pipeline: Fix MySQL datetime(4) zero-value binlog decoding in migration - [#35531](https://github.com/apache/shardingsphere/issues/35531)
+1. Pipeline: Fix MySQL zero-value temporal binlog decoding with fractional precision in migration - [#35531](https://github.com/apache/shardingsphere/issues/35531)
 
 ### Enhancements
 

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTime2BinlogProtocolValue.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTime2BinlogProtocolValue.java
@@ -40,10 +40,10 @@ public final class MySQLTime2BinlogProtocolValue implements MySQLBinlogProtocolV
     @Override
     public Serializable read(final MySQLBinlogColumnDef columnDef, final MySQLPacketPayload payload) {
         int time = payload.getByteBuf().readUnsignedMedium();
+        MySQLFractionalSeconds fractionalSeconds = new MySQLFractionalSeconds(columnDef.getColumnMeta(), payload);
         if (0x800000 == time) {
             return MySQLTimeValueUtils.ZERO_OF_TIME;
         }
-        MySQLFractionalSeconds fractionalSeconds = new MySQLFractionalSeconds(columnDef.getColumnMeta(), payload);
         int hour = (time >> 12) % (1 << 10);
         int minute = (time >> 6) % (1 << 6);
         int second = time % (1 << 6);

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTimestamp2BinlogProtocolValue.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTimestamp2BinlogProtocolValue.java
@@ -37,10 +37,10 @@ public final class MySQLTimestamp2BinlogProtocolValue implements MySQLBinlogProt
     @Override
     public Serializable read(final MySQLBinlogColumnDef columnDef, final MySQLPacketPayload payload) {
         int seconds = payload.getByteBuf().readInt();
+        int nanos = columnDef.getColumnMeta() > 0 ? new MySQLFractionalSeconds(columnDef.getColumnMeta(), payload).getNanos() : 0;
         if (0 == seconds) {
             return MySQLTimeValueUtils.DATETIME_OF_ZERO;
         }
-        int nanos = columnDef.getColumnMeta() > 0 ? new MySQLFractionalSeconds(columnDef.getColumnMeta(), payload).getNanos() : 0;
         Timestamp result = new Timestamp(seconds * 1000L);
         result.setNanos(nanos);
         return result;

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTime2BinlogProtocolValueTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTime2BinlogProtocolValueTest.java
@@ -31,6 +31,7 @@ import java.time.LocalTime;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -88,5 +89,15 @@ class MySQLTime2BinlogProtocolValueTest {
         when(payload.getByteBuf()).thenReturn(byteBuf);
         when(byteBuf.readUnsignedMedium()).thenReturn(0x800000);
         assertThat(new MySQLTime2BinlogProtocolValue().read(columnDef, payload), is(MySQLTimeValueUtils.ZERO_OF_TIME));
+    }
+    
+    @Test
+    void assertReadNullTimeWithFraction() {
+        columnDef.setColumnMeta(4);
+        when(payload.getByteBuf()).thenReturn(byteBuf);
+        when(byteBuf.readUnsignedMedium()).thenReturn(0x800000);
+        when(byteBuf.readUnsignedShort()).thenReturn(0);
+        assertThat(new MySQLTime2BinlogProtocolValue().read(columnDef, payload), is(MySQLTimeValueUtils.ZERO_OF_TIME));
+        verify(byteBuf).readUnsignedShort();
     }
 }

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTimestamp2BinlogProtocolValueTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/packet/binlog/row/column/value/time/MySQLTimestamp2BinlogProtocolValueTest.java
@@ -31,6 +31,7 @@ import java.sql.Timestamp;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -72,5 +73,14 @@ class MySQLTimestamp2BinlogProtocolValueTest {
     void assertReadNullTime() {
         when(byteBuf.readInt()).thenReturn(0);
         assertThat(new MySQLTimestamp2BinlogProtocolValue().read(columnDef, payload), is(MySQLTimeValueUtils.DATETIME_OF_ZERO));
+    }
+    
+    @Test
+    void assertReadNullTimeWithFraction() {
+        columnDef.setColumnMeta(4);
+        when(byteBuf.readInt()).thenReturn(0);
+        when(byteBuf.readUnsignedShort()).thenReturn(0);
+        assertThat(new MySQLTimestamp2BinlogProtocolValue().read(columnDef, payload), is(MySQLTimeValueUtils.DATETIME_OF_ZERO));
+        verify(byteBuf).readUnsignedShort();
     }
 }

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/cases/migration/general/MySQLTimeTypesMigrationE2EIT.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/cases/migration/general/MySQLTimeTypesMigrationE2EIT.java
@@ -42,8 +42,8 @@ import static org.hamcrest.Matchers.is;
 /**
  * E2E IT for time types of MySQL, includes.
  * 1) timestamp, datetime, date, year zero values
- * 2) timestamp(4) fractional default value, datetime(4) and time(4) zero default values in incremental migration
- * 3) trailing date default value after temporal columns with fractional precision
+ * 2) explicit timestamp(4), datetime(4) and time(4) values in incremental migration
+ * 3) explicit trailing date value after temporal columns with fractional precision
  */
 @PipelineE2ESettings(fetchSingle = true, database = @PipelineE2ESettings.PipelineE2EDatabaseSettings(type = "MySQL"))
 class MySQLTimeTypesMigrationE2EIT extends AbstractMigrationE2EIT {
@@ -54,18 +54,17 @@ class MySQLTimeTypesMigrationE2EIT extends AbstractMigrationE2EIT {
     void assertIllegalTimeTypesValueMigrationSuccess(final PipelineTestParameter testParam) throws Exception {
         try (PipelineContainerComposer containerComposer = new PipelineContainerComposer(testParam)) {
             String sql = "CREATE TABLE `time_e2e` ( `id` int NOT NULL, `t_timestamp` timestamp NULL DEFAULT NULL, `t_datetime` datetime DEFAULT NULL, `t_date` date DEFAULT NULL, "
-                    + "`t_year` year DEFAULT NULL, `t_timestamp_4` timestamp(4) NULL DEFAULT '2020-01-02 03:04:05.6789', "
-                    + "`t_datetime_4` datetime(4) DEFAULT '0000-00-00 00:00:00.0000', `t_time_4` time(4) DEFAULT '00:00:00.0000', "
-                    + "`t_date_tail` date NOT NULL DEFAULT '2024-01-01', PRIMARY KEY (`id`)) ENGINE=InnoDB;";
+                    + "`t_year` year DEFAULT NULL, `t_timestamp_4` timestamp(4) NULL, `t_datetime_4` datetime(4) NULL, "
+                    + "`t_time_4` time(4) NULL, `t_date_tail` date NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB;";
             containerComposer.sourceExecuteWithLog(sql);
-            insertInventoryRecordWithZeroValue(containerComposer, 1);
+            insertInventoryRecord(containerComposer, 1);
             addMigrationSourceResource(containerComposer);
             addMigrationTargetResource(containerComposer);
             startMigration(containerComposer, "time_e2e", "time_e2e");
             PipelineE2EDistSQLFacade distSQLFacade = new PipelineE2EDistSQLFacade(containerComposer, new MigrationJobType());
             String jobId = distSQLFacade.listJobIds().get(0);
             distSQLFacade.waitJobIncrementalStageStarted(jobId);
-            insertIncrementalRecordWithZeroDefaultValue(containerComposer, 2);
+            insertIncrementalRecord(containerComposer, 2);
             distSQLFacade.waitJobIncrementalStageFinished(jobId);
             distSQLFacade.loadAllSingleTables();
             assertTargetRowCount(containerComposer, 2);
@@ -73,10 +72,10 @@ class MySQLTimeTypesMigrationE2EIT extends AbstractMigrationE2EIT {
         }
     }
     
-    private void insertInventoryRecordWithZeroValue(final PipelineContainerComposer containerComposer, final int id) throws SQLException {
+    private void insertInventoryRecord(final PipelineContainerComposer containerComposer, final int id) throws SQLException {
         try (Connection connection = containerComposer.getSourceDataSource().getConnection()) {
             PreparedStatement preparedStatement = connection.prepareStatement(
-                    "INSERT INTO `time_e2e`(id, t_timestamp, t_datetime, t_date, t_year, t_timestamp_4, t_datetime_4, t_time_4) VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
+                    "INSERT INTO `time_e2e`(id, t_timestamp, t_datetime, t_date, t_year, t_timestamp_4, t_datetime_4, t_time_4, t_date_tail) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
             preparedStatement.setObject(1, id);
             preparedStatement.setObject(2, "0000-00-00 00:00:00");
             preparedStatement.setObject(3, "0000-00-00 00:00:00");
@@ -85,18 +84,24 @@ class MySQLTimeTypesMigrationE2EIT extends AbstractMigrationE2EIT {
             preparedStatement.setObject(6, null);
             preparedStatement.setObject(7, null);
             preparedStatement.setObject(8, null);
+            preparedStatement.setObject(9, "2024-01-01");
             preparedStatement.execute();
         }
     }
     
-    private void insertIncrementalRecordWithZeroDefaultValue(final PipelineContainerComposer containerComposer, final int id) throws SQLException {
+    private void insertIncrementalRecord(final PipelineContainerComposer containerComposer, final int id) throws SQLException {
         try (Connection connection = containerComposer.getSourceDataSource().getConnection()) {
-            PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO `time_e2e`(id, t_timestamp, t_datetime, t_date, t_year) VALUES (?, ?, ?, ?, ?)");
+            PreparedStatement preparedStatement = connection.prepareStatement(
+                    "INSERT INTO `time_e2e`(id, t_timestamp, t_datetime, t_date, t_year, t_timestamp_4, t_datetime_4, t_time_4, t_date_tail) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
             preparedStatement.setObject(1, id);
             preparedStatement.setObject(2, "0000-00-00 00:00:00");
             preparedStatement.setObject(3, "0000-00-00 00:00:00");
             preparedStatement.setObject(4, "0000-00-00");
             preparedStatement.setObject(5, "0000");
+            preparedStatement.setObject(6, "2020-01-02 03:04:05.6789");
+            preparedStatement.setObject(7, "0000-00-00 00:00:00.0000");
+            preparedStatement.setObject(8, "00:00:00.0000");
+            preparedStatement.setObject(9, "2024-01-01");
             preparedStatement.execute();
         }
     }

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/cases/migration/general/MySQLTimeTypesMigrationE2EIT.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/operation/pipeline/cases/migration/general/MySQLTimeTypesMigrationE2EIT.java
@@ -42,8 +42,8 @@ import static org.hamcrest.Matchers.is;
 /**
  * E2E IT for time types of MySQL, includes.
  * 1) timestamp, datetime, date, year zero values
- * 2) datetime(4) zero default value in incremental migration
- * 3) trailing date default value after datetime(4)
+ * 2) timestamp(4) fractional default value, datetime(4) and time(4) zero default values in incremental migration
+ * 3) trailing date default value after temporal columns with fractional precision
  */
 @PipelineE2ESettings(fetchSingle = true, database = @PipelineE2ESettings.PipelineE2EDatabaseSettings(type = "MySQL"))
 class MySQLTimeTypesMigrationE2EIT extends AbstractMigrationE2EIT {
@@ -54,7 +54,8 @@ class MySQLTimeTypesMigrationE2EIT extends AbstractMigrationE2EIT {
     void assertIllegalTimeTypesValueMigrationSuccess(final PipelineTestParameter testParam) throws Exception {
         try (PipelineContainerComposer containerComposer = new PipelineContainerComposer(testParam)) {
             String sql = "CREATE TABLE `time_e2e` ( `id` int NOT NULL, `t_timestamp` timestamp NULL DEFAULT NULL, `t_datetime` datetime DEFAULT NULL, `t_date` date DEFAULT NULL, "
-                    + "`t_year` year DEFAULT NULL, `t_datetime_4` datetime(4) DEFAULT '0000-00-00 00:00:00.0000', "
+                    + "`t_year` year DEFAULT NULL, `t_timestamp_4` timestamp(4) NULL DEFAULT '2020-01-02 03:04:05.6789', "
+                    + "`t_datetime_4` datetime(4) DEFAULT '0000-00-00 00:00:00.0000', `t_time_4` time(4) DEFAULT '00:00:00.0000', "
                     + "`t_date_tail` date NOT NULL DEFAULT '2024-01-01', PRIMARY KEY (`id`)) ENGINE=InnoDB;";
             containerComposer.sourceExecuteWithLog(sql);
             insertInventoryRecordWithZeroValue(containerComposer, 1);
@@ -74,13 +75,16 @@ class MySQLTimeTypesMigrationE2EIT extends AbstractMigrationE2EIT {
     
     private void insertInventoryRecordWithZeroValue(final PipelineContainerComposer containerComposer, final int id) throws SQLException {
         try (Connection connection = containerComposer.getSourceDataSource().getConnection()) {
-            PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO `time_e2e`(id, t_timestamp, t_datetime, t_date, t_year, t_datetime_4) VALUES (?, ?, ?, ?, ?, ?)");
+            PreparedStatement preparedStatement = connection.prepareStatement(
+                    "INSERT INTO `time_e2e`(id, t_timestamp, t_datetime, t_date, t_year, t_timestamp_4, t_datetime_4, t_time_4) VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
             preparedStatement.setObject(1, id);
             preparedStatement.setObject(2, "0000-00-00 00:00:00");
             preparedStatement.setObject(3, "0000-00-00 00:00:00");
             preparedStatement.setObject(4, "0000-00-00");
             preparedStatement.setObject(5, "0000");
             preparedStatement.setObject(6, null);
+            preparedStatement.setObject(7, null);
+            preparedStatement.setObject(8, null);
             preparedStatement.execute();
         }
     }


### PR DESCRIPTION
Related to #38629.

Changes proposed in this pull request:
  - protocol-mysql: consume zero-value fractional bytes for TIME2 and TIMESTAMP2
  - cover MySQL timestamp(4) and time(4) migration E2E

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
