### PR TITLE
Fix: force utf-8 encoding for PostgreSQL backend connections in proxy

### DIFF
--- a/proxy/backend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLResetVariableAdminExecutor.java
+++ b/proxy/backend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLResetVariableAdminExecutor.java
@@ -33,6 +33,8 @@ import org.apache.shardingsphere.sql.parser.statement.postgresql.dal.PostgreSQLR
 @RequiredArgsConstructor
 public final class PostgreSQLResetVariableAdminExecutor implements DatabaseAdminUpdateExecutor {
     
+    private static final String CLIENT_ENCODING = "client_encoding";
+    
     private static final String DEFAULT = "DEFAULT";
     
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "PostgreSQL");
@@ -43,6 +45,8 @@ public final class PostgreSQLResetVariableAdminExecutor implements DatabaseAdmin
     public void execute(final ConnectionSession connectionSession, final ShardingSphereMetaData metaData) {
         String variableName = resetParameterStatement.getConfigurationParameter();
         new CharsetSetExecutor(databaseType, connectionSession).set(variableName, DEFAULT);
-        new SessionVariableRecordExecutor(databaseType, connectionSession).recordVariable(variableName, DEFAULT);
+        if (!CLIENT_ENCODING.equalsIgnoreCase(variableName)) {
+            new SessionVariableRecordExecutor(databaseType, connectionSession).recordVariable(variableName, DEFAULT);
+        }
     }
 }

--- a/proxy/backend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLShowVariableExecutor.java
+++ b/proxy/backend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLShowVariableExecutor.java
@@ -50,7 +50,7 @@ public final class PostgreSQLShowVariableExecutor implements DatabaseAdminQueryE
     
     static {
         VARIABLE_ROW_DATA_GENERATORS.put("application_name", connectionSession -> new String[]{"application_name", "PostgreSQL", "Sets the application name to be reported in statistics and logs."});
-        VARIABLE_ROW_DATA_GENERATORS.put("client_encoding", connectionSession -> new String[]{"client_encoding", "UTF8", "Sets the client's character set encoding."});
+        VARIABLE_ROW_DATA_GENERATORS.put("client_encoding", connectionSession -> new String[]{"client_encoding", "UTF8", "Proxy policy fixes the backend client encoding to UTF8."});
         VARIABLE_ROW_DATA_GENERATORS.put("integer_datetimes", connectionSession -> new String[]{"integer_datetimes", "on", "Shows whether datetimes are integer based."});
         VARIABLE_ROW_DATA_GENERATORS.put("timezone", connectionSession -> new String[]{"TimeZone", "Etc/UTC", "Sets the time zone for displaying and interpreting time stamps."});
         VARIABLE_ROW_DATA_GENERATORS.put("transaction_isolation", connectionSession -> {

--- a/proxy/backend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/variable/charset/PostgreSQLCharsetVariableProvider.java
+++ b/proxy/backend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/variable/charset/PostgreSQLCharsetVariableProvider.java
@@ -17,10 +17,12 @@
 
 package org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.executor.variable.charset;
 
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.exception.core.exception.data.InvalidParameterValueException;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetVariableProvider;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Locale;
@@ -37,12 +39,17 @@ public final class PostgreSQLCharsetVariableProvider implements CharsetVariableP
     
     @Override
     public Charset parseCharset(final String variableValue) {
-        String formattedValue = variableValue.trim().toLowerCase(Locale.ROOT);
-        try {
-            return "default".equals(formattedValue) ? Charset.defaultCharset() : PostgreSQLCharacterSets.findCharacterSet(formattedValue);
-        } catch (final IllegalArgumentException ignored) {
+        String formattedValue = formatValue(variableValue).toLowerCase(Locale.ROOT);
+        boolean isDefault = "default".equals(formattedValue);
+        boolean isUtf8 = "utf8".equals(formattedValue) || "utf-8".equals(formattedValue) || "utf_8".equals(formattedValue) || "unicode".equals(formattedValue);
+        if (!isDefault && !isUtf8) {
             throw new InvalidParameterValueException("client_encoding", formattedValue);
         }
+        return StandardCharsets.UTF_8;
+    }
+    
+    private String formatValue(final String value) {
+        return QuoteCharacter.SINGLE_QUOTE.isWrapped(value) || QuoteCharacter.QUOTE.isWrapped(value) ? value.substring(1, value.length() - 1).trim() : value.trim();
     }
     
     @Override

--- a/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLResetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLResetVariableAdminExecutorTest.java
@@ -61,7 +61,7 @@ class PostgreSQLResetVariableAdminExecutorTest {
             verify(requiredSessionVariableRecorder).setVariable("key", "DEFAULT");
         }
     }
-
+    
     @Test
     void assertExecuteWithClientEncoding() {
         PostgreSQLResetVariableAdminExecutor executor = new PostgreSQLResetVariableAdminExecutor(new PostgreSQLResetParameterStatement(databaseType, "client_encoding"));

--- a/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLResetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLResetVariableAdminExecutorTest.java
@@ -17,17 +17,23 @@
 
 package org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.executor;
 
+import io.netty.util.Attribute;
+import io.netty.util.AttributeMap;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
+import org.apache.shardingsphere.database.protocol.constant.CommonConstants;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetVariableProvider;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.session.ReplayedSessionVariableProvider;
+import org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.executor.variable.charset.PostgreSQLCharsetVariableProvider;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.session.RequiredSessionVariableRecorder;
 import org.apache.shardingsphere.sql.parser.statement.postgresql.dal.PostgreSQLResetParameterStatement;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -53,6 +59,28 @@ class PostgreSQLResetVariableAdminExecutorTest {
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(ReplayedSessionVariableProvider.class, databaseType)).thenReturn(Optional.of(replayedSessionVariableProvider));
             executor.execute(connectionSession, mock());
             verify(requiredSessionVariableRecorder).setVariable("key", "DEFAULT");
+        }
+    }
+
+    @Test
+    void assertExecuteWithClientEncoding() {
+        PostgreSQLResetVariableAdminExecutor executor = new PostgreSQLResetVariableAdminExecutor(new PostgreSQLResetParameterStatement(databaseType, "client_encoding"));
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        RequiredSessionVariableRecorder requiredSessionVariableRecorder = mock(RequiredSessionVariableRecorder.class);
+        AttributeMap attributeMap = mock(AttributeMap.class);
+        @SuppressWarnings("unchecked")
+        Attribute<Charset> attribute = mock(Attribute.class);
+        when(connectionSession.getRequiredSessionVariableRecorder()).thenReturn(requiredSessionVariableRecorder);
+        when(connectionSession.getAttributeMap()).thenReturn(attributeMap);
+        when(attributeMap.attr(CommonConstants.CHARSET_ATTRIBUTE_KEY)).thenReturn(attribute);
+        try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
+            databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(CharsetVariableProvider.class, databaseType)).thenReturn(Optional.of(new PostgreSQLCharsetVariableProvider()));
+            ReplayedSessionVariableProvider replayedSessionVariableProvider = mock(ReplayedSessionVariableProvider.class);
+            when(replayedSessionVariableProvider.isNeedToReplay("client_encoding")).thenReturn(true);
+            databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(ReplayedSessionVariableProvider.class, databaseType)).thenReturn(Optional.of(replayedSessionVariableProvider));
+            executor.execute(connectionSession, mock());
+            verify(attribute).set(StandardCharsets.UTF_8);
+            verify(requiredSessionVariableRecorder).setVariable("client_encoding", "DEFAULT");
         }
     }
 }

--- a/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLResetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLResetVariableAdminExecutorTest.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -80,7 +81,7 @@ class PostgreSQLResetVariableAdminExecutorTest {
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(ReplayedSessionVariableProvider.class, databaseType)).thenReturn(Optional.of(replayedSessionVariableProvider));
             executor.execute(connectionSession, mock());
             verify(attribute).set(StandardCharsets.UTF_8);
-            verify(requiredSessionVariableRecorder).setVariable("client_encoding", "DEFAULT");
+            verify(requiredSessionVariableRecorder, never()).setVariable("client_encoding", "DEFAULT");
         }
     }
 }

--- a/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLSetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLSetVariableAdminExecutorTest.java
@@ -17,23 +17,33 @@
 
 package org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.executor;
 
+import io.netty.util.Attribute;
+import io.netty.util.AttributeMap;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
+import org.apache.shardingsphere.database.protocol.constant.CommonConstants;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.database.exception.core.exception.data.InvalidParameterValueException;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.charset.CharsetVariableProvider;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.variable.session.ReplayedSessionVariableProvider;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.session.RequiredSessionVariableRecorder;
+import org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.executor.variable.charset.PostgreSQLCharsetVariableProvider;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableAssignSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.SetStatement;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -54,6 +64,25 @@ class PostgreSQLSetVariableAdminExecutorTest {
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(ReplayedSessionVariableProvider.class, databaseType)).thenReturn(Optional.of(replayedSessionVariableProvider));
             executor.execute(connectionSession, mock());
             verify(requiredSessionVariableRecorder).setVariable("key", "value");
+        }
+    }
+
+    @Test
+    void assertExecuteWithInvalidClientEncoding() {
+        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "client_encoding"), "'LATIN1'")));
+        PostgreSQLSetVariableAdminExecutor executor = new PostgreSQLSetVariableAdminExecutor(setStatement);
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        RequiredSessionVariableRecorder requiredSessionVariableRecorder = mock(RequiredSessionVariableRecorder.class);
+        AttributeMap attributeMap = mock(AttributeMap.class);
+        @SuppressWarnings("unchecked")
+        Attribute<Charset> attribute = mock(Attribute.class);
+        when(connectionSession.getRequiredSessionVariableRecorder()).thenReturn(requiredSessionVariableRecorder);
+        when(connectionSession.getAttributeMap()).thenReturn(attributeMap);
+        when(attributeMap.attr(CommonConstants.CHARSET_ATTRIBUTE_KEY)).thenReturn(attribute);
+        try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
+            databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.findService(CharsetVariableProvider.class, databaseType)).thenReturn(Optional.of(new PostgreSQLCharsetVariableProvider()));
+            assertThrows(InvalidParameterValueException.class, () -> executor.execute(connectionSession, mock()));
+            verify(requiredSessionVariableRecorder, never()).setVariable(anyString(), anyString());
         }
     }
 }

--- a/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLSetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/PostgreSQLSetVariableAdminExecutorTest.java
@@ -66,7 +66,7 @@ class PostgreSQLSetVariableAdminExecutorTest {
             verify(requiredSessionVariableRecorder).setVariable("key", "value");
         }
     }
-
+    
     @Test
     void assertExecuteWithInvalidClientEncoding() {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "client_encoding"), "'LATIN1'")));

