### PR TITLE
Add prepared statement caching mechanism in proxy

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -45,6 +45,7 @@
 1. Sharding: Fix HASH_MOD routing mismatch for same negative numeric values across numeric Java types with compatibility switch `normalize-numeric-int-range` - [#38327](https://github.com/apache/shardingsphere/pull/38327)
 1. Proxy: Support non column projection for MySQL prepared statement in Proxy - [#38507](https://github.com/apache/shardingsphere/pull/38507)
 1. Proxy: Support driverClassName config in proxy storage unit to solve mysql and mariadb jdbc url conflict - [#38582](https://github.com/apache/shardingsphere/pull/38582)
+1. Proxy: Support Firebird prepared statement cache reuse for held connections - [#38644](https://github.com/apache/shardingsphere/pull/38644)
 
 ## Release 5.5.3
 

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManager.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManager.java
@@ -349,6 +349,7 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
             }
             cachedConnections.clear();
         }
+        connectionSession.getPreparedStatementCacheContext().closeAll();
         if (!forceRollback) {
             connectionPostProcessors.clear();
         }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManager.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManager.java
@@ -249,6 +249,16 @@ public final class ProxyDatabaseConnectionManager implements DatabaseConnectionM
     }
     
     /**
+     * Remove proxy backend handler resource.
+     *
+     * @param handler proxy backend handler to be removed
+     */
+    public void removeResource(final ProxyBackendHandler handler) {
+        proxyBackendHandlers.remove(handler);
+        inUseProxyBackendHandlers.remove(handler);
+    }
+    
+    /**
      * Handle auto commit.
      */
     public void handleAutoCommit() {

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnector.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnector.java
@@ -85,6 +85,7 @@ import org.apache.shardingsphere.transaction.api.TransactionType;
 import org.apache.shardingsphere.transaction.implicit.ImplicitTransactionCallback;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -393,6 +394,9 @@ public final class StandardDatabaseProxyConnector implements DatabaseProxyConnec
     private Collection<SQLException> closeStatements() {
         Collection<SQLException> result = new LinkedList<>();
         for (Statement each : cachedStatements) {
+            if (isCachedPreparedStatement(each)) {
+                continue;
+            }
             try {
                 each.cancel();
                 each.close();
@@ -402,6 +406,10 @@ public final class StandardDatabaseProxyConnector implements DatabaseProxyConnec
         }
         cachedStatements.clear();
         return result;
+    }
+    
+    private boolean isCachedPreparedStatement(final Statement statement) {
+        return statement instanceof PreparedStatement && databaseConnectionManager.getConnectionSession().getPreparedStatementCacheContext().contains(statement);
     }
     
     private Optional<SQLException> closeSQLFederationEngine() {

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatement.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatement.java
@@ -24,6 +24,8 @@ import org.apache.shardingsphere.infra.executor.sql.context.ExecutionUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMode;
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.jdbc.ExecutorJDBCStatementManager;
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.jdbc.StatementOption;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.backend.session.PreparedStatementCacheContext;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -39,6 +41,16 @@ import java.util.Optional;
  */
 public final class JDBCBackendStatement implements ExecutorJDBCStatementManager {
     
+    private final ConnectionSession connectionSession;
+    
+    public JDBCBackendStatement() {
+        this(null);
+    }
+    
+    public JDBCBackendStatement(final ConnectionSession connectionSession) {
+        this.connectionSession = connectionSession;
+    }
+    
     @Override
     public Statement createStorageResource(final Connection connection, final ConnectionMode connectionMode, final StatementOption option, final DatabaseType databaseType) throws SQLException {
         Statement result = connection.createStatement();
@@ -53,9 +65,8 @@ public final class JDBCBackendStatement implements ExecutorJDBCStatementManager 
                                            final ConnectionMode connectionMode, final StatementOption option, final DatabaseType databaseType) throws SQLException {
         String sql = executionUnit.getSqlUnit().getSql();
         List<Object> params = executionUnit.getSqlUnit().getParameters();
-        PreparedStatement result = option.isReturnGeneratedKeys()
-                ? connection.prepareStatement(executionUnit.getSqlUnit().getSql(), Statement.RETURN_GENERATED_KEYS)
-                : connection.prepareStatement(sql);
+        PreparedStatement result = getPreparedStatement(connection, sql, option.isReturnGeneratedKeys());
+        result.clearParameters();
         Iterator<Object> paramIterator = params.iterator();
         int index = 0;
         while (paramIterator.hasNext()) {
@@ -71,6 +82,18 @@ public final class JDBCBackendStatement implements ExecutorJDBCStatementManager 
             setFetchSize(result, databaseType);
         }
         return result;
+    }
+    
+    private PreparedStatement getPreparedStatement(final Connection connection, final String sql, final boolean returnGeneratedKeys) throws SQLException {
+        if (null == connectionSession) {
+            return createPreparedStatement(connection, sql, returnGeneratedKeys);
+        }
+        PreparedStatementCacheContext cacheContext = connectionSession.getPreparedStatementCacheContext();
+        return cacheContext.getOrCreate(connection, sql, returnGeneratedKeys, () -> createPreparedStatement(connection, sql, returnGeneratedKeys));
+    }
+    
+    private PreparedStatement createPreparedStatement(final Connection connection, final String sql, final boolean returnGeneratedKeys) throws SQLException {
+        return returnGeneratedKeys ? connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS) : connection.prepareStatement(sql);
     }
     
     private void setFetchSize(final Statement statement, final DatabaseType databaseType) throws SQLException {

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatement.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatement.java
@@ -65,7 +65,7 @@ public final class JDBCBackendStatement implements ExecutorJDBCStatementManager 
                                            final ConnectionMode connectionMode, final StatementOption option, final DatabaseType databaseType) throws SQLException {
         String sql = executionUnit.getSqlUnit().getSql();
         List<Object> params = executionUnit.getSqlUnit().getParameters();
-        PreparedStatement result = getPreparedStatement(connection, sql, option.isReturnGeneratedKeys());
+        PreparedStatement result = getPreparedStatement(connection, sql, option.isReturnGeneratedKeys(), databaseType);
         result.clearParameters();
         Iterator<Object> paramIterator = params.iterator();
         int index = 0;
@@ -84,16 +84,24 @@ public final class JDBCBackendStatement implements ExecutorJDBCStatementManager 
         return result;
     }
     
-    private PreparedStatement getPreparedStatement(final Connection connection, final String sql, final boolean returnGeneratedKeys) throws SQLException {
-        if (null == connectionSession) {
+    private PreparedStatement getPreparedStatement(final Connection connection, final String sql, final boolean returnGeneratedKeys, final DatabaseType databaseType) throws SQLException {
+        Integer statementId = null == connectionSession ? null : getFirebirdPreparedStatementId(databaseType);
+        if (null == statementId) {
             return createPreparedStatement(connection, sql, returnGeneratedKeys);
         }
         PreparedStatementCacheContext cacheContext = connectionSession.getPreparedStatementCacheContext();
-        return cacheContext.getOrCreate(connection, sql, returnGeneratedKeys, () -> createPreparedStatement(connection, sql, returnGeneratedKeys));
+        return cacheContext.getOrCreate(connection, sql, returnGeneratedKeys, statementId, () -> createPreparedStatement(connection, sql, returnGeneratedKeys));
     }
     
     private PreparedStatement createPreparedStatement(final Connection connection, final String sql, final boolean returnGeneratedKeys) throws SQLException {
         return returnGeneratedKeys ? connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS) : connection.prepareStatement(sql);
+    }
+    
+    private Integer getFirebirdPreparedStatementId(final DatabaseType databaseType) {
+        if (!"Firebird".equals(databaseType.getType())) {
+            return null;
+        }
+        return connectionSession.getCurrentFirebirdPreparedStatementId();
     }
     
     private void setFetchSize(final Statement statement, final DatabaseType databaseType) throws SQLException {

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatement.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatement.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMod
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.jdbc.ExecutorJDBCStatementManager;
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.jdbc.StatementOption;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.backend.session.PreparedStatementCacheKey;
 import org.apache.shardingsphere.proxy.backend.session.PreparedStatementCacheContext;
 
 import java.sql.Connection;
@@ -35,6 +36,7 @@ import java.sql.Types;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Objects;
 
 /**
  * JDBC backend statement.
@@ -43,12 +45,8 @@ public final class JDBCBackendStatement implements ExecutorJDBCStatementManager 
     
     private final ConnectionSession connectionSession;
     
-    public JDBCBackendStatement() {
-        this(null);
-    }
-    
     public JDBCBackendStatement(final ConnectionSession connectionSession) {
-        this.connectionSession = connectionSession;
+        this.connectionSession = Objects.requireNonNull(connectionSession, "connectionSession cannot be null.");
     }
     
     @Override
@@ -65,7 +63,7 @@ public final class JDBCBackendStatement implements ExecutorJDBCStatementManager 
                                            final ConnectionMode connectionMode, final StatementOption option, final DatabaseType databaseType) throws SQLException {
         String sql = executionUnit.getSqlUnit().getSql();
         List<Object> params = executionUnit.getSqlUnit().getParameters();
-        PreparedStatement result = getPreparedStatement(connection, sql, option.isReturnGeneratedKeys(), databaseType);
+        PreparedStatement result = getPreparedStatement(connection, sql, option.isReturnGeneratedKeys());
         result.clearParameters();
         Iterator<Object> paramIterator = params.iterator();
         int index = 0;
@@ -84,24 +82,17 @@ public final class JDBCBackendStatement implements ExecutorJDBCStatementManager 
         return result;
     }
     
-    private PreparedStatement getPreparedStatement(final Connection connection, final String sql, final boolean returnGeneratedKeys, final DatabaseType databaseType) throws SQLException {
-        Integer statementId = null == connectionSession ? null : getFirebirdPreparedStatementId(databaseType);
-        if (null == statementId) {
+    private PreparedStatement getPreparedStatement(final Connection connection, final String sql, final boolean returnGeneratedKeys) throws SQLException {
+        Optional<PreparedStatementCacheKey> preparedStatementCacheKey = connectionSession.getCurrentPreparedStatementCacheKey();
+        if (!preparedStatementCacheKey.isPresent()) {
             return createPreparedStatement(connection, sql, returnGeneratedKeys);
         }
         PreparedStatementCacheContext cacheContext = connectionSession.getPreparedStatementCacheContext();
-        return cacheContext.getOrCreate(connection, sql, returnGeneratedKeys, statementId, () -> createPreparedStatement(connection, sql, returnGeneratedKeys));
+        return cacheContext.getOrCreate(connection, sql, returnGeneratedKeys, preparedStatementCacheKey.get(), () -> createPreparedStatement(connection, sql, returnGeneratedKeys));
     }
     
     private PreparedStatement createPreparedStatement(final Connection connection, final String sql, final boolean returnGeneratedKeys) throws SQLException {
         return returnGeneratedKeys ? connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS) : connection.prepareStatement(sql);
-    }
-    
-    private Integer getFirebirdPreparedStatementId(final DatabaseType databaseType) {
-        if (!"Firebird".equals(databaseType.getType())) {
-            return null;
-        }
-        return connectionSession.getCurrentFirebirdPreparedStatementId();
     }
     
     private void setFetchSize(final Statement statement, final DatabaseType databaseType) throws SQLException {

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSession.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSession.java
@@ -65,6 +65,8 @@ public final class ConnectionSession {
     @SuppressWarnings("rawtypes")
     private final ExecutorStatementManager statementManager;
     
+    private final PreparedStatementCacheContext preparedStatementCacheContext = new PreparedStatementCacheContext();
+    
     private final ServerPreparedStatementRegistry serverPreparedStatementRegistry = new ServerPreparedStatementRegistry();
     
     private final AtomicReference<ConnectionContext> connectionContext = new AtomicReference<>();
@@ -80,7 +82,7 @@ public final class ConnectionSession {
         transactionStatus = new TransactionStatus();
         this.attributeMap = attributeMap;
         databaseConnectionManager = new ProxyDatabaseConnectionManager(this);
-        statementManager = new JDBCBackendStatement();
+        statementManager = new JDBCBackendStatement(this);
     }
     
     /**

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSession.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSession.java
@@ -71,7 +71,7 @@ public final class ConnectionSession {
     
     private final AtomicReference<ConnectionContext> connectionContext = new AtomicReference<>();
     
-    private final AtomicReference<Integer> currentFirebirdPreparedStatementId = new AtomicReference<>();
+    private final AtomicReference<Optional<PreparedStatementCacheKey>> currentPreparedStatementCacheKey = new AtomicReference<>(Optional.empty());
     
     private final RequiredSessionVariableRecorder requiredSessionVariableRecorder = new RequiredSessionVariableRecorder();
     
@@ -136,37 +136,37 @@ public final class ConnectionSession {
     }
     
     /**
-     * Begin Firebird prepared statement execution.
+     * Begin prepared statement cache.
      *
-     * @param statementId Firebird statement ID
+     * @param cacheKey prepared statement cache key
      */
-    public void beginFirebirdPreparedStatementExecution(final int statementId) {
-        currentFirebirdPreparedStatementId.set(statementId);
+    public void beginPreparedStatementCache(final PreparedStatementCacheKey cacheKey) {
+        currentPreparedStatementCacheKey.set(Optional.of(cacheKey));
     }
     
     /**
-     * Get current Firebird prepared statement ID.
+     * Get current prepared statement cache key.
      *
-     * @return Firebird prepared statement ID
+     * @return current prepared statement cache key
      */
-    public Integer getCurrentFirebirdPreparedStatementId() {
-        return currentFirebirdPreparedStatementId.get();
+    public Optional<PreparedStatementCacheKey> getCurrentPreparedStatementCacheKey() {
+        return currentPreparedStatementCacheKey.get();
     }
     
     /**
-     * Finish Firebird prepared statement execution.
+     * Finish prepared statement cache.
      */
-    public void finishFirebirdPreparedStatementExecution() {
-        currentFirebirdPreparedStatementId.set(null);
+    public void finishPreparedStatementCache() {
+        currentPreparedStatementCacheKey.set(Optional.empty());
     }
     
     /**
-     * Invalidate Firebird prepared statement cache.
+     * Invalidate prepared statement cache.
      *
-     * @param statementId Firebird statement ID
+     * @param cacheKey prepared statement cache key
      */
-    public void invalidateFirebirdPreparedStatementCache(final int statementId) {
-        preparedStatementCacheContext.invalidate(statementId);
+    public void invalidatePreparedStatementCache(final PreparedStatementCacheKey cacheKey) {
+        preparedStatementCacheContext.invalidate(cacheKey);
     }
     
     /**

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSession.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSession.java
@@ -71,6 +71,8 @@ public final class ConnectionSession {
     
     private final AtomicReference<ConnectionContext> connectionContext = new AtomicReference<>();
     
+    private final AtomicReference<Integer> currentFirebirdPreparedStatementId = new AtomicReference<>();
+    
     private final RequiredSessionVariableRecorder requiredSessionVariableRecorder = new RequiredSessionVariableRecorder();
     
     private volatile String processId;
@@ -131,6 +133,40 @@ public final class ConnectionSession {
      */
     public Optional<TransactionIsolationLevel> getIsolationLevel() {
         return Optional.ofNullable(isolationLevel);
+    }
+    
+    /**
+     * Begin Firebird prepared statement execution.
+     *
+     * @param statementId Firebird statement ID
+     */
+    public void beginFirebirdPreparedStatementExecution(final int statementId) {
+        currentFirebirdPreparedStatementId.set(statementId);
+    }
+    
+    /**
+     * Get current Firebird prepared statement ID.
+     *
+     * @return Firebird prepared statement ID
+     */
+    public Integer getCurrentFirebirdPreparedStatementId() {
+        return currentFirebirdPreparedStatementId.get();
+    }
+    
+    /**
+     * Finish Firebird prepared statement execution.
+     */
+    public void finishFirebirdPreparedStatementExecution() {
+        currentFirebirdPreparedStatementId.set(null);
+    }
+    
+    /**
+     * Invalidate Firebird prepared statement cache.
+     *
+     * @param statementId Firebird statement ID
+     */
+    public void invalidateFirebirdPreparedStatementCache(final int statementId) {
+        preparedStatementCacheContext.invalidate(statementId);
     }
     
     /**

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheContext.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheContext.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.backend.session;
+
+import lombok.Getter;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * Prepared statement cache context.
+ */
+public final class PreparedStatementCacheContext {
+    
+    private static final int DEFAULT_MAX_SIZE = 128;
+    
+    @Getter
+    private final int maxSize;
+    
+    private final Map<CacheKey, PreparedStatement> cachedPreparedStatements = new LinkedHashMap<>(16, 0.75F, true);
+    
+    public PreparedStatementCacheContext() {
+        this(DEFAULT_MAX_SIZE);
+    }
+    
+    public PreparedStatementCacheContext(final int maxSize) {
+        this.maxSize = Math.max(1, maxSize);
+    }
+    
+    /**
+     * Get or create prepared statement.
+     *
+     * @param connection connection
+     * @param sql SQL
+     * @param returnGeneratedKeys return generated keys flag
+     * @param supplier prepared statement supplier
+     * @return prepared statement
+     * @throws SQLException SQL exception
+     */
+    public synchronized PreparedStatement getOrCreate(final Connection connection, final String sql, final boolean returnGeneratedKeys,
+                                                      final PreparedStatementSupplier supplier) throws SQLException {
+        CacheKey cacheKey = new CacheKey(connection, sql, returnGeneratedKeys);
+        PreparedStatement cachedPreparedStatement = cachedPreparedStatements.get(cacheKey);
+        if (null != cachedPreparedStatement && !isClosed(cachedPreparedStatement)) {
+            return cachedPreparedStatement;
+        }
+        if (null != cachedPreparedStatement) {
+            cachedPreparedStatements.remove(cacheKey);
+            closeQuietly(cachedPreparedStatement);
+        }
+        PreparedStatement result = supplier.get();
+        cachedPreparedStatements.put(cacheKey, result);
+        evictIfNecessary();
+        return result;
+    }
+    
+    /**
+     * Check whether statement is cached.
+     *
+     * @param statement statement
+     * @return cached or not
+     */
+    public synchronized boolean contains(final Statement statement) {
+        return cachedPreparedStatements.containsValue(statement);
+    }
+    
+    /**
+     * Invalidate cached statement.
+     *
+     * @param statement statement
+     */
+    public synchronized void invalidate(final Statement statement) {
+        Iterator<Entry<CacheKey, PreparedStatement>> iterator = cachedPreparedStatements.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Entry<CacheKey, PreparedStatement> entry = iterator.next();
+            if (entry.getValue() == statement) {
+                iterator.remove();
+                closeQuietly(entry.getValue());
+                break;
+            }
+        }
+    }
+    
+    /**
+     * Close all cached statements.
+     */
+    public synchronized void closeAll() {
+        for (PreparedStatement each : cachedPreparedStatements.values()) {
+            closeQuietly(each);
+        }
+        cachedPreparedStatements.clear();
+    }
+    
+    /**
+     * Get cache size.
+     *
+     * @return cache size
+     */
+    public synchronized int size() {
+        return cachedPreparedStatements.size();
+    }
+    
+    private void evictIfNecessary() {
+        while (cachedPreparedStatements.size() > maxSize) {
+            Iterator<Entry<CacheKey, PreparedStatement>> iterator = cachedPreparedStatements.entrySet().iterator();
+            if (!iterator.hasNext()) {
+                break;
+            }
+            Entry<CacheKey, PreparedStatement> eldest = iterator.next();
+            iterator.remove();
+            closeQuietly(eldest.getValue());
+        }
+    }
+    
+    private boolean isClosed(final PreparedStatement preparedStatement) {
+        try {
+            return preparedStatement.isClosed();
+        } catch (final SQLException ignored) {
+            return true;
+        }
+    }
+    
+    private void closeQuietly(final PreparedStatement preparedStatement) {
+        try {
+            preparedStatement.close();
+        } catch (final SQLException ignored) {
+        }
+    }
+    
+    @FunctionalInterface
+    public interface PreparedStatementSupplier {
+        
+        /**
+         * Get prepared statement.
+         *
+         * @return prepared statement
+         * @throws SQLException SQL exception
+         */
+        PreparedStatement get() throws SQLException;
+    }
+    
+    private static final class CacheKey {
+        
+        private final Connection connection;
+        
+        private final String sql;
+        
+        private final boolean returnGeneratedKeys;
+        
+        private final int connectionIdentityHash;
+        
+        private CacheKey(final Connection connection, final String sql, final boolean returnGeneratedKeys) {
+            this.connection = connection;
+            this.sql = sql;
+            this.returnGeneratedKeys = returnGeneratedKeys;
+            connectionIdentityHash = System.identityHashCode(connection);
+        }
+        
+        @Override
+        public boolean equals(final Object obj) {
+            if (!(obj instanceof CacheKey)) {
+                return false;
+            }
+            CacheKey other = (CacheKey) obj;
+            return connection == other.connection && returnGeneratedKeys == other.returnGeneratedKeys && sql.equals(other.sql);
+        }
+        
+        @Override
+        public int hashCode() {
+            int result = connectionIdentityHash;
+            result = 31 * result + sql.hashCode();
+            result = 31 * result + Boolean.hashCode(returnGeneratedKeys);
+            return result;
+        }
+    }
+}

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheContext.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheContext.java
@@ -60,7 +60,23 @@ public final class PreparedStatementCacheContext {
      */
     public synchronized PreparedStatement getOrCreate(final Connection connection, final String sql, final boolean returnGeneratedKeys,
                                                       final PreparedStatementSupplier supplier) throws SQLException {
-        CacheKey cacheKey = new CacheKey(connection, sql, returnGeneratedKeys);
+        return getOrCreate(connection, sql, returnGeneratedKeys, null, supplier);
+    }
+    
+    /**
+     * Get or create prepared statement.
+     *
+     * @param connection connection
+     * @param sql SQL
+     * @param returnGeneratedKeys return generated keys flag
+     * @param statementId statement ID
+     * @param supplier prepared statement supplier
+     * @return prepared statement
+     * @throws SQLException SQL exception
+     */
+    public synchronized PreparedStatement getOrCreate(final Connection connection, final String sql, final boolean returnGeneratedKeys,
+                                                      final Integer statementId, final PreparedStatementSupplier supplier) throws SQLException {
+        CacheKey cacheKey = new CacheKey(connection, sql, returnGeneratedKeys, statementId);
         PreparedStatement cachedPreparedStatement = cachedPreparedStatements.get(cacheKey);
         if (null != cachedPreparedStatement && !isClosed(cachedPreparedStatement)) {
             return cachedPreparedStatement;
@@ -98,6 +114,22 @@ public final class PreparedStatementCacheContext {
                 iterator.remove();
                 closeQuietly(entry.getValue());
                 break;
+            }
+        }
+    }
+    
+    /**
+     * Invalidate cached statements by statement ID.
+     *
+     * @param statementId statement ID
+     */
+    public synchronized void invalidate(final int statementId) {
+        Iterator<Entry<CacheKey, PreparedStatement>> iterator = cachedPreparedStatements.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Entry<CacheKey, PreparedStatement> entry = iterator.next();
+            if (Integer.valueOf(statementId).equals(entry.getKey().statementId)) {
+                iterator.remove();
+                closeQuietly(entry.getValue());
             }
         }
     }
@@ -168,12 +200,15 @@ public final class PreparedStatementCacheContext {
         
         private final boolean returnGeneratedKeys;
         
+        private final Integer statementId;
+        
         private final int connectionIdentityHash;
         
-        private CacheKey(final Connection connection, final String sql, final boolean returnGeneratedKeys) {
+        private CacheKey(final Connection connection, final String sql, final boolean returnGeneratedKeys, final Integer statementId) {
             this.connection = connection;
             this.sql = sql;
             this.returnGeneratedKeys = returnGeneratedKeys;
+            this.statementId = statementId;
             connectionIdentityHash = System.identityHashCode(connection);
         }
         
@@ -183,7 +218,8 @@ public final class PreparedStatementCacheContext {
                 return false;
             }
             CacheKey other = (CacheKey) obj;
-            return connection == other.connection && returnGeneratedKeys == other.returnGeneratedKeys && sql.equals(other.sql);
+            return connection == other.connection && returnGeneratedKeys == other.returnGeneratedKeys && sql.equals(other.sql)
+                    && (null == statementId ? null == other.statementId : statementId.equals(other.statementId));
         }
         
         @Override
@@ -191,6 +227,7 @@ public final class PreparedStatementCacheContext {
             int result = connectionIdentityHash;
             result = 31 * result + sql.hashCode();
             result = 31 * result + Boolean.hashCode(returnGeneratedKeys);
+            result = 31 * result + (null == statementId ? 0 : statementId.hashCode());
             return result;
         }
     }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheContext.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheContext.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 /**
  * Prepared statement cache context.
@@ -54,29 +55,14 @@ public final class PreparedStatementCacheContext {
      * @param connection connection
      * @param sql SQL
      * @param returnGeneratedKeys return generated keys flag
+     * @param preparedStatementCacheKey prepared statement cache key
      * @param supplier prepared statement supplier
      * @return prepared statement
      * @throws SQLException SQL exception
      */
     public synchronized PreparedStatement getOrCreate(final Connection connection, final String sql, final boolean returnGeneratedKeys,
-                                                      final PreparedStatementSupplier supplier) throws SQLException {
-        return getOrCreate(connection, sql, returnGeneratedKeys, null, supplier);
-    }
-    
-    /**
-     * Get or create prepared statement.
-     *
-     * @param connection connection
-     * @param sql SQL
-     * @param returnGeneratedKeys return generated keys flag
-     * @param statementId statement ID
-     * @param supplier prepared statement supplier
-     * @return prepared statement
-     * @throws SQLException SQL exception
-     */
-    public synchronized PreparedStatement getOrCreate(final Connection connection, final String sql, final boolean returnGeneratedKeys,
-                                                      final Integer statementId, final PreparedStatementSupplier supplier) throws SQLException {
-        CacheKey cacheKey = new CacheKey(connection, sql, returnGeneratedKeys, statementId);
+                                                      final PreparedStatementCacheKey preparedStatementCacheKey, final PreparedStatementSupplier supplier) throws SQLException {
+        CacheKey cacheKey = new CacheKey(connection, sql, returnGeneratedKeys, preparedStatementCacheKey);
         PreparedStatement cachedPreparedStatement = cachedPreparedStatements.get(cacheKey);
         if (null != cachedPreparedStatement && !isClosed(cachedPreparedStatement)) {
             return cachedPreparedStatement;
@@ -119,15 +105,15 @@ public final class PreparedStatementCacheContext {
     }
     
     /**
-     * Invalidate cached statements by statement ID.
+     * Invalidate cached statements by prepared statement cache key.
      *
-     * @param statementId statement ID
+     * @param preparedStatementCacheKey prepared statement cache key
      */
-    public synchronized void invalidate(final int statementId) {
+    public synchronized void invalidate(final PreparedStatementCacheKey preparedStatementCacheKey) {
         Iterator<Entry<CacheKey, PreparedStatement>> iterator = cachedPreparedStatements.entrySet().iterator();
         while (iterator.hasNext()) {
             Entry<CacheKey, PreparedStatement> entry = iterator.next();
-            if (Integer.valueOf(statementId).equals(entry.getKey().statementId)) {
+            if (preparedStatementCacheKey.equals(entry.getKey().preparedStatementCacheKey)) {
                 iterator.remove();
                 closeQuietly(entry.getValue());
             }
@@ -200,15 +186,15 @@ public final class PreparedStatementCacheContext {
         
         private final boolean returnGeneratedKeys;
         
-        private final Integer statementId;
+        private final PreparedStatementCacheKey preparedStatementCacheKey;
         
         private final int connectionIdentityHash;
         
-        private CacheKey(final Connection connection, final String sql, final boolean returnGeneratedKeys, final Integer statementId) {
+        private CacheKey(final Connection connection, final String sql, final boolean returnGeneratedKeys, final PreparedStatementCacheKey preparedStatementCacheKey) {
             this.connection = connection;
             this.sql = sql;
             this.returnGeneratedKeys = returnGeneratedKeys;
-            this.statementId = statementId;
+            this.preparedStatementCacheKey = Objects.requireNonNull(preparedStatementCacheKey, "preparedStatementCacheKey cannot be null.");
             connectionIdentityHash = System.identityHashCode(connection);
         }
         
@@ -219,7 +205,7 @@ public final class PreparedStatementCacheContext {
             }
             CacheKey other = (CacheKey) obj;
             return connection == other.connection && returnGeneratedKeys == other.returnGeneratedKeys && sql.equals(other.sql)
-                    && (null == statementId ? null == other.statementId : statementId.equals(other.statementId));
+                    && preparedStatementCacheKey.equals(other.preparedStatementCacheKey);
         }
         
         @Override
@@ -227,7 +213,7 @@ public final class PreparedStatementCacheContext {
             int result = connectionIdentityHash;
             result = 31 * result + sql.hashCode();
             result = 31 * result + Boolean.hashCode(returnGeneratedKeys);
-            result = 31 * result + (null == statementId ? 0 : statementId.hashCode());
+            result = 31 * result + preparedStatementCacheKey.hashCode();
             return result;
         }
     }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheKey.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheKey.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.backend.session;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.Objects;
+
+/**
+ * Prepared statement cache key.
+ */
+@Getter
+@EqualsAndHashCode
+public final class PreparedStatementCacheKey {
+    
+    private final String token;
+    
+    public PreparedStatementCacheKey(final String token) {
+        this.token = Objects.requireNonNull(token, "token cannot be null.");
+    }
+}

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManagerTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManagerTest.java
@@ -22,7 +22,10 @@ import lombok.SneakyThrows;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.mode.ModeConfiguration;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.executor.sql.context.ExecutionUnit;
+import org.apache.shardingsphere.infra.executor.sql.context.SQLUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMode;
+import org.apache.shardingsphere.infra.executor.sql.prepare.driver.jdbc.StatementOption;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstanceContext;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -43,6 +46,7 @@ import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.exception.BackendConnectionException;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.backend.session.PreparedStatementCacheContext;
 import org.apache.shardingsphere.proxy.backend.session.RequiredSessionVariableRecorder;
 import org.apache.shardingsphere.proxy.backend.session.transaction.TransactionStatus;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.TransactionIsolationLevel;
@@ -67,6 +71,7 @@ import org.mockito.quality.Strictness;
 
 import java.lang.reflect.Field;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
@@ -95,6 +100,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -259,6 +265,18 @@ class ProxyDatabaseConnectionManagerTest {
         verify(connection).close();
         assertTrue(cachedConnections.isEmpty());
         verifyConnectionPostProcessorsEmpty();
+    }
+    
+    @Test
+    void assertCloseConnectionsClosesPreparedStatementCache() throws SQLException {
+        PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        Connection connection = prepareCachedConnections();
+        cacheContext.getOrCreate(connection, "SELECT 1", false, 1, () -> preparedStatement);
+        when(connectionSession.getPreparedStatementCacheContext()).thenReturn(cacheContext);
+        databaseConnectionManager.closeConnections(false);
+        verify(preparedStatement).close();
+        assertThat(cacheContext.size(), is(0));
     }
     
     @SuppressWarnings("unchecked")
@@ -494,6 +512,33 @@ class ProxyDatabaseConnectionManagerTest {
         verifyNoInteractions(inUseHandler, cachedConnection);
         assertThat(getProxyBackendHandlers(), is(Collections.singleton(inUseHandler)));
         assertThat(getInUseProxyBackendHandlers(), is(Collections.singleton(inUseHandler)));
+    }
+    
+    @Test
+    void assertCloseExecutionResourcesKeepsFirebirdPreparedStatementCacheInHeldTransaction() throws SQLException, BackendConnectionException {
+        connectionSession.getTransactionStatus().setInTransaction(true);
+        connectionSession.getConnectionContext().getTransactionContext().beginTransaction(TransactionType.XA.name(), null);
+        PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
+        when(connectionSession.getPreparedStatementCacheContext()).thenReturn(cacheContext);
+        when(connectionSession.getCurrentFirebirdPreparedStatementId()).thenReturn(1);
+        DatabaseType firebirdDatabaseType = mock(DatabaseType.class);
+        when(firebirdDatabaseType.getType()).thenReturn("Firebird");
+        JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
+        Connection cachedConnection = prepareCachedConnections();
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(cachedConnection.prepareStatement("SELECT 1")).thenReturn(preparedStatement);
+        StatementOption statementOption = new StatementOption(false);
+        backendStatement.createStorageResource(
+                new ExecutionUnit("ds", new SQLUnit("SELECT 1", Collections.singletonList(1))),
+                cachedConnection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
+        databaseConnectionManager.closeExecutionResources();
+        backendStatement.createStorageResource(
+                new ExecutionUnit("ds", new SQLUnit("SELECT 1", Collections.singletonList(2))),
+                cachedConnection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
+        verify(cachedConnection).prepareStatement("SELECT 1");
+        verify(preparedStatement, times(2)).clearParameters();
+        verify(cachedConnection, never()).close();
+        assertThat(cacheContext.size(), is(1));
     }
     
     @Test

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManagerTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManagerTest.java
@@ -46,6 +46,7 @@ import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.exception.BackendConnectionException;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.backend.session.PreparedStatementCacheKey;
 import org.apache.shardingsphere.proxy.backend.session.PreparedStatementCacheContext;
 import org.apache.shardingsphere.proxy.backend.session.RequiredSessionVariableRecorder;
 import org.apache.shardingsphere.proxy.backend.session.transaction.TransactionStatus;
@@ -131,9 +132,10 @@ class ProxyDatabaseConnectionManagerTest {
         when(connectionSession.getConnectionContext().getTransactionContext()).thenReturn(new TransactionConnectionContext());
         when(connectionSession.getTransactionStatus()).thenReturn(new TransactionStatus());
         when(connectionSession.getUsedDatabaseName()).thenReturn(String.format(SCHEMA_PATTERN, 0));
+        when(connectionSession.getCurrentPreparedStatementCacheKey()).thenReturn(Optional.empty());
         databaseConnectionManager = new ProxyDatabaseConnectionManager(connectionSession);
         when(connectionSession.getDatabaseConnectionManager()).thenReturn(databaseConnectionManager);
-        JDBCBackendStatement backendStatement = new JDBCBackendStatement();
+        JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
         when(connectionSession.getStatementManager()).thenReturn(backendStatement);
         when(connectionSession.getRequiredSessionVariableRecorder()).thenReturn(new RequiredSessionVariableRecorder());
     }
@@ -272,7 +274,7 @@ class ProxyDatabaseConnectionManagerTest {
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
         Connection connection = prepareCachedConnections();
-        cacheContext.getOrCreate(connection, "SELECT 1", false, 1, () -> preparedStatement);
+        cacheContext.getOrCreate(connection, "SELECT 1", false, new PreparedStatementCacheKey("statement-1"), () -> preparedStatement);
         when(connectionSession.getPreparedStatementCacheContext()).thenReturn(cacheContext);
         databaseConnectionManager.closeConnections(false);
         verify(preparedStatement).close();
@@ -520,9 +522,8 @@ class ProxyDatabaseConnectionManagerTest {
         connectionSession.getConnectionContext().getTransactionContext().beginTransaction(TransactionType.XA.name(), null);
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
         when(connectionSession.getPreparedStatementCacheContext()).thenReturn(cacheContext);
-        when(connectionSession.getCurrentFirebirdPreparedStatementId()).thenReturn(1);
+        when(connectionSession.getCurrentPreparedStatementCacheKey()).thenReturn(Optional.of(new PreparedStatementCacheKey("statement-1")));
         DatabaseType firebirdDatabaseType = mock(DatabaseType.class);
-        when(firebirdDatabaseType.getType()).thenReturn("Firebird");
         JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
         Connection cachedConnection = prepareCachedConnections();
         PreparedStatement preparedStatement = mock(PreparedStatement.class);

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManagerTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManagerTest.java
@@ -515,7 +515,7 @@ class ProxyDatabaseConnectionManagerTest {
     }
     
     @Test
-    void assertCloseExecutionResourcesKeepsFirebirdPreparedStatementCacheInHeldTransaction() throws SQLException, BackendConnectionException {
+    void assertCloseExecutionResourcesKeepsFirebirdPreparedStatementReuseInHeldTransaction() throws SQLException, BackendConnectionException {
         connectionSession.getTransactionStatus().setInTransaction(true);
         connectionSession.getConnectionContext().getTransactionContext().beginTransaction(TransactionType.XA.name(), null);
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
@@ -535,8 +535,10 @@ class ProxyDatabaseConnectionManagerTest {
         backendStatement.createStorageResource(
                 new ExecutionUnit("ds", new SQLUnit("SELECT 1", Collections.singletonList(2))),
                 cachedConnection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
-        verify(cachedConnection).prepareStatement("SELECT 1");
+        verify(cachedConnection, times(1)).prepareStatement("SELECT 1");
         verify(preparedStatement, times(2)).clearParameters();
+        verify(preparedStatement).setObject(1, 1);
+        verify(preparedStatement).setObject(1, 2);
         verify(cachedConnection, never()).close();
         assertThat(cacheContext.size(), is(1));
     }

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManagerTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxyDatabaseConnectionManagerTest.java
@@ -465,6 +465,18 @@ class ProxyDatabaseConnectionManagerTest {
     }
     
     @Test
+    void assertRemoveDatabaseProxyConnectorResource() {
+        ProxyBackendHandler engine = mock(DatabaseProxyConnector.class);
+        Collection<ProxyBackendHandler> backendHandlers = getProxyBackendHandlers();
+        Collection<ProxyBackendHandler> inUseProxyBackendHandlers = getInUseProxyBackendHandlers();
+        backendHandlers.add(engine);
+        inUseProxyBackendHandlers.add(engine);
+        databaseConnectionManager.removeResource(engine);
+        assertFalse(backendHandlers.contains(engine));
+        assertFalse(inUseProxyBackendHandlers.contains(engine));
+    }
+    
+    @Test
     void assertCloseHandlers() throws SQLException {
         ProxyBackendHandler engine = mock(DatabaseProxyConnector.class);
         ProxyBackendHandler inUseEngine = mock(DatabaseProxyConnector.class);

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
@@ -89,6 +89,7 @@ import org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeader
 import org.apache.shardingsphere.proxy.backend.response.header.query.QueryResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.backend.session.PreparedStatementCacheKey;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sql.parser.engine.api.CacheOption;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.cursor.CursorNameSegment;
@@ -535,15 +536,15 @@ class StandardDatabaseProxyConnectorTest {
                 MockedStatic<ShardingSphereServiceLoader> serviceLoader = mockStatic(ShardingSphereServiceLoader.class, CALLS_REAL_METHODS)) {
             DatabaseProxyConnector engine = createFirebirdPreparedStatementConnector(testContext);
             serviceLoader.when(() -> ShardingSphereServiceLoader.getServiceInstances(AdvancedProxySQLExecutor.class)).thenReturn(Collections.emptyList());
-            testContext.connectionSession.beginFirebirdPreparedStatementExecution(1);
+            testContext.connectionSession.beginPreparedStatementCache(createPreparedStatementCacheKey(1));
             assertThat(engine.execute(), isA(UpdateResponseHeader.class));
             assertThat(testContext.connectionSession.getPreparedStatementCacheContext().size(), is(1));
-            testContext.connectionSession.finishFirebirdPreparedStatementExecution();
+            testContext.connectionSession.finishPreparedStatementCache();
             testContext.connectionSession.getDatabaseConnectionManager().closeExecutionResources();
             assertThat(testContext.connectionSession.getPreparedStatementCacheContext().size(), is(1));
-            testContext.connectionSession.beginFirebirdPreparedStatementExecution(1);
+            testContext.connectionSession.beginPreparedStatementCache(createPreparedStatementCacheKey(1));
             assertThat(engine.execute(), isA(UpdateResponseHeader.class));
-            testContext.connectionSession.finishFirebirdPreparedStatementExecution();
+            testContext.connectionSession.finishPreparedStatementCache();
             assertTrue(mockedDatabaseTypeRegistry.constructed().size() >= 3);
             assertThat(mockedKernelProcessor.constructed().size(), is(2));
         }
@@ -577,14 +578,14 @@ class StandardDatabaseProxyConnectorTest {
                 MockedStatic<ShardingSphereServiceLoader> serviceLoader = mockStatic(ShardingSphereServiceLoader.class, CALLS_REAL_METHODS)) {
             DatabaseProxyConnector engine = createFirebirdPreparedStatementConnector(testContext);
             serviceLoader.when(() -> ShardingSphereServiceLoader.getServiceInstances(AdvancedProxySQLExecutor.class)).thenReturn(Collections.emptyList());
-            testContext.connectionSession.beginFirebirdPreparedStatementExecution(1);
+            testContext.connectionSession.beginPreparedStatementCache(createPreparedStatementCacheKey(1));
             assertThat(engine.execute(), isA(UpdateResponseHeader.class));
-            testContext.connectionSession.finishFirebirdPreparedStatementExecution();
-            testContext.connectionSession.invalidateFirebirdPreparedStatementCache(1);
+            testContext.connectionSession.finishPreparedStatementCache();
+            testContext.connectionSession.invalidatePreparedStatementCache(createPreparedStatementCacheKey(1));
             assertThat(testContext.connectionSession.getPreparedStatementCacheContext().size(), is(0));
-            testContext.connectionSession.beginFirebirdPreparedStatementExecution(1);
+            testContext.connectionSession.beginPreparedStatementCache(createPreparedStatementCacheKey(1));
             assertThat(engine.execute(), isA(UpdateResponseHeader.class));
-            testContext.connectionSession.finishFirebirdPreparedStatementExecution();
+            testContext.connectionSession.finishPreparedStatementCache();
             assertTrue(mockedDatabaseTypeRegistry.constructed().size() >= 3);
             assertThat(mockedKernelProcessor.constructed().size(), is(2));
         }
@@ -621,14 +622,14 @@ class StandardDatabaseProxyConnectorTest {
                 MockedStatic<ShardingSphereServiceLoader> serviceLoader = mockStatic(ShardingSphereServiceLoader.class, CALLS_REAL_METHODS)) {
             DatabaseProxyConnector engine = createFirebirdPreparedStatementConnector(testContext);
             serviceLoader.when(() -> ShardingSphereServiceLoader.getServiceInstances(AdvancedProxySQLExecutor.class)).thenReturn(Collections.emptyList());
-            testContext.connectionSession.beginFirebirdPreparedStatementExecution(1);
+            testContext.connectionSession.beginPreparedStatementCache(createPreparedStatementCacheKey(1));
             assertThat(engine.execute(), isA(UpdateResponseHeader.class));
-            testContext.connectionSession.finishFirebirdPreparedStatementExecution();
+            testContext.connectionSession.finishPreparedStatementCache();
             assertThat(testContext.connectionSession.getDatabaseConnectionManager().closeConnections(false), is(Collections.emptyList()));
             assertThat(testContext.connectionSession.getPreparedStatementCacheContext().size(), is(0));
-            testContext.connectionSession.beginFirebirdPreparedStatementExecution(1);
+            testContext.connectionSession.beginPreparedStatementCache(createPreparedStatementCacheKey(1));
             assertThat(engine.execute(), isA(UpdateResponseHeader.class));
-            testContext.connectionSession.finishFirebirdPreparedStatementExecution();
+            testContext.connectionSession.finishPreparedStatementCache();
             assertTrue(mockedDatabaseTypeRegistry.constructed().size() >= 3);
             assertThat(mockedKernelProcessor.constructed().size(), is(2));
         }
@@ -1111,6 +1112,10 @@ class StandardDatabaseProxyConnectorTest {
         return new ExecutionContext(new QueryContext(testContext.sqlStatementContext, testContext.sql, Collections.singletonList(parameter),
                 new HintValueContext(), testContext.connectionSession.getConnectionContext(), testContext.metaData),
                 Collections.singletonList(new ExecutionUnit("ds", new SQLUnit(testContext.sql, Collections.singletonList(parameter)))), mock());
+    }
+    
+    private PreparedStatementCacheKey createPreparedStatementCacheKey(final int statementId) {
+        return new PreparedStatementCacheKey("firebird:" + statementId);
     }
     
     private DatabaseProxyConnector createFirebirdPreparedStatementConnector(final FirebirdPreparedStatementExecutionTestContext testContext) throws SQLException {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
@@ -130,6 +130,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -144,6 +145,7 @@ import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -642,6 +644,55 @@ class StandardDatabaseProxyConnectorTest {
         verify(firstPreparedStatement).close();
         verify(firstConnection).close();
         assertThat(testContext.connectionSession.getPreparedStatementCacheContext().size(), is(1));
+    }
+    
+    @Test
+    void assertCloseExecutionResourcesAfterHandlerCleanupAndCacheInvalidation() throws SQLException, BackendConnectionException {
+        Connection connection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        AtomicBoolean closed = new AtomicBoolean(false);
+        doAnswer(invocation -> {
+            if (closed.get()) {
+                throw new SQLException("cancel after close");
+            }
+            return null;
+        }).when(preparedStatement).cancel();
+        doAnswer(invocation -> {
+            closed.set(true);
+            return null;
+        }).when(preparedStatement).close();
+        when(preparedStatement.isClosed()).thenAnswer(invocation -> closed.get());
+        FirebirdPreparedStatementExecutionTestContext testContext = createFirebirdPreparedStatementExecutionTestContext("UPDATE tbl SET col = ?", connection);
+        when(connection.prepareStatement("UPDATE tbl SET col = ?")).thenReturn(preparedStatement);
+        ExecutionContext executionContext = createFirebirdExecutionContext(testContext, 1);
+        DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class, RETURNS_DEEP_STUBS);
+        try (
+                MockedConstruction<DatabaseTypeRegistry> mockedDatabaseTypeRegistry = mockConstruction(DatabaseTypeRegistry.class,
+                        (mock, context) -> {
+                            when(mock.getDefaultSchemaName("foo_db")).thenReturn("foo_db");
+                            when(mock.getDialectDatabaseMetaData()).thenReturn(dialectDatabaseMetaData);
+                        });
+                MockedConstruction<KernelProcessor> mockedKernelProcessor = mockConstruction(KernelProcessor.class,
+                        (mock, context) -> when(mock.generateExecutionContext(any(QueryContext.class), any(RuleMetaData.class), any(ConfigurationProperties.class))).thenReturn(executionContext));
+                MockedStatic<ShardingSphereServiceLoader> serviceLoader = mockStatic(ShardingSphereServiceLoader.class, CALLS_REAL_METHODS)) {
+            DatabaseProxyConnector engine = createFirebirdPreparedStatementConnector(testContext);
+            testContext.connectionSession.getDatabaseConnectionManager().add(engine);
+            testContext.connectionSession.getDatabaseConnectionManager().markResourceInUse(engine);
+            serviceLoader.when(() -> ShardingSphereServiceLoader.getServiceInstances(AdvancedProxySQLExecutor.class)).thenReturn(Collections.emptyList());
+            testContext.connectionSession.beginPreparedStatementCache(createPreparedStatementCacheKey(1));
+            assertThat(engine.execute(), isA(UpdateResponseHeader.class));
+            testContext.connectionSession.finishPreparedStatementCache();
+            testContext.connectionSession.getDatabaseConnectionManager().removeResource(engine);
+            engine.close();
+            testContext.connectionSession.invalidatePreparedStatementCache(createPreparedStatementCacheKey(1));
+            testContext.connectionSession.getDatabaseConnectionManager().closeExecutionResources();
+            assertTrue(mockedDatabaseTypeRegistry.constructed().size() >= 2);
+            assertThat(mockedKernelProcessor.constructed().size(), is(1));
+        }
+        verify(connection).prepareStatement("UPDATE tbl SET col = ?");
+        verify(preparedStatement, never()).cancel();
+        verify(preparedStatement).close();
+        assertTrue(closed.get());
     }
     
     @Test

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.database.metad
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
+import org.apache.shardingsphere.driver.jdbc.core.resultset.ShardingSphereResultSetMetaData;
 import org.apache.shardingsphere.infra.binder.context.segment.insert.keygen.GeneratedKeyContext;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.ProjectionsContext;
@@ -871,11 +872,11 @@ class StandardDatabaseProxyConnectorTest {
         return result;
     }
     
-    private QueryResultMetaData createQueryResultMetaData() throws SQLException {
-        QueryResultMetaData result = mock(QueryResultMetaData.class);
-        when(result.getColumnLabel(1)).thenReturn("order_id");
-        when(result.getColumnName(1)).thenReturn("order_id");
-        return result;
+    private ShardingSphereResultSetMetaData createResultSetMetaData() throws SQLException {
+        ResultSetMetaData resultSetMetaData = mock(ResultSetMetaData.class);
+        when(resultSetMetaData.getColumnLabel(1)).thenReturn("order_id");
+        when(resultSetMetaData.getColumnName(1)).thenReturn("order_id");
+        return new ShardingSphereResultSetMetaData(resultSetMetaData, mock(ShardingSphereDatabase.class), null);
     }
     
     private ResponseHeader executeWithImplicitCommitCondition(final SQLStatement sqlStatement, final String transactionType, final boolean inTransaction,
@@ -1077,8 +1078,6 @@ class StandardDatabaseProxyConnectorTest {
         StorageUnit storageUnit = mock(StorageUnit.class);
         DatabaseType storageDatabaseType = mock(DatabaseType.class);
         JDBCBackendDataSource backendDataSource = mock(JDBCBackendDataSource.class);
-        ConnectionSession connectionSession = createFirebirdConnectionSession(contextManager);
-        SQLStatementContext sqlStatementContext = createSQLStatementContext(new SQLStatement(firebirdDatabaseType));
         when(metaData.containsDatabase("foo_db")).thenReturn(true);
         when(metaData.getDatabase("foo_db")).thenReturn(database);
         when(metaData.getAllDatabases()).thenReturn(Collections.singleton(database));
@@ -1102,6 +1101,8 @@ class StandardDatabaseProxyConnectorTest {
         } else {
             when(backendDataSource.getConnections(eq("foo_db"), eq("ds"), eq(1), any())).thenReturn(Collections.singletonList(connections[0]), Collections.singletonList(connections[1]));
         }
+        ConnectionSession connectionSession = createFirebirdConnectionSession(contextManager);
+        SQLStatementContext sqlStatementContext = createSQLStatementContext(new SQLStatement(firebirdDatabaseType));
         return new FirebirdPreparedStatementExecutionTestContext(connectionSession, metaData, sqlStatementContext,
                 new QueryContext(sqlStatementContext, sql, Collections.singletonList(1), new HintValueContext(), connectionSession.getConnectionContext(), metaData), sql);
     }
@@ -1112,7 +1113,7 @@ class StandardDatabaseProxyConnectorTest {
                 Collections.singletonList(new ExecutionUnit("ds", new SQLUnit(testContext.sql, Collections.singletonList(parameter)))), mock());
     }
     
-    private DatabaseProxyConnector createFirebirdPreparedStatementConnector(final FirebirdPreparedStatementExecutionTestContext testContext) {
+    private DatabaseProxyConnector createFirebirdPreparedStatementConnector(final FirebirdPreparedStatementExecutionTestContext testContext) throws SQLException {
         DatabaseProxyConnector result = new StandardDatabaseProxyConnector(
                 JDBCDriverType.PREPARED_STATEMENT, testContext.queryContext, testContext.connectionSession.getDatabaseConnectionManager());
         ProxySQLExecutor proxySQLExecutor = getField(result, "proxySQLExecutor");

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.database.connector.core.metadata.database.metad
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
-import org.apache.shardingsphere.driver.jdbc.core.resultset.ShardingSphereResultSetMetaData;
 import org.apache.shardingsphere.infra.binder.context.segment.insert.keygen.GeneratedKeyContext;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.ProjectionsContext;
@@ -32,12 +31,15 @@ import org.apache.shardingsphere.infra.binder.context.statement.type.ddl.CursorH
 import org.apache.shardingsphere.infra.binder.context.statement.type.ddl.CursorStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.InsertStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
+import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.connection.kernel.KernelProcessor;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.resource.storageunit.EmptyStorageUnitException;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.EmptyRuleException;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionContext;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionUnit;
+import org.apache.shardingsphere.infra.executor.sql.context.SQLUnit;
+import org.apache.shardingsphere.infra.executor.sql.execute.result.ExecuteResult;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResult;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResultMetaData;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.update.UpdateResult;
@@ -49,6 +51,7 @@ import org.apache.shardingsphere.infra.merge.result.impl.memory.MemoryMergedResu
 import org.apache.shardingsphere.infra.merge.result.impl.memory.MemoryQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
 import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
@@ -72,15 +75,19 @@ import org.apache.shardingsphere.mode.metadata.refresher.pushdown.PushDownMetaDa
 import org.apache.shardingsphere.parser.config.SQLParserRuleConfiguration;
 import org.apache.shardingsphere.parser.rule.SQLParserRule;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.fixture.QueryHeaderBuilderFixture;
+import org.apache.shardingsphere.proxy.backend.connector.jdbc.datasource.JDBCBackendDataSource;
+import org.apache.shardingsphere.proxy.backend.connector.jdbc.executor.ProxyJDBCExecutor;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.statement.JDBCBackendStatement;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.transaction.ProxyBackendTransactionManager;
 import org.apache.shardingsphere.proxy.backend.context.BackendExecutorContext;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.proxy.backend.exception.BackendConnectionException;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilder;
 import org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilderEngine;
 import org.apache.shardingsphere.proxy.backend.response.header.query.QueryResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sql.parser.engine.api.CacheOption;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.cursor.CursorNameSegment;
@@ -95,6 +102,7 @@ import org.apache.shardingsphere.sqlfederation.rule.SQLFederationRule;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
 import org.junit.jupiter.api.AfterEach;
+import org.apache.shardingsphere.infra.metadata.user.Grantee;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -107,6 +115,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.lang.reflect.Field;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -129,6 +138,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
@@ -138,6 +148,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -147,6 +159,8 @@ import static org.mockito.Mockito.when;
 class StandardDatabaseProxyConnectorTest {
     
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
+    
+    private final DatabaseType firebirdDatabaseType = TypedSPILoader.getService(DatabaseType.class, "Firebird");
     
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ProxyDatabaseConnectionManager databaseConnectionManager;
@@ -500,6 +514,135 @@ class StandardDatabaseProxyConnectorTest {
     }
     
     @Test
+    void assertExecuteWithFirebirdPreparedStatementReuseInHeldConnection() throws SQLException, BackendConnectionException {
+        Connection connection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        FirebirdPreparedStatementExecutionTestContext testContext = createFirebirdPreparedStatementExecutionTestContext("UPDATE tbl SET col = ?", connection);
+        when(connection.prepareStatement("UPDATE tbl SET col = ?")).thenReturn(preparedStatement);
+        ExecutionContext firstExecutionContext = createFirebirdExecutionContext(testContext, 1);
+        ExecutionContext secondExecutionContext = createFirebirdExecutionContext(testContext, 2);
+        DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class, RETURNS_DEEP_STUBS);
+        try (
+                MockedConstruction<DatabaseTypeRegistry> mockedDatabaseTypeRegistry = mockConstruction(DatabaseTypeRegistry.class,
+                        (mock, context) -> {
+                            when(mock.getDefaultSchemaName("foo_db")).thenReturn("foo_db");
+                            when(mock.getDialectDatabaseMetaData()).thenReturn(dialectDatabaseMetaData);
+                        });
+                MockedConstruction<KernelProcessor> mockedKernelProcessor = mockConstruction(KernelProcessor.class,
+                        (mock, context) -> when(mock.generateExecutionContext(any(QueryContext.class), any(RuleMetaData.class), any(ConfigurationProperties.class)))
+                                .thenReturn(1 == context.getCount() ? firstExecutionContext : secondExecutionContext));
+                MockedStatic<ShardingSphereServiceLoader> serviceLoader = mockStatic(ShardingSphereServiceLoader.class, CALLS_REAL_METHODS)) {
+            DatabaseProxyConnector engine = createFirebirdPreparedStatementConnector(testContext);
+            serviceLoader.when(() -> ShardingSphereServiceLoader.getServiceInstances(AdvancedProxySQLExecutor.class)).thenReturn(Collections.emptyList());
+            testContext.connectionSession.beginFirebirdPreparedStatementExecution(1);
+            assertThat(engine.execute(), isA(UpdateResponseHeader.class));
+            assertThat(testContext.connectionSession.getPreparedStatementCacheContext().size(), is(1));
+            testContext.connectionSession.finishFirebirdPreparedStatementExecution();
+            testContext.connectionSession.getDatabaseConnectionManager().closeExecutionResources();
+            assertThat(testContext.connectionSession.getPreparedStatementCacheContext().size(), is(1));
+            testContext.connectionSession.beginFirebirdPreparedStatementExecution(1);
+            assertThat(engine.execute(), isA(UpdateResponseHeader.class));
+            testContext.connectionSession.finishFirebirdPreparedStatementExecution();
+            assertTrue(mockedDatabaseTypeRegistry.constructed().size() >= 3);
+            assertThat(mockedKernelProcessor.constructed().size(), is(2));
+        }
+        verify(connection).prepareStatement("UPDATE tbl SET col = ?");
+        verify(preparedStatement, times(2)).clearParameters();
+        verify(preparedStatement).setObject(1, 1);
+        verify(preparedStatement).setObject(1, 2);
+        verify(connection, never()).close();
+        assertThat(testContext.connectionSession.getPreparedStatementCacheContext().size(), is(1));
+    }
+    
+    @Test
+    void assertExecuteWithNewPreparedStatementAfterFirebirdPreparedStatementInvalidation() throws SQLException, BackendConnectionException {
+        Connection connection = mock(Connection.class);
+        PreparedStatement firstPreparedStatement = mock(PreparedStatement.class);
+        PreparedStatement secondPreparedStatement = mock(PreparedStatement.class);
+        FirebirdPreparedStatementExecutionTestContext testContext = createFirebirdPreparedStatementExecutionTestContext("UPDATE tbl SET col = ?", connection);
+        when(connection.prepareStatement("UPDATE tbl SET col = ?")).thenReturn(firstPreparedStatement, secondPreparedStatement);
+        ExecutionContext firstExecutionContext = createFirebirdExecutionContext(testContext, 1);
+        ExecutionContext secondExecutionContext = createFirebirdExecutionContext(testContext, 2);
+        DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class, RETURNS_DEEP_STUBS);
+        try (
+                MockedConstruction<DatabaseTypeRegistry> mockedDatabaseTypeRegistry = mockConstruction(DatabaseTypeRegistry.class,
+                        (mock, context) -> {
+                            when(mock.getDefaultSchemaName("foo_db")).thenReturn("foo_db");
+                            when(mock.getDialectDatabaseMetaData()).thenReturn(dialectDatabaseMetaData);
+                        });
+                MockedConstruction<KernelProcessor> mockedKernelProcessor = mockConstruction(KernelProcessor.class,
+                        (mock, context) -> when(mock.generateExecutionContext(any(QueryContext.class), any(RuleMetaData.class), any(ConfigurationProperties.class)))
+                                .thenReturn(1 == context.getCount() ? firstExecutionContext : secondExecutionContext));
+                MockedStatic<ShardingSphereServiceLoader> serviceLoader = mockStatic(ShardingSphereServiceLoader.class, CALLS_REAL_METHODS)) {
+            DatabaseProxyConnector engine = createFirebirdPreparedStatementConnector(testContext);
+            serviceLoader.when(() -> ShardingSphereServiceLoader.getServiceInstances(AdvancedProxySQLExecutor.class)).thenReturn(Collections.emptyList());
+            testContext.connectionSession.beginFirebirdPreparedStatementExecution(1);
+            assertThat(engine.execute(), isA(UpdateResponseHeader.class));
+            testContext.connectionSession.finishFirebirdPreparedStatementExecution();
+            testContext.connectionSession.invalidateFirebirdPreparedStatementCache(1);
+            assertThat(testContext.connectionSession.getPreparedStatementCacheContext().size(), is(0));
+            testContext.connectionSession.beginFirebirdPreparedStatementExecution(1);
+            assertThat(engine.execute(), isA(UpdateResponseHeader.class));
+            testContext.connectionSession.finishFirebirdPreparedStatementExecution();
+            assertTrue(mockedDatabaseTypeRegistry.constructed().size() >= 3);
+            assertThat(mockedKernelProcessor.constructed().size(), is(2));
+        }
+        verify(connection, times(2)).prepareStatement("UPDATE tbl SET col = ?");
+        verify(firstPreparedStatement).clearParameters();
+        verify(secondPreparedStatement).clearParameters();
+        verify(firstPreparedStatement).setObject(1, 1);
+        verify(secondPreparedStatement).setObject(1, 2);
+        verify(firstPreparedStatement).close();
+        assertThat(testContext.connectionSession.getPreparedStatementCacheContext().size(), is(1));
+    }
+    
+    @Test
+    void assertExecuteWithNewPreparedStatementAfterClosingConnections() throws SQLException, BackendConnectionException {
+        Connection firstConnection = mock(Connection.class);
+        Connection secondConnection = mock(Connection.class);
+        PreparedStatement firstPreparedStatement = mock(PreparedStatement.class);
+        PreparedStatement secondPreparedStatement = mock(PreparedStatement.class);
+        FirebirdPreparedStatementExecutionTestContext testContext = createFirebirdPreparedStatementExecutionTestContext("UPDATE tbl SET col = ?", firstConnection, secondConnection);
+        when(firstConnection.prepareStatement("UPDATE tbl SET col = ?")).thenReturn(firstPreparedStatement);
+        when(secondConnection.prepareStatement("UPDATE tbl SET col = ?")).thenReturn(secondPreparedStatement);
+        ExecutionContext firstExecutionContext = createFirebirdExecutionContext(testContext, 1);
+        ExecutionContext secondExecutionContext = createFirebirdExecutionContext(testContext, 2);
+        DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class, RETURNS_DEEP_STUBS);
+        try (
+                MockedConstruction<DatabaseTypeRegistry> mockedDatabaseTypeRegistry = mockConstruction(DatabaseTypeRegistry.class,
+                        (mock, context) -> {
+                            when(mock.getDefaultSchemaName("foo_db")).thenReturn("foo_db");
+                            when(mock.getDialectDatabaseMetaData()).thenReturn(dialectDatabaseMetaData);
+                        });
+                MockedConstruction<KernelProcessor> mockedKernelProcessor = mockConstruction(KernelProcessor.class,
+                        (mock, context) -> when(mock.generateExecutionContext(any(QueryContext.class), any(RuleMetaData.class), any(ConfigurationProperties.class)))
+                                .thenReturn(1 == context.getCount() ? firstExecutionContext : secondExecutionContext));
+                MockedStatic<ShardingSphereServiceLoader> serviceLoader = mockStatic(ShardingSphereServiceLoader.class, CALLS_REAL_METHODS)) {
+            DatabaseProxyConnector engine = createFirebirdPreparedStatementConnector(testContext);
+            serviceLoader.when(() -> ShardingSphereServiceLoader.getServiceInstances(AdvancedProxySQLExecutor.class)).thenReturn(Collections.emptyList());
+            testContext.connectionSession.beginFirebirdPreparedStatementExecution(1);
+            assertThat(engine.execute(), isA(UpdateResponseHeader.class));
+            testContext.connectionSession.finishFirebirdPreparedStatementExecution();
+            assertThat(testContext.connectionSession.getDatabaseConnectionManager().closeConnections(false), is(Collections.emptyList()));
+            assertThat(testContext.connectionSession.getPreparedStatementCacheContext().size(), is(0));
+            testContext.connectionSession.beginFirebirdPreparedStatementExecution(1);
+            assertThat(engine.execute(), isA(UpdateResponseHeader.class));
+            testContext.connectionSession.finishFirebirdPreparedStatementExecution();
+            assertTrue(mockedDatabaseTypeRegistry.constructed().size() >= 3);
+            assertThat(mockedKernelProcessor.constructed().size(), is(2));
+        }
+        verify(firstConnection).prepareStatement("UPDATE tbl SET col = ?");
+        verify(secondConnection).prepareStatement("UPDATE tbl SET col = ?");
+        verify(firstPreparedStatement).clearParameters();
+        verify(secondPreparedStatement).clearParameters();
+        verify(firstPreparedStatement).setObject(1, 1);
+        verify(secondPreparedStatement).setObject(1, 2);
+        verify(firstPreparedStatement).close();
+        verify(firstConnection).close();
+        assertThat(testContext.connectionSession.getPreparedStatementCacheContext().size(), is(1));
+    }
+    
+    @Test
     void assertExecuteWithQueryResult() throws SQLException {
         SQLStatementContext sqlStatementContext = createSQLStatementContext(new SQLStatement(databaseType));
         QueryContext queryContext = createQueryContext(sqlStatementContext, mockDatabase());
@@ -728,8 +871,8 @@ class StandardDatabaseProxyConnectorTest {
         return result;
     }
     
-    private ShardingSphereResultSetMetaData createResultSetMetaData() throws SQLException {
-        ShardingSphereResultSetMetaData result = mock(ShardingSphereResultSetMetaData.class);
+    private QueryResultMetaData createQueryResultMetaData() throws SQLException {
+        QueryResultMetaData result = mock(QueryResultMetaData.class);
         when(result.getColumnLabel(1)).thenReturn("order_id");
         when(result.getColumnName(1)).thenReturn("order_id");
         return result;
@@ -917,6 +1060,69 @@ class StandardDatabaseProxyConnectorTest {
         return result;
     }
     
+    private ConnectionSession createFirebirdConnectionSession(final ContextManager contextManager) {
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        ConnectionSession result = new ConnectionSession(firebirdDatabaseType, null);
+        result.setGrantee(new Grantee("foo_user"));
+        result.setCurrentDatabaseName("foo_db");
+        result.getConnectionContext().getTransactionContext().beginTransaction("XA", null);
+        result.getTransactionStatus().setInTransaction(true);
+        return result;
+    }
+    
+    private FirebirdPreparedStatementExecutionTestContext createFirebirdPreparedStatementExecutionTestContext(final String sql, final Connection... connections) throws SQLException {
+        ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
+        ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        StorageUnit storageUnit = mock(StorageUnit.class);
+        DatabaseType storageDatabaseType = mock(DatabaseType.class);
+        JDBCBackendDataSource backendDataSource = mock(JDBCBackendDataSource.class);
+        ConnectionSession connectionSession = createFirebirdConnectionSession(contextManager);
+        SQLStatementContext sqlStatementContext = createSQLStatementContext(new SQLStatement(firebirdDatabaseType));
+        when(metaData.containsDatabase("foo_db")).thenReturn(true);
+        when(metaData.getDatabase("foo_db")).thenReturn(database);
+        when(metaData.getAllDatabases()).thenReturn(Collections.singleton(database));
+        when(metaData.getProps().<Integer>getValue(ConfigurationPropertyKey.KERNEL_EXECUTOR_SIZE)).thenReturn(1);
+        when(metaData.getProps().<Integer>getValue(ConfigurationPropertyKey.MAX_CONNECTIONS_SIZE_PER_QUERY)).thenReturn(1);
+        when(metaData.getGlobalRuleMetaData()).thenReturn(new RuleMetaData(Collections.singletonList(sqlFederationRule)));
+        when(database.getName()).thenReturn("foo_db");
+        when(database.containsDataSource()).thenReturn(true);
+        when(database.isComplete()).thenReturn(true);
+        when(database.getProtocolType()).thenReturn(firebirdDatabaseType);
+        when(database.getRuleMetaData().getRules()).thenReturn(Collections.emptyList());
+        when(database.getRuleMetaData().getAttributes(DataNodeRuleAttribute.class)).thenReturn(Collections.emptyList());
+        when(database.getResourceMetaData().getStorageUnits()).thenReturn(Collections.singletonMap("ds", storageUnit));
+        when(storageDatabaseType.getType()).thenReturn("Firebird");
+        when(storageUnit.getStorageType()).thenReturn(storageDatabaseType);
+        when(contextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
+        when(contextManager.getDatabase("foo_db")).thenReturn(database);
+        when(ProxyContext.getInstance().getBackendDataSource()).thenReturn(backendDataSource);
+        if (1 == connections.length) {
+            when(backendDataSource.getConnections(eq("foo_db"), eq("ds"), eq(1), any())).thenReturn(Collections.singletonList(connections[0]));
+        } else {
+            when(backendDataSource.getConnections(eq("foo_db"), eq("ds"), eq(1), any())).thenReturn(Collections.singletonList(connections[0]), Collections.singletonList(connections[1]));
+        }
+        return new FirebirdPreparedStatementExecutionTestContext(connectionSession, metaData, sqlStatementContext,
+                new QueryContext(sqlStatementContext, sql, Collections.singletonList(1), new HintValueContext(), connectionSession.getConnectionContext(), metaData), sql);
+    }
+    
+    private ExecutionContext createFirebirdExecutionContext(final FirebirdPreparedStatementExecutionTestContext testContext, final int parameter) {
+        return new ExecutionContext(new QueryContext(testContext.sqlStatementContext, testContext.sql, Collections.singletonList(parameter),
+                new HintValueContext(), testContext.connectionSession.getConnectionContext(), testContext.metaData),
+                Collections.singletonList(new ExecutionUnit("ds", new SQLUnit(testContext.sql, Collections.singletonList(parameter)))), mock());
+    }
+    
+    private DatabaseProxyConnector createFirebirdPreparedStatementConnector(final FirebirdPreparedStatementExecutionTestContext testContext) {
+        DatabaseProxyConnector result = new StandardDatabaseProxyConnector(
+                JDBCDriverType.PREPARED_STATEMENT, testContext.queryContext, testContext.connectionSession.getDatabaseConnectionManager());
+        ProxySQLExecutor proxySQLExecutor = getField(result, "proxySQLExecutor");
+        ProxyJDBCExecutor proxyJDBCExecutor = mock(ProxyJDBCExecutor.class);
+        List<ExecuteResult> executeResults = Collections.singletonList(new UpdateResult(1, 0L));
+        when(proxyJDBCExecutor.execute(any(), any(), eq(false), anyBoolean())).thenReturn(executeResults);
+        setProxySQLExecutorField(proxySQLExecutor, "regularExecutor", proxyJDBCExecutor);
+        return result;
+    }
+    
     @SuppressWarnings("unchecked")
     @SneakyThrows(ReflectiveOperationException.class)
     private <T> T getField(final DatabaseProxyConnector target, final String fieldName) {
@@ -926,5 +1132,32 @@ class StandardDatabaseProxyConnectorTest {
     @SneakyThrows(ReflectiveOperationException.class)
     private void setField(final DatabaseProxyConnector target, final String fieldName, final Object value) {
         Plugins.getMemberAccessor().set(StandardDatabaseProxyConnector.class.getDeclaredField(fieldName), target, value);
+    }
+    
+    @SneakyThrows(ReflectiveOperationException.class)
+    private void setProxySQLExecutorField(final ProxySQLExecutor target, final String fieldName, final Object value) {
+        Plugins.getMemberAccessor().set(ProxySQLExecutor.class.getDeclaredField(fieldName), target, value);
+    }
+    
+    private static final class FirebirdPreparedStatementExecutionTestContext {
+        
+        private final ConnectionSession connectionSession;
+        
+        private final ShardingSphereMetaData metaData;
+        
+        private final SQLStatementContext sqlStatementContext;
+        
+        private final QueryContext queryContext;
+        
+        private final String sql;
+        
+        private FirebirdPreparedStatementExecutionTestContext(final ConnectionSession connectionSession, final ShardingSphereMetaData metaData,
+                                                              final SQLStatementContext sqlStatementContext, final QueryContext queryContext, final String sql) {
+            this.connectionSession = connectionSession;
+            this.metaData = metaData;
+            this.sqlStatementContext = sqlStatementContext;
+            this.queryContext = queryContext;
+            this.sql = sql;
+        }
     }
 }

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
@@ -107,6 +107,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.lang.reflect.Field;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -136,6 +137,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -800,6 +802,22 @@ class StandardDatabaseProxyConnectorTest {
         verify(statement).cancel();
         verify(statement).close();
         assertTrue(cachedResultSets.isEmpty());
+        assertTrue(cachedStatements.isEmpty());
+    }
+    
+    @Test
+    void assertCloseSkipCachedPreparedStatement() throws SQLException {
+        SQLStatementContext sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
+        when(sqlStatementContext.getTablesContext().getDatabaseNames()).thenReturn(Collections.emptyList());
+        when(sqlStatementContext.getSqlStatement().getDatabaseType()).thenReturn(databaseType);
+        DatabaseProxyConnector engine = createDatabaseProxyConnector(JDBCDriverType.STATEMENT, createQueryContext(sqlStatementContext, mockDatabase()));
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        Collection<Statement> cachedStatements = getField(engine, "cachedStatements");
+        cachedStatements.add(preparedStatement);
+        when(databaseConnectionManager.getConnectionSession().getPreparedStatementCacheContext().contains(preparedStatement)).thenReturn(true);
+        engine.close();
+        verify(preparedStatement, never()).cancel();
+        verify(preparedStatement, never()).close();
         assertTrue(cachedStatements.isEmpty());
     }
     

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatementTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatementTest.java
@@ -25,6 +25,8 @@ import org.apache.shardingsphere.infra.executor.sql.context.SQLUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMode;
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.jdbc.StatementOption;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.backend.session.PreparedStatementCacheContext;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
 import org.junit.jupiter.api.Test;
@@ -39,9 +41,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -89,5 +92,27 @@ class JDBCBackendStatementTest {
         Statement actualWithoutGeneratedKeys = backendStatement.createStorageResource(
                 new ExecutionUnit("ds", new SQLUnit(sql, Collections.emptyList())), connection, 0, ConnectionMode.CONNECTION_STRICTLY, new StatementOption(false), databaseType);
         assertThat(actualWithoutGeneratedKeys, is(preparedStatement));
+    }
+    
+    @Test
+    void assertCreateStorageResourceWithPreparedStatementCache() throws SQLException {
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
+        when(connectionSession.getPreparedStatementCacheContext()).thenReturn(cacheContext);
+        JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
+        Connection connection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        String sql = "SELECT * FROM foo WHERE id = ?";
+        when(connection.prepareStatement(sql)).thenReturn(preparedStatement);
+        when(DatabaseTypedSPILoader.findService(StatementMemoryStrictlyFetchSizeSetter.class, databaseType)).thenReturn(Optional.empty());
+        StatementOption statementOption = new StatementOption(false);
+        backendStatement.createStorageResource(
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(1))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, databaseType);
+        backendStatement.createStorageResource(
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, databaseType);
+        verify(connection).prepareStatement(sql);
+        verify(preparedStatement, times(2)).clearParameters();
+        verify(preparedStatement).setObject(1, 1);
+        verify(preparedStatement).setObject(1, 2);
     }
 }

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatementTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatementTest.java
@@ -56,9 +56,9 @@ import static org.mockito.Mockito.when;
 @ExtendWith(AutoMockExtension.class)
 @StaticMockSettings(DatabaseTypedSPILoader.class)
 class JDBCBackendStatementTest {
-
+    
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
-
+    
     @Test
     void assertCreateStorageResourceWithStatementSetsFetchSizeOnlyInMemoryStrictly() throws SQLException {
         JDBCBackendStatement backendStatement = new JDBCBackendStatement();
@@ -74,7 +74,7 @@ class JDBCBackendStatementTest {
         assertThat(backendStatement.createStorageResource(connection, ConnectionMode.CONNECTION_STRICTLY, statementOption, databaseType), is(statement));
         verifyNoMoreInteractions(fetchSizeSetter);
     }
-
+    
     @Test
     void assertCreateStorageResourceWithPreparedStatement() throws SQLException {
         JDBCBackendStatement backendStatement = new JDBCBackendStatement();
@@ -97,7 +97,7 @@ class JDBCBackendStatementTest {
                 new ExecutionUnit("ds", new SQLUnit(sql, Collections.emptyList())), connection, 0, ConnectionMode.CONNECTION_STRICTLY, new StatementOption(false), databaseType);
         assertThat(actualWithoutGeneratedKeys, is(preparedStatement));
     }
-
+    
     @Test
     void assertCreateStorageResourceReusesPreparedStatementForSameFirebirdStatementId() throws SQLException {
         ConnectionSession connectionSession = mock(ConnectionSession.class);
@@ -121,7 +121,7 @@ class JDBCBackendStatementTest {
         verify(preparedStatement).setObject(1, 1);
         verify(preparedStatement).setObject(1, 2);
     }
-
+    
     @ParameterizedTest(name = "{0}")
     @MethodSource("nonFirebirdDatabaseTypes")
     void assertCreateStorageResourceWithoutPreparedStatementCacheForNonFirebird(final String scenario, final String databaseTypeName) throws SQLException {
@@ -140,7 +140,7 @@ class JDBCBackendStatementTest {
                 new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, nonFirebirdDatabaseType);
         verify(connection, times(2)).prepareStatement(sql);
     }
-
+    
     @Test
     void assertCreateStorageResourceWithDifferentFirebirdPreparedStatementId() throws SQLException {
         ConnectionSession connectionSession = mock(ConnectionSession.class);
@@ -161,7 +161,7 @@ class JDBCBackendStatementTest {
                 new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
         verify(connection, times(2)).prepareStatement(sql);
     }
-
+    
     @Test
     void assertCreateNewPreparedStatementAfterCacheInvalidation() throws SQLException {
         ConnectionSession connectionSession = mock(ConnectionSession.class);
@@ -185,7 +185,7 @@ class JDBCBackendStatementTest {
         verify(connection, times(2)).prepareStatement(sql);
         verify(firstPreparedStatement).close();
     }
-
+    
     private static Stream<Arguments> nonFirebirdDatabaseTypes() {
         return Stream.of(
                 Arguments.of("createStorageResource_mysqlDoesNotUsePreparedStatementCache", "MySQL"),

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatementTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatementTest.java
@@ -31,6 +31,9 @@ import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExt
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -40,6 +43,7 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -98,21 +102,70 @@ class JDBCBackendStatementTest {
     void assertCreateStorageResourceWithPreparedStatementCache() throws SQLException {
         ConnectionSession connectionSession = mock(ConnectionSession.class);
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
+        DatabaseType firebirdDatabaseType = mock(DatabaseType.class);
+        when(firebirdDatabaseType.getType()).thenReturn("Firebird");
+        when(connectionSession.getPreparedStatementCacheContext()).thenReturn(cacheContext);
+        when(connectionSession.getCurrentFirebirdPreparedStatementId()).thenReturn(1);
+        JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
+        Connection connection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        String sql = "SELECT * FROM foo WHERE id = ?";
+        when(connection.prepareStatement(sql)).thenReturn(preparedStatement);
+        StatementOption statementOption = new StatementOption(false);
+        backendStatement.createStorageResource(
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(1))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
+        backendStatement.createStorageResource(
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
+        verify(connection).prepareStatement(sql);
+        verify(preparedStatement, times(2)).clearParameters();
+        verify(preparedStatement).setObject(1, 1);
+        verify(preparedStatement).setObject(1, 2);
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("nonFirebirdDatabaseTypes")
+    void assertCreateStorageResourceWithoutPreparedStatementCacheForNonFirebird(final String scenario, final String databaseTypeName) throws SQLException {
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
+        Connection connection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        String sql = "SELECT * FROM foo WHERE id = ?";
+        DatabaseType nonFirebirdDatabaseType = mock(DatabaseType.class);
+        when(nonFirebirdDatabaseType.getType()).thenReturn(databaseTypeName);
+        when(connection.prepareStatement(sql)).thenReturn(preparedStatement);
+        StatementOption statementOption = new StatementOption(false);
+        backendStatement.createStorageResource(
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(1))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, nonFirebirdDatabaseType);
+        backendStatement.createStorageResource(
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, nonFirebirdDatabaseType);
+        verify(connection, times(2)).prepareStatement(sql);
+    }
+    
+    @Test
+    void assertCreateStorageResourceWithDifferentFirebirdPreparedStatementId() throws SQLException {
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
+        DatabaseType firebirdDatabaseType = mock(DatabaseType.class);
+        when(firebirdDatabaseType.getType()).thenReturn("Firebird");
         when(connectionSession.getPreparedStatementCacheContext()).thenReturn(cacheContext);
         JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
         Connection connection = mock(Connection.class);
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
         String sql = "SELECT * FROM foo WHERE id = ?";
         when(connection.prepareStatement(sql)).thenReturn(preparedStatement);
-        when(DatabaseTypedSPILoader.findService(StatementMemoryStrictlyFetchSizeSetter.class, databaseType)).thenReturn(Optional.empty());
         StatementOption statementOption = new StatementOption(false);
+        when(connectionSession.getCurrentFirebirdPreparedStatementId()).thenReturn(1, 2);
         backendStatement.createStorageResource(
-                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(1))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, databaseType);
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(1))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
         backendStatement.createStorageResource(
-                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, databaseType);
-        verify(connection).prepareStatement(sql);
-        verify(preparedStatement, times(2)).clearParameters();
-        verify(preparedStatement).setObject(1, 1);
-        verify(preparedStatement).setObject(1, 2);
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
+        verify(connection, times(2)).prepareStatement(sql);
+    }
+    
+    private static Stream<Arguments> nonFirebirdDatabaseTypes() {
+        return Stream.of(
+                Arguments.of("createStorageResource_mysqlDoesNotUsePreparedStatementCache", "MySQL"),
+                Arguments.of("createStorageResource_postgresqlDoesNotUsePreparedStatementCache", "PostgreSQL"),
+                Arguments.of("createStorageResource_openGaussDoesNotUsePreparedStatementCache", "openGauss"));
     }
 }

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatementTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatementTest.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMod
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.jdbc.StatementOption;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.backend.session.PreparedStatementCacheKey;
 import org.apache.shardingsphere.proxy.backend.session.PreparedStatementCacheContext;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
@@ -61,7 +62,8 @@ class JDBCBackendStatementTest {
     
     @Test
     void assertCreateStorageResourceWithStatementSetsFetchSizeOnlyInMemoryStrictly() throws SQLException {
-        JDBCBackendStatement backendStatement = new JDBCBackendStatement();
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
         Connection connection = mock(Connection.class);
         Statement statement = mock(Statement.class);
         when(connection.createStatement()).thenReturn(statement);
@@ -77,7 +79,9 @@ class JDBCBackendStatementTest {
     
     @Test
     void assertCreateStorageResourceWithPreparedStatement() throws SQLException {
-        JDBCBackendStatement backendStatement = new JDBCBackendStatement();
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        when(connectionSession.getCurrentPreparedStatementCacheKey()).thenReturn(Optional.empty());
+        JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
         Connection connection = mock(Connection.class);
         PreparedStatement preparedStatementWithGeneratedKeys = mock(PreparedStatement.class);
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
@@ -99,13 +103,11 @@ class JDBCBackendStatementTest {
     }
     
     @Test
-    void assertCreateStorageResourceReusesPreparedStatementForSameFirebirdStatementId() throws SQLException {
+    void assertCreateStorageResourceReusesPreparedStatementForSamePreparedStatementCacheKey() throws SQLException {
         ConnectionSession connectionSession = mock(ConnectionSession.class);
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
-        DatabaseType firebirdDatabaseType = mock(DatabaseType.class);
-        when(firebirdDatabaseType.getType()).thenReturn("Firebird");
         when(connectionSession.getPreparedStatementCacheContext()).thenReturn(cacheContext);
-        when(connectionSession.getCurrentFirebirdPreparedStatementId()).thenReturn(1);
+        when(connectionSession.getCurrentPreparedStatementCacheKey()).thenReturn(Optional.of(new PreparedStatementCacheKey("statement-1")));
         JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
         Connection connection = mock(Connection.class);
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
@@ -113,9 +115,9 @@ class JDBCBackendStatementTest {
         when(connection.prepareStatement(sql)).thenReturn(preparedStatement);
         StatementOption statementOption = new StatementOption(false);
         backendStatement.createStorageResource(
-                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(1))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(1))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, databaseType);
         backendStatement.createStorageResource(
-                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, databaseType);
         verify(connection).prepareStatement(sql);
         verify(preparedStatement, times(2)).clearParameters();
         verify(preparedStatement).setObject(1, 1);
@@ -124,14 +126,14 @@ class JDBCBackendStatementTest {
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("nonFirebirdDatabaseTypes")
-    void assertCreateStorageResourceWithoutPreparedStatementCacheForNonFirebird(final String scenario, final String databaseTypeName) throws SQLException {
+    void assertCreateStorageResourceWithoutPreparedStatementCacheWithoutActiveKey(final String scenario, final String databaseTypeName) throws SQLException {
         ConnectionSession connectionSession = mock(ConnectionSession.class);
+        when(connectionSession.getCurrentPreparedStatementCacheKey()).thenReturn(Optional.empty());
         JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
         Connection connection = mock(Connection.class);
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
         String sql = "SELECT * FROM foo WHERE id = ?";
         DatabaseType nonFirebirdDatabaseType = mock(DatabaseType.class);
-        when(nonFirebirdDatabaseType.getType()).thenReturn(databaseTypeName);
         when(connection.prepareStatement(sql)).thenReturn(preparedStatement);
         StatementOption statementOption = new StatementOption(false);
         backendStatement.createStorageResource(
@@ -142,11 +144,9 @@ class JDBCBackendStatementTest {
     }
     
     @Test
-    void assertCreateStorageResourceWithDifferentFirebirdPreparedStatementId() throws SQLException {
+    void assertCreateStorageResourceWithDifferentPreparedStatementCacheKey() throws SQLException {
         ConnectionSession connectionSession = mock(ConnectionSession.class);
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
-        DatabaseType firebirdDatabaseType = mock(DatabaseType.class);
-        when(firebirdDatabaseType.getType()).thenReturn("Firebird");
         when(connectionSession.getPreparedStatementCacheContext()).thenReturn(cacheContext);
         JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
         Connection connection = mock(Connection.class);
@@ -154,11 +154,12 @@ class JDBCBackendStatementTest {
         String sql = "SELECT * FROM foo WHERE id = ?";
         when(connection.prepareStatement(sql)).thenReturn(preparedStatement);
         StatementOption statementOption = new StatementOption(false);
-        when(connectionSession.getCurrentFirebirdPreparedStatementId()).thenReturn(1, 2);
+        when(connectionSession.getCurrentPreparedStatementCacheKey()).thenReturn(
+                Optional.of(new PreparedStatementCacheKey("statement-1")), Optional.of(new PreparedStatementCacheKey("statement-2")));
         backendStatement.createStorageResource(
-                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(1))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(1))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, databaseType);
         backendStatement.createStorageResource(
-                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, databaseType);
         verify(connection, times(2)).prepareStatement(sql);
     }
     
@@ -166,10 +167,9 @@ class JDBCBackendStatementTest {
     void assertCreateNewPreparedStatementAfterCacheInvalidation() throws SQLException {
         ConnectionSession connectionSession = mock(ConnectionSession.class);
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
-        DatabaseType firebirdDatabaseType = mock(DatabaseType.class);
-        when(firebirdDatabaseType.getType()).thenReturn("Firebird");
+        PreparedStatementCacheKey preparedStatementCacheKey = new PreparedStatementCacheKey("statement-1");
         when(connectionSession.getPreparedStatementCacheContext()).thenReturn(cacheContext);
-        when(connectionSession.getCurrentFirebirdPreparedStatementId()).thenReturn(1);
+        when(connectionSession.getCurrentPreparedStatementCacheKey()).thenReturn(Optional.of(preparedStatementCacheKey));
         JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
         Connection connection = mock(Connection.class);
         PreparedStatement firstPreparedStatement = mock(PreparedStatement.class);
@@ -178,10 +178,10 @@ class JDBCBackendStatementTest {
         when(connection.prepareStatement(sql)).thenReturn(firstPreparedStatement, secondPreparedStatement);
         StatementOption statementOption = new StatementOption(false);
         backendStatement.createStorageResource(
-                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(1))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
-        cacheContext.invalidate(1);
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(1))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, databaseType);
+        cacheContext.invalidate(preparedStatementCacheKey);
         backendStatement.createStorageResource(
-                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, databaseType);
         verify(connection, times(2)).prepareStatement(sql);
         verify(firstPreparedStatement).close();
     }

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatementTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/statement/JDBCBackendStatementTest.java
@@ -56,9 +56,9 @@ import static org.mockito.Mockito.when;
 @ExtendWith(AutoMockExtension.class)
 @StaticMockSettings(DatabaseTypedSPILoader.class)
 class JDBCBackendStatementTest {
-    
+
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
-    
+
     @Test
     void assertCreateStorageResourceWithStatementSetsFetchSizeOnlyInMemoryStrictly() throws SQLException {
         JDBCBackendStatement backendStatement = new JDBCBackendStatement();
@@ -74,7 +74,7 @@ class JDBCBackendStatementTest {
         assertThat(backendStatement.createStorageResource(connection, ConnectionMode.CONNECTION_STRICTLY, statementOption, databaseType), is(statement));
         verifyNoMoreInteractions(fetchSizeSetter);
     }
-    
+
     @Test
     void assertCreateStorageResourceWithPreparedStatement() throws SQLException {
         JDBCBackendStatement backendStatement = new JDBCBackendStatement();
@@ -97,9 +97,9 @@ class JDBCBackendStatementTest {
                 new ExecutionUnit("ds", new SQLUnit(sql, Collections.emptyList())), connection, 0, ConnectionMode.CONNECTION_STRICTLY, new StatementOption(false), databaseType);
         assertThat(actualWithoutGeneratedKeys, is(preparedStatement));
     }
-    
+
     @Test
-    void assertCreateStorageResourceWithPreparedStatementCache() throws SQLException {
+    void assertCreateStorageResourceReusesPreparedStatementForSameFirebirdStatementId() throws SQLException {
         ConnectionSession connectionSession = mock(ConnectionSession.class);
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
         DatabaseType firebirdDatabaseType = mock(DatabaseType.class);
@@ -121,7 +121,7 @@ class JDBCBackendStatementTest {
         verify(preparedStatement).setObject(1, 1);
         verify(preparedStatement).setObject(1, 2);
     }
-    
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("nonFirebirdDatabaseTypes")
     void assertCreateStorageResourceWithoutPreparedStatementCacheForNonFirebird(final String scenario, final String databaseTypeName) throws SQLException {
@@ -140,7 +140,7 @@ class JDBCBackendStatementTest {
                 new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, nonFirebirdDatabaseType);
         verify(connection, times(2)).prepareStatement(sql);
     }
-    
+
     @Test
     void assertCreateStorageResourceWithDifferentFirebirdPreparedStatementId() throws SQLException {
         ConnectionSession connectionSession = mock(ConnectionSession.class);
@@ -161,7 +161,31 @@ class JDBCBackendStatementTest {
                 new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
         verify(connection, times(2)).prepareStatement(sql);
     }
-    
+
+    @Test
+    void assertCreateNewPreparedStatementAfterCacheInvalidation() throws SQLException {
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
+        DatabaseType firebirdDatabaseType = mock(DatabaseType.class);
+        when(firebirdDatabaseType.getType()).thenReturn("Firebird");
+        when(connectionSession.getPreparedStatementCacheContext()).thenReturn(cacheContext);
+        when(connectionSession.getCurrentFirebirdPreparedStatementId()).thenReturn(1);
+        JDBCBackendStatement backendStatement = new JDBCBackendStatement(connectionSession);
+        Connection connection = mock(Connection.class);
+        PreparedStatement firstPreparedStatement = mock(PreparedStatement.class);
+        PreparedStatement secondPreparedStatement = mock(PreparedStatement.class);
+        String sql = "SELECT * FROM foo WHERE id = ?";
+        when(connection.prepareStatement(sql)).thenReturn(firstPreparedStatement, secondPreparedStatement);
+        StatementOption statementOption = new StatementOption(false);
+        backendStatement.createStorageResource(
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(1))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
+        cacheContext.invalidate(1);
+        backendStatement.createStorageResource(
+                new ExecutionUnit("ds", new SQLUnit(sql, Collections.singletonList(2))), connection, 0, ConnectionMode.CONNECTION_STRICTLY, statementOption, firebirdDatabaseType);
+        verify(connection, times(2)).prepareStatement(sql);
+        verify(firstPreparedStatement).close();
+    }
+
     private static Stream<Arguments> nonFirebirdDatabaseTypes() {
         return Stream.of(
                 Arguments.of("createStorageResource_mysqlDoesNotUsePreparedStatementCache", "MySQL"),

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSessionTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSessionTest.java
@@ -164,6 +164,11 @@ class ConnectionSessionTest {
         assertNull(connectionSession.getQueryContext());
     }
     
+    @Test
+    void assertPreparedStatementCacheContext() {
+        assertNotNull(connectionSession.getPreparedStatementCacheContext());
+    }
+    
     @SuppressWarnings("unchecked")
     private AtomicReference<ConnectionContext> getConnectionContextReference() throws ReflectiveOperationException {
         return (AtomicReference<ConnectionContext>) Plugins.getMemberAccessor().get(ConnectionSession.class.getDeclaredField("connectionContext"), connectionSession);

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSessionTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSessionTest.java
@@ -169,6 +169,14 @@ class ConnectionSessionTest {
         assertNotNull(connectionSession.getPreparedStatementCacheContext());
     }
     
+    @Test
+    void assertFirebirdPreparedStatementExecutionContext() {
+        connectionSession.beginFirebirdPreparedStatementExecution(1);
+        assertThat(connectionSession.getCurrentFirebirdPreparedStatementId(), is(1));
+        connectionSession.finishFirebirdPreparedStatementExecution();
+        assertNull(connectionSession.getCurrentFirebirdPreparedStatementId());
+    }
+    
     @SuppressWarnings("unchecked")
     private AtomicReference<ConnectionContext> getConnectionContextReference() throws ReflectiveOperationException {
         return (AtomicReference<ConnectionContext>) Plugins.getMemberAccessor().get(ConnectionSession.class.getDeclaredField("connectionContext"), connectionSession);

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSessionTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSessionTest.java
@@ -36,7 +36,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.internal.configuration.plugins.Plugins;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.is;
@@ -170,11 +174,18 @@ class ConnectionSessionTest {
     }
     
     @Test
-    void assertFirebirdPreparedStatementExecutionContext() {
-        connectionSession.beginFirebirdPreparedStatementExecution(1);
-        assertThat(connectionSession.getCurrentFirebirdPreparedStatementId(), is(1));
-        connectionSession.finishFirebirdPreparedStatementExecution();
-        assertNull(connectionSession.getCurrentFirebirdPreparedStatementId());
+    void assertPreparedStatementCacheLifecycle() throws SQLException {
+        PreparedStatementCacheKey preparedStatementCacheKey = new PreparedStatementCacheKey("statement-1");
+        connectionSession.beginPreparedStatementCache(preparedStatementCacheKey);
+        assertThat(connectionSession.getCurrentPreparedStatementCacheKey(), is(Optional.of(preparedStatementCacheKey)));
+        Connection connection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        connectionSession.getPreparedStatementCacheContext().getOrCreate(connection, "SELECT 1", false, preparedStatementCacheKey, () -> preparedStatement);
+        connectionSession.invalidatePreparedStatementCache(preparedStatementCacheKey);
+        assertFalse(connectionSession.getPreparedStatementCacheContext().contains(preparedStatement));
+        connectionSession.finishPreparedStatementCache();
+        assertThat(connectionSession.getCurrentPreparedStatementCacheKey(), is(Optional.empty()));
+        verify(preparedStatement).close();
     }
     
     @SuppressWarnings("unchecked")

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheContextTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheContextTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.backend.session;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class PreparedStatementCacheContextTest {
+    
+    @Test
+    void assertGetOrCreate() throws SQLException {
+        PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
+        Connection connection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        int[] invokedCount = {0};
+        PreparedStatement actualFirst = cacheContext.getOrCreate(connection, "SELECT 1", false, () -> {
+            invokedCount[0]++;
+            return preparedStatement;
+        });
+        PreparedStatement actualSecond = cacheContext.getOrCreate(connection, "SELECT 1", false, () -> {
+            invokedCount[0]++;
+            return mock(PreparedStatement.class);
+        });
+        assertThat(actualFirst, is(preparedStatement));
+        assertThat(actualSecond, is(preparedStatement));
+        assertThat(invokedCount[0], is(1));
+        assertTrue(cacheContext.contains(preparedStatement));
+    }
+    
+    @Test
+    void assertEvictWithLRU() throws SQLException {
+        PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(2);
+        Connection connection = mock(Connection.class);
+        PreparedStatement first = mock(PreparedStatement.class);
+        PreparedStatement second = mock(PreparedStatement.class);
+        PreparedStatement third = mock(PreparedStatement.class);
+        cacheContext.getOrCreate(connection, "SELECT 1", false, () -> first);
+        cacheContext.getOrCreate(connection, "SELECT 2", false, () -> second);
+        cacheContext.getOrCreate(connection, "SELECT 1", false, () -> first);
+        cacheContext.getOrCreate(connection, "SELECT 3", false, () -> third);
+        assertFalse(cacheContext.contains(second));
+        assertTrue(cacheContext.contains(first));
+        assertTrue(cacheContext.contains(third));
+        verify(second).close();
+    }
+    
+    @Test
+    void assertInvalidate() throws SQLException {
+        PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
+        Connection connection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        cacheContext.getOrCreate(connection, "SELECT 1", false, () -> preparedStatement);
+        cacheContext.invalidate(preparedStatement);
+        assertFalse(cacheContext.contains(preparedStatement));
+        verify(preparedStatement).close();
+    }
+    
+    @Test
+    void assertCloseAll() throws SQLException {
+        PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
+        Connection connection = mock(Connection.class);
+        PreparedStatement first = mock(PreparedStatement.class);
+        PreparedStatement second = mock(PreparedStatement.class);
+        cacheContext.getOrCreate(connection, "SELECT 1", false, () -> first);
+        cacheContext.getOrCreate(connection, "SELECT 2", false, () -> second);
+        cacheContext.closeAll();
+        assertThat(cacheContext.size(), is(0));
+        verify(first).close();
+        verify(second).close();
+    }
+}

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheContextTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheContextTest.java
@@ -81,6 +81,20 @@ class PreparedStatementCacheContextTest {
     }
     
     @Test
+    void assertInvalidateByStatementId() throws SQLException {
+        PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
+        Connection connection = mock(Connection.class);
+        PreparedStatement first = mock(PreparedStatement.class);
+        PreparedStatement second = mock(PreparedStatement.class);
+        cacheContext.getOrCreate(connection, "SELECT 1", false, 1, () -> first);
+        cacheContext.getOrCreate(connection, "SELECT 1", false, 2, () -> second);
+        cacheContext.invalidate(1);
+        assertFalse(cacheContext.contains(first));
+        assertTrue(cacheContext.contains(second));
+        verify(first).close();
+    }
+    
+    @Test
     void assertCloseAll() throws SQLException {
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
         Connection connection = mock(Connection.class);

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheContextTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheContextTest.java
@@ -29,20 +29,22 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class PreparedStatementCacheContextTest {
     
     @Test
-    void assertGetOrCreate() throws SQLException {
+    void assertGetOrCreateWithSamePreparedStatementCacheKey() throws SQLException {
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
         Connection connection = mock(Connection.class);
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        PreparedStatementCacheKey preparedStatementCacheKey = new PreparedStatementCacheKey("statement-1");
         int[] invokedCount = {0};
-        PreparedStatement actualFirst = cacheContext.getOrCreate(connection, "SELECT 1", false, () -> {
+        PreparedStatement actualFirst = cacheContext.getOrCreate(connection, "SELECT 1", false, preparedStatementCacheKey, () -> {
             invokedCount[0]++;
             return preparedStatement;
         });
-        PreparedStatement actualSecond = cacheContext.getOrCreate(connection, "SELECT 1", false, () -> {
+        PreparedStatement actualSecond = cacheContext.getOrCreate(connection, "SELECT 1", false, preparedStatementCacheKey, () -> {
             invokedCount[0]++;
             return mock(PreparedStatement.class);
         });
@@ -53,16 +55,28 @@ class PreparedStatementCacheContextTest {
     }
     
     @Test
+    void assertGetOrCreateWithDifferentPreparedStatementCacheKey() throws SQLException {
+        PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
+        Connection connection = mock(Connection.class);
+        PreparedStatement firstPreparedStatement = mock(PreparedStatement.class);
+        PreparedStatement secondPreparedStatement = mock(PreparedStatement.class);
+        PreparedStatement actualFirst = cacheContext.getOrCreate(connection, "SELECT 1", false, new PreparedStatementCacheKey("statement-1"), () -> firstPreparedStatement);
+        PreparedStatement actualSecond = cacheContext.getOrCreate(connection, "SELECT 1", false, new PreparedStatementCacheKey("statement-2"), () -> secondPreparedStatement);
+        assertThat(actualFirst, is(firstPreparedStatement));
+        assertThat(actualSecond, is(secondPreparedStatement));
+    }
+    
+    @Test
     void assertEvictWithLRU() throws SQLException {
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(2);
         Connection connection = mock(Connection.class);
         PreparedStatement first = mock(PreparedStatement.class);
         PreparedStatement second = mock(PreparedStatement.class);
         PreparedStatement third = mock(PreparedStatement.class);
-        cacheContext.getOrCreate(connection, "SELECT 1", false, () -> first);
-        cacheContext.getOrCreate(connection, "SELECT 2", false, () -> second);
-        cacheContext.getOrCreate(connection, "SELECT 1", false, () -> first);
-        cacheContext.getOrCreate(connection, "SELECT 3", false, () -> third);
+        cacheContext.getOrCreate(connection, "SELECT 1", false, new PreparedStatementCacheKey("statement-1"), () -> first);
+        cacheContext.getOrCreate(connection, "SELECT 2", false, new PreparedStatementCacheKey("statement-2"), () -> second);
+        cacheContext.getOrCreate(connection, "SELECT 1", false, new PreparedStatementCacheKey("statement-1"), () -> first);
+        cacheContext.getOrCreate(connection, "SELECT 3", false, new PreparedStatementCacheKey("statement-3"), () -> third);
         assertFalse(cacheContext.contains(second));
         assertTrue(cacheContext.contains(first));
         assertTrue(cacheContext.contains(third));
@@ -74,24 +88,40 @@ class PreparedStatementCacheContextTest {
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
         Connection connection = mock(Connection.class);
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
-        cacheContext.getOrCreate(connection, "SELECT 1", false, () -> preparedStatement);
+        cacheContext.getOrCreate(connection, "SELECT 1", false, new PreparedStatementCacheKey("statement-1"), () -> preparedStatement);
         cacheContext.invalidate(preparedStatement);
         assertFalse(cacheContext.contains(preparedStatement));
         verify(preparedStatement).close();
     }
     
     @Test
-    void assertInvalidateByStatementId() throws SQLException {
+    void assertInvalidateByPreparedStatementCacheKey() throws SQLException {
         PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
         Connection connection = mock(Connection.class);
         PreparedStatement first = mock(PreparedStatement.class);
         PreparedStatement second = mock(PreparedStatement.class);
-        cacheContext.getOrCreate(connection, "SELECT 1", false, 1, () -> first);
-        cacheContext.getOrCreate(connection, "SELECT 1", false, 2, () -> second);
-        cacheContext.invalidate(1);
+        PreparedStatementCacheKey firstPreparedStatementCacheKey = new PreparedStatementCacheKey("statement-1");
+        PreparedStatementCacheKey secondPreparedStatementCacheKey = new PreparedStatementCacheKey("statement-2");
+        cacheContext.getOrCreate(connection, "SELECT 1", false, firstPreparedStatementCacheKey, () -> first);
+        cacheContext.getOrCreate(connection, "SELECT 1", false, secondPreparedStatementCacheKey, () -> second);
+        cacheContext.invalidate(firstPreparedStatementCacheKey);
         assertFalse(cacheContext.contains(first));
         assertTrue(cacheContext.contains(second));
         verify(first).close();
+    }
+    
+    @Test
+    void assertGetOrCreateWithClosedPreparedStatement() throws SQLException {
+        PreparedStatementCacheContext cacheContext = new PreparedStatementCacheContext(8);
+        Connection connection = mock(Connection.class);
+        PreparedStatement firstPreparedStatement = mock(PreparedStatement.class);
+        PreparedStatement secondPreparedStatement = mock(PreparedStatement.class);
+        when(firstPreparedStatement.isClosed()).thenReturn(true);
+        PreparedStatementCacheKey preparedStatementCacheKey = new PreparedStatementCacheKey("statement-1");
+        cacheContext.getOrCreate(connection, "SELECT 1", false, preparedStatementCacheKey, () -> firstPreparedStatement);
+        PreparedStatement actualPreparedStatement = cacheContext.getOrCreate(connection, "SELECT 1", false, preparedStatementCacheKey, () -> secondPreparedStatement);
+        assertThat(actualPreparedStatement, is(secondPreparedStatement));
+        verify(firstPreparedStatement).close();
     }
     
     @Test
@@ -100,8 +130,8 @@ class PreparedStatementCacheContextTest {
         Connection connection = mock(Connection.class);
         PreparedStatement first = mock(PreparedStatement.class);
         PreparedStatement second = mock(PreparedStatement.class);
-        cacheContext.getOrCreate(connection, "SELECT 1", false, () -> first);
-        cacheContext.getOrCreate(connection, "SELECT 2", false, () -> second);
+        cacheContext.getOrCreate(connection, "SELECT 1", false, new PreparedStatementCacheKey("statement-1"), () -> first);
+        cacheContext.getOrCreate(connection, "SELECT 2", false, new PreparedStatementCacheKey("statement-2"), () -> second);
         cacheContext.closeAll();
         assertThat(cacheContext.size(), is(0));
         verify(first).close();

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheKeyTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/session/PreparedStatementCacheKeyTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.backend.session;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PreparedStatementCacheKeyTest {
+    
+    @Test
+    void assertGetToken() {
+        PreparedStatementCacheKey preparedStatementCacheKey = new PreparedStatementCacheKey("statement-1");
+        assertThat(preparedStatementCacheKey.getToken(), is("statement-1"));
+        assertThat(preparedStatementCacheKey, is(new PreparedStatementCacheKey("statement-1")));
+    }
+    
+    @Test
+    void assertConstructorWithNullToken() {
+        NullPointerException actual = assertThrows(NullPointerException.class, () -> new PreparedStatementCacheKey(null));
+        assertThat(actual.getMessage(), is("token cannot be null."));
+    }
+}

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/FirebirdStatementResourceCleaner.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/FirebirdStatementResourceCleaner.java
@@ -24,6 +24,8 @@ import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.session.PreparedStatementCacheKey;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.fetch.FirebirdFetchStatementCache;
 
+import java.sql.SQLException;
+
 /**
  * Firebird statement resource cleaner.
  */
@@ -48,16 +50,30 @@ public final class FirebirdStatementResourceCleaner {
      * @param connectionSession connection session
      * @param statementId statement ID
      * @param invalidatePreparedStatementCache whether invalidate prepared statement cache
+     * @throws SQLException SQL exception
      */
-    public static void clean(final ConnectionSession connectionSession, final int statementId, final boolean invalidatePreparedStatementCache) {
+    public static void clean(final ConnectionSession connectionSession, final int statementId, final boolean invalidatePreparedStatementCache) throws SQLException {
+        ProxyBackendHandler proxyBackendHandler = FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(connectionSession.getConnectionId(), statementId);
+        if (null != proxyBackendHandler) {
+            connectionSession.getDatabaseConnectionManager().removeResource(proxyBackendHandler);
+            FirebirdFetchStatementCache.getInstance().unregisterStatement(connectionSession.getConnectionId(), statementId);
+            connectionSession.getConnectionContext().clearCursorContext();
+            try {
+                proxyBackendHandler.close();
+            } finally {
+                invalidatePreparedStatementCacheIfNecessary(connectionSession, statementId, invalidatePreparedStatementCache);
+            }
+            return;
+        }
+        FirebirdFetchStatementCache.getInstance().unregisterStatement(connectionSession.getConnectionId(), statementId);
+        connectionSession.getConnectionContext().clearCursorContext();
+        invalidatePreparedStatementCacheIfNecessary(connectionSession, statementId, invalidatePreparedStatementCache);
+    }
+    
+    private static void invalidatePreparedStatementCacheIfNecessary(final ConnectionSession connectionSession, final int statementId,
+                                                                    final boolean invalidatePreparedStatementCache) {
         if (invalidatePreparedStatementCache) {
             connectionSession.invalidatePreparedStatementCache(createPreparedStatementCacheKey(statementId));
         }
-        connectionSession.getConnectionContext().clearCursorContext();
-        ProxyBackendHandler proxyBackendHandler = FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(connectionSession.getConnectionId(), statementId);
-        if (null != proxyBackendHandler) {
-            connectionSession.getDatabaseConnectionManager().unmarkResourceInUse(proxyBackendHandler);
-        }
-        FirebirdFetchStatementCache.getInstance().unregisterStatement(connectionSession.getConnectionId(), statementId);
     }
 }

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/FirebirdStatementResourceCleaner.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/FirebirdStatementResourceCleaner.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.backend.session.PreparedStatementCacheKey;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.fetch.FirebirdFetchStatementCache;
 
 /**
@@ -28,6 +29,18 @@ import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class FirebirdStatementResourceCleaner {
+    
+    private static final String PREPARED_STATEMENT_CACHE_KEY_PREFIX = "firebird:";
+    
+    /**
+     * Create prepared statement cache key.
+     *
+     * @param statementId statement ID
+     * @return prepared statement cache key
+     */
+    public static PreparedStatementCacheKey createPreparedStatementCacheKey(final int statementId) {
+        return new PreparedStatementCacheKey(PREPARED_STATEMENT_CACHE_KEY_PREFIX + statementId);
+    }
     
     /**
      * Clean Firebird statement resources.
@@ -38,7 +51,7 @@ public final class FirebirdStatementResourceCleaner {
      */
     public static void clean(final ConnectionSession connectionSession, final int statementId, final boolean invalidatePreparedStatementCache) {
         if (invalidatePreparedStatementCache) {
-            connectionSession.invalidateFirebirdPreparedStatementCache(statementId);
+            connectionSession.invalidatePreparedStatementCache(createPreparedStatementCacheKey(statementId));
         }
         connectionSession.getConnectionContext().clearCursorContext();
         ProxyBackendHandler proxyBackendHandler = FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(connectionSession.getConnectionId(), statementId);

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/FirebirdStatementResourceCleaner.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/FirebirdStatementResourceCleaner.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.fetch.FirebirdFetchStatementCache;
+
+/**
+ * Firebird statement resource cleaner.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class FirebirdStatementResourceCleaner {
+    
+    /**
+     * Clean Firebird statement resources.
+     *
+     * @param connectionSession connection session
+     * @param statementId statement ID
+     * @param invalidatePreparedStatementCache whether invalidate prepared statement cache
+     */
+    public static void clean(final ConnectionSession connectionSession, final int statementId, final boolean invalidatePreparedStatementCache) {
+        if (invalidatePreparedStatementCache) {
+            connectionSession.invalidateFirebirdPreparedStatementCache(statementId);
+        }
+        connectionSession.getConnectionContext().clearCursorContext();
+        ProxyBackendHandler proxyBackendHandler = FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(connectionSession.getConnectionId(), statementId);
+        if (null != proxyBackendHandler) {
+            connectionSession.getDatabaseConnectionManager().unmarkResourceInUse(proxyBackendHandler);
+        }
+        FirebirdFetchStatementCache.getInstance().unregisterStatement(connectionSession.getConnectionId(), statementId);
+    }
+}

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/execute/FirebirdExecuteStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/execute/FirebirdExecuteStatementCommandExecutor.java
@@ -44,6 +44,7 @@ import org.apache.shardingsphere.proxy.frontend.command.executor.CommandExecutor
 import org.apache.shardingsphere.proxy.frontend.command.executor.ResponseType;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.FirebirdServerPreparedStatement;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.upload.FirebirdBlobUploadCache;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.FirebirdStatementResourceCleaner;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.fetch.FirebirdFetchStatementCache;
 
 import java.sql.SQLException;
@@ -70,7 +71,7 @@ public final class FirebirdExecuteStatementCommandExecutor implements CommandExe
     
     @Override
     public Collection<DatabasePacket> execute() throws SQLException {
-        connectionSession.beginFirebirdPreparedStatementExecution(packet.getStatementId());
+        connectionSession.beginPreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(packet.getStatementId()));
         try {
             FirebirdServerPreparedStatement preparedStatement = connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(packet.getStatementId());
             ResponseHeader responseHeader = executePreparedStatement(preparedStatement, packet.getParameterValues());
@@ -88,7 +89,7 @@ public final class FirebirdExecuteStatementCommandExecutor implements CommandExe
             result.add(new FirebirdGenericResponsePacket());
             return result;
         } finally {
-            connectionSession.finishFirebirdPreparedStatementExecution();
+            connectionSession.finishPreparedStatementCache();
         }
     }
     

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/execute/FirebirdExecuteStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/execute/FirebirdExecuteStatementCommandExecutor.java
@@ -70,9 +70,30 @@ public final class FirebirdExecuteStatementCommandExecutor implements CommandExe
     
     @Override
     public Collection<DatabasePacket> execute() throws SQLException {
-        FirebirdServerPreparedStatement preparedStatement = connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(packet.getStatementId());
-        List<Object> params = packet.getParameterValues();
-        final List<Long> blobIdsToRemove = bindBlobParameters(params);
+        connectionSession.beginFirebirdPreparedStatementExecution(packet.getStatementId());
+        try {
+            FirebirdServerPreparedStatement preparedStatement = connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(packet.getStatementId());
+            ResponseHeader responseHeader = executePreparedStatement(preparedStatement, packet.getParameterValues());
+            if (responseHeader instanceof QueryResponseHeader) {
+                responseType = ResponseType.QUERY;
+                FirebirdFetchStatementCache.getInstance().registerStatement(connectionSession.getConnectionId(), packet.getStatementId(), proxyBackendHandler);
+                connectionSession.getDatabaseConnectionManager().markResourceInUse(proxyBackendHandler);
+            } else {
+                responseType = ResponseType.UPDATE;
+            }
+            Collection<DatabasePacket> result = new LinkedList<>();
+            if (packet.isStoredProcedure() && proxyBackendHandler.next()) {
+                result.add(getSQLResponse());
+            }
+            result.add(new FirebirdGenericResponsePacket());
+            return result;
+        } finally {
+            connectionSession.finishFirebirdPreparedStatementExecution();
+        }
+    }
+    
+    private ResponseHeader executePreparedStatement(final FirebirdServerPreparedStatement preparedStatement, final List<Object> params) throws SQLException {
+        List<Long> blobIdsToRemove = bindBlobParameters(params);
         SQLStatementContext sqlStatementContext = preparedStatement.getSqlStatementContext();
         if (sqlStatementContext instanceof ParameterAware) {
             ((ParameterAware) sqlStatementContext).bindParameters(params);
@@ -80,22 +101,10 @@ public final class FirebirdExecuteStatementCommandExecutor implements CommandExe
         QueryContext queryContext = new QueryContext(sqlStatementContext, preparedStatement.getSql(), params, preparedStatement.getHintValueContext(), connectionSession.getConnectionContext(),
                 ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData(), true);
         proxyBackendHandler = ProxyBackendHandlerFactory.newInstance(TypedSPILoader.getService(DatabaseType.class, "Firebird"), queryContext, connectionSession, true);
-        ResponseHeader responseHeader = proxyBackendHandler.execute();
-        if (responseHeader instanceof QueryResponseHeader) {
-            responseType = ResponseType.QUERY;
-            FirebirdFetchStatementCache.getInstance().registerStatement(connectionSession.getConnectionId(), packet.getStatementId(), proxyBackendHandler);
-            connectionSession.getDatabaseConnectionManager().markResourceInUse(proxyBackendHandler);
-        } else {
-            responseType = ResponseType.UPDATE;
-        }
-        if (responseHeader instanceof UpdateResponseHeader) {
+        ResponseHeader result = proxyBackendHandler.execute();
+        if (result instanceof UpdateResponseHeader) {
             clearBlobUploads(blobIdsToRemove);
         }
-        Collection<DatabasePacket> result = new LinkedList<>();
-        if (packet.isStoredProcedure() && proxyBackendHandler.next()) {
-            result.add(getSQLResponse());
-        }
-        result.add(new FirebirdGenericResponsePacket());
         return result;
     }
     

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCache.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCache.java
@@ -61,7 +61,10 @@ public final class FirebirdFetchStatementCache {
      * @param proxyBackendHandler proxy backend handler
      */
     public void registerStatement(final int connectionId, final int statementId, final ProxyBackendHandler proxyBackendHandler) {
-        statementRegistry.get(connectionId).put(statementId, proxyBackendHandler);
+        Map<Integer, ProxyBackendHandler> statements = statementRegistry.get(connectionId);
+        if (null != statements) {
+            statements.put(statementId, proxyBackendHandler);
+        }
     }
     
     /**
@@ -72,7 +75,8 @@ public final class FirebirdFetchStatementCache {
      * @return fetch response packets
      */
     public ProxyBackendHandler getFetchBackendHandler(final int connectionId, final int statementId) {
-        return statementRegistry.get(connectionId).get(statementId);
+        Map<Integer, ProxyBackendHandler> statements = statementRegistry.get(connectionId);
+        return null == statements ? null : statements.get(statementId);
     }
     
     /**
@@ -82,7 +86,10 @@ public final class FirebirdFetchStatementCache {
      * @param statementId statement ID
      */
     public void unregisterStatement(final int connectionId, final int statementId) {
-        statementRegistry.get(connectionId).remove(statementId);
+        Map<Integer, ProxyBackendHandler> statements = statementRegistry.get(connectionId);
+        if (null != statements) {
+            statements.remove(statementId);
+        }
     }
     
     /**

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutor.java
@@ -22,10 +22,9 @@ import org.apache.shardingsphere.database.protocol.firebird.exception.FirebirdPr
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.statement.FirebirdFreeStatementPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
-import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.frontend.command.executor.CommandExecutor;
-import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.fetch.FirebirdFetchStatementCache;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.FirebirdStatementResourceCleaner;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -46,24 +45,14 @@ public final class FirebirdFreeStatementCommandExecutor implements CommandExecut
             case FirebirdFreeStatementPacket.DROP:
             case FirebirdFreeStatementPacket.UNPREPARE:
                 connectionSession.getServerPreparedStatementRegistry().removePreparedStatement(packet.getStatementId());
-                connectionSession.invalidateFirebirdPreparedStatementCache(packet.getStatementId());
-                cleanupStatementResources();
+                FirebirdStatementResourceCleaner.clean(connectionSession, packet.getStatementId(), true);
                 break;
             case FirebirdFreeStatementPacket.CLOSE:
-                cleanupStatementResources();
+                FirebirdStatementResourceCleaner.clean(connectionSession, packet.getStatementId(), false);
                 break;
             default:
                 throw new FirebirdProtocolException("Unknown DSQL option type %d", packet.getOption());
         }
         return Collections.singleton(new FirebirdGenericResponsePacket());
-    }
-    
-    private void cleanupStatementResources() {
-        connectionSession.getConnectionContext().clearCursorContext();
-        ProxyBackendHandler proxyBackendHandler = FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(connectionSession.getConnectionId(), packet.getStatementId());
-        if (null != proxyBackendHandler) {
-            connectionSession.getDatabaseConnectionManager().unmarkResourceInUse(proxyBackendHandler);
-        }
-        FirebirdFetchStatementCache.getInstance().unregisterStatement(connectionSession.getConnectionId(), packet.getStatementId());
     }
 }

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutor.java
@@ -35,11 +35,11 @@ import java.util.Collections;
  */
 @RequiredArgsConstructor
 public final class FirebirdFreeStatementCommandExecutor implements CommandExecutor {
-
+    
     private final FirebirdFreeStatementPacket packet;
-
+    
     private final ConnectionSession connectionSession;
-
+    
     @Override
     public Collection<DatabasePacket> execute() {
         switch (packet.getOption()) {
@@ -57,7 +57,7 @@ public final class FirebirdFreeStatementCommandExecutor implements CommandExecut
         }
         return Collections.singleton(new FirebirdGenericResponsePacket());
     }
-
+    
     private void cleanupStatementResources() {
         connectionSession.getConnectionContext().clearCursorContext();
         ProxyBackendHandler proxyBackendHandler = FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(connectionSession.getConnectionId(), packet.getStatementId());

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutor.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.frontend.command.executor.CommandExecutor;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.FirebirdStatementResourceCleaner;
 
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -40,7 +41,7 @@ public final class FirebirdFreeStatementCommandExecutor implements CommandExecut
     private final ConnectionSession connectionSession;
     
     @Override
-    public Collection<DatabasePacket> execute() {
+    public Collection<DatabasePacket> execute() throws SQLException {
         switch (packet.getOption()) {
             case FirebirdFreeStatementPacket.DROP:
             case FirebirdFreeStatementPacket.UNPREPARE:

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutor.java
@@ -46,6 +46,7 @@ public final class FirebirdFreeStatementCommandExecutor implements CommandExecut
             case FirebirdFreeStatementPacket.DROP:
             case FirebirdFreeStatementPacket.UNPREPARE:
                 connectionSession.getServerPreparedStatementRegistry().removePreparedStatement(packet.getStatementId());
+                connectionSession.invalidateFirebirdPreparedStatementCache(packet.getStatementId());
                 break;
             case FirebirdFreeStatementPacket.CLOSE:
                 connectionSession.getConnectionContext().clearCursorContext();

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutor.java
@@ -35,11 +35,11 @@ import java.util.Collections;
  */
 @RequiredArgsConstructor
 public final class FirebirdFreeStatementCommandExecutor implements CommandExecutor {
-    
+
     private final FirebirdFreeStatementPacket packet;
-    
+
     private final ConnectionSession connectionSession;
-    
+
     @Override
     public Collection<DatabasePacket> execute() {
         switch (packet.getOption()) {
@@ -47,16 +47,23 @@ public final class FirebirdFreeStatementCommandExecutor implements CommandExecut
             case FirebirdFreeStatementPacket.UNPREPARE:
                 connectionSession.getServerPreparedStatementRegistry().removePreparedStatement(packet.getStatementId());
                 connectionSession.invalidateFirebirdPreparedStatementCache(packet.getStatementId());
+                cleanupStatementResources();
                 break;
             case FirebirdFreeStatementPacket.CLOSE:
-                connectionSession.getConnectionContext().clearCursorContext();
-                ProxyBackendHandler proxyBackendHandler = FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(connectionSession.getConnectionId(), packet.getStatementId());
-                connectionSession.getDatabaseConnectionManager().unmarkResourceInUse(proxyBackendHandler);
-                FirebirdFetchStatementCache.getInstance().unregisterStatement(connectionSession.getConnectionId(), packet.getStatementId());
+                cleanupStatementResources();
                 break;
             default:
                 throw new FirebirdProtocolException("Unknown DSQL option type %d", packet.getOption());
         }
         return Collections.singleton(new FirebirdGenericResponsePacket());
+    }
+
+    private void cleanupStatementResources() {
+        connectionSession.getConnectionContext().clearCursorContext();
+        ProxyBackendHandler proxyBackendHandler = FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(connectionSession.getConnectionId(), packet.getStatementId());
+        if (null != proxyBackendHandler) {
+            connectionSession.getDatabaseConnectionManager().unmarkResourceInUse(proxyBackendHandler);
+        }
+        FirebirdFetchStatementCache.getInstance().unregisterStatement(connectionSession.getConnectionId(), packet.getStatementId());
     }
 }

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutor.java
@@ -86,6 +86,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.type.tcl.Ro
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.tcl.SavepointStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collection;
 import java.util.Collections;
@@ -107,7 +108,7 @@ public final class FirebirdPrepareStatementCommandExecutor implements CommandExe
     private ReturningSegment returningSegment;
     
     @Override
-    public Collection<DatabasePacket> execute() {
+    public Collection<DatabasePacket> execute() throws SQLException {
         MetaDataContexts metaDataContexts = ProxyContext.getInstance().getContextManager().getMetaDataContexts();
         SQLParserRule sqlParserRule = metaDataContexts.getMetaData().getGlobalRuleMetaData().getSingleRule(SQLParserRule.class);
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "Firebird");

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutor.java
@@ -57,6 +57,7 @@ import org.apache.shardingsphere.proxy.frontend.command.executor.CommandExecutor
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.FirebirdServerPreparedStatement;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.metadata.FirebirdBlobColumnMetaData;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.metadata.FirebirdBlobColumnMetaDataResolver;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.FirebirdStatementResourceCleaner;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.FirebirdStatementIdGenerator;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.ReturningSegment;
@@ -113,8 +114,12 @@ public final class FirebirdPrepareStatementCommandExecutor implements CommandExe
         SQLStatement sqlStatement = sqlParserRule.getSQLParserEngine(databaseType).parse(packet.getSQL(), true);
         SQLStatementContext sqlStatementContext = new SQLBindEngine(
                 metaDataContexts.getMetaData(), connectionSession.getCurrentDatabaseName(), packet.getHintValueContext()).bind(sqlStatement);
+        int statementId = getStatementId();
+        if (packet.isValidStatementHandle()) {
+            FirebirdStatementResourceCleaner.clean(connectionSession, statementId, true);
+        }
         FirebirdServerPreparedStatement serverPreparedStatement = new FirebirdServerPreparedStatement(packet.getSQL(), sqlStatementContext, packet.getHintValueContext());
-        connectionSession.getServerPreparedStatementRegistry().addPreparedStatement(getStatementId(), serverPreparedStatement);
+        connectionSession.getServerPreparedStatementRegistry().addPreparedStatement(statementId, serverPreparedStatement);
         return createResponse(sqlStatementContext, metaDataContexts);
     }
     

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/FirebirdStatementResourceCleanerTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/FirebirdStatementResourceCleanerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement;
+
+import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
+import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.fetch.FirebirdFetchStatementCache;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FirebirdStatementResourceCleanerTest {
+    
+    private static final int CONNECTION_ID = 1;
+    
+    private static final int STATEMENT_ID = 2;
+    
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private ConnectionSession connectionSession;
+    
+    @Mock
+    private ProxyDatabaseConnectionManager connectionManager;
+    
+    @Mock
+    private ProxyBackendHandler proxyBackendHandler;
+    
+    @AfterEach
+    void tearDown() {
+        FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
+        FirebirdFetchStatementCache.getInstance().unregisterConnection(CONNECTION_ID);
+    }
+    
+    @Test
+    void assertCreatePreparedStatementCacheKey() {
+        assertThat(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(STATEMENT_ID).getToken(), is("firebird:2"));
+    }
+    
+    @Test
+    void assertCleanWithPreparedStatementCacheInvalidation() {
+        FirebirdFetchStatementCache.getInstance().registerConnection(CONNECTION_ID);
+        FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
+        when(connectionSession.getConnectionId()).thenReturn(CONNECTION_ID);
+        when(connectionSession.getDatabaseConnectionManager()).thenReturn(connectionManager);
+        FirebirdStatementResourceCleaner.clean(connectionSession, STATEMENT_ID, true);
+        verify(connectionSession).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(STATEMENT_ID));
+        verify(connectionSession.getConnectionContext()).clearCursorContext();
+        verify(connectionManager).unmarkResourceInUse(proxyBackendHandler);
+        assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
+    }
+}

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/FirebirdStatementResourceCleanerTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/FirebirdStatementResourceCleanerTest.java
@@ -17,24 +17,42 @@
 
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement;
 
+import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
+import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.proxy.backend.exception.BackendConnectionException;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.infra.session.connection.ConnectionContext;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.fetch.FirebirdFetchStatementCache;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Answers;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
+import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
+
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(AutoMockExtension.class)
+@StaticMockSettings(ProxyContext.class)
 class FirebirdStatementResourceCleanerTest {
     
     private static final int CONNECTION_ID = 1;
@@ -46,6 +64,9 @@ class FirebirdStatementResourceCleanerTest {
     
     @Mock
     private ProxyDatabaseConnectionManager connectionManager;
+    
+    @Mock
+    private ConnectionContext connectionContext;
     
     @Mock
     private ProxyBackendHandler proxyBackendHandler;
@@ -62,15 +83,75 @@ class FirebirdStatementResourceCleanerTest {
     }
     
     @Test
-    void assertCleanWithPreparedStatementCacheInvalidation() {
+    void assertCleanWithPreparedStatementCacheInvalidation() throws SQLException {
         FirebirdFetchStatementCache.getInstance().registerConnection(CONNECTION_ID);
         FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
         when(connectionSession.getConnectionId()).thenReturn(CONNECTION_ID);
         when(connectionSession.getDatabaseConnectionManager()).thenReturn(connectionManager);
+        when(connectionSession.getConnectionContext()).thenReturn(connectionContext);
         FirebirdStatementResourceCleaner.clean(connectionSession, STATEMENT_ID, true);
+        InOrder inOrder = inOrder(connectionManager, connectionContext, proxyBackendHandler, connectionSession);
+        inOrder.verify(connectionManager).removeResource(proxyBackendHandler);
+        inOrder.verify(connectionContext).clearCursorContext();
+        inOrder.verify(proxyBackendHandler).close();
+        inOrder.verify(connectionSession).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(STATEMENT_ID));
+        assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
+    }
+    
+    @Test
+    void assertCleanWithPreparedStatementCacheInvalidationWithoutFetchHandler() throws SQLException {
+        when(connectionSession.getConnectionId()).thenReturn(CONNECTION_ID);
+        when(connectionSession.getConnectionContext()).thenReturn(connectionContext);
+        FirebirdStatementResourceCleaner.clean(connectionSession, STATEMENT_ID, true);
+        verify(connectionContext).clearCursorContext();
         verify(connectionSession).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(STATEMENT_ID));
-        verify(connectionSession.getConnectionContext()).clearCursorContext();
-        verify(connectionManager).unmarkResourceInUse(proxyBackendHandler);
+        verifyNoInteractions(connectionManager, proxyBackendHandler);
+    }
+    
+    @Test
+    void assertCleanWithoutPreparedStatementCacheInvalidation() throws SQLException {
+        FirebirdFetchStatementCache.getInstance().registerConnection(CONNECTION_ID);
+        FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
+        when(connectionSession.getConnectionId()).thenReturn(CONNECTION_ID);
+        when(connectionSession.getDatabaseConnectionManager()).thenReturn(connectionManager);
+        when(connectionSession.getConnectionContext()).thenReturn(connectionContext);
+        FirebirdStatementResourceCleaner.clean(connectionSession, STATEMENT_ID, false);
+        verify(connectionManager).removeResource(proxyBackendHandler);
+        verify(proxyBackendHandler).close();
+        verify(connectionContext).clearCursorContext();
+        verify(connectionSession, never()).invalidatePreparedStatementCache(any());
+        assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
+    }
+    
+    @Test
+    void assertCleanBeforeCloseExecutionResources() throws SQLException, BackendConnectionException {
+        ConnectionSession actualConnectionSession = mock(ConnectionSession.class, Answers.RETURNS_DEEP_STUBS);
+        ConnectionContext actualConnectionContext = mock(ConnectionContext.class, Answers.RETURNS_DEEP_STUBS);
+        ContextManager contextManager = mock(ContextManager.class, Answers.RETURNS_DEEP_STUBS);
+        ProxyBackendHandler actualProxyBackendHandler = mock(ProxyBackendHandler.class);
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        when(contextManager.getMetaDataContexts().getMetaData().getGlobalRuleMetaData().getRules()).thenReturn(Collections.emptyList());
+        when(actualConnectionSession.getConnectionId()).thenReturn(CONNECTION_ID);
+        when(actualConnectionSession.getConnectionContext()).thenReturn(actualConnectionContext);
+        when(actualConnectionContext.getTransactionContext().getTransactionType()).thenReturn(Optional.of("XA"));
+        when(actualConnectionSession.getTransactionStatus().isInConnectionHeldTransaction(any())).thenReturn(true);
+        ProxyDatabaseConnectionManager actualConnectionManager = new ProxyDatabaseConnectionManager(actualConnectionSession);
+        when(actualConnectionSession.getDatabaseConnectionManager()).thenReturn(actualConnectionManager);
+        FirebirdFetchStatementCache.getInstance().registerConnection(CONNECTION_ID);
+        FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, actualProxyBackendHandler);
+        actualConnectionManager.add(actualProxyBackendHandler);
+        actualConnectionManager.markResourceInUse(actualProxyBackendHandler);
+        final AtomicBoolean closed = new AtomicBoolean(false);
+        org.mockito.Mockito.doAnswer(invocation -> {
+            if (closed.getAndSet(true)) {
+                throw new SQLException("close twice");
+            }
+            return null;
+        }).when(actualProxyBackendHandler).close();
+        FirebirdStatementResourceCleaner.clean(actualConnectionSession, STATEMENT_ID, true);
+        actualConnectionManager.closeExecutionResources();
+        verify(actualProxyBackendHandler, times(1)).close();
+        verify(actualConnectionSession).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(STATEMENT_ID));
         assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/execute/FirebirdExecuteStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/execute/FirebirdExecuteStatementCommandExecutorTest.java
@@ -46,6 +46,7 @@ import org.apache.shardingsphere.proxy.backend.session.ServerPreparedStatementRe
 import org.apache.shardingsphere.proxy.frontend.command.executor.ResponseType;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.FirebirdServerPreparedStatement;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.upload.FirebirdBlobUploadCache;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.FirebirdStatementResourceCleaner;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.fetch.FirebirdFetchStatementCache;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.UpdateStatement;
@@ -157,8 +158,8 @@ class FirebirdExecuteStatementCommandExecutorTest {
         assertThat(iterator.next(), isA(FirebirdGenericResponsePacket.class));
         assertFalse(iterator.hasNext());
         assertThat(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID), is(proxyBackendHandler));
-        verify(connectionSession).beginFirebirdPreparedStatementExecution(1);
-        verify(connectionSession).finishFirebirdPreparedStatementExecution();
+        verify(connectionSession).beginPreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(1));
+        verify(connectionSession).finishPreparedStatementCache();
     }
     
     @Test
@@ -173,8 +174,8 @@ class FirebirdExecuteStatementCommandExecutorTest {
         assertThat(executor.getResponseType(), is(ResponseType.UPDATE));
         assertThat(actual.iterator().next(), isA(FirebirdGenericResponsePacket.class));
         assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
-        verify(connectionSession).beginFirebirdPreparedStatementExecution(2);
-        verify(connectionSession).finishFirebirdPreparedStatementExecution();
+        verify(connectionSession).beginPreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(2));
+        verify(connectionSession).finishPreparedStatementCache();
     }
     
     @Test

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/execute/FirebirdExecuteStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/execute/FirebirdExecuteStatementCommandExecutorTest.java
@@ -77,6 +77,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(AutoMockExtension.class)
@@ -156,6 +157,8 @@ class FirebirdExecuteStatementCommandExecutorTest {
         assertThat(iterator.next(), isA(FirebirdGenericResponsePacket.class));
         assertFalse(iterator.hasNext());
         assertThat(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID), is(proxyBackendHandler));
+        verify(connectionSession).beginFirebirdPreparedStatementExecution(1);
+        verify(connectionSession).finishFirebirdPreparedStatementExecution();
     }
     
     @Test
@@ -170,6 +173,8 @@ class FirebirdExecuteStatementCommandExecutorTest {
         assertThat(executor.getResponseType(), is(ResponseType.UPDATE));
         assertThat(actual.iterator().next(), isA(FirebirdGenericResponsePacket.class));
         assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
+        verify(connectionSession).beginFirebirdPreparedStatementExecution(2);
+        verify(connectionSession).finishFirebirdPreparedStatementExecution();
     }
     
     @Test

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCacheTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCacheTest.java
@@ -32,29 +32,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class FirebirdFetchStatementCacheTest {
-
+    
     private final FirebirdFetchStatementCache cache = FirebirdFetchStatementCache.getInstance();
-
+    
     private Map<Integer, Map<Integer, ProxyBackendHandler>> statementRegistry;
-
+    
     @SuppressWarnings("unchecked")
     @BeforeEach
     void setUp() throws ReflectiveOperationException {
         statementRegistry = (Map<Integer, Map<Integer, ProxyBackendHandler>>) Plugins.getMemberAccessor().get(FirebirdFetchStatementCache.class.getDeclaredField("statementRegistry"), cache);
         statementRegistry.clear();
     }
-
+    
     @Test
     void assertGetInstance() {
         assertThat(FirebirdFetchStatementCache.getInstance(), is(cache));
     }
-
+    
     @Test
     void assertRegisterConnection() {
         cache.registerConnection(1);
         assertTrue(statementRegistry.containsKey(1));
     }
-
+    
     @Test
     void assertRegisterStatement() {
         ProxyBackendHandler handler = mock(ProxyBackendHandler.class);
@@ -62,7 +62,7 @@ class FirebirdFetchStatementCacheTest {
         cache.registerStatement(1, 10, handler);
         assertThat(statementRegistry.get(1).get(10), is(handler));
     }
-
+    
     @Test
     void assertGetFetchBackendHandler() {
         ProxyBackendHandler handler = mock(ProxyBackendHandler.class);
@@ -71,12 +71,12 @@ class FirebirdFetchStatementCacheTest {
         assertThat(cache.getFetchBackendHandler(1, 10), is(handler));
         assertNull(cache.getFetchBackendHandler(1, 11));
     }
-
+    
     @Test
     void assertGetFetchBackendHandlerWithoutConnection() {
         assertNull(cache.getFetchBackendHandler(1, 10));
     }
-
+    
     @Test
     void assertUnregisterStatement() {
         cache.registerConnection(1);
@@ -84,13 +84,13 @@ class FirebirdFetchStatementCacheTest {
         cache.unregisterStatement(1, 10);
         assertNull(cache.getFetchBackendHandler(1, 10));
     }
-
+    
     @Test
     void assertUnregisterStatementWithoutConnection() {
         cache.unregisterStatement(1, 10);
         assertFalse(statementRegistry.containsKey(1));
     }
-
+    
     @Test
     void assertUnregisterConnection() {
         cache.registerConnection(1);

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCacheTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCacheTest.java
@@ -32,29 +32,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class FirebirdFetchStatementCacheTest {
-    
+
     private final FirebirdFetchStatementCache cache = FirebirdFetchStatementCache.getInstance();
-    
+
     private Map<Integer, Map<Integer, ProxyBackendHandler>> statementRegistry;
-    
+
     @SuppressWarnings("unchecked")
     @BeforeEach
     void setUp() throws ReflectiveOperationException {
         statementRegistry = (Map<Integer, Map<Integer, ProxyBackendHandler>>) Plugins.getMemberAccessor().get(FirebirdFetchStatementCache.class.getDeclaredField("statementRegistry"), cache);
         statementRegistry.clear();
     }
-    
+
     @Test
     void assertGetInstance() {
         assertThat(FirebirdFetchStatementCache.getInstance(), is(cache));
     }
-    
+
     @Test
     void assertRegisterConnection() {
         cache.registerConnection(1);
         assertTrue(statementRegistry.containsKey(1));
     }
-    
+
     @Test
     void assertRegisterStatement() {
         ProxyBackendHandler handler = mock(ProxyBackendHandler.class);
@@ -62,7 +62,7 @@ class FirebirdFetchStatementCacheTest {
         cache.registerStatement(1, 10, handler);
         assertThat(statementRegistry.get(1).get(10), is(handler));
     }
-    
+
     @Test
     void assertGetFetchBackendHandler() {
         ProxyBackendHandler handler = mock(ProxyBackendHandler.class);
@@ -71,7 +71,12 @@ class FirebirdFetchStatementCacheTest {
         assertThat(cache.getFetchBackendHandler(1, 10), is(handler));
         assertNull(cache.getFetchBackendHandler(1, 11));
     }
-    
+
+    @Test
+    void assertGetFetchBackendHandlerWithoutConnection() {
+        assertNull(cache.getFetchBackendHandler(1, 10));
+    }
+
     @Test
     void assertUnregisterStatement() {
         cache.registerConnection(1);
@@ -79,7 +84,13 @@ class FirebirdFetchStatementCacheTest {
         cache.unregisterStatement(1, 10);
         assertNull(cache.getFetchBackendHandler(1, 10));
     }
-    
+
+    @Test
+    void assertUnregisterStatementWithoutConnection() {
+        cache.unregisterStatement(1, 10);
+        assertFalse(statementRegistry.containsKey(1));
+    }
+
     @Test
     void assertUnregisterConnection() {
         cache.registerConnection(1);

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
@@ -49,25 +49,25 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
 class FirebirdFetchStatementCommandExecutorTest {
-
+    
     private static final int CONNECTION_ID = 1;
-
+    
     private static final int STATEMENT_ID = 1;
-
+    
     @Mock
     private FirebirdFetchStatementPacket packet;
-
+    
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ConnectionSession connectionSession;
-
+    
     @Mock
     private ProxyDatabaseConnectionManager databaseConnectionManager;
-
+    
     @Mock
     private ProxyBackendHandler proxyBackendHandler;
-
+    
     private FirebirdFetchStatementCommandExecutor executor;
-
+    
     @BeforeEach
     void setup() {
         FirebirdFetchStatementCache.getInstance().registerConnection(CONNECTION_ID);
@@ -75,18 +75,18 @@ class FirebirdFetchStatementCommandExecutorTest {
         when(connectionSession.getDatabaseConnectionManager()).thenReturn(databaseConnectionManager);
         when(packet.getStatementId()).thenReturn(STATEMENT_ID);
     }
-
+    
     @AfterEach
     void tearDown() {
         FirebirdFetchStatementCache.getInstance().unregisterConnection(CONNECTION_ID);
     }
-
+    
     @Test
     void assertExecuteWhenNoBackendHandler() throws SQLException {
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
         assertNoMoreRowsResponse(executor.execute());
     }
-
+    
     @Test
     void assertExecuteWhenNoBackendHandlerAfterPreparedStatementFree() throws SQLException {
         FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
@@ -94,7 +94,7 @@ class FirebirdFetchStatementCommandExecutorTest {
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
         assertNoMoreRowsResponse(executor.execute());
     }
-
+    
     @Test
     void assertExecuteWithRowsAndFetchEnd() throws SQLException {
         FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
@@ -119,7 +119,7 @@ class FirebirdFetchStatementCommandExecutorTest {
         assertThat(actualEndPacket.getCount(), is(0));
         assertNull(actualEndPacket.getRow());
     }
-
+    
     @Test
     void assertExecuteStopsWhenRowsExhausted() throws SQLException {
         FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
@@ -141,7 +141,7 @@ class FirebirdFetchStatementCommandExecutorTest {
         assertNull(actualNoMorePacket.getRow());
         verify(databaseConnectionManager).unmarkResourceInUse(proxyBackendHandler);
     }
-
+    
     private void assertNoMoreRowsResponse(final Collection<DatabasePacket> actualPackets) {
         Iterator<DatabasePacket> packetIterator = actualPackets.iterator();
         FirebirdFetchResponsePacket actualPacket = (FirebirdFetchResponsePacket) packetIterator.next();

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
@@ -88,7 +88,7 @@ class FirebirdFetchStatementCommandExecutorTest {
     }
     
     @Test
-    void assertExecuteWhenNoBackendHandlerAfterPreparedStatementFree() throws SQLException {
+    void assertExecuteWhenNoBackendHandlerAfterSameHandleReprepare() throws SQLException {
         FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
         FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
@@ -49,25 +49,25 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
 class FirebirdFetchStatementCommandExecutorTest {
-    
+
     private static final int CONNECTION_ID = 1;
-    
+
     private static final int STATEMENT_ID = 1;
-    
+
     @Mock
     private FirebirdFetchStatementPacket packet;
-    
+
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ConnectionSession connectionSession;
-    
+
     @Mock
     private ProxyDatabaseConnectionManager databaseConnectionManager;
-    
+
     @Mock
     private ProxyBackendHandler proxyBackendHandler;
-    
+
     private FirebirdFetchStatementCommandExecutor executor;
-    
+
     @BeforeEach
     void setup() {
         FirebirdFetchStatementCache.getInstance().registerConnection(CONNECTION_ID);
@@ -75,24 +75,26 @@ class FirebirdFetchStatementCommandExecutorTest {
         when(connectionSession.getDatabaseConnectionManager()).thenReturn(databaseConnectionManager);
         when(packet.getStatementId()).thenReturn(STATEMENT_ID);
     }
-    
+
     @AfterEach
     void tearDown() {
         FirebirdFetchStatementCache.getInstance().unregisterConnection(CONNECTION_ID);
     }
-    
+
     @Test
     void assertExecuteWhenNoBackendHandler() throws SQLException {
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
-        Collection<DatabasePacket> actualPackets = executor.execute();
-        Iterator<DatabasePacket> packetIterator = actualPackets.iterator();
-        FirebirdFetchResponsePacket actualPacket = (FirebirdFetchResponsePacket) packetIterator.next();
-        assertThat(actualPackets.size(), is(1));
-        assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_NO_MORE_ROWS));
-        assertThat(actualPacket.getCount(), is(0));
-        assertNull(actualPacket.getRow());
+        assertNoMoreRowsResponse(executor.execute());
     }
-    
+
+    @Test
+    void assertExecuteWhenNoBackendHandlerAfterPreparedStatementFree() throws SQLException {
+        FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
+        FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
+        executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
+        assertNoMoreRowsResponse(executor.execute());
+    }
+
     @Test
     void assertExecuteWithRowsAndFetchEnd() throws SQLException {
         FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
@@ -117,7 +119,7 @@ class FirebirdFetchStatementCommandExecutorTest {
         assertThat(actualEndPacket.getCount(), is(0));
         assertNull(actualEndPacket.getRow());
     }
-    
+
     @Test
     void assertExecuteStopsWhenRowsExhausted() throws SQLException {
         FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
@@ -138,5 +140,14 @@ class FirebirdFetchStatementCommandExecutorTest {
         assertThat(actualNoMorePacket.getCount(), is(0));
         assertNull(actualNoMorePacket.getRow());
         verify(databaseConnectionManager).unmarkResourceInUse(proxyBackendHandler);
+    }
+
+    private void assertNoMoreRowsResponse(final Collection<DatabasePacket> actualPackets) {
+        Iterator<DatabasePacket> packetIterator = actualPackets.iterator();
+        FirebirdFetchResponsePacket actualPacket = (FirebirdFetchResponsePacket) packetIterator.next();
+        assertThat(actualPackets.size(), is(1));
+        assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_NO_MORE_ROWS));
+        assertThat(actualPacket.getCount(), is(0));
+        assertNull(actualPacket.getRow());
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutorTest.java
@@ -42,6 +42,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -91,6 +92,7 @@ class FirebirdFreeStatementCommandExecutorTest {
         Collection<DatabasePacket> actual = executor.execute();
         assertThat(actual.iterator().next(), isA(FirebirdGenericResponsePacket.class));
         verify(registry).removePreparedStatement(1);
+        verify(connectionSession).invalidateFirebirdPreparedStatementCache(1);
     }
     
     @Test
@@ -100,6 +102,7 @@ class FirebirdFreeStatementCommandExecutorTest {
         Collection<DatabasePacket> actual = executor.execute();
         assertThat(actual.iterator().next(), isA(FirebirdGenericResponsePacket.class));
         verify(registry).removePreparedStatement(1);
+        verify(connectionSession).invalidateFirebirdPreparedStatementCache(1);
     }
     
     @Test
@@ -108,6 +111,7 @@ class FirebirdFreeStatementCommandExecutorTest {
         new FirebirdFreeStatementCommandExecutor(packet, connectionSession).execute();
         verify(connectionSession.getConnectionContext()).clearCursorContext();
         verify(connectionManager).unmarkResourceInUse(proxyBackendHandler);
+        verify(connectionSession, never()).invalidateFirebirdPreparedStatementCache(STATEMENT_ID);
         assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
     }
     

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutorTest.java
@@ -53,26 +53,26 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class FirebirdFreeStatementCommandExecutorTest {
-
+    
     private static final int CONNECTION_ID = 1;
-
+    
     private static final int STATEMENT_ID = 1;
-
+    
     @Mock
     private FirebirdFreeStatementPacket packet;
-
+    
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ConnectionSession connectionSession;
-
+    
     @Mock
     private ServerPreparedStatementRegistry registry;
-
+    
     @Mock
     private ProxyDatabaseConnectionManager connectionManager;
-
+    
     @Mock
     private ProxyBackendHandler proxyBackendHandler;
-
+    
     @BeforeEach
     void setUp() {
         FirebirdFetchStatementCache.getInstance().registerConnection(CONNECTION_ID);
@@ -82,13 +82,13 @@ class FirebirdFreeStatementCommandExecutorTest {
         when(connectionSession.getServerPreparedStatementRegistry()).thenReturn(registry);
         when(connectionSession.getDatabaseConnectionManager()).thenReturn(connectionManager);
     }
-
+    
     @AfterEach
     void tearDown() {
         FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
         FirebirdFetchStatementCache.getInstance().unregisterConnection(CONNECTION_ID);
     }
-
+    
     @ParameterizedTest(name = "{0}")
     @MethodSource("preparedStatementFreeOptions")
     void assertExecuteWithPreparedStatementFreeOption(final String scenario, final int option) {
@@ -102,7 +102,7 @@ class FirebirdFreeStatementCommandExecutorTest {
         verify(connectionManager).unmarkResourceInUse(proxyBackendHandler);
         assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
     }
-
+    
     @Test
     void assertExecuteWithClose() {
         when(packet.getOption()).thenReturn(FirebirdFreeStatementPacket.CLOSE);
@@ -112,7 +112,7 @@ class FirebirdFreeStatementCommandExecutorTest {
         verify(connectionSession, never()).invalidateFirebirdPreparedStatementCache(STATEMENT_ID);
         assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
     }
-
+    
     @ParameterizedTest(name = "{0}")
     @MethodSource("preparedStatementFreeOptions")
     void assertExecuteWithPreparedStatementFreeOptionWithoutFetchHandler(final String scenario, final int option) {
@@ -124,13 +124,13 @@ class FirebirdFreeStatementCommandExecutorTest {
         verify(connectionSession.getConnectionContext()).clearCursorContext();
         verify(connectionManager, never()).unmarkResourceInUse(proxyBackendHandler);
     }
-
+    
     @Test
     void assertExecuteWithUnknownOption() {
         when(packet.getOption()).thenReturn(999);
         assertThrows(FirebirdProtocolException.class, new FirebirdFreeStatementCommandExecutor(packet, connectionSession)::execute);
     }
-
+    
     private static Stream<Arguments> preparedStatementFreeOptions() {
         return Stream.of(
                 Arguments.of("execute_dropCleansPreparedStatementAndFetchResources", FirebirdFreeStatementPacket.DROP),

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutorTest.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnection
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.session.ServerPreparedStatementRegistry;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.FirebirdStatementResourceCleaner;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.fetch.FirebirdFetchStatementCache;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -97,7 +98,7 @@ class FirebirdFreeStatementCommandExecutorTest {
         Collection<DatabasePacket> actual = executor.execute();
         assertThat(actual.iterator().next(), isA(FirebirdGenericResponsePacket.class));
         verify(registry).removePreparedStatement(STATEMENT_ID);
-        verify(connectionSession).invalidateFirebirdPreparedStatementCache(STATEMENT_ID);
+        verify(connectionSession).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(STATEMENT_ID));
         verify(connectionSession.getConnectionContext()).clearCursorContext();
         verify(connectionManager).unmarkResourceInUse(proxyBackendHandler);
         assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
@@ -109,7 +110,7 @@ class FirebirdFreeStatementCommandExecutorTest {
         new FirebirdFreeStatementCommandExecutor(packet, connectionSession).execute();
         verify(connectionSession.getConnectionContext()).clearCursorContext();
         verify(connectionManager).unmarkResourceInUse(proxyBackendHandler);
-        verify(connectionSession, never()).invalidateFirebirdPreparedStatementCache(STATEMENT_ID);
+        verify(connectionSession, never()).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(STATEMENT_ID));
         assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
     }
     
@@ -120,7 +121,7 @@ class FirebirdFreeStatementCommandExecutorTest {
         when(packet.getOption()).thenReturn(option);
         new FirebirdFreeStatementCommandExecutor(packet, connectionSession).execute();
         verify(registry).removePreparedStatement(STATEMENT_ID);
-        verify(connectionSession).invalidateFirebirdPreparedStatementCache(STATEMENT_ID);
+        verify(connectionSession).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(STATEMENT_ID));
         verify(connectionSession.getConnectionContext()).clearCursorContext();
         verify(connectionManager, never()).unmarkResourceInUse(proxyBackendHandler);
     }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutorTest.java
@@ -21,7 +21,6 @@ import org.apache.shardingsphere.database.protocol.firebird.exception.FirebirdPr
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.statement.FirebirdFreeStatementPacket;
 import org.apache.shardingsphere.database.protocol.firebird.packet.generic.FirebirdGenericResponsePacket;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
-import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.session.ServerPreparedStatementRegistry;
@@ -47,6 +46,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -69,9 +69,6 @@ class FirebirdFreeStatementCommandExecutorTest {
     private ServerPreparedStatementRegistry registry;
     
     @Mock
-    private ProxyDatabaseConnectionManager connectionManager;
-    
-    @Mock
     private ProxyBackendHandler proxyBackendHandler;
     
     @BeforeEach
@@ -81,7 +78,6 @@ class FirebirdFreeStatementCommandExecutorTest {
         when(packet.getStatementId()).thenReturn(STATEMENT_ID);
         when(connectionSession.getConnectionId()).thenReturn(CONNECTION_ID);
         when(connectionSession.getServerPreparedStatementRegistry()).thenReturn(registry);
-        when(connectionSession.getDatabaseConnectionManager()).thenReturn(connectionManager);
     }
     
     @AfterEach
@@ -92,38 +88,32 @@ class FirebirdFreeStatementCommandExecutorTest {
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("preparedStatementFreeOptions")
-    void assertExecuteWithPreparedStatementFreeOption(final String scenario, final int option) {
+    void assertExecuteWithPreparedStatementFreeOption(final String scenario, final int option) throws Exception {
         when(packet.getOption()).thenReturn(option);
         FirebirdFreeStatementCommandExecutor executor = new FirebirdFreeStatementCommandExecutor(packet, connectionSession);
         Collection<DatabasePacket> actual = executor.execute();
         assertThat(actual.iterator().next(), isA(FirebirdGenericResponsePacket.class));
         verify(registry).removePreparedStatement(STATEMENT_ID);
         verify(connectionSession).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(STATEMENT_ID));
-        verify(connectionSession.getConnectionContext()).clearCursorContext();
-        verify(connectionManager).unmarkResourceInUse(proxyBackendHandler);
         assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
     }
     
     @Test
-    void assertExecuteWithClose() {
+    void assertExecuteWithClose() throws Exception {
         when(packet.getOption()).thenReturn(FirebirdFreeStatementPacket.CLOSE);
         new FirebirdFreeStatementCommandExecutor(packet, connectionSession).execute();
-        verify(connectionSession.getConnectionContext()).clearCursorContext();
-        verify(connectionManager).unmarkResourceInUse(proxyBackendHandler);
-        verify(connectionSession, never()).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(STATEMENT_ID));
+        verify(connectionSession, never()).invalidatePreparedStatementCache(any());
         assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
     }
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("preparedStatementFreeOptions")
-    void assertExecuteWithPreparedStatementFreeOptionWithoutFetchHandler(final String scenario, final int option) {
+    void assertExecuteWithPreparedStatementFreeOptionWithoutFetchHandler(final String scenario, final int option) throws Exception {
         FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
         when(packet.getOption()).thenReturn(option);
         new FirebirdFreeStatementCommandExecutor(packet, connectionSession).execute();
         verify(registry).removePreparedStatement(STATEMENT_ID);
         verify(connectionSession).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(STATEMENT_ID));
-        verify(connectionSession.getConnectionContext()).clearCursorContext();
-        verify(connectionManager, never()).unmarkResourceInUse(proxyBackendHandler);
     }
     
     @Test

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/free/FirebirdFreeStatementCommandExecutorTest.java
@@ -30,6 +30,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -37,6 +40,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.util.Collection;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
@@ -49,26 +53,26 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class FirebirdFreeStatementCommandExecutorTest {
-    
+
     private static final int CONNECTION_ID = 1;
-    
+
     private static final int STATEMENT_ID = 1;
-    
+
     @Mock
     private FirebirdFreeStatementPacket packet;
-    
+
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ConnectionSession connectionSession;
-    
+
     @Mock
     private ServerPreparedStatementRegistry registry;
-    
+
     @Mock
     private ProxyDatabaseConnectionManager connectionManager;
-    
+
     @Mock
     private ProxyBackendHandler proxyBackendHandler;
-    
+
     @BeforeEach
     void setUp() {
         FirebirdFetchStatementCache.getInstance().registerConnection(CONNECTION_ID);
@@ -78,33 +82,27 @@ class FirebirdFreeStatementCommandExecutorTest {
         when(connectionSession.getServerPreparedStatementRegistry()).thenReturn(registry);
         when(connectionSession.getDatabaseConnectionManager()).thenReturn(connectionManager);
     }
-    
+
     @AfterEach
     void tearDown() {
         FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
         FirebirdFetchStatementCache.getInstance().unregisterConnection(CONNECTION_ID);
     }
-    
-    @Test
-    void assertExecuteWithDrop() {
-        when(packet.getOption()).thenReturn(FirebirdFreeStatementPacket.DROP);
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("preparedStatementFreeOptions")
+    void assertExecuteWithPreparedStatementFreeOption(final String scenario, final int option) {
+        when(packet.getOption()).thenReturn(option);
         FirebirdFreeStatementCommandExecutor executor = new FirebirdFreeStatementCommandExecutor(packet, connectionSession);
         Collection<DatabasePacket> actual = executor.execute();
         assertThat(actual.iterator().next(), isA(FirebirdGenericResponsePacket.class));
-        verify(registry).removePreparedStatement(1);
-        verify(connectionSession).invalidateFirebirdPreparedStatementCache(1);
+        verify(registry).removePreparedStatement(STATEMENT_ID);
+        verify(connectionSession).invalidateFirebirdPreparedStatementCache(STATEMENT_ID);
+        verify(connectionSession.getConnectionContext()).clearCursorContext();
+        verify(connectionManager).unmarkResourceInUse(proxyBackendHandler);
+        assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
     }
-    
-    @Test
-    void assertExecuteWithUnprepare() {
-        when(packet.getOption()).thenReturn(FirebirdFreeStatementPacket.UNPREPARE);
-        FirebirdFreeStatementCommandExecutor executor = new FirebirdFreeStatementCommandExecutor(packet, connectionSession);
-        Collection<DatabasePacket> actual = executor.execute();
-        assertThat(actual.iterator().next(), isA(FirebirdGenericResponsePacket.class));
-        verify(registry).removePreparedStatement(1);
-        verify(connectionSession).invalidateFirebirdPreparedStatementCache(1);
-    }
-    
+
     @Test
     void assertExecuteWithClose() {
         when(packet.getOption()).thenReturn(FirebirdFreeStatementPacket.CLOSE);
@@ -114,10 +112,28 @@ class FirebirdFreeStatementCommandExecutorTest {
         verify(connectionSession, never()).invalidateFirebirdPreparedStatementCache(STATEMENT_ID);
         assertNull(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, STATEMENT_ID));
     }
-    
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("preparedStatementFreeOptions")
+    void assertExecuteWithPreparedStatementFreeOptionWithoutFetchHandler(final String scenario, final int option) {
+        FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
+        when(packet.getOption()).thenReturn(option);
+        new FirebirdFreeStatementCommandExecutor(packet, connectionSession).execute();
+        verify(registry).removePreparedStatement(STATEMENT_ID);
+        verify(connectionSession).invalidateFirebirdPreparedStatementCache(STATEMENT_ID);
+        verify(connectionSession.getConnectionContext()).clearCursorContext();
+        verify(connectionManager, never()).unmarkResourceInUse(proxyBackendHandler);
+    }
+
     @Test
     void assertExecuteWithUnknownOption() {
         when(packet.getOption()).thenReturn(999);
         assertThrows(FirebirdProtocolException.class, new FirebirdFreeStatementCommandExecutor(packet, connectionSession)::execute);
+    }
+
+    private static Stream<Arguments> preparedStatementFreeOptions() {
+        return Stream.of(
+                Arguments.of("execute_dropCleansPreparedStatementAndFetchResources", FirebirdFreeStatementPacket.DROP),
+                Arguments.of("execute_unprepareCleansPreparedStatementAndFetchResources", FirebirdFreeStatementPacket.UNPREPARE));
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutorTest.java
@@ -45,13 +45,17 @@ import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.parser.config.SQLParserRuleConfiguration;
 import org.apache.shardingsphere.parser.rule.SQLParserRule;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.session.ServerPreparedStatementRegistry;
+import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.FirebirdServerPreparedStatement;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.fetch.FirebirdFetchStatementCache;
 import org.apache.shardingsphere.sql.parser.engine.api.CacheOption;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -77,6 +81,8 @@ import static org.mockito.Mockito.when;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class FirebirdPrepareStatementCommandExecutorTest {
     
+    private static final int CONNECTION_ID = 1;
+    
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "Firebird");
     
     @Mock
@@ -85,12 +91,21 @@ class FirebirdPrepareStatementCommandExecutorTest {
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ConnectionSession connectionSession;
     
+    @Mock
+    private ProxyDatabaseConnectionManager connectionManager;
+    
+    @Mock
+    private ProxyBackendHandler proxyBackendHandler;
+    
     @BeforeEach
     void setUp() {
+        FirebirdFetchStatementCache.getInstance().registerConnection(CONNECTION_ID);
         ConnectionContext connectionContext = new ConnectionContext(Collections::emptySet, new Grantee("foo_user"));
         when(connectionSession.getServerPreparedStatementRegistry()).thenReturn(new ServerPreparedStatementRegistry());
         when(connectionSession.getCurrentDatabaseName()).thenReturn("foo_db");
         when(connectionSession.getConnectionContext()).thenReturn(connectionContext);
+        when(connectionSession.getConnectionId()).thenReturn(CONNECTION_ID);
+        when(connectionSession.getDatabaseConnectionManager()).thenReturn(connectionManager);
         when(packet.getSQL()).thenReturn("SELECT 1");
         when(packet.getHintValueContext()).thenReturn(new HintValueContext());
         when(packet.isValidStatementHandle()).thenReturn(true);
@@ -98,6 +113,12 @@ class FirebirdPrepareStatementCommandExecutorTest {
         when(packet.nextItem()).thenReturn(true, false);
         when(packet.getCurrentItem()).thenReturn(FirebirdSQLInfoPacketType.STMT_TYPE);
         when(ProxyContext.getInstance().getContextManager().getMetaDataContexts()).thenReturn(createMetaDataContexts());
+    }
+    
+    @AfterEach
+    void tearDown() {
+        FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, 1);
+        FirebirdFetchStatementCache.getInstance().unregisterConnection(CONNECTION_ID);
     }
     
     private MetaDataContexts createMetaDataContexts() {
@@ -146,5 +167,24 @@ class FirebirdPrepareStatementCommandExecutorTest {
         FirebirdReturnColumnPacket columnPacket = returnPacket.getDescribeSelect().get(0);
         columnPacket.write(payload);
         verify(payload).writeInt4LE(FirebirdBinaryColumnType.INT64.getValue() + 1);
+    }
+    
+    @Test
+    void assertExecuteWithValidStatementHandleCleansPreviousPreparedStatementResources() {
+        connectionSession.getServerPreparedStatementRegistry().addPreparedStatement(1, new FirebirdServerPreparedStatement("SELECT 0", mock(SelectStatementContext.class), new HintValueContext()));
+        FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, 1, proxyBackendHandler);
+        FirebirdPrepareStatementCommandExecutor executor = new FirebirdPrepareStatementCommandExecutor(packet, connectionSession);
+        executor.execute();
+        verify(connectionSession).invalidateFirebirdPreparedStatementCache(1);
+        verify(connectionManager).unmarkResourceInUse(proxyBackendHandler);
+        assertThat(connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(1).getSql(), is("SELECT 1"));
+        assertThat(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, 1), is((ProxyBackendHandler) null));
+    }
+    
+    @Test
+    void assertExecuteWithValidStatementHandleWithoutFetchHandler() {
+        FirebirdPrepareStatementCommandExecutor executor = new FirebirdPrepareStatementCommandExecutor(packet, connectionSession);
+        executor.execute();
+        verify(connectionSession).invalidateFirebirdPreparedStatementCache(1);
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutorTest.java
@@ -50,6 +50,7 @@ import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.session.ServerPreparedStatementRegistry;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.FirebirdServerPreparedStatement;
+import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.FirebirdStatementResourceCleaner;
 import org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.fetch.FirebirdFetchStatementCache;
 import org.apache.shardingsphere.sql.parser.engine.api.CacheOption;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
@@ -175,7 +176,7 @@ class FirebirdPrepareStatementCommandExecutorTest {
         FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, 1, proxyBackendHandler);
         FirebirdPrepareStatementCommandExecutor executor = new FirebirdPrepareStatementCommandExecutor(packet, connectionSession);
         executor.execute();
-        verify(connectionSession).invalidateFirebirdPreparedStatementCache(1);
+        verify(connectionSession).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(1));
         verify(connectionManager).unmarkResourceInUse(proxyBackendHandler);
         assertThat(connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(1).getSql(), is("SELECT 1"));
         assertThat(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, 1), is((ProxyBackendHandler) null));
@@ -185,6 +186,6 @@ class FirebirdPrepareStatementCommandExecutorTest {
     void assertExecuteWithValidStatementHandleWithoutFetchHandler() {
         FirebirdPrepareStatementCommandExecutor executor = new FirebirdPrepareStatementCommandExecutor(packet, connectionSession);
         executor.execute();
-        verify(connectionSession).invalidateFirebirdPreparedStatementCache(1);
+        verify(connectionSession).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(1));
     }
 }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutorTest.java
@@ -98,13 +98,16 @@ class FirebirdPrepareStatementCommandExecutorTest {
     @Mock
     private ProxyBackendHandler proxyBackendHandler;
     
+    @Mock
+    private ConnectionContext connectionContext;
+    
     @BeforeEach
     void setUp() {
         FirebirdFetchStatementCache.getInstance().registerConnection(CONNECTION_ID);
-        ConnectionContext connectionContext = new ConnectionContext(Collections::emptySet, new Grantee("foo_user"));
         when(connectionSession.getServerPreparedStatementRegistry()).thenReturn(new ServerPreparedStatementRegistry());
         when(connectionSession.getCurrentDatabaseName()).thenReturn("foo_db");
         when(connectionSession.getConnectionContext()).thenReturn(connectionContext);
+        when(connectionContext.getGrantee()).thenReturn(new Grantee("foo_user"));
         when(connectionSession.getConnectionId()).thenReturn(CONNECTION_ID);
         when(connectionSession.getDatabaseConnectionManager()).thenReturn(connectionManager);
         when(packet.getSQL()).thenReturn("SELECT 1");
@@ -137,7 +140,7 @@ class FirebirdPrepareStatementCommandExecutorTest {
     }
     
     @Test
-    void assertExecute() {
+    void assertExecute() throws Exception {
         FirebirdPrepareStatementCommandExecutor executor = new FirebirdPrepareStatementCommandExecutor(packet, connectionSession);
         Collection<DatabasePacket> actual = executor.execute();
         FirebirdGenericResponsePacket responsePacket = (FirebirdGenericResponsePacket) actual.iterator().next();
@@ -149,7 +152,7 @@ class FirebirdPrepareStatementCommandExecutorTest {
     }
     
     @Test
-    void assertDescribeCountReturnsBigintType() {
+    void assertDescribeCountReturnsBigintType() throws Exception {
         when(packet.getSQL()).thenReturn("SELECT COUNT(*) FROM foo_tbl");
         when(packet.nextItem()).thenReturn(true, true, true, true, true, false);
         when(packet.getCurrentItem()).thenReturn(
@@ -171,19 +174,18 @@ class FirebirdPrepareStatementCommandExecutorTest {
     }
     
     @Test
-    void assertExecuteWithValidStatementHandleCleansPreviousPreparedStatementResources() {
+    void assertExecuteWithValidStatementHandleCleansPreviousPreparedStatementResources() throws Exception {
         connectionSession.getServerPreparedStatementRegistry().addPreparedStatement(1, new FirebirdServerPreparedStatement("SELECT 0", mock(SelectStatementContext.class), new HintValueContext()));
         FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, 1, proxyBackendHandler);
         FirebirdPrepareStatementCommandExecutor executor = new FirebirdPrepareStatementCommandExecutor(packet, connectionSession);
         executor.execute();
         verify(connectionSession).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(1));
-        verify(connectionManager).unmarkResourceInUse(proxyBackendHandler);
         assertThat(connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(1).getSql(), is("SELECT 1"));
         assertThat(FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(CONNECTION_ID, 1), is((ProxyBackendHandler) null));
     }
     
     @Test
-    void assertExecuteWithValidStatementHandleWithoutFetchHandler() {
+    void assertExecuteWithValidStatementHandleWithoutFetchHandler() throws Exception {
         FirebirdPrepareStatementCommandExecutor executor = new FirebirdPrepareStatementCommandExecutor(packet, connectionSession);
         executor.execute();
         verify(connectionSession).invalidatePreparedStatementCache(FirebirdStatementResourceCleaner.createPreparedStatementCacheKey(1));


### PR DESCRIPTION
Fixes #37274

Changes proposed in this pull request:

Add a Firebird-only connection-held prepared statement cache for Proxy backend execution:
- Introduce `PreparedStatementCacheContext` with LRU eviction (`LinkedHashMap` with access order).
- Introduce `PreparedStatementCacheKey` and corresponding cache lifecycle hooks in shared backend-core only as internal generic infrastructure, while the current and only enabled usage remains Firebird.
- Reuse prepared statements in `JDBCBackendStatement` only when the Firebird frontend explicitly activates a cache key in `ConnectionSession`.
- Use a cache key composed of physical connection identity, SQL text, `returnGeneratedKeys`, and Firebird prepared statement identity.

Reuse prepared statements only while the backend connection is still held:
- Reuse cached prepared statements for repeated execution of the same Firebird prepared statement within a held Proxy connection.
- Call `clearParameters()` before rebinding parameters on every reuse.
- Do not claim reuse after physical connection close or across the normal auto-commit connection teardown path.

Keep Firebird statement-handle semantics and cleanup owned by the Firebird frontend:
- Activate and clear the current prepared statement cache key in `FirebirdExecuteStatementCommandExecutor`.
- Generate cache keys from Firebird statement handles in the Firebird frontend; the shared backend-core does not add MySQL, PostgreSQL, or openGauss prepared statement cache behavior.
- Invalidate the matching cached prepared statement on Firebird `DROP` / `UNPREPARE`.
- Keep `CLOSE` limited to cursor/fetch cleanup and do not invalidate prepared statement cache entries.
- Add same-handle `PREPARE` cleanup so re-preparing an existing Firebird statement handle performs implicit unprepare-style resource cleanup.
- Clean up fetch handlers together with Firebird free/reprepare resource release.
- Close all cached prepared statements in `ProxyDatabaseConnectionManager#closeConnections(...)` as the final connection cleanup step.

Add and extend tests for Firebird-only cache behavior and lifecycle safety:
- `PreparedStatementCacheContextTest`
- `PreparedStatementCacheKeyTest`
- `JDBCBackendStatementTest`
- `ConnectionSessionTest`
- `ProxyDatabaseConnectionManagerTest`
- `StandardDatabaseProxyConnectorTest`
- `FirebirdExecuteStatementCommandExecutorTest`
- `FirebirdPrepareStatementCommandExecutorTest`
- `FirebirdFreeStatementCommandExecutorTest`
- `FirebirdFetchStatementCacheTest`
- `FirebirdFetchStatementCommandExecutorTest`
- `FirebirdStatementResourceCleanerTest`

The intended scope of this change is:
- Firebird only
- connection-level cache
- reduced physical prepare count for repeated execution of the same Firebird statement in Connection Held scenarios
- no prepared statement reuse after physical connection close
- shared backend-core generic hooks added only to support the Firebird implementation in this pull request, without enabling cache reuse for other databases

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
