### PR TITLE
Fix IllegalStateException when importing database configuration in Proxy

### DIFF
--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/util/YamlDatabaseConfigurationImportExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/util/YamlDatabaseConfigurationImportExecutor.java
@@ -134,7 +134,9 @@ public final class YamlDatabaseConfigurationImportExecutor {
     private void addRule(final Collection<RuleConfiguration> ruleConfigs, final RuleConfiguration ruleConfig, final ShardingSphereDatabase database) {
         DatabaseRuleConfigurationCheckEngine.check(ruleConfig, database);
         ruleConfigs.add(ruleConfig);
-        database.getRuleMetaData().getRules().add(buildRule(ruleConfig, database));
+        Collection<ShardingSphereRule> rules = database.getRuleMetaData().getRules();
+        rules.removeIf(each -> each.getConfiguration().getClass().equals(ruleConfig.getClass()));
+        rules.add(buildRule(ruleConfig, database));
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/imports/ImportDatabaseConfigurationExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/imports/ImportDatabaseConfigurationExecutorTest.java
@@ -88,6 +88,7 @@ class ImportDatabaseConfigurationExecutorTest {
     private static Stream<Arguments> importSuccessCases() {
         return Stream.of(
                 Arguments.of("import sharding", "sharding_db", "/conf/import/database-sharding.yaml"),
+                Arguments.of("import single", "single_db", "/conf/import/database-single.yaml"),
                 Arguments.of("import readwrite splitting", "readwrite_splitting_db", "/conf/import/database-readwrite-splitting.yaml"),
                 Arguments.of("import encrypt", "encrypt_db", "/conf/import/database-encrypt.yaml"),
                 Arguments.of("import shadow", "shadow_db", "/conf/import/database-shadow.yaml"),

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/util/YamlDatabaseConfigurationImportExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/util/YamlDatabaseConfigurationImportExecutorTest.java
@@ -48,6 +48,8 @@ import org.apache.shardingsphere.mode.persist.service.MetaDataManagerPersistServ
 import org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyDataSourceConfiguration;
 import org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyDatabaseConfiguration;
 import org.apache.shardingsphere.proxy.backend.config.yaml.swapper.YamlProxyDataSourceConfigurationSwapper;
+import org.apache.shardingsphere.single.config.SingleRuleConfiguration;
+import org.apache.shardingsphere.single.rule.SingleRule;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,6 +70,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -78,6 +81,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -197,6 +201,97 @@ class YamlDatabaseConfigurationImportExecutorTest {
             assertThat(storageUnits.get("foo_ds"), is(mockedConstruction.constructed().get(0)));
         }
         assertThat(rules, is(Collections.singletonList(expectedRule)));
+        ArgumentCaptor<Collection<RuleConfiguration>> ruleConfigsCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(databaseRulePersistService).persist(eq("foo_db"), ruleConfigsCaptor.capture());
+        assertThat(ruleConfigsCaptor.getValue(), is(Collections.singletonList(ruleConfig)));
+    }
+    
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void assertImportDatabaseConfigurationReplacesDefaultSingleRule() {
+        Map<String, StorageUnit> storageUnits = new HashMap<>(1, 1F);
+        LinkedList<ShardingSphereRule> rules = new LinkedList<>();
+        SingleRule existedRule = mock(SingleRule.class);
+        when(existedRule.getConfiguration()).thenReturn(new SingleRuleConfiguration());
+        rules.add(existedRule);
+        mockMetaDataContexts(mockDatabase(storageUnits, rules), new ConfigurationProperties(new Properties()));
+        MetaDataManagerPersistService metaDataManagerService = mock(MetaDataManagerPersistService.class);
+        when(contextManager.getPersistServiceFacade().getModeFacade().getMetaDataManagerService()).thenReturn(metaDataManagerService);
+        DatabaseRulePersistService databaseRulePersistService = mock(DatabaseRulePersistService.class);
+        when(contextManager.getPersistServiceFacade().getMetaDataFacade().getDatabaseRuleService()).thenReturn(databaseRulePersistService);
+        DataSourceConfiguration dataSourceConfig = mock(DataSourceConfiguration.class);
+        when(dataSourceConfigSwapper.swap(any(YamlProxyDataSourceConfiguration.class))).thenReturn(dataSourceConfig);
+        DataSourcePoolProperties poolProperties = mock(DataSourcePoolProperties.class, RETURNS_DEEP_STUBS);
+        when(DataSourcePoolPropertiesCreator.create(dataSourceConfig)).thenReturn(poolProperties);
+        when(StorageUnitNodeMapCreator.create(anyMap(), anyBoolean())).thenReturn(Collections.singletonMap("foo_ds", mock(StorageNode.class)));
+        when(DataSourcePoolCreator.create(poolProperties)).thenReturn(mock(DataSource.class));
+        when(DatabaseTypeEngine.getProtocolType(anyMap(), any(ConfigurationProperties.class))).thenReturn(mock(DatabaseType.class));
+        SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration();
+        ruleConfig.setDefaultDataSource("foo_ds");
+        YamlRuleConfiguration yamlRuleConfig = mock(YamlRuleConfiguration.class);
+        when(yamlRuleConfig.getRuleConfigurationType()).thenReturn((Class) SingleRuleConfiguration.class);
+        YamlRuleConfigurationSwapper swapper = mock(YamlRuleConfigurationSwapper.class);
+        when(swapper.swapToObject(yamlRuleConfig)).thenReturn(ruleConfig);
+        when(swapper.getOrder()).thenReturn(1);
+        when(OrderedSPILoader.getServicesByClass(eq(YamlRuleConfigurationSwapper.class), anyCollection())).thenReturn(Collections.singletonMap(SingleRuleConfiguration.class, swapper));
+        when(OrderedSPILoader.getServicesByClass(eq(DatabaseRuleConfigurationChecker.class), anyCollection())).thenReturn(Collections.singletonMap(SingleRuleConfiguration.class, null));
+        DatabaseRuleBuilder builder = mock(DatabaseRuleBuilder.class);
+        SingleRule importedRule = mock(SingleRule.class);
+        when(builder.build(eq(ruleConfig), anyString(), any(DatabaseType.class), any(ResourceMetaData.class), anyCollection(), any())).thenReturn(importedRule);
+        when(OrderedSPILoader.getServices(DatabaseRuleBuilder.class, Collections.singleton(ruleConfig))).thenReturn(Collections.singletonMap(ruleConfig, builder));
+        YamlProxyDatabaseConfiguration yamlConfig = createYamlConfiguration();
+        yamlConfig.setRules(Collections.singletonList(yamlRuleConfig));
+        try (MockedConstruction<StorageUnit> ignored = mockConstruction(StorageUnit.class)) {
+            executor.importDatabaseConfiguration(yamlConfig);
+        }
+        assertThat(rules, contains(importedRule));
+        ArgumentCaptor<Collection<RuleConfiguration>> ruleConfigsCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(databaseRulePersistService).persist(eq("foo_db"), ruleConfigsCaptor.capture());
+        assertThat(ruleConfigsCaptor.getValue(), is(Collections.singletonList(ruleConfig)));
+    }
+    
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void assertImportDatabaseConfigurationWhenSingleRuleCreatedDuringStorageUnitRegistration() {
+        Map<String, StorageUnit> storageUnits = new HashMap<>(1, 1F);
+        LinkedList<ShardingSphereRule> rules = new LinkedList<>();
+        mockMetaDataContexts(mockDatabase(storageUnits, rules), new ConfigurationProperties(new Properties()));
+        MetaDataManagerPersistService metaDataManagerService = mock(MetaDataManagerPersistService.class);
+        when(contextManager.getPersistServiceFacade().getModeFacade().getMetaDataManagerService()).thenReturn(metaDataManagerService);
+        SingleRule existedRule = mock(SingleRule.class);
+        when(existedRule.getConfiguration()).thenReturn(new SingleRuleConfiguration());
+        doAnswer(invocation -> {
+            rules.add(existedRule);
+            return null;
+        }).when(metaDataManagerService).registerStorageUnits(eq("foo_db"), anyMap());
+        DatabaseRulePersistService databaseRulePersistService = mock(DatabaseRulePersistService.class);
+        when(contextManager.getPersistServiceFacade().getMetaDataFacade().getDatabaseRuleService()).thenReturn(databaseRulePersistService);
+        DataSourceConfiguration dataSourceConfig = mock(DataSourceConfiguration.class);
+        when(dataSourceConfigSwapper.swap(any(YamlProxyDataSourceConfiguration.class))).thenReturn(dataSourceConfig);
+        DataSourcePoolProperties poolProperties = mock(DataSourcePoolProperties.class, RETURNS_DEEP_STUBS);
+        when(DataSourcePoolPropertiesCreator.create(dataSourceConfig)).thenReturn(poolProperties);
+        when(StorageUnitNodeMapCreator.create(anyMap(), anyBoolean())).thenReturn(Collections.singletonMap("foo_ds", mock(StorageNode.class)));
+        when(DataSourcePoolCreator.create(poolProperties)).thenReturn(mock(DataSource.class));
+        when(DatabaseTypeEngine.getProtocolType(anyMap(), any(ConfigurationProperties.class))).thenReturn(mock(DatabaseType.class));
+        SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration();
+        ruleConfig.setDefaultDataSource("foo_ds");
+        YamlRuleConfiguration yamlRuleConfig = mock(YamlRuleConfiguration.class);
+        when(yamlRuleConfig.getRuleConfigurationType()).thenReturn((Class) SingleRuleConfiguration.class);
+        YamlRuleConfigurationSwapper swapper = mock(YamlRuleConfigurationSwapper.class);
+        when(swapper.swapToObject(yamlRuleConfig)).thenReturn(ruleConfig);
+        when(swapper.getOrder()).thenReturn(1);
+        when(OrderedSPILoader.getServicesByClass(eq(YamlRuleConfigurationSwapper.class), anyCollection())).thenReturn(Collections.singletonMap(SingleRuleConfiguration.class, swapper));
+        when(OrderedSPILoader.getServicesByClass(eq(DatabaseRuleConfigurationChecker.class), anyCollection())).thenReturn(Collections.singletonMap(SingleRuleConfiguration.class, null));
+        DatabaseRuleBuilder builder = mock(DatabaseRuleBuilder.class);
+        SingleRule importedRule = mock(SingleRule.class);
+        when(builder.build(eq(ruleConfig), anyString(), any(DatabaseType.class), any(ResourceMetaData.class), anyCollection(), any())).thenReturn(importedRule);
+        when(OrderedSPILoader.getServices(DatabaseRuleBuilder.class, Collections.singleton(ruleConfig))).thenReturn(Collections.singletonMap(ruleConfig, builder));
+        YamlProxyDatabaseConfiguration yamlConfig = createYamlConfiguration();
+        yamlConfig.setRules(Collections.singletonList(yamlRuleConfig));
+        try (MockedConstruction<StorageUnit> ignored = mockConstruction(StorageUnit.class)) {
+            executor.importDatabaseConfiguration(yamlConfig);
+        }
+        assertThat(rules, contains(importedRule));
         ArgumentCaptor<Collection<RuleConfiguration>> ruleConfigsCaptor = ArgumentCaptor.forClass(Collection.class);
         verify(databaseRulePersistService).persist(eq("foo_db"), ruleConfigsCaptor.capture());
         assertThat(ruleConfigsCaptor.getValue(), is(Collections.singletonList(ruleConfig)));

--- a/proxy/backend/core/src/test/resources/conf/import/database-single.yaml
+++ b/proxy/backend/core/src/test/resources/conf/import/database-single.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+databaseName: single_db
+
+dataSources:
+  foo_ds:
+    dataSourceClassName: org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource
+    url: jdbc:mock://127.0.0.1/demo_single_ds
+    username: root
+    password:
+    connectionTimeoutMilliseconds: 30000
+    idleTimeoutMilliseconds: 60000
+    maxLifetimeMilliseconds: 1800000
+    maxPoolSize: 50
+    minPoolSize: 1
+
+rules:
+  - !SINGLE
+    defaultDataSource: foo_ds


### PR DESCRIPTION
Fixes #38640 .

In cluster mode, IMPORT DATABASE CONFIGURATION registers storage units before importing rules. That registration triggers a metadata rebuild, which injects a default empty SingleRule because the new database still has no explicit rule configs. The import path then adds the YAML-derived SingleRule again, leaving two SingleRule instances and causing later getSingleRule(SingleRule.class) calls to fail.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