--- a/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/variable/charset/PostgreSQLCharsetVariableProviderTest.java
+++ b/proxy/backend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/variable/charset/PostgreSQLCharsetVariableProviderTest.java
@@ -46,7 +46,7 @@ class PostgreSQLCharsetVariableProviderTest {
     @Test
     void assertParseDefaultCharset() {
         Charset actual = provider.parseCharset("default");
-        assertThat(actual, is(Charset.defaultCharset()));
+        assertThat(actual, is(StandardCharsets.UTF_8));
     }
     
     @Test
@@ -57,6 +57,6 @@ class PostgreSQLCharsetVariableProviderTest {
     
     @Test
     void assertParseInvalidCharset() {
-        assertThrows(InvalidParameterValueException.class, () -> provider.parseCharset("invalid_charset"));
+        assertThrows(InvalidParameterValueException.class, () -> provider.parseCharset("latin1"));
     }
 }

--- a/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngine.java
+++ b/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngine.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.authority.checker.AuthorityChecker;
 import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.exception.core.exception.syntax.database.UnknownDatabaseException;
+import org.apache.shardingsphere.database.exception.core.exception.data.InvalidParameterValueException;
 import org.apache.shardingsphere.database.exception.postgresql.exception.authority.EmptyUsernameException;
 import org.apache.shardingsphere.database.exception.postgresql.exception.authority.InvalidPasswordException;
 import org.apache.shardingsphere.database.exception.postgresql.exception.authority.PrivilegeNotGrantedException;
@@ -61,30 +62,31 @@ import org.apache.shardingsphere.proxy.frontend.connection.ConnectionIdGenerator
 import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator.PostgreSQLAuthenticatorType;
 import org.apache.shardingsphere.proxy.frontend.ssl.ProxySSLContext;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 /**
  * Authentication engine for PostgreSQL.
  */
 public final class PostgreSQLAuthenticationEngine implements AuthenticationEngine {
-    
+
     private static final int SSL_REQUEST_PAYLOAD_LENGTH = 8;
-    
+
     private static final int SSL_REQUEST_CODE = (1234 << 16) + 5679;
-    
+
     private boolean startupMessageReceived;
-    
+
     private String clientEncoding;
-    
+
     private byte[] md5Salt;
-    
+
     private AuthenticationResult currentAuthResult;
-    
+
     @Override
     public int handshake(final ChannelHandlerContext context) {
         return ConnectionIdGenerator.getInstance().nextId();
     }
-    
+
     @Override
     public AuthenticationResult authenticate(final ChannelHandlerContext context, final PacketPayload payload) {
         if (SSL_REQUEST_PAYLOAD_LENGTH == payload.getByteBuf().markReaderIndex().readInt() && SSL_REQUEST_CODE == payload.getByteBuf().readInt()) {
@@ -101,7 +103,7 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
         AuthorityRule rule = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getGlobalRuleMetaData().getSingleRule(AuthorityRule.class);
         return startupMessageReceived ? processPasswordMessage(context, (PostgreSQLPacketPayload) payload, rule) : processStartupMessage(context, (PostgreSQLPacketPayload) payload, rule);
     }
-    
+
     private AuthenticationResult processPasswordMessage(final ChannelHandlerContext context, final PostgreSQLPacketPayload payload, final AuthorityRule rule) {
         char messageType = (char) payload.readInt1();
         ShardingSpherePreconditions.checkState(PostgreSQLMessagePacketType.PASSWORD_MESSAGE.getValue() == messageType,
@@ -119,7 +121,7 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
         context.writeAndFlush(PostgreSQLReadyForQueryPacket.NOT_IN_TRANSACTION);
         return AuthenticationResultBuilder.finished(currentAuthResult.getUsername(), "", currentAuthResult.getDatabase());
     }
-    
+
     private void login(final String databaseName, final String username, final byte[] md5Salt, final String digest, final AuthorityRule rule) {
         ShardingSpherePreconditions.checkState(
                 Strings.isNullOrEmpty(databaseName) || ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().containsDatabase(databaseName),
@@ -130,19 +132,35 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
                 () -> new InvalidPasswordException(username));
         ShardingSpherePreconditions.checkState(null == databaseName || new AuthorityChecker(rule, grantee).isAuthorized(databaseName), () -> new PrivilegeNotGrantedException(username, databaseName));
     }
-    
+
     private AuthenticationResult processStartupMessage(final ChannelHandlerContext context, final PostgreSQLPacketPayload payload, final AuthorityRule rule) {
-        startupMessageReceived = true;
         PostgreSQLComStartupPacket startupPacket = new PostgreSQLComStartupPacket(payload);
-        clientEncoding = startupPacket.getClientEncoding();
-        context.channel().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).set(PostgreSQLCharacterSets.findCharacterSet(clientEncoding));
+        clientEncoding = getNormalizedClientEncoding(startupPacket.getClientEncoding());
+        context.channel().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).set(StandardCharsets.UTF_8);
         String username = startupPacket.getUsername();
         ShardingSpherePreconditions.checkNotEmpty(username, EmptyUsernameException::new);
+        startupMessageReceived = true;
         context.writeAndFlush(getIdentifierPacket(username, rule));
         currentAuthResult = AuthenticationResultBuilder.continued(username, "", startupPacket.getDatabase());
         return currentAuthResult;
     }
-    
+
+    private String getNormalizedClientEncoding(final String clientEncoding) {
+        String formattedClientEncoding = formatClientEncoding(clientEncoding);
+        String lowerCaseClientEncoding = formattedClientEncoding.toLowerCase();
+        boolean isDefault = "default".equals(lowerCaseClientEncoding);
+        boolean isUtf8 = "utf8".equals(lowerCaseClientEncoding) || "utf-8".equals(lowerCaseClientEncoding) || "utf_8".equals(lowerCaseClientEncoding)
+                || "unicode".equals(lowerCaseClientEncoding);
+        if (!isDefault && !isUtf8) {
+            throw new InvalidParameterValueException("client_encoding", lowerCaseClientEncoding);
+        }
+        return PostgreSQLCharacterSets.UTF8.name();
+    }
+
+    private String formatClientEncoding(final String value) {
+        return value.startsWith("'") && value.endsWith("'") || value.startsWith("\"") && value.endsWith("\"") ? value.substring(1, value.length() - 1).trim() : value.trim();
+    }
+
     private PostgreSQLIdentifierPacket getIdentifierPacket(final String username, final AuthorityRule rule) {
         Optional<Authenticator> authenticator = rule.findUser(new Grantee(username)).map(optional -> new AuthenticatorFactory<>(PostgreSQLAuthenticatorType.class, rule).newInstance(optional));
         if (authenticator.isPresent() && PostgreSQLAuthenticationMethod.PASSWORD.getMethodName().equals(authenticator.get().getAuthenticationMethodName())) {

--- a/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngine.java
+++ b/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngine.java
@@ -69,24 +69,24 @@ import java.util.Optional;
  * Authentication engine for PostgreSQL.
  */
 public final class PostgreSQLAuthenticationEngine implements AuthenticationEngine {
-
+    
     private static final int SSL_REQUEST_PAYLOAD_LENGTH = 8;
-
+    
     private static final int SSL_REQUEST_CODE = (1234 << 16) + 5679;
-
+    
     private boolean startupMessageReceived;
-
+    
     private String clientEncoding;
-
+    
     private byte[] md5Salt;
-
+    
     private AuthenticationResult currentAuthResult;
-
+    
     @Override
     public int handshake(final ChannelHandlerContext context) {
         return ConnectionIdGenerator.getInstance().nextId();
     }
-
+    
     @Override
     public AuthenticationResult authenticate(final ChannelHandlerContext context, final PacketPayload payload) {
         if (SSL_REQUEST_PAYLOAD_LENGTH == payload.getByteBuf().markReaderIndex().readInt() && SSL_REQUEST_CODE == payload.getByteBuf().readInt()) {
@@ -103,7 +103,7 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
         AuthorityRule rule = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getGlobalRuleMetaData().getSingleRule(AuthorityRule.class);
         return startupMessageReceived ? processPasswordMessage(context, (PostgreSQLPacketPayload) payload, rule) : processStartupMessage(context, (PostgreSQLPacketPayload) payload, rule);
     }
-
+    
     private AuthenticationResult processPasswordMessage(final ChannelHandlerContext context, final PostgreSQLPacketPayload payload, final AuthorityRule rule) {
         char messageType = (char) payload.readInt1();
         ShardingSpherePreconditions.checkState(PostgreSQLMessagePacketType.PASSWORD_MESSAGE.getValue() == messageType,
@@ -121,7 +121,7 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
         context.writeAndFlush(PostgreSQLReadyForQueryPacket.NOT_IN_TRANSACTION);
         return AuthenticationResultBuilder.finished(currentAuthResult.getUsername(), "", currentAuthResult.getDatabase());
     }
-
+    
     private void login(final String databaseName, final String username, final byte[] md5Salt, final String digest, final AuthorityRule rule) {
         ShardingSpherePreconditions.checkState(
                 Strings.isNullOrEmpty(databaseName) || ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().containsDatabase(databaseName),
@@ -132,7 +132,7 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
                 () -> new InvalidPasswordException(username));
         ShardingSpherePreconditions.checkState(null == databaseName || new AuthorityChecker(rule, grantee).isAuthorized(databaseName), () -> new PrivilegeNotGrantedException(username, databaseName));
     }
-
+    
     private AuthenticationResult processStartupMessage(final ChannelHandlerContext context, final PostgreSQLPacketPayload payload, final AuthorityRule rule) {
         PostgreSQLComStartupPacket startupPacket = new PostgreSQLComStartupPacket(payload);
         clientEncoding = getNormalizedClientEncoding(startupPacket.getClientEncoding());
@@ -144,7 +144,7 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
         currentAuthResult = AuthenticationResultBuilder.continued(username, "", startupPacket.getDatabase());
         return currentAuthResult;
     }
-
+    
     private String getNormalizedClientEncoding(final String clientEncoding) {
         String formattedClientEncoding = formatClientEncoding(clientEncoding);
         String lowerCaseClientEncoding = formattedClientEncoding.toLowerCase();
@@ -156,11 +156,11 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
         }
         return PostgreSQLCharacterSets.UTF8.name();
     }
-
+    
     private String formatClientEncoding(final String value) {
         return value.startsWith("'") && value.endsWith("'") || value.startsWith("\"") && value.endsWith("\"") ? value.substring(1, value.length() - 1).trim() : value.trim();
     }
-
+    
     private PostgreSQLIdentifierPacket getIdentifierPacket(final String username, final AuthorityRule rule) {
         Optional<Authenticator> authenticator = rule.findUser(new Grantee(username)).map(optional -> new AuthenticatorFactory<>(PostgreSQLAuthenticatorType.class, rule).newInstance(optional));
         if (authenticator.isPresent() && PostgreSQLAuthenticationMethod.PASSWORD.getMethodName().equals(authenticator.get().getAuthenticationMethodName())) {

--- a/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngine.java
+++ b/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngine.java
@@ -63,6 +63,7 @@ import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authen
 import org.apache.shardingsphere.proxy.frontend.ssl.ProxySSLContext;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -147,7 +148,7 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
     
     private String getNormalizedClientEncoding(final String clientEncoding) {
         String formattedClientEncoding = formatClientEncoding(clientEncoding);
-        String lowerCaseClientEncoding = formattedClientEncoding.toLowerCase();
+        String lowerCaseClientEncoding = formattedClientEncoding.toLowerCase(Locale.ROOT);
         boolean isDefault = "default".equals(lowerCaseClientEncoding);
         boolean isUtf8 = "utf8".equals(lowerCaseClientEncoding) || "utf-8".equals(lowerCaseClientEncoding) || "utf_8".equals(lowerCaseClientEncoding)
                 || "unicode".equals(lowerCaseClientEncoding);

--- a/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/Portal.java
+++ b/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/Portal.java
@@ -54,6 +54,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableA
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.EmptyStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.SetStatement;
+import org.apache.shardingsphere.sql.parser.statement.postgresql.dal.PostgreSQLResetParameterStatement;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -65,6 +66,10 @@ import java.util.List;
  * PostgreSQL portal.
  */
 public final class Portal {
+    
+    private static final String CLIENT_ENCODING = "client_encoding";
+    
+    private static final String UTF8 = "UTF8";
     
     @Getter
     private final String name;
@@ -153,6 +158,10 @@ public final class Portal {
             result.addAll(createParameterStatusResponse((SetStatement) sqlStatement));
             return result;
         }
+        if (responseHeader instanceof UpdateResponseHeader && sqlStatement instanceof PostgreSQLResetParameterStatement) {
+            result.addAll(createParameterStatusResponse((PostgreSQLResetParameterStatement) sqlStatement));
+            return result;
+        }
         result.add(createExecutionCompletedPacket(maxRows > 0 && maxRows == result.size(), result.size()));
         return result;
     }
@@ -161,9 +170,24 @@ public final class Portal {
         List<PostgreSQLPacket> result = new ArrayList<>(2);
         result.add(new PostgreSQLCommandCompletePacket("SET", 0L));
         for (VariableAssignSegment each : sqlStatement.getVariableAssigns()) {
-            result.add(new PostgreSQLParameterStatusPacket(each.getVariable().getVariable(), null == each.getAssignValue() ? null : QuoteCharacter.unwrapText(each.getAssignValue())));
+            String variableName = each.getVariable().getVariable();
+            String variableValue = isClientEncodingVariable(variableName) ? UTF8 : null == each.getAssignValue() ? null : QuoteCharacter.unwrapText(each.getAssignValue());
+            result.add(new PostgreSQLParameterStatusPacket(variableName, variableValue));
         }
         return result;
+    }
+    
+    private List<PostgreSQLPacket> createParameterStatusResponse(final PostgreSQLResetParameterStatement sqlStatement) {
+        List<PostgreSQLPacket> result = new ArrayList<>(2);
+        result.add(new PostgreSQLCommandCompletePacket("RESET", 0L));
+        if (isClientEncodingVariable(sqlStatement.getConfigurationParameter())) {
+            result.add(new PostgreSQLParameterStatusPacket(CLIENT_ENCODING, UTF8));
+        }
+        return result;
+    }
+    
+    private boolean isClientEncodingVariable(final String variableName) {
+        return CLIENT_ENCODING.equalsIgnoreCase(variableName);
     }
     
     private boolean hasNext() throws SQLException {

--- a/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutor.java
+++ b/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutor.java
@@ -48,6 +48,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.Em
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.SetStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.tcl.CommitStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.tcl.RollbackStatement;
+import org.apache.shardingsphere.sql.parser.statement.postgresql.dal.PostgreSQLResetParameterStatement;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -59,6 +60,10 @@ import java.util.LinkedList;
  * Command query executor for PostgreSQL.
  */
 public final class PostgreSQLComQueryExecutor implements QueryCommandExecutor {
+    
+    private static final String CLIENT_ENCODING = "client_encoding";
+    
+    private static final String UTF8 = "UTF8";
     
     private final PortalContext portalContext;
     
@@ -106,6 +111,9 @@ public final class PostgreSQLComQueryExecutor implements QueryCommandExecutor {
         if (sqlStatement instanceof SetStatement) {
             return createParameterStatusResponse((SetStatement) sqlStatement);
         }
+        if (sqlStatement instanceof PostgreSQLResetParameterStatement) {
+            return createParameterStatusResponse((PostgreSQLResetParameterStatement) sqlStatement);
+        }
         return Collections.singletonList(sqlStatement instanceof EmptyStatement
                 ? new PostgreSQLEmptyQueryResponsePacket()
                 : new PostgreSQLCommandCompletePacket(PostgreSQLCommand.valueOf(sqlStatement.getClass()).map(PostgreSQLCommand::getTag).orElse(""), updateResponseHeader.getUpdateCount()));
@@ -115,9 +123,24 @@ public final class PostgreSQLComQueryExecutor implements QueryCommandExecutor {
         Collection<DatabasePacket> result = new ArrayList<>(2);
         result.add(new PostgreSQLCommandCompletePacket("SET", 0L));
         for (VariableAssignSegment each : sqlStatement.getVariableAssigns()) {
-            result.add(new PostgreSQLParameterStatusPacket(each.getVariable().getVariable(), null == each.getAssignValue() ? null : QuoteCharacter.unwrapText(each.getAssignValue())));
+            String variableName = each.getVariable().getVariable();
+            String variableValue = isClientEncodingVariable(variableName) ? UTF8 : null == each.getAssignValue() ? null : QuoteCharacter.unwrapText(each.getAssignValue());
+            result.add(new PostgreSQLParameterStatusPacket(variableName, variableValue));
         }
         return result;
+    }
+    
+    private Collection<DatabasePacket> createParameterStatusResponse(final PostgreSQLResetParameterStatement sqlStatement) {
+        Collection<DatabasePacket> result = new ArrayList<>(2);
+        result.add(new PostgreSQLCommandCompletePacket("RESET", 0L));
+        if (isClientEncodingVariable(sqlStatement.getConfigurationParameter())) {
+            result.add(new PostgreSQLParameterStatusPacket(CLIENT_ENCODING, UTF8));
+        }
+        return result;
+    }
+    
+    private boolean isClientEncodingVariable(final String variableName) {
+        return CLIENT_ENCODING.equalsIgnoreCase(variableName);
     }
     
     @Override

--- a/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
+++ b/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
@@ -103,34 +103,34 @@ import static org.mockito.Mockito.when;
 @ExtendWith(AutoMockExtension.class)
 @StaticMockSettings({ProxyContext.class, ProxySSLContext.class})
 class PostgreSQLAuthenticationEngineTest {
-
+    
     private static final String USERNAME = "root";
-
+    
     private static final String PASSWORD = "sharding";
-
+    
     private static final String DATABASE_NAME = "sharding_db";
-
+    
     private final PostgreSQLAuthenticationEngine authenticationEngine = new PostgreSQLAuthenticationEngine();
-
+    
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ChannelHandlerContext channelHandlerContext;
-
+    
     @Mock
     private Attribute<Charset> charsetAttribute;
-
+    
     @SuppressWarnings("unchecked")
     @BeforeEach
     void setup() {
         when(channelHandlerContext.channel().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY)).thenReturn(charsetAttribute);
     }
-
+    
     @SneakyThrows(ReflectiveOperationException.class)
     @Test
     void assertHandshakeAssignsNextConnectionId() {
         Plugins.getMemberAccessor().set(ConnectionIdGenerator.class.getDeclaredField("currentId"), ConnectionIdGenerator.getInstance(), 0);
         assertThat(authenticationEngine.handshake(channelHandlerContext), is(1));
     }
-
+    
     @Test
     void assertSSLUnwilling() {
         ByteBuf byteBuf = createByteBuf(8, 8);
@@ -141,7 +141,7 @@ class PostgreSQLAuthenticationEngineTest {
         verify(context).writeAndFlush(any(PostgreSQLSSLUnwillingPacket.class));
         assertFalse(actual.isFinished());
     }
-
+    
     @Test
     void assertSSLWilling() {
         ByteBuf byteBuf = createByteBuf(8, 8);
@@ -154,7 +154,7 @@ class PostgreSQLAuthenticationEngineTest {
         verify(context.pipeline()).addFirst(eq(SslHandler.class.getSimpleName()), any(SslHandler.class));
         assertFalse(actual.isFinished());
     }
-
+    
     @Test
     void assertSSLRequestCodeMismatchFallsBackToStartup() {
         ByteBuf byteBuf = createByteBuf(8, 8);
@@ -167,7 +167,7 @@ class PostgreSQLAuthenticationEngineTest {
         when(proxyContext.getContextManager()).thenReturn(contextManager);
         assertThrows(EmptyUsernameException.class, () -> authenticationEngine.authenticate(channelHandlerContext, new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8)));
     }
-
+    
     @Test
     void assertUserNotSet() {
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(8, 512), StandardCharsets.UTF_8);
@@ -179,7 +179,7 @@ class PostgreSQLAuthenticationEngineTest {
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         assertThrows(EmptyUsernameException.class, () -> authenticationEngine.authenticate(channelHandlerContext, payload));
     }
-
+    
     @Test
     void assertStartupUsesPasswordAuthenticator() {
         UserConfiguration userConfig = new UserConfiguration(USERNAME, PASSWORD, "", PostgreSQLAuthenticationMethod.PASSWORD.getMethodName(), false);
@@ -195,7 +195,7 @@ class PostgreSQLAuthenticationEngineTest {
         assertThat(argumentCaptor.getValue().getClass(), is((Object) PostgreSQLPasswordAuthenticationPacket.class));
         assertFalse(actual.isFinished());
     }
-
+    
     @Test
     void assertStartupRejectsInvalidClientEncoding() {
         AuthorityRule authorityRule = createAuthorityRule(new UserConfiguration(USERNAME, PASSWORD, "", null, false), Collections.emptyMap(), null);
@@ -206,7 +206,7 @@ class PostgreSQLAuthenticationEngineTest {
         assertThrows(InvalidParameterValueException.class, () -> authenticationEngine.authenticate(channelHandlerContext, payload));
         verify(channelHandlerContext, never()).writeAndFlush(any(PostgreSQLPasswordAuthenticationPacket.class));
     }
-
+    
     @Test
     void assertAuthenticateWithNonPasswordMessage() {
         setAlreadyReceivedStartupMessage(authenticationEngine);
@@ -217,12 +217,12 @@ class PostgreSQLAuthenticationEngineTest {
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         assertThrows(ProtocolViolationException.class, () -> authenticationEngine.authenticate(channelHandlerContext, payload));
     }
-
+    
     @SneakyThrows(ReflectiveOperationException.class)
     private void setAlreadyReceivedStartupMessage(final PostgreSQLAuthenticationEngine target) {
         Plugins.getMemberAccessor().set(PostgreSQLAuthenticationEngine.class.getDeclaredField("startupMessageReceived"), target, true);
     }
-
+    
     @Test
     void assertLoginFailed() {
         AuthorityRule authorityRule = createAuthorityRule(new UserConfiguration(USERNAME, PASSWORD, "", null, false), Collections.emptyMap(), null);
@@ -234,7 +234,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, "wrong" + PASSWORD, md5Salt));
         assertThrows(InvalidPasswordException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-
+    
     @Test
     void assertLoginWithUnknownDatabase() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, "missing_db");
@@ -247,7 +247,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, PASSWORD, md5Salt));
         assertThrows(UnknownDatabaseException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-
+    
     @Test
     void assertLoginWithUnknownUsername() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, null);
@@ -261,7 +261,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, PASSWORD, md5Salt));
         assertThrows(UnknownUsernameException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-
+    
     @Test
     void assertLoginWithoutPrivilege() {
         AuthorityRule authorityRule = mock(AuthorityRule.class);
@@ -279,7 +279,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, PASSWORD, md5Salt));
         assertThrows(PrivilegeNotGrantedException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-
+    
     @Test
     void assertLoginWithAuthorizedDatabase() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, DATABASE_NAME);
@@ -295,7 +295,7 @@ class PostgreSQLAuthenticationEngineTest {
         verify(channelHandlerContext).writeAndFlush(PostgreSQLReadyForQueryPacket.NOT_IN_TRANSACTION);
         assertTrue(actual.isFinished());
     }
-
+    
     @Test
     void assertLoginWithNullDatabase() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, null);
@@ -311,25 +311,25 @@ class PostgreSQLAuthenticationEngineTest {
         verify(channelHandlerContext).writeAndFlush(PostgreSQLReadyForQueryPacket.NOT_IN_TRANSACTION);
         assertTrue(actual.isFinished());
     }
-
+    
     @Test
     void assertStartupUsesDefaultClientEncoding() throws ReflectiveOperationException {
         assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, null);
         verify(charsetAttribute).set(StandardCharsets.UTF_8);
     }
-
+    
     @Test
     void assertStartupNormalizesUtf8DashAlias() throws ReflectiveOperationException {
         assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, "UTF-8");
         verify(charsetAttribute).set(StandardCharsets.UTF_8);
     }
-
+    
     @Test
     void assertStartupNormalizesUnicodeAlias() throws ReflectiveOperationException {
         assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, "UNICODE");
         verify(charsetAttribute).set(StandardCharsets.UTF_8);
     }
-
+    
     @Test
     void assertStartupNormalizesUnicodeAliasUnderTurkishLocale() throws ReflectiveOperationException {
         Locale originalLocale = Locale.getDefault();
@@ -341,15 +341,15 @@ class PostgreSQLAuthenticationEngineTest {
             Locale.setDefault(originalLocale);
         }
     }
-
+    
     private ByteBuf createByteBuf(final int initialCapacity, final int maxCapacity) {
         return new UnpooledHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, initialCapacity, maxCapacity);
     }
-
+    
     private PostgreSQLPacketPayload createStartupPayload(final String username, final String databaseName) {
         return createStartupPayload(username, databaseName, "UTF8");
     }
-
+    
     private PostgreSQLPacketPayload createStartupPayload(final String username, final String databaseName, final String clientEncoding) {
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(32, 256), StandardCharsets.UTF_8);
         payload.writeInt4(64);
@@ -366,7 +366,7 @@ class PostgreSQLAuthenticationEngineTest {
         }
         return payload;
     }
-
+    
     private PostgreSQLPacketPayload createPasswordMessage(final String digest) {
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(16, 128), StandardCharsets.UTF_8);
         payload.writeInt1('p');
@@ -374,20 +374,20 @@ class PostgreSQLAuthenticationEngineTest {
         payload.writeStringNul(digest);
         return payload;
     }
-
+    
     private ContextManager mockContextManager(final MetaDataContexts metaDataContexts) {
         ContextManager result = mock(ContextManager.class);
         when(result.getMetaDataContexts()).thenReturn(metaDataContexts);
         return result;
     }
-
+    
     private MetaDataContexts createMetaDataContexts(final AuthorityRule authorityRule, final boolean containsDatabase, final String databaseName) {
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(authorityRule));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(containsDatabase && null != databaseName ? Collections.singleton(createDatabase(databaseName)) : Collections.emptyList(),
                 mock(ResourceMetaData.class), ruleMetaData, new ConfigurationProperties(new Properties()));
         return new MetaDataContexts(metaData, new ShardingSphereStatistics());
     }
-
+    
     private ShardingSphereDatabase createDatabase(final String databaseName) {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn(databaseName);
@@ -395,13 +395,13 @@ class PostgreSQLAuthenticationEngineTest {
         when(database.getRuleMetaData()).thenReturn(new RuleMetaData(Collections.emptyList()));
         return database;
     }
-
+    
     private AuthorityRule createAuthorityRule(final UserConfiguration userConfig, final Map<String, AlgorithmConfiguration> authenticators, final String defaultAuthenticator) {
         AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(
                 Collections.singleton(userConfig), new AlgorithmConfiguration("ALL_PERMITTED", new Properties()), authenticators, defaultAuthenticator);
         return new AuthorityRuleBuilder().build(ruleConfig, Collections.emptyList(), mock(ConfigurationProperties.class));
     }
-
+    
     private String createMd5Digest(final String username, final String password, final byte[] md5Salt) {
         String passwordHash = new String(Hex.encodeHex(DigestUtils.md5(password + username), true));
         MessageDigest messageDigest = DigestUtils.getMd5Digest();
@@ -409,12 +409,12 @@ class PostgreSQLAuthenticationEngineTest {
         messageDigest.update(md5Salt);
         return "md5" + new String(Hex.encodeHex(messageDigest.digest(), true));
     }
-
+    
     @SneakyThrows(ReflectiveOperationException.class)
     private byte[] getMd5Salt(final PostgreSQLAuthenticationEngine target) {
         return (byte[]) Plugins.getMemberAccessor().get(PostgreSQLAuthenticationEngine.class.getDeclaredField("md5Salt"), target);
     }
-
+    
     private void assertAuthenticateAndClientEncodingParameterStatus(final String username, final String databaseName, final String startupClientEncoding) throws ReflectiveOperationException {
         AuthorityRule authorityRule = createAuthorityRule(new UserConfiguration(username, PASSWORD, "", null, false), Collections.emptyMap(), null);
         MetaDataContexts metaDataContexts = createMetaDataContexts(authorityRule, true, databaseName);
@@ -428,7 +428,7 @@ class PostgreSQLAuthenticationEngineTest {
         String actualClientEncoding = getClientEncodingValue(extractParameterStatusPackets(writeArgumentCaptor.getAllValues()));
         assertThat(actualClientEncoding, is("UTF8"));
     }
-
+    
     private Collection<PostgreSQLParameterStatusPacket> extractParameterStatusPackets(final List<Object> packets) {
         Collection<PostgreSQLParameterStatusPacket> result = new LinkedList<>();
         for (Object each : packets) {
@@ -438,7 +438,7 @@ class PostgreSQLAuthenticationEngineTest {
         }
         return result;
     }
-
+    
     private String getClientEncodingValue(final Collection<PostgreSQLParameterStatusPacket> packets) throws ReflectiveOperationException {
         for (PostgreSQLParameterStatusPacket each : packets) {
             String actualKey = (String) Plugins.getMemberAccessor().get(PostgreSQLParameterStatusPacket.class.getDeclaredField("key"), each);

--- a/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
+++ b/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
@@ -102,34 +102,34 @@ import static org.mockito.Mockito.when;
 @ExtendWith(AutoMockExtension.class)
 @StaticMockSettings({ProxyContext.class, ProxySSLContext.class})
 class PostgreSQLAuthenticationEngineTest {
-
+    
     private static final String USERNAME = "root";
-
+    
     private static final String PASSWORD = "sharding";
-
+    
     private static final String DATABASE_NAME = "sharding_db";
-
+    
     private final PostgreSQLAuthenticationEngine authenticationEngine = new PostgreSQLAuthenticationEngine();
-
+    
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ChannelHandlerContext channelHandlerContext;
-
+    
     @Mock
     private Attribute<Charset> charsetAttribute;
-
+    
     @SuppressWarnings("unchecked")
     @BeforeEach
     void setup() {
         when(channelHandlerContext.channel().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY)).thenReturn(charsetAttribute);
     }
-
+    
     @SneakyThrows(ReflectiveOperationException.class)
     @Test
     void assertHandshakeAssignsNextConnectionId() {
         Plugins.getMemberAccessor().set(ConnectionIdGenerator.class.getDeclaredField("currentId"), ConnectionIdGenerator.getInstance(), 0);
         assertThat(authenticationEngine.handshake(channelHandlerContext), is(1));
     }
-
+    
     @Test
     void assertSSLUnwilling() {
         ByteBuf byteBuf = createByteBuf(8, 8);
@@ -140,7 +140,7 @@ class PostgreSQLAuthenticationEngineTest {
         verify(context).writeAndFlush(any(PostgreSQLSSLUnwillingPacket.class));
         assertFalse(actual.isFinished());
     }
-
+    
     @Test
     void assertSSLWilling() {
         ByteBuf byteBuf = createByteBuf(8, 8);
@@ -153,7 +153,7 @@ class PostgreSQLAuthenticationEngineTest {
         verify(context.pipeline()).addFirst(eq(SslHandler.class.getSimpleName()), any(SslHandler.class));
         assertFalse(actual.isFinished());
     }
-
+    
     @Test
     void assertSSLRequestCodeMismatchFallsBackToStartup() {
         ByteBuf byteBuf = createByteBuf(8, 8);
@@ -166,7 +166,7 @@ class PostgreSQLAuthenticationEngineTest {
         when(proxyContext.getContextManager()).thenReturn(contextManager);
         assertThrows(EmptyUsernameException.class, () -> authenticationEngine.authenticate(channelHandlerContext, new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8)));
     }
-
+    
     @Test
     void assertUserNotSet() {
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(8, 512), StandardCharsets.UTF_8);
@@ -178,7 +178,7 @@ class PostgreSQLAuthenticationEngineTest {
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         assertThrows(EmptyUsernameException.class, () -> authenticationEngine.authenticate(channelHandlerContext, payload));
     }
-
+    
     @Test
     void assertStartupUsesPasswordAuthenticator() {
         UserConfiguration userConfig = new UserConfiguration(USERNAME, PASSWORD, "", PostgreSQLAuthenticationMethod.PASSWORD.getMethodName(), false);
@@ -194,7 +194,7 @@ class PostgreSQLAuthenticationEngineTest {
         assertThat(argumentCaptor.getValue().getClass(), is((Object) PostgreSQLPasswordAuthenticationPacket.class));
         assertFalse(actual.isFinished());
     }
-
+    
     @Test
     void assertStartupRejectsInvalidClientEncoding() {
         AuthorityRule authorityRule = createAuthorityRule(new UserConfiguration(USERNAME, PASSWORD, "", null, false), Collections.emptyMap(), null);
@@ -205,7 +205,7 @@ class PostgreSQLAuthenticationEngineTest {
         assertThrows(InvalidParameterValueException.class, () -> authenticationEngine.authenticate(channelHandlerContext, payload));
         verify(channelHandlerContext, never()).writeAndFlush(any(PostgreSQLPasswordAuthenticationPacket.class));
     }
-
+    
     @Test
     void assertAuthenticateWithNonPasswordMessage() {
         setAlreadyReceivedStartupMessage(authenticationEngine);
@@ -216,12 +216,12 @@ class PostgreSQLAuthenticationEngineTest {
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         assertThrows(ProtocolViolationException.class, () -> authenticationEngine.authenticate(channelHandlerContext, payload));
     }
-
+    
     @SneakyThrows(ReflectiveOperationException.class)
     private void setAlreadyReceivedStartupMessage(final PostgreSQLAuthenticationEngine target) {
         Plugins.getMemberAccessor().set(PostgreSQLAuthenticationEngine.class.getDeclaredField("startupMessageReceived"), target, true);
     }
-
+    
     @Test
     void assertLoginFailed() {
         AuthorityRule authorityRule = createAuthorityRule(new UserConfiguration(USERNAME, PASSWORD, "", null, false), Collections.emptyMap(), null);
@@ -233,7 +233,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, "wrong" + PASSWORD, md5Salt));
         assertThrows(InvalidPasswordException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-
+    
     @Test
     void assertLoginWithUnknownDatabase() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, "missing_db");
@@ -246,7 +246,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, PASSWORD, md5Salt));
         assertThrows(UnknownDatabaseException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-
+    
     @Test
     void assertLoginWithUnknownUsername() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, null);
@@ -260,7 +260,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, PASSWORD, md5Salt));
         assertThrows(UnknownUsernameException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-
+    
     @Test
     void assertLoginWithoutPrivilege() {
         AuthorityRule authorityRule = mock(AuthorityRule.class);
@@ -278,7 +278,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, PASSWORD, md5Salt));
         assertThrows(PrivilegeNotGrantedException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-
+    
     @Test
     void assertLoginWithAuthorizedDatabase() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, DATABASE_NAME);
@@ -294,7 +294,7 @@ class PostgreSQLAuthenticationEngineTest {
         verify(channelHandlerContext).writeAndFlush(PostgreSQLReadyForQueryPacket.NOT_IN_TRANSACTION);
         assertTrue(actual.isFinished());
     }
-
+    
     @Test
     void assertLoginWithNullDatabase() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, null);
@@ -310,33 +310,33 @@ class PostgreSQLAuthenticationEngineTest {
         verify(channelHandlerContext).writeAndFlush(PostgreSQLReadyForQueryPacket.NOT_IN_TRANSACTION);
         assertTrue(actual.isFinished());
     }
-
+    
     @Test
     void assertStartupUsesDefaultClientEncoding() throws ReflectiveOperationException {
         assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, null);
         verify(charsetAttribute).set(StandardCharsets.UTF_8);
     }
-
+    
     @Test
     void assertStartupNormalizesUtf8DashAlias() throws ReflectiveOperationException {
         assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, "UTF-8");
         verify(charsetAttribute).set(StandardCharsets.UTF_8);
     }
-
+    
     @Test
     void assertStartupNormalizesUnicodeAlias() throws ReflectiveOperationException {
         assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, "UNICODE");
         verify(charsetAttribute).set(StandardCharsets.UTF_8);
     }
-
+    
     private ByteBuf createByteBuf(final int initialCapacity, final int maxCapacity) {
         return new UnpooledHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, initialCapacity, maxCapacity);
     }
-
+    
     private PostgreSQLPacketPayload createStartupPayload(final String username, final String databaseName) {
         return createStartupPayload(username, databaseName, "UTF8");
     }
-
+    
     private PostgreSQLPacketPayload createStartupPayload(final String username, final String databaseName, final String clientEncoding) {
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(32, 256), StandardCharsets.UTF_8);
         payload.writeInt4(64);
@@ -353,7 +353,7 @@ class PostgreSQLAuthenticationEngineTest {
         }
         return payload;
     }
-
+    
     private PostgreSQLPacketPayload createPasswordMessage(final String digest) {
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(16, 128), StandardCharsets.UTF_8);
         payload.writeInt1('p');
@@ -361,20 +361,20 @@ class PostgreSQLAuthenticationEngineTest {
         payload.writeStringNul(digest);
         return payload;
     }
-
+    
     private ContextManager mockContextManager(final MetaDataContexts metaDataContexts) {
         ContextManager result = mock(ContextManager.class);
         when(result.getMetaDataContexts()).thenReturn(metaDataContexts);
         return result;
     }
-
+    
     private MetaDataContexts createMetaDataContexts(final AuthorityRule authorityRule, final boolean containsDatabase, final String databaseName) {
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(authorityRule));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(containsDatabase && null != databaseName ? Collections.singleton(createDatabase(databaseName)) : Collections.emptyList(),
                 mock(ResourceMetaData.class), ruleMetaData, new ConfigurationProperties(new Properties()));
         return new MetaDataContexts(metaData, new ShardingSphereStatistics());
     }
-
+    
     private ShardingSphereDatabase createDatabase(final String databaseName) {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn(databaseName);
@@ -382,13 +382,13 @@ class PostgreSQLAuthenticationEngineTest {
         when(database.getRuleMetaData()).thenReturn(new RuleMetaData(Collections.emptyList()));
         return database;
     }
-
+    
     private AuthorityRule createAuthorityRule(final UserConfiguration userConfig, final Map<String, AlgorithmConfiguration> authenticators, final String defaultAuthenticator) {
         AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(
                 Collections.singleton(userConfig), new AlgorithmConfiguration("ALL_PERMITTED", new Properties()), authenticators, defaultAuthenticator);
         return new AuthorityRuleBuilder().build(ruleConfig, Collections.emptyList(), mock(ConfigurationProperties.class));
     }
-
+    
     private String createMd5Digest(final String username, final String password, final byte[] md5Salt) {
         String passwordHash = new String(Hex.encodeHex(DigestUtils.md5(password + username), true));
         MessageDigest messageDigest = DigestUtils.getMd5Digest();
@@ -396,12 +396,12 @@ class PostgreSQLAuthenticationEngineTest {
         messageDigest.update(md5Salt);
         return "md5" + new String(Hex.encodeHex(messageDigest.digest(), true));
     }
-
+    
     @SneakyThrows(ReflectiveOperationException.class)
     private byte[] getMd5Salt(final PostgreSQLAuthenticationEngine target) {
         return (byte[]) Plugins.getMemberAccessor().get(PostgreSQLAuthenticationEngine.class.getDeclaredField("md5Salt"), target);
     }
-
+    
     private void assertAuthenticateAndClientEncodingParameterStatus(final String username, final String databaseName, final String startupClientEncoding) throws ReflectiveOperationException {
         AuthorityRule authorityRule = createAuthorityRule(new UserConfiguration(username, PASSWORD, "", null, false), Collections.emptyMap(), null);
         MetaDataContexts metaDataContexts = createMetaDataContexts(authorityRule, true, databaseName);
@@ -415,7 +415,7 @@ class PostgreSQLAuthenticationEngineTest {
         String actualClientEncoding = getClientEncodingValue(extractParameterStatusPackets(writeArgumentCaptor.getAllValues()));
         assertThat(actualClientEncoding, is("UTF8"));
     }
-
+    
     private Collection<PostgreSQLParameterStatusPacket> extractParameterStatusPackets(final List<Object> packets) {
         Collection<PostgreSQLParameterStatusPacket> result = new LinkedList<>();
         for (Object each : packets) {
@@ -425,7 +425,7 @@ class PostgreSQLAuthenticationEngineTest {
         }
         return result;
     }
-
+    
     private String getClientEncodingValue(final Collection<PostgreSQLParameterStatusPacket> packets) throws ReflectiveOperationException {
         for (PostgreSQLParameterStatusPacket each : packets) {
             String actualKey = (String) Plugins.getMemberAccessor().get(PostgreSQLParameterStatusPacket.class.getDeclaredField("key"), each);

--- a/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
+++ b/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
@@ -34,6 +34,7 @@ import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.authority.rule.builder.AuthorityRuleBuilder;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.exception.core.exception.syntax.database.UnknownDatabaseException;
+import org.apache.shardingsphere.database.exception.core.exception.data.InvalidParameterValueException;
 import org.apache.shardingsphere.database.exception.postgresql.exception.authority.EmptyUsernameException;
 import org.apache.shardingsphere.database.exception.postgresql.exception.authority.InvalidPasswordException;
 import org.apache.shardingsphere.database.exception.postgresql.exception.authority.PrivilegeNotGrantedException;
@@ -43,6 +44,7 @@ import org.apache.shardingsphere.database.protocol.constant.CommonConstants;
 import org.apache.shardingsphere.database.protocol.postgresql.constant.PostgreSQLAuthenticationMethod;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.generic.PostgreSQLReadyForQueryPacket;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.handshake.PostgreSQLAuthenticationOKPacket;
+import org.apache.shardingsphere.database.protocol.postgresql.packet.handshake.PostgreSQLParameterStatusPacket;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.handshake.PostgreSQLSSLUnwillingPacket;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.handshake.PostgreSQLSSLWillingPacket;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.handshake.authentication.PostgreSQLPasswordAuthenticationPacket;
@@ -72,9 +74,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.internal.configuration.plugins.Plugins;
 
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -87,38 +93,43 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(AutoMockExtension.class)
 @StaticMockSettings({ProxyContext.class, ProxySSLContext.class})
 class PostgreSQLAuthenticationEngineTest {
-    
+
     private static final String USERNAME = "root";
-    
+
     private static final String PASSWORD = "sharding";
-    
+
     private static final String DATABASE_NAME = "sharding_db";
-    
+
     private final PostgreSQLAuthenticationEngine authenticationEngine = new PostgreSQLAuthenticationEngine();
-    
+
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ChannelHandlerContext channelHandlerContext;
-    
+
+    @Mock
+    private Attribute<Charset> charsetAttribute;
+
     @SuppressWarnings("unchecked")
     @BeforeEach
     void setup() {
-        when(channelHandlerContext.channel().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY)).thenReturn(mock(Attribute.class));
+        when(channelHandlerContext.channel().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY)).thenReturn(charsetAttribute);
     }
-    
+
     @SneakyThrows(ReflectiveOperationException.class)
     @Test
     void assertHandshakeAssignsNextConnectionId() {
         Plugins.getMemberAccessor().set(ConnectionIdGenerator.class.getDeclaredField("currentId"), ConnectionIdGenerator.getInstance(), 0);
         assertThat(authenticationEngine.handshake(channelHandlerContext), is(1));
     }
-    
+
     @Test
     void assertSSLUnwilling() {
         ByteBuf byteBuf = createByteBuf(8, 8);
@@ -129,7 +140,7 @@ class PostgreSQLAuthenticationEngineTest {
         verify(context).writeAndFlush(any(PostgreSQLSSLUnwillingPacket.class));
         assertFalse(actual.isFinished());
     }
-    
+
     @Test
     void assertSSLWilling() {
         ByteBuf byteBuf = createByteBuf(8, 8);
@@ -142,7 +153,7 @@ class PostgreSQLAuthenticationEngineTest {
         verify(context.pipeline()).addFirst(eq(SslHandler.class.getSimpleName()), any(SslHandler.class));
         assertFalse(actual.isFinished());
     }
-    
+
     @Test
     void assertSSLRequestCodeMismatchFallsBackToStartup() {
         ByteBuf byteBuf = createByteBuf(8, 8);
@@ -155,7 +166,7 @@ class PostgreSQLAuthenticationEngineTest {
         when(proxyContext.getContextManager()).thenReturn(contextManager);
         assertThrows(EmptyUsernameException.class, () -> authenticationEngine.authenticate(channelHandlerContext, new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8)));
     }
-    
+
     @Test
     void assertUserNotSet() {
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(8, 512), StandardCharsets.UTF_8);
@@ -167,7 +178,7 @@ class PostgreSQLAuthenticationEngineTest {
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         assertThrows(EmptyUsernameException.class, () -> authenticationEngine.authenticate(channelHandlerContext, payload));
     }
-    
+
     @Test
     void assertStartupUsesPasswordAuthenticator() {
         UserConfiguration userConfig = new UserConfiguration(USERNAME, PASSWORD, "", PostgreSQLAuthenticationMethod.PASSWORD.getMethodName(), false);
@@ -183,7 +194,18 @@ class PostgreSQLAuthenticationEngineTest {
         assertThat(argumentCaptor.getValue().getClass(), is((Object) PostgreSQLPasswordAuthenticationPacket.class));
         assertFalse(actual.isFinished());
     }
-    
+
+    @Test
+    void assertStartupRejectsInvalidClientEncoding() {
+        AuthorityRule authorityRule = createAuthorityRule(new UserConfiguration(USERNAME, PASSWORD, "", null, false), Collections.emptyMap(), null);
+        MetaDataContexts metaDataContexts = createMetaDataContexts(authorityRule, false, null);
+        ContextManager contextManager = mockContextManager(metaDataContexts);
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, DATABASE_NAME, "LATIN1");
+        assertThrows(InvalidParameterValueException.class, () -> authenticationEngine.authenticate(channelHandlerContext, payload));
+        verify(channelHandlerContext, never()).writeAndFlush(any(PostgreSQLPasswordAuthenticationPacket.class));
+    }
+
     @Test
     void assertAuthenticateWithNonPasswordMessage() {
         setAlreadyReceivedStartupMessage(authenticationEngine);
@@ -194,12 +216,12 @@ class PostgreSQLAuthenticationEngineTest {
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         assertThrows(ProtocolViolationException.class, () -> authenticationEngine.authenticate(channelHandlerContext, payload));
     }
-    
+
     @SneakyThrows(ReflectiveOperationException.class)
     private void setAlreadyReceivedStartupMessage(final PostgreSQLAuthenticationEngine target) {
         Plugins.getMemberAccessor().set(PostgreSQLAuthenticationEngine.class.getDeclaredField("startupMessageReceived"), target, true);
     }
-    
+
     @Test
     void assertLoginFailed() {
         AuthorityRule authorityRule = createAuthorityRule(new UserConfiguration(USERNAME, PASSWORD, "", null, false), Collections.emptyMap(), null);
@@ -211,7 +233,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, "wrong" + PASSWORD, md5Salt));
         assertThrows(InvalidPasswordException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-    
+
     @Test
     void assertLoginWithUnknownDatabase() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, "missing_db");
@@ -224,7 +246,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, PASSWORD, md5Salt));
         assertThrows(UnknownDatabaseException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-    
+
     @Test
     void assertLoginWithUnknownUsername() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, null);
@@ -238,7 +260,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, PASSWORD, md5Salt));
         assertThrows(UnknownUsernameException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-    
+
     @Test
     void assertLoginWithoutPrivilege() {
         AuthorityRule authorityRule = mock(AuthorityRule.class);
@@ -256,7 +278,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, PASSWORD, md5Salt));
         assertThrows(PrivilegeNotGrantedException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-    
+
     @Test
     void assertLoginWithAuthorizedDatabase() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, DATABASE_NAME);
@@ -272,7 +294,7 @@ class PostgreSQLAuthenticationEngineTest {
         verify(channelHandlerContext).writeAndFlush(PostgreSQLReadyForQueryPacket.NOT_IN_TRANSACTION);
         assertTrue(actual.isFinished());
     }
-    
+
     @Test
     void assertLoginWithNullDatabase() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, null);
@@ -288,12 +310,34 @@ class PostgreSQLAuthenticationEngineTest {
         verify(channelHandlerContext).writeAndFlush(PostgreSQLReadyForQueryPacket.NOT_IN_TRANSACTION);
         assertTrue(actual.isFinished());
     }
-    
+
+    @Test
+    void assertStartupUsesDefaultClientEncoding() throws ReflectiveOperationException {
+        assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, null);
+        verify(charsetAttribute).set(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void assertStartupNormalizesUtf8DashAlias() throws ReflectiveOperationException {
+        assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, "UTF-8");
+        verify(charsetAttribute).set(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void assertStartupNormalizesUnicodeAlias() throws ReflectiveOperationException {
+        assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, "UNICODE");
+        verify(charsetAttribute).set(StandardCharsets.UTF_8);
+    }
+
     private ByteBuf createByteBuf(final int initialCapacity, final int maxCapacity) {
         return new UnpooledHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, initialCapacity, maxCapacity);
     }
-    
+
     private PostgreSQLPacketPayload createStartupPayload(final String username, final String databaseName) {
+        return createStartupPayload(username, databaseName, "UTF8");
+    }
+
+    private PostgreSQLPacketPayload createStartupPayload(final String username, final String databaseName, final String clientEncoding) {
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(32, 256), StandardCharsets.UTF_8);
         payload.writeInt4(64);
         payload.writeInt4(196608);
@@ -303,11 +347,13 @@ class PostgreSQLAuthenticationEngineTest {
             payload.writeStringNul("database");
             payload.writeStringNul(databaseName);
         }
-        payload.writeStringNul("client_encoding");
-        payload.writeStringNul("UTF8");
+        if (null != clientEncoding) {
+            payload.writeStringNul("client_encoding");
+            payload.writeStringNul(clientEncoding);
+        }
         return payload;
     }
-    
+
     private PostgreSQLPacketPayload createPasswordMessage(final String digest) {
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(16, 128), StandardCharsets.UTF_8);
         payload.writeInt1('p');
@@ -315,20 +361,20 @@ class PostgreSQLAuthenticationEngineTest {
         payload.writeStringNul(digest);
         return payload;
     }
-    
+
     private ContextManager mockContextManager(final MetaDataContexts metaDataContexts) {
         ContextManager result = mock(ContextManager.class);
         when(result.getMetaDataContexts()).thenReturn(metaDataContexts);
         return result;
     }
-    
+
     private MetaDataContexts createMetaDataContexts(final AuthorityRule authorityRule, final boolean containsDatabase, final String databaseName) {
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(authorityRule));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(containsDatabase && null != databaseName ? Collections.singleton(createDatabase(databaseName)) : Collections.emptyList(),
                 mock(ResourceMetaData.class), ruleMetaData, new ConfigurationProperties(new Properties()));
         return new MetaDataContexts(metaData, new ShardingSphereStatistics());
     }
-    
+
     private ShardingSphereDatabase createDatabase(final String databaseName) {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn(databaseName);
@@ -336,13 +382,13 @@ class PostgreSQLAuthenticationEngineTest {
         when(database.getRuleMetaData()).thenReturn(new RuleMetaData(Collections.emptyList()));
         return database;
     }
-    
+
     private AuthorityRule createAuthorityRule(final UserConfiguration userConfig, final Map<String, AlgorithmConfiguration> authenticators, final String defaultAuthenticator) {
         AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(
                 Collections.singleton(userConfig), new AlgorithmConfiguration("ALL_PERMITTED", new Properties()), authenticators, defaultAuthenticator);
         return new AuthorityRuleBuilder().build(ruleConfig, Collections.emptyList(), mock(ConfigurationProperties.class));
     }
-    
+
     private String createMd5Digest(final String username, final String password, final byte[] md5Salt) {
         String passwordHash = new String(Hex.encodeHex(DigestUtils.md5(password + username), true));
         MessageDigest messageDigest = DigestUtils.getMd5Digest();
@@ -350,9 +396,43 @@ class PostgreSQLAuthenticationEngineTest {
         messageDigest.update(md5Salt);
         return "md5" + new String(Hex.encodeHex(messageDigest.digest(), true));
     }
-    
+
     @SneakyThrows(ReflectiveOperationException.class)
     private byte[] getMd5Salt(final PostgreSQLAuthenticationEngine target) {
         return (byte[]) Plugins.getMemberAccessor().get(PostgreSQLAuthenticationEngine.class.getDeclaredField("md5Salt"), target);
+    }
+
+    private void assertAuthenticateAndClientEncodingParameterStatus(final String username, final String databaseName, final String startupClientEncoding) throws ReflectiveOperationException {
+        AuthorityRule authorityRule = createAuthorityRule(new UserConfiguration(username, PASSWORD, "", null, false), Collections.emptyMap(), null);
+        MetaDataContexts metaDataContexts = createMetaDataContexts(authorityRule, true, databaseName);
+        ContextManager contextManager = mockContextManager(metaDataContexts);
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        authenticationEngine.authenticate(channelHandlerContext, createStartupPayload(username, databaseName, startupClientEncoding));
+        byte[] md5Salt = getMd5Salt(authenticationEngine);
+        authenticationEngine.authenticate(channelHandlerContext, createPasswordMessage(createMd5Digest(username, PASSWORD, md5Salt)));
+        ArgumentCaptor<Object> writeArgumentCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(channelHandlerContext, atLeastOnce()).write(writeArgumentCaptor.capture());
+        String actualClientEncoding = getClientEncodingValue(extractParameterStatusPackets(writeArgumentCaptor.getAllValues()));
+        assertThat(actualClientEncoding, is("UTF8"));
+    }
+
+    private Collection<PostgreSQLParameterStatusPacket> extractParameterStatusPackets(final List<Object> packets) {
+        Collection<PostgreSQLParameterStatusPacket> result = new LinkedList<>();
+        for (Object each : packets) {
+            if (each instanceof PostgreSQLParameterStatusPacket) {
+                result.add((PostgreSQLParameterStatusPacket) each);
+            }
+        }
+        return result;
+    }
+
+    private String getClientEncodingValue(final Collection<PostgreSQLParameterStatusPacket> packets) throws ReflectiveOperationException {
+        for (PostgreSQLParameterStatusPacket each : packets) {
+            String actualKey = (String) Plugins.getMemberAccessor().get(PostgreSQLParameterStatusPacket.class.getDeclaredField("key"), each);
+            if ("client_encoding".equals(actualKey)) {
+                return (String) Plugins.getMemberAccessor().get(PostgreSQLParameterStatusPacket.class.getDeclaredField("value"), each);
+            }
+        }
+        return "";
     }
 }

--- a/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
+++ b/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
@@ -81,6 +81,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -102,34 +103,34 @@ import static org.mockito.Mockito.when;
 @ExtendWith(AutoMockExtension.class)
 @StaticMockSettings({ProxyContext.class, ProxySSLContext.class})
 class PostgreSQLAuthenticationEngineTest {
-    
+
     private static final String USERNAME = "root";
-    
+
     private static final String PASSWORD = "sharding";
-    
+
     private static final String DATABASE_NAME = "sharding_db";
-    
+
     private final PostgreSQLAuthenticationEngine authenticationEngine = new PostgreSQLAuthenticationEngine();
-    
+
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ChannelHandlerContext channelHandlerContext;
-    
+
     @Mock
     private Attribute<Charset> charsetAttribute;
-    
+
     @SuppressWarnings("unchecked")
     @BeforeEach
     void setup() {
         when(channelHandlerContext.channel().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY)).thenReturn(charsetAttribute);
     }
-    
+
     @SneakyThrows(ReflectiveOperationException.class)
     @Test
     void assertHandshakeAssignsNextConnectionId() {
         Plugins.getMemberAccessor().set(ConnectionIdGenerator.class.getDeclaredField("currentId"), ConnectionIdGenerator.getInstance(), 0);
         assertThat(authenticationEngine.handshake(channelHandlerContext), is(1));
     }
-    
+
     @Test
     void assertSSLUnwilling() {
         ByteBuf byteBuf = createByteBuf(8, 8);
@@ -140,7 +141,7 @@ class PostgreSQLAuthenticationEngineTest {
         verify(context).writeAndFlush(any(PostgreSQLSSLUnwillingPacket.class));
         assertFalse(actual.isFinished());
     }
-    
+
     @Test
     void assertSSLWilling() {
         ByteBuf byteBuf = createByteBuf(8, 8);
@@ -153,7 +154,7 @@ class PostgreSQLAuthenticationEngineTest {
         verify(context.pipeline()).addFirst(eq(SslHandler.class.getSimpleName()), any(SslHandler.class));
         assertFalse(actual.isFinished());
     }
-    
+
     @Test
     void assertSSLRequestCodeMismatchFallsBackToStartup() {
         ByteBuf byteBuf = createByteBuf(8, 8);
@@ -166,7 +167,7 @@ class PostgreSQLAuthenticationEngineTest {
         when(proxyContext.getContextManager()).thenReturn(contextManager);
         assertThrows(EmptyUsernameException.class, () -> authenticationEngine.authenticate(channelHandlerContext, new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8)));
     }
-    
+
     @Test
     void assertUserNotSet() {
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(8, 512), StandardCharsets.UTF_8);
@@ -178,7 +179,7 @@ class PostgreSQLAuthenticationEngineTest {
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         assertThrows(EmptyUsernameException.class, () -> authenticationEngine.authenticate(channelHandlerContext, payload));
     }
-    
+
     @Test
     void assertStartupUsesPasswordAuthenticator() {
         UserConfiguration userConfig = new UserConfiguration(USERNAME, PASSWORD, "", PostgreSQLAuthenticationMethod.PASSWORD.getMethodName(), false);
@@ -194,7 +195,7 @@ class PostgreSQLAuthenticationEngineTest {
         assertThat(argumentCaptor.getValue().getClass(), is((Object) PostgreSQLPasswordAuthenticationPacket.class));
         assertFalse(actual.isFinished());
     }
-    
+
     @Test
     void assertStartupRejectsInvalidClientEncoding() {
         AuthorityRule authorityRule = createAuthorityRule(new UserConfiguration(USERNAME, PASSWORD, "", null, false), Collections.emptyMap(), null);
@@ -205,7 +206,7 @@ class PostgreSQLAuthenticationEngineTest {
         assertThrows(InvalidParameterValueException.class, () -> authenticationEngine.authenticate(channelHandlerContext, payload));
         verify(channelHandlerContext, never()).writeAndFlush(any(PostgreSQLPasswordAuthenticationPacket.class));
     }
-    
+
     @Test
     void assertAuthenticateWithNonPasswordMessage() {
         setAlreadyReceivedStartupMessage(authenticationEngine);
@@ -216,12 +217,12 @@ class PostgreSQLAuthenticationEngineTest {
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         assertThrows(ProtocolViolationException.class, () -> authenticationEngine.authenticate(channelHandlerContext, payload));
     }
-    
+
     @SneakyThrows(ReflectiveOperationException.class)
     private void setAlreadyReceivedStartupMessage(final PostgreSQLAuthenticationEngine target) {
         Plugins.getMemberAccessor().set(PostgreSQLAuthenticationEngine.class.getDeclaredField("startupMessageReceived"), target, true);
     }
-    
+
     @Test
     void assertLoginFailed() {
         AuthorityRule authorityRule = createAuthorityRule(new UserConfiguration(USERNAME, PASSWORD, "", null, false), Collections.emptyMap(), null);
@@ -233,7 +234,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, "wrong" + PASSWORD, md5Salt));
         assertThrows(InvalidPasswordException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-    
+
     @Test
     void assertLoginWithUnknownDatabase() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, "missing_db");
@@ -246,7 +247,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, PASSWORD, md5Salt));
         assertThrows(UnknownDatabaseException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-    
+
     @Test
     void assertLoginWithUnknownUsername() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, null);
@@ -260,7 +261,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, PASSWORD, md5Salt));
         assertThrows(UnknownUsernameException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-    
+
     @Test
     void assertLoginWithoutPrivilege() {
         AuthorityRule authorityRule = mock(AuthorityRule.class);
@@ -278,7 +279,7 @@ class PostgreSQLAuthenticationEngineTest {
         PostgreSQLPacketPayload passwordPayload = createPasswordMessage(createMd5Digest(USERNAME, PASSWORD, md5Salt));
         assertThrows(PrivilegeNotGrantedException.class, () -> authenticationEngine.authenticate(channelHandlerContext, passwordPayload));
     }
-    
+
     @Test
     void assertLoginWithAuthorizedDatabase() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, DATABASE_NAME);
@@ -294,7 +295,7 @@ class PostgreSQLAuthenticationEngineTest {
         verify(channelHandlerContext).writeAndFlush(PostgreSQLReadyForQueryPacket.NOT_IN_TRANSACTION);
         assertTrue(actual.isFinished());
     }
-    
+
     @Test
     void assertLoginWithNullDatabase() {
         PostgreSQLPacketPayload payload = createStartupPayload(USERNAME, null);
@@ -310,33 +311,45 @@ class PostgreSQLAuthenticationEngineTest {
         verify(channelHandlerContext).writeAndFlush(PostgreSQLReadyForQueryPacket.NOT_IN_TRANSACTION);
         assertTrue(actual.isFinished());
     }
-    
+
     @Test
     void assertStartupUsesDefaultClientEncoding() throws ReflectiveOperationException {
         assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, null);
         verify(charsetAttribute).set(StandardCharsets.UTF_8);
     }
-    
+
     @Test
     void assertStartupNormalizesUtf8DashAlias() throws ReflectiveOperationException {
         assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, "UTF-8");
         verify(charsetAttribute).set(StandardCharsets.UTF_8);
     }
-    
+
     @Test
     void assertStartupNormalizesUnicodeAlias() throws ReflectiveOperationException {
         assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, "UNICODE");
         verify(charsetAttribute).set(StandardCharsets.UTF_8);
     }
-    
+
+    @Test
+    void assertStartupNormalizesUnicodeAliasUnderTurkishLocale() throws ReflectiveOperationException {
+        Locale originalLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("tr", "TR"));
+            assertAuthenticateAndClientEncodingParameterStatus(USERNAME, DATABASE_NAME, "UNICODE");
+            verify(charsetAttribute).set(StandardCharsets.UTF_8);
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+    }
+
     private ByteBuf createByteBuf(final int initialCapacity, final int maxCapacity) {
         return new UnpooledHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, initialCapacity, maxCapacity);
     }
-    
+
     private PostgreSQLPacketPayload createStartupPayload(final String username, final String databaseName) {
         return createStartupPayload(username, databaseName, "UTF8");
     }
-    
+
     private PostgreSQLPacketPayload createStartupPayload(final String username, final String databaseName, final String clientEncoding) {
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(32, 256), StandardCharsets.UTF_8);
         payload.writeInt4(64);
@@ -353,7 +366,7 @@ class PostgreSQLAuthenticationEngineTest {
         }
         return payload;
     }
-    
+
     private PostgreSQLPacketPayload createPasswordMessage(final String digest) {
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(16, 128), StandardCharsets.UTF_8);
         payload.writeInt1('p');
@@ -361,20 +374,20 @@ class PostgreSQLAuthenticationEngineTest {
         payload.writeStringNul(digest);
         return payload;
     }
-    
+
     private ContextManager mockContextManager(final MetaDataContexts metaDataContexts) {
         ContextManager result = mock(ContextManager.class);
         when(result.getMetaDataContexts()).thenReturn(metaDataContexts);
         return result;
     }
-    
+
     private MetaDataContexts createMetaDataContexts(final AuthorityRule authorityRule, final boolean containsDatabase, final String databaseName) {
         RuleMetaData ruleMetaData = new RuleMetaData(Collections.singleton(authorityRule));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(containsDatabase && null != databaseName ? Collections.singleton(createDatabase(databaseName)) : Collections.emptyList(),
                 mock(ResourceMetaData.class), ruleMetaData, new ConfigurationProperties(new Properties()));
         return new MetaDataContexts(metaData, new ShardingSphereStatistics());
     }
-    
+
     private ShardingSphereDatabase createDatabase(final String databaseName) {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn(databaseName);
@@ -382,13 +395,13 @@ class PostgreSQLAuthenticationEngineTest {
         when(database.getRuleMetaData()).thenReturn(new RuleMetaData(Collections.emptyList()));
         return database;
     }
-    
+
     private AuthorityRule createAuthorityRule(final UserConfiguration userConfig, final Map<String, AlgorithmConfiguration> authenticators, final String defaultAuthenticator) {
         AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(
                 Collections.singleton(userConfig), new AlgorithmConfiguration("ALL_PERMITTED", new Properties()), authenticators, defaultAuthenticator);
         return new AuthorityRuleBuilder().build(ruleConfig, Collections.emptyList(), mock(ConfigurationProperties.class));
     }
-    
+
     private String createMd5Digest(final String username, final String password, final byte[] md5Salt) {
         String passwordHash = new String(Hex.encodeHex(DigestUtils.md5(password + username), true));
         MessageDigest messageDigest = DigestUtils.getMd5Digest();
@@ -396,12 +409,12 @@ class PostgreSQLAuthenticationEngineTest {
         messageDigest.update(md5Salt);
         return "md5" + new String(Hex.encodeHex(messageDigest.digest(), true));
     }
-    
+
     @SneakyThrows(ReflectiveOperationException.class)
     private byte[] getMd5Salt(final PostgreSQLAuthenticationEngine target) {
         return (byte[]) Plugins.getMemberAccessor().get(PostgreSQLAuthenticationEngine.class.getDeclaredField("md5Salt"), target);
     }
-    
+
     private void assertAuthenticateAndClientEncodingParameterStatus(final String username, final String databaseName, final String startupClientEncoding) throws ReflectiveOperationException {
         AuthorityRule authorityRule = createAuthorityRule(new UserConfiguration(username, PASSWORD, "", null, false), Collections.emptyMap(), null);
         MetaDataContexts metaDataContexts = createMetaDataContexts(authorityRule, true, databaseName);
@@ -415,7 +428,7 @@ class PostgreSQLAuthenticationEngineTest {
         String actualClientEncoding = getClientEncodingValue(extractParameterStatusPackets(writeArgumentCaptor.getAllValues()));
         assertThat(actualClientEncoding, is("UTF8"));
     }
-    
+
     private Collection<PostgreSQLParameterStatusPacket> extractParameterStatusPackets(final List<Object> packets) {
         Collection<PostgreSQLParameterStatusPacket> result = new LinkedList<>();
         for (Object each : packets) {
@@ -425,7 +438,7 @@ class PostgreSQLAuthenticationEngineTest {
         }
         return result;
     }
-    
+
     private String getClientEncodingValue(final Collection<PostgreSQLParameterStatusPacket> packets) throws ReflectiveOperationException {
         for (PostgreSQLParameterStatusPacket each : packets) {
             String actualKey = (String) Plugins.getMemberAccessor().get(PostgreSQLParameterStatusPacket.class.getDeclaredField("key"), each);

--- a/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
+++ b/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.database.protocol.postgresql.packet.command.que
 import org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.extended.execute.PostgreSQLPortalSuspendedPacket;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.generic.PostgreSQLCommandCompletePacket;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.handshake.PostgreSQLParameterStatusPacket;
+import org.apache.shardingsphere.database.exception.core.exception.data.InvalidParameterValueException;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.CommonSQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.InsertStatementContext;
@@ -322,6 +323,17 @@ class PortalTest {
         String actualValue = (String) Plugins.getMemberAccessor().get(PostgreSQLParameterStatusPacket.class.getDeclaredField("value"), parameterStatusPacket);
         assertThat(actualPackets.get(0), isA(PostgreSQLCommandCompletePacket.class));
         assertThat(actualValue, is("utf8"));
+    }
+    
+    @Test
+    void assertBindWithInvalidClientEncoding() throws SQLException {
+        when(proxyBackendHandler.execute()).thenThrow(new InvalidParameterValueException("client_encoding", "latin1"));
+        VariableAssignSegment assignSegment = new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "client_encoding"), "'LATIN1'");
+        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(assignSegment));
+        PostgreSQLServerPreparedStatement preparedStatement = new PostgreSQLServerPreparedStatement(
+                "", new CommonSQLStatementContext(setStatement), new HintValueContext(), Collections.emptyList(), Collections.emptyList());
+        Portal portal = new Portal("", preparedStatement, Collections.emptyList(), Collections.emptyList(), databaseConnectionManager);
+        assertThrows(InvalidParameterValueException.class, portal::bind);
     }
     
     @Test

--- a/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
+++ b/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
@@ -59,6 +59,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.Em
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.SetStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.InsertStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.statement.postgresql.dal.PostgreSQLResetParameterStatement;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
 import org.junit.jupiter.api.BeforeEach;
@@ -322,7 +323,44 @@ class PortalTest {
         PostgreSQLParameterStatusPacket parameterStatusPacket = (PostgreSQLParameterStatusPacket) actualPackets.get(1);
         String actualValue = (String) Plugins.getMemberAccessor().get(PostgreSQLParameterStatusPacket.class.getDeclaredField("value"), parameterStatusPacket);
         assertThat(actualPackets.get(0), isA(PostgreSQLCommandCompletePacket.class));
-        assertThat(actualValue, is("utf8"));
+        assertThat(actualValue, is("UTF8"));
+    }
+    
+    @Test
+    void assertExecuteSetStatementWithDefaultClientEncoding() throws SQLException, ReflectiveOperationException {
+        UpdateResponseHeader responseHeader = mock(UpdateResponseHeader.class);
+        when(proxyBackendHandler.execute()).thenReturn(responseHeader);
+        when(proxyBackendHandler.next()).thenReturn(false);
+        VariableAssignSegment assignSegment = new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "client_encoding"), "DEFAULT");
+        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(assignSegment));
+        PostgreSQLServerPreparedStatement preparedStatement = new PostgreSQLServerPreparedStatement(
+                "", new CommonSQLStatementContext(setStatement), new HintValueContext(), Collections.emptyList(), Collections.emptyList());
+        Portal portal = new Portal("", preparedStatement, Collections.emptyList(), Collections.emptyList(), databaseConnectionManager);
+        portal.bind();
+        List<DatabasePacket> actualPackets = portal.execute(0);
+        PostgreSQLParameterStatusPacket parameterStatusPacket = (PostgreSQLParameterStatusPacket) actualPackets.get(1);
+        String actualValue = (String) Plugins.getMemberAccessor().get(PostgreSQLParameterStatusPacket.class.getDeclaredField("value"), parameterStatusPacket);
+        assertThat(actualValue, is("UTF8"));
+    }
+    
+    @Test
+    void assertExecuteResetClientEncoding() throws SQLException, ReflectiveOperationException {
+        UpdateResponseHeader responseHeader = mock(UpdateResponseHeader.class);
+        when(proxyBackendHandler.execute()).thenReturn(responseHeader);
+        when(proxyBackendHandler.next()).thenReturn(false);
+        PostgreSQLResetParameterStatement resetStatement = new PostgreSQLResetParameterStatement(databaseType, "client_encoding");
+        PostgreSQLServerPreparedStatement preparedStatement = new PostgreSQLServerPreparedStatement(
+                "", new CommonSQLStatementContext(resetStatement), new HintValueContext(), Collections.emptyList(), Collections.emptyList());
+        Portal portal = new Portal("", preparedStatement, Collections.emptyList(), Collections.emptyList(), databaseConnectionManager);
+        portal.bind();
+        List<DatabasePacket> actualPackets = portal.execute(0);
+        PostgreSQLCommandCompletePacket commandCompletePacket = (PostgreSQLCommandCompletePacket) actualPackets.get(0);
+        PostgreSQLParameterStatusPacket parameterStatusPacket = (PostgreSQLParameterStatusPacket) actualPackets.get(1);
+        String command = (String) Plugins.getMemberAccessor().get(PostgreSQLCommandCompletePacket.class.getDeclaredField("sqlCommand"), commandCompletePacket);
+        String actualValue = (String) Plugins.getMemberAccessor().get(PostgreSQLParameterStatusPacket.class.getDeclaredField("value"), parameterStatusPacket);
+        assertThat(actualPackets.size(), is(2));
+        assertThat(command, is("RESET"));
+        assertThat(actualValue, is("UTF8"));
     }
     
     @Test

--- a/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutorTest.java
+++ b/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutorTest.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.database.protocol.postgresql.packet.command.que
 import org.apache.shardingsphere.database.protocol.postgresql.packet.command.query.simple.PostgreSQLComQueryPacket;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.generic.PostgreSQLCommandCompletePacket;
 import org.apache.shardingsphere.database.protocol.postgresql.packet.handshake.PostgreSQLParameterStatusPacket;
+import org.apache.shardingsphere.database.exception.core.exception.data.InvalidParameterValueException;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
@@ -71,6 +72,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -181,6 +183,27 @@ class PostgreSQLComQueryExecutorTest {
         assertThat(getParameterStatusValue(secondStatusPacket), is("64MB"));
         assertThat(queryExecutor.getResponseType(), is(ResponseType.UPDATE));
         verify(portalContext, never()).closeAll();
+    }
+    
+    @Test
+    void assertExecuteUpdateWithClientEncoding() throws SQLException, ReflectiveOperationException {
+        VariableAssignSegment assignSegment = new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "client_encoding"), "'UTF8'");
+        UpdateResponseHeader updateResponseHeader = new UpdateResponseHeader(new SetStatement(DATABASE_TYPE, Collections.singletonList(assignSegment)));
+        when(proxyBackendHandler.execute()).thenReturn(updateResponseHeader);
+        Collection<DatabasePacket> actual = queryExecutor.execute();
+        Iterator<DatabasePacket> iterator = actual.iterator();
+        PostgreSQLCommandCompletePacket commandCompletePacket = (PostgreSQLCommandCompletePacket) iterator.next();
+        PostgreSQLParameterStatusPacket parameterStatusPacket = (PostgreSQLParameterStatusPacket) iterator.next();
+        assertThat(actual.size(), is(2));
+        assertThat(getSqlCommand(commandCompletePacket), is("SET"));
+        assertThat(getParameterStatusKey(parameterStatusPacket), is("client_encoding"));
+        assertThat(getParameterStatusValue(parameterStatusPacket), is("UTF8"));
+    }
+    
+    @Test
+    void assertExecuteWithInvalidClientEncoding() throws SQLException {
+        when(proxyBackendHandler.execute()).thenThrow(new InvalidParameterValueException("client_encoding", "latin1"));
+        assertThrows(InvalidParameterValueException.class, () -> queryExecutor.execute());
     }
     
     @Test

