### PR TITLE
Use first storage unit database type to build table scope identifier context

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
@@ -116,10 +116,6 @@ public final class DatabaseIdentifierContextFactory {
     
     private static IdentifierCaseRuleSet createRuleSet(final DatabaseType protocolType, final ResourceMetaData resourceMetaData, final ConfigurationProperties props) {
         IdentifierCaseRuleResolver resolver = new IdentifierCaseRuleResolver();
-        if (hasMixedIdentifierRuleDatabaseTypes(resourceMetaData)) {
-            IdentifierCaseRuleSet insensitiveRuleSet = IdentifierCaseRuleSets.newInsensitiveRuleSet();
-            return createScopeAwareRuleSet(resolver.resolve(protocolType, props, null), insensitiveRuleSet);
-        }
         DatabaseType resolvedDatabaseType = getIdentifierRuleDatabaseType(resourceMetaData).orElse(protocolType);
         return createScopeAwareRuleSet(resolver.resolve(protocolType, props, null), resolver.resolve(resolvedDatabaseType, props, getFirstDataSource(resourceMetaData)));
     }
@@ -146,19 +142,5 @@ public final class DatabaseIdentifierContextFactory {
             storageDatabaseTypes.add(each.getStorageType());
         }
         return storageDatabaseTypes.stream().findFirst();
-    }
-    
-    private static boolean hasMixedIdentifierRuleDatabaseTypes(final ResourceMetaData resourceMetaData) {
-        if (null == resourceMetaData || null == resourceMetaData.getStorageUnits() || resourceMetaData.getStorageUnits().isEmpty()) {
-            return false;
-        }
-        Collection<DatabaseType> storageDatabaseTypes = new LinkedHashSet<>(resourceMetaData.getStorageUnits().size(), 1F);
-        for (StorageUnit each : resourceMetaData.getStorageUnits().values()) {
-            storageDatabaseTypes.add(each.getStorageType());
-            if (1 < storageDatabaseTypes.size()) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtilsTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtilsTest.java
@@ -41,6 +41,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -146,9 +150,9 @@ class SchemaMetaDataUtilsTest {
     }
     
     @Test
-    void assertGetMetaDataLoaderMaterialsNormalizeActualTableNamesByStorageTypeWithMixedStorageUnits() {
+    void assertGetMetaDataLoaderMaterialsNormalizeActualTableNamesByStorageTypeWithMixedStorageUnits() throws SQLException {
         Map<String, StorageUnit> storageUnits = new LinkedHashMap<>(2, 1F);
-        storageUnits.put("ds_mysql", mockStorageUnit(MYSQL_DATABASE_TYPE, mock(DataSource.class)));
+        storageUnits.put("ds_mysql", mockStorageUnit(MYSQL_DATABASE_TYPE, mockMySQLDataSource(1)));
         storageUnits.put("ds_oracle", mockStorageUnit(ORACLE_DATABASE_TYPE, mock(DataSource.class)));
         ConfigurationProperties props = createProperties(Boolean.TRUE, null);
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits, Collections.singleton(
@@ -216,6 +220,19 @@ class SchemaMetaDataUtilsTest {
         StorageUnit result = mock(StorageUnit.class);
         when(result.getStorageType()).thenReturn(storageType);
         when(result.getDataSource()).thenReturn(dataSource);
+        return result;
+    }
+    
+    private static DataSource mockMySQLDataSource(final int lowerCaseTableNames) throws SQLException {
+        DataSource result = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(result.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement("SELECT @@lower_case_table_names")).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getInt(1)).thenReturn(lowerCaseTableNames);
         return result;
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -304,9 +304,9 @@ class DatabaseIdentifierContextFactoryTest {
                         createConfigurationProperties(MetadataIdentifierCaseSensitivity.SENSITIVE), LookupMode.EXACT, "Foo", "foo", false),
                 Arguments.of("storage type overrides protocol type for oracle backend", MYSQL_DATABASE_TYPE, createResourceMetaDataWithStorageUrls("jdbc:oracle:thin:@localhost:1521:xe"),
                         new ConfigurationProperties(new Properties()), LookupMode.NORMALIZED, "T_ORDER", "t_order", true),
-                Arguments.of("mixed storage trunk types fallback to insensitive rules", MYSQL_DATABASE_TYPE,
+                Arguments.of("mixed storage trunk types use first data source rules", MYSQL_DATABASE_TYPE,
                         createResourceMetaDataWithStorageUrls("jdbc:mysql://localhost:3306/foo_db", "jdbc:oracle:thin:@localhost:1521:xe"),
-                        createConfigurationProperties(MetadataIdentifierCaseSensitivity.SENSITIVE), LookupMode.NORMALIZED, "Foo", "foo", true));
+                        createConfigurationProperties(MetadataIdentifierCaseSensitivity.SENSITIVE), LookupMode.EXACT, "Foo", "foo", false));
     }
     
     private static Stream<Arguments> refreshWithProtocolTypeAndPropsArguments() {
@@ -358,9 +358,9 @@ class DatabaseIdentifierContextFactoryTest {
                         createConfigurationProperties(MetadataIdentifierCaseSensitivity.SENSITIVE), LookupMode.EXACT, "Foo", "foo", false),
                 Arguments.of("refresh uses oracle storage type when protocol type is mysql", MYSQL_DATABASE_TYPE, createResourceMetaDataWithStorageUrls("jdbc:oracle:thin:@localhost:1521:xe"),
                         new ConfigurationProperties(new Properties()), LookupMode.NORMALIZED, "T_ORDER", "t_order", true),
-                Arguments.of("refresh falls back to insensitive rules for mixed storage types", MYSQL_DATABASE_TYPE,
+                Arguments.of("refresh uses first data source rules for mixed storage types", MYSQL_DATABASE_TYPE,
                         createResourceMetaDataWithStorageUrls("jdbc:mysql://localhost:3306/foo_db", "jdbc:oracle:thin:@localhost:1521:xe"),
-                        createConfigurationProperties(MetadataIdentifierCaseSensitivity.SENSITIVE), LookupMode.NORMALIZED, "Foo", "foo", true));
+                        createConfigurationProperties(MetadataIdentifierCaseSensitivity.SENSITIVE), LookupMode.EXACT, "Foo", "foo", false));
     }
     
     private static Stream<Arguments> refreshWithSupportedDatabaseSchemaLookupArguments() {


### PR DESCRIPTION


Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
