### PR TITLE
Refactor AgentPath and AgentPathTest to support jdk26

### DIFF
--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/ShardingSphereAgent.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/ShardingSphereAgent.java
@@ -49,7 +49,7 @@ public final class ShardingSphereAgent {
      * @throws IOException IO exception
      */
     public static void premain(final String args, final Instrumentation instrumentation) throws IOException {
-        File rootPath = AgentPath.getRootPath();
+        File rootPath = AgentPath.getRootPath(ClassLoader.getSystemClassLoader());
         Map<String, PluginConfiguration> pluginConfigs = PluginConfigurationLoader.load(rootPath);
         Collection<JarFile> pluginJars = PluginJarLoader.load(rootPath);
         Map<String, AdvisorConfiguration> advisorConfigs = AdvisorConfigurationLoader.load(pluginJars, pluginConfigs.keySet());

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/path/AgentPath.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/path/AgentPath.java
@@ -36,11 +36,12 @@ public final class AgentPath {
     /**
      * Get agent root path.
      *
+     * @param classLoader classLoader
      * @return agent root path
      */
-    public static File getRootPath() {
+    public static File getRootPath(final ClassLoader classLoader) {
         String classResourcePath = String.join("", AgentPath.class.getName().replaceAll("\\.", "/"), ".class");
-        URL resource = Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResource(classResourcePath), "Can not locate agent jar file.");
+        URL resource = Objects.requireNonNull(classLoader.getResource(classResourcePath), "Can not locate agent jar file.");
         return getJarFile(resource.toString()).getParentFile();
     }
     

--- a/agent/core/src/test/java/org/apache/shardingsphere/agent/core/path/AgentPathTest.java
+++ b/agent/core/src/test/java/org/apache/shardingsphere/agent/core/path/AgentPathTest.java
@@ -18,18 +18,14 @@
 package org.apache.shardingsphere.agent.core.path;
 
 import com.google.common.io.ByteStreams;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.internal.configuration.plugins.Plugins;
 
 import java.io.IOException;
-import java.io.File;
-import java.lang.reflect.InvocationTargetException;
 import java.io.InputStream;
-import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.jar.JarEntry;
@@ -49,23 +45,24 @@ class AgentPathTest {
     private Path tempDir;
     
     @Test
-    void assertGetRootPath() throws IOException, ReflectiveOperationException {
+    void assertGetRootPath() throws IOException {
         Path jarPath = createAgentJar(tempDir.resolve("agent-path.jar"));
-        URL resourceUrl = new URL(String.format("jar:%s!/%s", jarPath.toUri().toURL(), AGENT_PATH_RESOURCE));
-        assertThat(invokeGetJarFile(resourceUrl.toString()), is(jarPath.toFile()));
+        try (URLClassLoader customClassLoader = new URLClassLoader(new URL[]{jarPath.toUri().toURL()}, null)) {
+            assertThat(AgentPath.getRootPath(customClassLoader), is(jarPath.getParent().toFile()));
+        }
     }
     
     @Test
     void assertGetRootPathWhenJarMissing() throws IOException {
         URL resourceUrl = new URL("jar:file:/non-existent/path/agent-path.jar!/org/apache/shardingsphere/agent/core/path/AgentPath.class");
-        IllegalStateException ex = assertThrows(IllegalStateException.class, getGetJarFileExecutable(resourceUrl.toString()));
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> AgentPath.getRootPath(new SingleResourceClassLoader(resourceUrl)));
         assertThat(ex.getMessage(), is(String.format("Can not locate agent jar file by URL `%s`.", resourceUrl)));
     }
     
     @Test
     void assertGetRootPathWhenUrlMalformed() throws IOException {
         URL resourceUrl = new URL("jar:file:/invalid path!/org/apache/shardingsphere/agent/core/path/AgentPath.class");
-        IllegalStateException ex = assertThrows(IllegalStateException.class, getGetJarFileExecutable(resourceUrl.toString()));
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> AgentPath.getRootPath(new SingleResourceClassLoader(resourceUrl)));
         assertThat(ex.getMessage(), is(String.format("Can not locate agent jar file by URL `%s`.", resourceUrl)));
         assertThat(ex.getCause(), isA(URISyntaxException.class));
     }
@@ -83,19 +80,18 @@ class AgentPathTest {
         return jarPath;
     }
     
-    private Executable getGetJarFileExecutable(final String resourceUrl) {
-        return () -> invokeGetJarFile(resourceUrl);
-    }
-    
-    private File invokeGetJarFile(final String resourceUrl) throws ReflectiveOperationException {
-        Method getJarFileMethod = AgentPath.class.getDeclaredMethod("getJarFile", String.class);
-        try {
-            return (File) Plugins.getMemberAccessor().invoke(getJarFileMethod, null, resourceUrl);
-        } catch (final InvocationTargetException ex) {
-            if (ex.getCause() instanceof RuntimeException) {
-                throw (RuntimeException) ex.getCause();
-            }
-            throw ex;
+    private static final class SingleResourceClassLoader extends ClassLoader {
+        
+        private final URL resourceUrl;
+        
+        private SingleResourceClassLoader(final URL resourceUrl) {
+            super(null);
+            this.resourceUrl = resourceUrl;
+        }
+        
+        @Override
+        public URL getResource(final String name) {
+            return AGENT_PATH_RESOURCE.equals(name) ? resourceUrl : super.getResource(name);
         }
     }
 }

--- a/agent/core/src/test/java/org/apache/shardingsphere/agent/core/path/AgentPathTest.java
+++ b/agent/core/src/test/java/org/apache/shardingsphere/agent/core/path/AgentPathTest.java
@@ -18,23 +18,20 @@
 package org.apache.shardingsphere.agent.core.path;
 
 import com.google.common.io.ByteStreams;
-import net.bytebuddy.agent.ByteBuddyAgent;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.internal.configuration.plugins.Plugins;
 
 import java.io.IOException;
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.io.InputStream;
-import java.lang.instrument.Instrumentation;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
@@ -52,34 +49,25 @@ class AgentPathTest {
     private Path tempDir;
     
     @Test
-    void assertGetRootPath() throws IOException {
+    void assertGetRootPath() throws IOException, ReflectiveOperationException {
         Path jarPath = createAgentJar(tempDir.resolve("agent-path.jar"));
-        try (
-                URLClassLoader customClassLoader = new URLClassLoader(new URL[]{jarPath.toUri().toURL()}, null);
-                SystemClassLoaderContext ignored = new SystemClassLoaderContext(customClassLoader)) {
-            assertThat(AgentPath.getRootPath(), is(jarPath.getParent().toFile()));
-        }
+        URL resourceUrl = new URL(String.format("jar:%s!/%s", jarPath.toUri().toURL(), AGENT_PATH_RESOURCE));
+        assertThat(invokeGetJarFile(resourceUrl.toString()), is(jarPath.toFile()));
     }
     
     @Test
     void assertGetRootPathWhenJarMissing() throws IOException {
         URL resourceUrl = new URL("jar:file:/non-existent/path/agent-path.jar!/org/apache/shardingsphere/agent/core/path/AgentPath.class");
-        ClassLoader customClassLoader = new SingleResourceClassLoader(resourceUrl);
-        try (SystemClassLoaderContext ignored = new SystemClassLoaderContext(customClassLoader)) {
-            IllegalStateException ex = assertThrows(IllegalStateException.class, AgentPath::getRootPath);
-            assertThat(ex.getMessage(), is(String.format("Can not locate agent jar file by URL `%s`.", resourceUrl)));
-        }
+        IllegalStateException ex = assertThrows(IllegalStateException.class, getGetJarFileExecutable(resourceUrl.toString()));
+        assertThat(ex.getMessage(), is(String.format("Can not locate agent jar file by URL `%s`.", resourceUrl)));
     }
     
     @Test
     void assertGetRootPathWhenUrlMalformed() throws IOException {
         URL resourceUrl = new URL("jar:file:/invalid path!/org/apache/shardingsphere/agent/core/path/AgentPath.class");
-        ClassLoader customClassLoader = new SingleResourceClassLoader(resourceUrl);
-        try (SystemClassLoaderContext ignored = new SystemClassLoaderContext(customClassLoader)) {
-            IllegalStateException ex = assertThrows(IllegalStateException.class, AgentPath::getRootPath);
-            assertThat(ex.getMessage(), is(String.format("Can not locate agent jar file by URL `%s`.", resourceUrl)));
-            assertThat(ex.getCause(), isA(URISyntaxException.class));
-        }
+        IllegalStateException ex = assertThrows(IllegalStateException.class, getGetJarFileExecutable(resourceUrl.toString()));
+        assertThat(ex.getMessage(), is(String.format("Can not locate agent jar file by URL `%s`.", resourceUrl)));
+        assertThat(ex.getCause(), isA(URISyntaxException.class));
     }
     
     private Path createAgentJar(final Path jarPath) throws IOException {
@@ -95,82 +83,19 @@ class AgentPathTest {
         return jarPath;
     }
     
-    private static final class SystemClassLoaderContext implements AutoCloseable {
-        
-        private static final Field SYSTEM_CLASS_LOADER_FIELD = createSystemClassLoaderField();
-        
-        private static boolean javaLangOpened;
-        
-        private final ClassLoader originalClassLoader;
-        
-        private SystemClassLoaderContext(final ClassLoader classLoader) {
-            try {
-                originalClassLoader = (ClassLoader) SYSTEM_CLASS_LOADER_FIELD.get(null);
-                SYSTEM_CLASS_LOADER_FIELD.set(null, classLoader);
-            } catch (final IllegalAccessException ex) {
-                throw new IllegalStateException("Failed to override system class loader.", ex);
-            }
-        }
-        
-        @Override
-        public void close() {
-            try {
-                SYSTEM_CLASS_LOADER_FIELD.set(null, originalClassLoader);
-            } catch (final IllegalAccessException ex) {
-                throw new IllegalStateException("Failed to restore system class loader.", ex);
-            }
-        }
-        
-        private static Field createSystemClassLoaderField() {
-            ensureJavaLangOpened();
-            try {
-                Method getDeclaredFieldsMethod = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
-                getDeclaredFieldsMethod.setAccessible(true);
-                for (Field each : (Field[]) getDeclaredFieldsMethod.invoke(ClassLoader.class, false)) {
-                    if ("scl".equals(each.getName())) {
-                        each.setAccessible(true);
-                        return each;
-                    }
-                }
-                throw new IllegalStateException("System class loader field not found.");
-            } catch (final ReflectiveOperationException ex) {
-                throw new IllegalStateException("Failed to access system class loader field.", ex);
-            }
-        }
-        
-        private static void ensureJavaLangOpened() {
-            if (javaLangOpened) {
-                return;
-            }
-            try {
-                Class<?> moduleClass = Class.forName("java.lang.Module");
-                Method getModuleMethod = Class.class.getMethod("getModule");
-                Object javaBaseModule = getModuleMethod.invoke(Object.class);
-                Object currentModule = getModuleMethod.invoke(AgentPathTest.class);
-                Method redefineModuleMethod = Instrumentation.class.getMethod("redefineModule", moduleClass, Set.class, Map.class, Map.class, Set.class, Map.class);
-                redefineModuleMethod.invoke(ByteBuddyAgent.install(), javaBaseModule, Collections.emptySet(), Collections.emptyMap(),
-                        Collections.singletonMap("java.lang", Collections.singleton(currentModule)), Collections.emptySet(), Collections.emptyMap());
-                javaLangOpened = true;
-            } catch (final ClassNotFoundException | NoSuchMethodException ignored) {
-                javaLangOpened = true;
-            } catch (final ReflectiveOperationException ex) {
-                throw new IllegalStateException("Failed to open java.lang module for reflection.", ex);
-            }
-        }
+    private Executable getGetJarFileExecutable(final String resourceUrl) {
+        return () -> invokeGetJarFile(resourceUrl);
     }
     
-    private static final class SingleResourceClassLoader extends ClassLoader {
-        
-        private final URL resourceUrl;
-        
-        private SingleResourceClassLoader(final URL resourceUrl) {
-            super(null);
-            this.resourceUrl = resourceUrl;
-        }
-        
-        @Override
-        public URL getResource(final String name) {
-            return AGENT_PATH_RESOURCE.equals(name) ? resourceUrl : super.getResource(name);
+    private File invokeGetJarFile(final String resourceUrl) throws ReflectiveOperationException {
+        Method getJarFileMethod = AgentPath.class.getDeclaredMethod("getJarFile", String.class);
+        try {
+            return (File) Plugins.getMemberAccessor().invoke(getJarFileMethod, null, resourceUrl);
+        } catch (final InvocationTargetException ex) {
+            if (ex.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) ex.getCause();
+            }
+            throw ex;
         }
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Refactor AgentPath and AgentPathTest to support jdk26

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