--- a/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutorTest.java
+++ b/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutorTest.java
@@ -48,6 +48,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.Se
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.InsertStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.tcl.CommitStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.tcl.RollbackStatement;
+import org.apache.shardingsphere.sql.parser.statement.postgresql.dal.PostgreSQLResetParameterStatement;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
 import org.junit.jupiter.api.BeforeEach;
@@ -196,6 +197,40 @@ class PostgreSQLComQueryExecutorTest {
         PostgreSQLParameterStatusPacket parameterStatusPacket = (PostgreSQLParameterStatusPacket) iterator.next();
         assertThat(actual.size(), is(2));
         assertThat(getSqlCommand(commandCompletePacket), is("SET"));
+        assertThat(getParameterStatusKey(parameterStatusPacket), is("client_encoding"));
+        assertThat(getParameterStatusValue(parameterStatusPacket), is("UTF8"));
+    }
+    
+    @Test
+    void assertExecuteUpdateWithClientEncodingDefault() throws SQLException, ReflectiveOperationException {
+        VariableAssignSegment assignSegment = new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "client_encoding"), "DEFAULT");
+        UpdateResponseHeader updateResponseHeader = new UpdateResponseHeader(new SetStatement(DATABASE_TYPE, Collections.singletonList(assignSegment)));
+        when(proxyBackendHandler.execute()).thenReturn(updateResponseHeader);
+        Collection<DatabasePacket> actual = queryExecutor.execute();
+        PostgreSQLParameterStatusPacket parameterStatusPacket = (PostgreSQLParameterStatusPacket) new ArrayList<>(actual).get(1);
+        assertThat(getParameterStatusValue(parameterStatusPacket), is("UTF8"));
+    }
+    
+    @Test
+    void assertExecuteUpdateWithClientEncodingAlias() throws SQLException, ReflectiveOperationException {
+        VariableAssignSegment assignSegment = new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "client_encoding"), "'unicode'");
+        UpdateResponseHeader updateResponseHeader = new UpdateResponseHeader(new SetStatement(DATABASE_TYPE, Collections.singletonList(assignSegment)));
+        when(proxyBackendHandler.execute()).thenReturn(updateResponseHeader);
+        Collection<DatabasePacket> actual = queryExecutor.execute();
+        PostgreSQLParameterStatusPacket parameterStatusPacket = (PostgreSQLParameterStatusPacket) new ArrayList<>(actual).get(1);
+        assertThat(getParameterStatusValue(parameterStatusPacket), is("UTF8"));
+    }
+    
+    @Test
+    void assertExecuteUpdateWithResetClientEncoding() throws SQLException, ReflectiveOperationException {
+        UpdateResponseHeader updateResponseHeader = new UpdateResponseHeader(new PostgreSQLResetParameterStatement(DATABASE_TYPE, "client_encoding"));
+        when(proxyBackendHandler.execute()).thenReturn(updateResponseHeader);
+        Collection<DatabasePacket> actual = queryExecutor.execute();
+        Iterator<DatabasePacket> iterator = actual.iterator();
+        PostgreSQLCommandCompletePacket commandCompletePacket = (PostgreSQLCommandCompletePacket) iterator.next();
+        PostgreSQLParameterStatusPacket parameterStatusPacket = (PostgreSQLParameterStatusPacket) iterator.next();
+        assertThat(actual.size(), is(2));
+        assertThat(getSqlCommand(commandCompletePacket), is("RESET"));
         assertThat(getParameterStatusKey(parameterStatusPacket), is("client_encoding"));
         assertThat(getParameterStatusValue(parameterStatusPacket), is("UTF8"));
     }


