### PR TITLE
Support parsing Doris CANCEL MATERIALIZED VIEW TASK syntax

### DIFF
--- a/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
+++ b/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
@@ -299,6 +299,8 @@ public enum SQLVisitorRule {
     
     CANCEL_TASK("CancelTask", SQLStatementType.DDL),
     
+    CANCEL_MATERIALIZED_VIEW_TASK("CancelMaterializedViewTask", SQLStatementType.DDL),
+    
     RESUME_JOB("ResumeJob", SQLStatementType.DDL),
     
     RESUME_SYNC_JOB("ResumeSyncJob", SQLStatementType.DDL),

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DDLStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DDLStatement.g4
@@ -1038,6 +1038,10 @@ cancelTask
     : CANCEL TASK WHERE jobName EQ_ stringLiterals AND identifier EQ_ numberLiterals
     ;
 
+cancelMaterializedViewTask
+    : CANCEL MATERIALIZED VIEW TASK numberLiterals ON tableName
+    ;
+
 resumeSyncJob
     : RESUME SYNC JOB (owner DOT_)? identifier
     ;

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
@@ -168,6 +168,7 @@ execute
     | createJob
     | createStreamingJob
     | cancelTask
+    | cancelMaterializedViewTask
     | backup
     | cancelBackup
     | cancelLoadStatement

--- a/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDDLStatementVisitor.java
@@ -137,6 +137,7 @@ import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RenameR
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RenameTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RepeatStatementContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.ReplaceTableContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CancelMaterializedViewTaskContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CancelTaskContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.ResumeJobContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.ResumeSyncJobContext;
@@ -276,6 +277,7 @@ import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisCreateStrea
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisCreateSyncJobStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisDropFunctionStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisPauseSyncJobStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisCancelMaterializedViewTaskStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisCancelTaskStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisAlterJobStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisDropJobStatement;
@@ -564,6 +566,13 @@ public final class DorisDDLStatementVisitor extends DorisStatementVisitor implem
         String jobName = SQLUtils.getExactlyValue(ctx.stringLiterals().getText());
         long taskId = Long.parseLong(ctx.numberLiterals().getText());
         return new DorisCancelTaskStatement(getDatabaseType(), jobName, taskId);
+    }
+    
+    @Override
+    public ASTNode visitCancelMaterializedViewTask(final CancelMaterializedViewTaskContext ctx) {
+        long taskId = Long.parseLong(ctx.numberLiterals().getText());
+        String mvName = ctx.tableName().getText();
+        return new DorisCancelMaterializedViewTaskStatement(getDatabaseType(), taskId, mvName);
     }
     
     private JobScheduleSegment createJobScheduleSegment(final JobScheduleExpressionContext ctx) {

--- a/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/ddl/DorisCancelMaterializedViewTaskStatement.java
+++ b/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/ddl/DorisCancelMaterializedViewTaskStatement.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.doris.ddl;
+
+import lombok.Getter;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.DDLStatement;
+
+/**
+ * Cancel materialized view task statement for Doris.
+ */
+@Getter
+public final class DorisCancelMaterializedViewTaskStatement extends DDLStatement {
+    
+    private final long taskId;
+    
+    private final String mvName;
+    
+    public DorisCancelMaterializedViewTaskStatement(final DatabaseType databaseType, final long taskId, final String mvName) {
+        super(databaseType);
+        this.taskId = taskId;
+        this.mvName = mvName;
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/dialect/doris/DorisCancelMaterializedViewTaskStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/dialect/doris/DorisCancelMaterializedViewTaskStatementAssert.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ddl.dialect.doris;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisCancelMaterializedViewTaskStatement;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCancelMaterializedViewTaskStatementTestCase;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Cancel materialized view task statement assert for Doris.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DorisCancelMaterializedViewTaskStatementAssert {
+    
+    /**
+     * Assert cancel materialized view task statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual cancel materialized view task statement
+     * @param expected expected cancel materialized view task statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final DorisCancelMaterializedViewTaskStatement actual, final DorisCancelMaterializedViewTaskStatementTestCase expected) {
+        assertThat(assertContext.getText("Task ID does not match: "), actual.getTaskId(), is(expected.getTaskId()));
+        assertThat(assertContext.getText("Materialized view name does not match: "), actual.getMvName(), is(expected.getMvName()));
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/dialect/doris/DorisDDLStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/dialect/doris/DorisDDLStatementAssert.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisAlterColoca
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisAlterStoragePolicyStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisCreateFunctionStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisDropFunctionStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisCancelMaterializedViewTaskStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisCancelTaskStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisAlterJobStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.ddl.DorisDropJobStatement;
@@ -43,6 +44,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisAlterStoragePolicyStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCreateJobStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisDropFunctionStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCancelMaterializedViewTaskStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCancelTaskStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisAlterJobStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisDropJobStatementTestCase;
@@ -99,6 +101,8 @@ public final class DorisDDLStatementAssert {
             DorisCreateStreamingJobStatementAssert.assertIs(assertContext, (DorisCreateStreamingJobStatement) actual, (DorisCreateStreamingJobStatementTestCase) expected);
         } else if (actual instanceof DorisCancelTaskStatement) {
             DorisCancelTaskStatementAssert.assertIs(assertContext, (DorisCancelTaskStatement) actual, (DorisCancelTaskStatementTestCase) expected);
+        } else if (actual instanceof DorisCancelMaterializedViewTaskStatement) {
+            DorisCancelMaterializedViewTaskStatementAssert.assertIs(assertContext, (DorisCancelMaterializedViewTaskStatement) actual, (DorisCancelMaterializedViewTaskStatementTestCase) expected);
         }
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
@@ -44,6 +44,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisPauseSyncJobStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisStopSyncJobStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCreateJobStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCancelMaterializedViewTaskStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCancelTaskStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCreateStreamingJobStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris.DorisCreateSyncJobStatementTestCase;
@@ -1374,6 +1375,9 @@ public final class RootSQLParserTestCases {
     
     @XmlElement(name = "cancel-task")
     private final List<DorisCancelTaskStatementTestCase> cancelTaskTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "cancel-materialized-view-task")
+    private final List<DorisCancelMaterializedViewTaskStatementTestCase> cancelMaterializedViewTaskTestCases = new LinkedList<>();
     
     @XmlElement(name = "drop-shadow-algorithm")
     private final List<DropShadowAlgorithmStatementTestCase> dropShadowAlgorithmTestCases = new LinkedList<>();

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/dialect/doris/DorisCancelMaterializedViewTaskStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/dialect/doris/DorisCancelMaterializedViewTaskStatementTestCase.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.dialect.doris;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * Cancel materialized view task statement test case for Doris.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@Setter
+public final class DorisCancelMaterializedViewTaskStatementTestCase extends SQLParserTestCase {
+    
+    @XmlElement(name = "task-id")
+    private long taskId;
+    
+    @XmlElement(name = "mv-name")
+    private String mvName;
+}

--- a/test/it/parser/src/main/resources/case/ddl/cancel-materialized-view-task.xml
+++ b/test/it/parser/src/main/resources/case/ddl/cancel-materialized-view-task.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <cancel-materialized-view-task sql-case-id="cancel_materialized_view_task">
+        <task-id>1</task-id>
+        <mv-name>mv1</mv-name>
+    </cancel-materialized-view-task>
+
+    <cancel-materialized-view-task sql-case-id="cancel_materialized_view_task_with_qualified_name">
+        <task-id>42</task-id>
+        <mv-name>example_db.mv_stats</mv-name>
+    </cancel-materialized-view-task>
+</sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/cancel-materialized-view-task.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/cancel-materialized-view-task.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="cancel_materialized_view_task" value="CANCEL MATERIALIZED VIEW TASK 1 ON mv1" db-types="Doris" />
+    <sql-case id="cancel_materialized_view_task_with_qualified_name" value="CANCEL MATERIALIZED VIEW TASK 42 ON example_db.mv_stats" db-types="Doris" />
+</sql-cases>


### PR DESCRIPTION
## Problem

Doris supports `CANCEL MATERIALIZED VIEW TASK taskId ON mvName` to cancel a running task of a materialized view refresh, but ShardingSphere's Doris SQL parser does not currently recognize this statement. Attempting to parse it fails with an ANTLR error.

## Root Cause

The Doris DDL grammar only covers the related `cancelTask`, `cancelBuildIndex`, and `cancelAlterTable` variants. There is no rule for the `CANCEL MATERIALIZED VIEW TASK ... ON ...` form described in the Doris SQL manual.

## Fix

- Add the `cancelMaterializedViewTask` rule in `DDLStatement.g4` next to the other cancel-* rules, matching `CANCEL MATERIALIZED VIEW TASK numberLiterals ON tableName`.
- Register the new rule as an alternative in the `execute` rule of `DorisStatement.g4`.
- Add `visitCancelMaterializedViewTask` in `DorisDDLStatementVisitor`, producing a new `DorisCancelMaterializedViewTaskStatement` that carries the task id and materialized view name.
- Register the statement type in `SQLVisitorRule` as `CANCEL_MATERIALIZED_VIEW_TASK` (DDL).
- Add an `instanceof` branch in `DorisDDLStatementAssert` that dispatches to the new `DorisCancelMaterializedViewTaskStatementAssert`.

All four Doris keywords involved (`CANCEL`, `MATERIALIZED`, `VIEW`, `TASK`) already exist in `DorisKeyword.g4`; no keyword additions are needed.

## Tests Added

| Change Point | Test |
|-------------|------|
| New grammar rule `cancelMaterializedViewTask` + `execute` alternative | `cancel_materialized_view_task` — parses `CANCEL MATERIALIZED VIEW TASK 1 ON mv1` |
| Qualified materialized view name (`db.mv`) handled via `tableName` | `cancel_materialized_view_task_with_qualified_name` — parses `CANCEL MATERIALIZED VIEW TASK 42 ON example_db.mv_stats` |
| Visitor extracts `taskId` and `mvName` into the statement | Both cases assert `task-id` and `mv-name` in `case/ddl/cancel-materialized-view-task.xml` |
| Assert dispatch for the new statement type | Exercised by both cases (without the `instanceof` branch, assertions would never run) |

Test cases are registered in `sql/supported/ddl/cancel-materialized-view-task.xml` and `case/ddl/cancel-materialized-view-task.xml`. `InternalSQLParserIT` will execute them through the usual flow.

## Impact

- Only extends the Doris parser; no changes to other dialects, routing, or execution layers.
- Backward compatible — no existing grammar rule, visitor method, or statement class is modified in behavior.

Refs #31470 (extends the open list of Doris SQL cases with the `CANCEL MATERIALIZED VIEW TASK` item).