### PR TITLE
Add missing max() and min() return types in FirebirdPrepareState

### DIFF
--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/prepare/FirebirdPrepareStatementCommandExecutor.java
@@ -424,6 +424,8 @@ public final class FirebirdPrepareStatementCommandExecutor implements CommandExe
                 return Types.VARCHAR;
             case "gen_id":
             case "count":
+            case "min":
+            case "max":
                 return Types.BIGINT;
             case "current_timestamp":
                 return Types.TIMESTAMP;


### PR DESCRIPTION
Changes proposed in this pull request:
  - add missing max() and min() return types in FirebirdPrepareState

---

Before committing this PR, I'm sure that I have checked the following options:
- [X] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [X] I have self-reviewed the commit code.
- [X] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
