### PR TITLE
Fix 'occured' -> 'occurred' in ZookeeperExceptionHandler log

### DIFF
--- a/mode/type/cluster/repository/provider/zookeeper/src/main/java/org/apache/shardingsphere/mode/repository/cluster/zookeeper/exception/ZookeeperExceptionHandler.java
+++ b/mode/type/cluster/repository/provider/zookeeper/src/main/java/org/apache/shardingsphere/mode/repository/cluster/zookeeper/exception/ZookeeperExceptionHandler.java
@@ -51,7 +51,7 @@ public final class ZookeeperExceptionHandler {
             log.info("InterruptedException caught");
             Thread.currentThread().interrupt();
         } else {
-            log.error("Zookeeper exception occured.", cause);
+            log.error("Zookeeper exception occurred.", cause);
             throw new ClusterRepositoryPersistException(cause);
         }
     }


### PR DESCRIPTION
Trivial spelling fix on a user-visible error log emitted by `ZookeeperExceptionHandler.handleException` when an unrecognised Zookeeper exception bubbles through:

`log.error("Zookeeper exception occurred.", cause);`

No functional changes.