### PR TITLE
Fix openGauss LIMIT offset, row-count parameter marker order

### DIFF
--- a/parser/sql/engine/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitor.java
+++ b/parser/sql/engine/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitor.java
@@ -1451,8 +1451,8 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementParser
     private LimitSegment createLimitSegmentWhenRowCountOrOffsetAbsent(final SelectLimitContext ctx) {
         if (null != ctx.limitClause()) {
             if (null != ctx.limitClause().selectOffsetValue()) {
-                LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectLimitValue());
                 LimitValueSegment offset = (LimitValueSegment) visit(ctx.limitClause().selectOffsetValue());
+                LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectLimitValue());
                 return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), offset, limit);
             }
             if (null != ctx.limitClause().selectFetchValue()) {

--- a/parser/sql/engine/dialect/opengauss/src/test/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitorTest.java
+++ b/parser/sql/engine/dialect/opengauss/src/test/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitorTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.engine.opengauss.visitor.statement;
+
+import org.apache.shardingsphere.sql.parser.engine.api.CacheOption;
+import org.apache.shardingsphere.sql.parser.engine.api.SQLParserEngine;
+import org.apache.shardingsphere.sql.parser.engine.api.SQLStatementVisitorEngine;
+import org.apache.shardingsphere.sql.parser.engine.core.ParseASTNode;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.PaginationValueSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.limit.LimitSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.limit.NumberLiteralLimitValueSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.limit.ParameterMarkerLimitValueSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenGaussStatementVisitorTest {
+
+    @Test
+    void assertVisitLimitWithOffsetAndRowCountParameterMarkers() {
+        String sql = "SELECT * FROM t_order ORDER BY order_id LIMIT ?, ?";
+        SelectStatement statement = parseSelect(sql);
+        LimitSegment limit = statement.getLimit().orElseThrow(AssertionError::new);
+        Optional<PaginationValueSegment> offset = limit.getOffset();
+        Optional<PaginationValueSegment> rowCount = limit.getRowCount();
+        assertTrue(offset.isPresent());
+        assertTrue(rowCount.isPresent());
+        assertThat(offset.get(), instanceOf(ParameterMarkerLimitValueSegment.class));
+        assertThat(rowCount.get(), instanceOf(ParameterMarkerLimitValueSegment.class));
+        assertThat(((ParameterMarkerLimitValueSegment) offset.get()).getParameterIndex(), is(0));
+        assertThat(((ParameterMarkerLimitValueSegment) rowCount.get()).getParameterIndex(), is(1));
+    }
+
+    @Test
+    void assertVisitLimitWithLiteralOffsetAndRowCount() {
+        String sql = "SELECT * FROM t_order LIMIT 1, 2";
+        SelectStatement statement = parseSelect(sql);
+        LimitSegment limit = statement.getLimit().orElseThrow(AssertionError::new);
+        Optional<PaginationValueSegment> offset = limit.getOffset();
+        Optional<PaginationValueSegment> rowCount = limit.getRowCount();
+        assertTrue(offset.isPresent());
+        assertTrue(rowCount.isPresent());
+        assertThat(((NumberLiteralLimitValueSegment) offset.get()).getValue(), is(1L));
+        assertThat(((NumberLiteralLimitValueSegment) rowCount.get()).getValue(), is(2L));
+    }
+
+    @Test
+    void assertVisitLimitWithOnlyRowCountParameterMarker() {
+        String sql = "SELECT * FROM t_order LIMIT ?";
+        SelectStatement statement = parseSelect(sql);
+        LimitSegment limit = statement.getLimit().orElseThrow(AssertionError::new);
+        assertTrue(limit.getRowCount().isPresent());
+        assertThat(limit.getOffset().isPresent(), is(false));
+        assertThat(((ParameterMarkerLimitValueSegment) limit.getRowCount().get()).getParameterIndex(), is(0));
+    }
+
+    @Test
+    void assertVisitOffsetAndLimitWithParameterMarkers() {
+        String sql = "SELECT * FROM t_order ORDER BY order_id OFFSET ? LIMIT ?";
+        SelectStatement statement = parseSelect(sql);
+        LimitSegment limit = statement.getLimit().orElseThrow(AssertionError::new);
+        Optional<PaginationValueSegment> offset = limit.getOffset();
+        Optional<PaginationValueSegment> rowCount = limit.getRowCount();
+        assertTrue(offset.isPresent());
+        assertTrue(rowCount.isPresent());
+        assertThat(((ParameterMarkerLimitValueSegment) offset.get()).getParameterIndex(), is(0));
+        assertThat(((ParameterMarkerLimitValueSegment) rowCount.get()).getParameterIndex(), is(1));
+    }
+
+    private SelectStatement parseSelect(final String sql) {
+        ParseASTNode parseASTNode = new SQLParserEngine("openGauss", new CacheOption(128, 1024L)).parse(sql, false);
+        return (SelectStatement) new SQLStatementVisitorEngine("openGauss").visit(parseASTNode);
+    }
+}


### PR DESCRIPTION
## Problem

On ShardingSphere-Proxy against openGauss, a prepared statement that uses the MySQL-style `LIMIT offset, count` shortcut with parameter markers returns rows in the wrong window. For example, `SELECT * FROM employees ORDER BY id LIMIT ?, ?` bound with `setInt(1, 2); setInt(2, 1)` is expected to skip 2 rows and return 1 row, but ShardingSphere treats the first `?` as row-count and the second `?` as offset, so it returns 2 rows starting from offset 1.

## Root Cause

`OpenGaussStatementVisitor.createLimitSegmentWhenRowCountOrOffsetAbsent` builds the `LimitSegment` for the `LIMIT selectOffsetValue COMMA_ selectLimitValue` grammar branch by visiting `selectLimitValue` before `selectOffsetValue`. Parameter marker indices are assigned from the visitor counter in visit order (see `OpenGaussStatementVisitor.visitParameterMarker` and the `parameterMarkerSegments` collection), not from lexical position. Visiting the row-count child first therefore gives the second `?` index 0 and the first `?` index 1, which is the reverse of the user-facing parameter order.

## Fix

Visit `selectOffsetValue` first, then `selectLimitValue`, in `createLimitSegmentWhenRowCountOrOffsetAbsent`. Parameter marker indices now line up with lexical order, matching how `DorisStatementVisitor.visitLimitClause` already handles the identical MySQL-style shortcut.

## Tests Added

Added `OpenGaussStatementVisitorTest` under `parser/sql/engine/dialect/opengauss/src/test`:

| Change point | Test |
|-------------|------|
| Swap visit order so `LIMIT ?, ?` offset gets index 0 and row-count gets index 1 | `assertVisitLimitWithOffsetAndRowCountParameterMarkers` - asserts `offset.parameterIndex == 0`, `rowCount.parameterIndex == 1` (fails without the fix, passes with it) |
| Regression: literal `LIMIT n, m` still parses correctly | `assertVisitLimitWithLiteralOffsetAndRowCount` - asserts offset value 1 and row-count value 2 |
| Regression: single-marker `LIMIT ?` unchanged | `assertVisitLimitWithOnlyRowCountParameterMarker` - asserts row-count parameter index 0 and no offset |
| Regression: separate `OFFSET ? LIMIT ?` clauses unchanged | `assertVisitOffsetAndLimitWithParameterMarkers` - asserts offset parameter index 0 and row-count parameter index 1 |

## Impact

- Touches only the MySQL-style `LIMIT offset, count` branch in the openGauss visitor.
- Literal-valued `LIMIT n, m`, plain `LIMIT ?`, `LIMIT ? OFFSET ?`, and `FETCH` paths are unchanged.
- PostgreSQL parser is not affected (its grammar does not accept the `LIMIT offset, count` shortcut).

Fixes #34961