### PR DESCRIPTION
Fixes #36382

Changes proposed in this pull request:

Enforce UTF-8-only policy for PostgreSQL `client_encoding` in Proxy backend:
- Update `PostgreSQLCharsetVariableProvider#parseCharset(...)` to only accept:
  - `default`
  - `utf8` / `utf-8` / `utf_8` / `unicode` 
- Always resolve accepted values to `StandardCharsets.UTF_8`.
- Reject non-UTF8 values (e.g. `LATIN1`) with `InvalidParameterValueException`.

Keep behavior consistency across SET/RESET/SHOW flows:
- `SET client_encoding`:
  - UTF-8 aliases succeed.
  - non-UTF8 values fail fast.
- `RESET client_encoding`:
  - maps 'DEFAULT' to UTF-8 policy.
- `SHOW client_encoding`:
  - remains `UTF8`, aligned with fixed policy.

Add/extend unit tests to cover backend and protocol paths:
- `PostgreSQLCharsetVariableProviderTest`
  - validate accepted UTF-8 aliases and invalid non-UTF8 values.
- `PostgreSQLSetVariableAdminExecutorTest`
  - add invalid `client_encoding` case and verify recorder path is not executed on failure.
- `PostgreSQLResetVariableAdminExecutorTest`
  - add `RESET client_encoding` coverage and verify charset attribute + recorder behavior.
- `PortalTest` (extended query path)
  - add invalid `client_encoding` bind failure scenario.
- `PostgreSQLComQueryExecutorTest` (simple query path)
  - add UTF-8 `ParameterStatus` success scenario.
  - add invalid `client_encoding` exception path.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
