### PR TITLE
Fix PostgreSQL window aggregate merge on empty sharded table

### DIFF
--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByMemoryMergedResultTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByMemoryMergedResultTest.java
@@ -37,6 +37,8 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.Shor
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.GroupBySegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.OrderBySegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.item.IndexOrderByItemSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.AliasSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
@@ -210,6 +212,38 @@ class GroupByMemoryMergedResultTest {
         ShardingDQLResultMerger merger = new ShardingDQLResultMerger(databaseType);
         MergedResult actual = merger.merge(Arrays.asList(queryResult, queryResult, queryResult), createSelectStatementContext(database), database, mock(ConnectionContext.class));
         assertFalse(actual.next());
+    }
+    
+    @Test
+    void assertNextForEmptyResultWithWindowAggregation() throws SQLException {
+        when(database.getName()).thenReturn("db_schema");
+        QueryResult queryResult1 = createEmptyQueryResultWithWindowAggregation();
+        QueryResult queryResult2 = createEmptyQueryResultWithWindowAggregation();
+        ShardingDQLResultMerger resultMerger = new ShardingDQLResultMerger(databaseType);
+        MergedResult actual = resultMerger.merge(Arrays.asList(queryResult1, queryResult2), createSelectStatementContextForWindowAggregation(), database, mock(ConnectionContext.class));
+        assertFalse(actual.next());
+    }
+    
+    private QueryResult createEmptyQueryResultWithWindowAggregation() throws SQLException {
+        QueryResult result = mock(QueryResult.class, RETURNS_DEEP_STUBS);
+        when(result.getMetaData().getColumnCount()).thenReturn(1);
+        when(result.getMetaData().getColumnLabel(1)).thenReturn("c_5");
+        when(result.next()).thenReturn(false);
+        return result;
+    }
+    
+    private SelectStatementContext createSelectStatementContextForWindowAggregation() {
+        ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
+        AggregationProjectionSegment aggregationProjectionSegment = new AggregationProjectionSegment(
+                0, 0, AggregationType.MAX, "pg_catalog.max(ref_0.c36) over (partition by ref_0.c39 order by ref_0.vkey desc)");
+        aggregationProjectionSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("c_5")));
+        aggregationProjectionSegment.setWindow(new WindowItemSegment(29, 86));
+        projectionsSegment.getProjections().add(aggregationProjectionSegment);
+        SelectStatement selectStatement = SelectStatement.builder().databaseType(databaseType).projections(projectionsSegment).build();
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        when(database.getName()).thenReturn("foo_db");
+        return new SelectStatementContext(
+                selectStatement, new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), mock()), "foo_db", Collections.emptyList());
     }
     
     @Test

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngine.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngine.java
@@ -116,7 +116,10 @@ public final class ProjectionEngine {
         return new ExpressionProjection(projectionSegment, projectionSegment.getAlias().orElse(null), databaseType);
     }
     
-    private AggregationDistinctProjection createProjection(final AggregationDistinctProjectionSegment projectionSegment) {
+    private Projection createProjection(final AggregationDistinctProjectionSegment projectionSegment) {
+        if (projectionSegment.getWindow().isPresent()) {
+            return createExpressionProjection(projectionSegment);
+        }
         IdentifierValue alias =
                 projectionSegment.getAlias().orElseGet(() -> new IdentifierValue(DerivedColumn.AGGREGATION_DISTINCT_DERIVED.getDerivedColumnAlias(aggregationDistinctDerivedColumnCount++)));
         AggregationDistinctProjection result = new AggregationDistinctProjection(
@@ -128,7 +131,10 @@ public final class ProjectionEngine {
         return result;
     }
     
-    private AggregationProjection createProjection(final AggregationProjectionSegment projectionSegment) {
+    private Projection createProjection(final AggregationProjectionSegment projectionSegment) {
+        if (projectionSegment.getWindow().isPresent()) {
+            return createExpressionProjection(projectionSegment);
+        }
         AggregationProjection result =
                 new AggregationProjection(projectionSegment.getType(), projectionSegment, projectionSegment.getAlias().orElse(null), databaseType,
                         projectionSegment.getSeparator().orElse(null));
@@ -137,6 +143,12 @@ public final class ProjectionEngine {
             // TODO replace avg to constant, avoid calculate useless avg
         }
         return result;
+    }
+    
+    private ExpressionProjection createExpressionProjection(final AggregationProjectionSegment projectionSegment) {
+        ExpressionProjectionSegment expressionSegment =
+                new ExpressionProjectionSegment(projectionSegment.getStartIndex(), projectionSegment.getStopIndex(), projectionSegment.getExpression(), projectionSegment);
+        return new ExpressionProjection(expressionSegment, projectionSegment.getAlias().orElse(null), databaseType);
     }
     
     private void appendAverageDistinctDerivedProjection(final AggregationDistinctProjection averageDistinctProjection) {

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngineTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngineTest.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.Expr
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ShorthandProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.AliasSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.OwnerSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -115,6 +116,17 @@ class ProjectionEngineTest {
         Optional<Projection> actual = new ProjectionEngine(databaseType).createProjection(aggregationProjectionSegment);
         assertTrue(actual.isPresent());
         assertThat(actual.get(), isA(AggregationProjection.class));
+    }
+    
+    @Test
+    void assertCreateExpressionProjectionWhenAggregationProjectionSegmentContainsWindow() {
+        AggregationProjectionSegment aggregationProjectionSegment = new AggregationProjectionSegment(0, 25, AggregationType.MAX, "MAX(id) OVER ()");
+        aggregationProjectionSegment.setWindow(new WindowItemSegment(8, 25));
+        aggregationProjectionSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("max_id")));
+        Optional<Projection> actual = new ProjectionEngine(databaseType).createProjection(aggregationProjectionSegment);
+        assertTrue(actual.isPresent());
+        assertThat(actual.get(), isA(ExpressionProjection.class));
+        assertThat(actual.get().getAlias().map(IdentifierValue::getValue).orElse(null), is("max_id"));
     }
     
     @Test

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngineTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngineTest.java
@@ -39,18 +39,15 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.Owner
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(MockitoExtension.class)
 class ProjectionEngineTest {
     
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");

--- a/infra/binder/dialect/opengauss/src/test/java/org/apache/shardingsphere/infra/binder/opengauss/OpenGaussProjectionIdentifierExtractorTest.java
+++ b/infra/binder/dialect/opengauss/src/test/java/org/apache/shardingsphere/infra/binder/opengauss/OpenGaussProjectionIdentifierExtractorTest.java
@@ -20,18 +20,27 @@ package org.apache.shardingsphere.infra.binder.opengauss;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;
+import org.apache.shardingsphere.infra.binder.context.segment.select.projection.engine.ProjectionEngine;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.extractor.DialectProjectionIdentifierExtractor;
+import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ExpressionProjection;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.AggregationType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.FunctionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubquerySegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ExpressionProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.SubqueryProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OpenGaussProjectionIdentifierExtractorTest {
     
@@ -60,7 +69,17 @@ class OpenGaussProjectionIdentifierExtractorTest {
     }
     
     @Test
+    void assertGetColumnLabelFromWindowAggregationProjection() {
+        AggregationProjectionSegment aggregationProjectionSegment = new AggregationProjectionSegment(0, 0, AggregationType.MAX, "pg_catalog.max(ref_0.c36) over ()");
+        aggregationProjectionSegment.setWindow(new WindowItemSegment(19, 27));
+        Optional<Projection> actual = new ProjectionEngine(databaseType).createProjection(aggregationProjectionSegment);
+        assertTrue(actual.isPresent());
+        assertThat(actual.get(), isA(ExpressionProjection.class));
+        assertThat(actual.get().getColumnLabel(), is("max"));
+    }
+    
+    @Test
     void assertGetColumnNameFromSubquery() {
-        assertThat(extractor.getColumnNameFromSubquery(new SubqueryProjectionSegment(mock(SubquerySegment.class), "text")), is("text"));
+        assertThat(extractor.getColumnNameFromSubquery(new SubqueryProjectionSegment(new SubquerySegment(0, 0, "text"), "text")), is("text"));
     }
 }

--- a/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractor.java
+++ b/infra/binder/dialect/postgresql/src/main/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractor.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.binder.postgresql;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.extractor.DialectProjectionIdentifierExtractor;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.FunctionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ExpressionProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.SubqueryProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
@@ -41,9 +42,18 @@ public final class PostgreSQLProjectionIdentifierExtractor implements DialectPro
     
     @Override
     public String getColumnNameFromExpression(final ExpressionSegment expressionSegment) {
-        return expressionSegment instanceof ExpressionProjectionSegment && ((ExpressionProjectionSegment) expressionSegment).getExpr() instanceof FunctionSegment
-                ? ((FunctionSegment) ((ExpressionProjectionSegment) expressionSegment).getExpr()).getFunctionName()
-                : "?column?";
+        if (!(expressionSegment instanceof ExpressionProjectionSegment)) {
+            return "?column?";
+        }
+        ExpressionSegment innerExpressionSegment = ((ExpressionProjectionSegment) expressionSegment).getExpr();
+        if (innerExpressionSegment instanceof FunctionSegment) {
+            return ((FunctionSegment) innerExpressionSegment).getFunctionName();
+        }
+        if (innerExpressionSegment instanceof AggregationProjectionSegment) {
+            AggregationProjectionSegment aggregationProjectionSegment = (AggregationProjectionSegment) innerExpressionSegment;
+            return getColumnNameFromFunction(aggregationProjectionSegment.getType().name(), aggregationProjectionSegment.getExpression());
+        }
+        return "?column?";
     }
     
     @Override

--- a/infra/binder/dialect/postgresql/src/test/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractorTest.java
+++ b/infra/binder/dialect/postgresql/src/test/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractorTest.java
@@ -22,14 +22,14 @@ import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoa
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.engine.ProjectionEngine;
-import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ExpressionProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.extractor.DialectProjectionIdentifierExtractor;
-import org.apache.shardingsphere.sql.parser.statement.core.enums.AggregationType;
+import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ExpressionProjection;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.AggregationType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.FunctionSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubquerySegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ExpressionProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.SubqueryProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
@@ -41,7 +41,6 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
-import static org.mockito.Mockito.mock;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PostgreSQLProjectionIdentifierExtractorTest {
@@ -67,7 +66,7 @@ class PostgreSQLProjectionIdentifierExtractorTest {
     
     @Test
     void assertGetColumnNameFromExpressionWithNonExpressionProjection() {
-        assertThat(extractor.getColumnNameFromExpression(mock(ExpressionSegment.class)), is("?column?"));
+        assertThat(extractor.getColumnNameFromExpression(new ParameterMarkerExpressionSegment(0, 0, 0)), is("?column?"));
     }
     
     @Test
@@ -87,6 +86,6 @@ class PostgreSQLProjectionIdentifierExtractorTest {
     
     @Test
     void assertGetColumnNameFromSubquery() {
-        assertThat(extractor.getColumnNameFromSubquery(new SubqueryProjectionSegment(mock(SubquerySegment.class), "text")), is("text"));
+        assertThat(extractor.getColumnNameFromSubquery(new SubqueryProjectionSegment(new SubquerySegment(0, 0, "text"), "text")), is("text"));
     }
 }

--- a/infra/binder/dialect/postgresql/src/test/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractorTest.java
+++ b/infra/binder/dialect/postgresql/src/test/java/org/apache/shardingsphere/infra/binder/postgresql/PostgreSQLProjectionIdentifierExtractorTest.java
@@ -20,19 +20,29 @@ package org.apache.shardingsphere.infra.binder.postgresql;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;
+import org.apache.shardingsphere.infra.binder.context.segment.select.projection.engine.ProjectionEngine;
+import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ExpressionProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.extractor.DialectProjectionIdentifierExtractor;
+import org.apache.shardingsphere.sql.parser.statement.core.enums.AggregationType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.FunctionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubquerySegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ExpressionProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.SubqueryProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PostgreSQLProjectionIdentifierExtractorTest {
     
@@ -63,6 +73,16 @@ class PostgreSQLProjectionIdentifierExtractorTest {
     @Test
     void assertGetColumnNameFromFunctionExpression() {
         assertThat(extractor.getColumnNameFromExpression(new ExpressionProjectionSegment(0, 0, "SUM(ID)", new FunctionSegment(0, 0, "SUM", "SUM(ID)"))), is("SUM"));
+    }
+    
+    @Test
+    void assertGetColumnLabelFromWindowAggregationProjection() {
+        AggregationProjectionSegment aggregationProjectionSegment = new AggregationProjectionSegment(0, 0, AggregationType.MAX, "pg_catalog.max(ref_0.c36) over ()");
+        aggregationProjectionSegment.setWindow(new WindowItemSegment(19, 27));
+        Optional<Projection> actual = new ProjectionEngine(databaseType).createProjection(aggregationProjectionSegment);
+        assertTrue(actual.isPresent());
+        assertThat(actual.get(), isA(ExpressionProjection.class));
+        assertThat(actual.get().getColumnLabel(), is("max"));
     }
     
     @Test

--- a/parser/sql/engine/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitor.java
+++ b/parser/sql/engine/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitor.java
@@ -80,6 +80,7 @@ import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.Nat
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.NullsOrderContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.NumberLiteralsContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.OptOnDuplicateKeyContext;
+import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.OverClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.OuterJoinTypeContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.OwnerContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.ParameterMarkerContext;
@@ -116,6 +117,7 @@ import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.Whe
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.WindowClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.WindowDefinitionContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.WindowDefinitionListContext;
+import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.WindowSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.WithClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParserBaseVisitor;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.AggregationType;
@@ -453,7 +455,60 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementParser
         if (null != ctx.functionExprCommonSubexpr()) {
             return visit(ctx.functionExprCommonSubexpr());
         }
-        return visit(ctx.funcApplication());
+        ASTNode result = visit(ctx.funcApplication());
+        return null == ctx.overClause() ? result : appendWindow(ctx, result);
+    }
+    
+    private ASTNode appendWindow(final FuncExprContext ctx, final ASTNode node) {
+        WindowItemSegment window = (WindowItemSegment) visit(ctx.overClause());
+        if (node instanceof AggregationDistinctProjectionSegment) {
+            AggregationDistinctProjectionSegment result = createAggregationDistinctSegmentWithWindow(ctx, (AggregationDistinctProjectionSegment) node, window);
+            return result;
+        }
+        if (node instanceof AggregationProjectionSegment) {
+            AggregationProjectionSegment result = createAggregationSegmentWithWindow(ctx, (AggregationProjectionSegment) node, window);
+            return result;
+        }
+        if (node instanceof FunctionSegment) {
+            FunctionSegment result = createFunctionSegmentWithWindow(ctx, (FunctionSegment) node, window);
+            return result;
+        }
+        return node;
+    }
+    
+    private AggregationDistinctProjectionSegment createAggregationDistinctSegmentWithWindow(final FuncExprContext ctx, final AggregationDistinctProjectionSegment segment,
+                                                                                            final WindowItemSegment window) {
+        AggregationDistinctProjectionSegment result = new AggregationDistinctProjectionSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), segment.getType(), getOriginalText(ctx),
+                segment.getDistinctInnerExpression(), segment.getSeparator().orElse(null));
+        result.getParameters().addAll(segment.getParameters());
+        result.setWindow(window);
+        return result;
+    }
+    
+    private AggregationProjectionSegment createAggregationSegmentWithWindow(final FuncExprContext ctx, final AggregationProjectionSegment segment, final WindowItemSegment window) {
+        AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), segment.getType(), getOriginalText(ctx),
+                segment.getSeparator().orElse(null));
+        result.getParameters().addAll(segment.getParameters());
+        result.setWindow(window);
+        return result;
+    }
+    
+    private FunctionSegment createFunctionSegmentWithWindow(final FuncExprContext ctx, final FunctionSegment segment, final WindowItemSegment window) {
+        FunctionSegment result = new FunctionSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), segment.getFunctionName(), getOriginalText(ctx));
+        result.setOwner(segment.getOwner());
+        result.getParameters().addAll(segment.getParameters());
+        result.setWindow(window);
+        return result;
+    }
+    
+    @Override
+    public ASTNode visitOverClause(final OverClauseContext ctx) {
+        if (null != ctx.windowSpecification()) {
+            return createWindowItem(ctx.windowSpecification());
+        }
+        WindowItemSegment result = new WindowItemSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex());
+        result.setWindowName(new IdentifierValue(ctx.colId().getText()));
+        return result;
     }
     
     @Override
@@ -1096,24 +1151,36 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementParser
         windowItems.add((WindowItemSegment) visit(ctx.windowDefinition()));
     }
     
-    @SuppressWarnings("unchecked")
     @Override
     public ASTNode visitWindowDefinition(final WindowDefinitionContext ctx) {
         WindowItemSegment result = new WindowItemSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex());
         result.setWindowName(new IdentifierValue(ctx.colId().getText()));
-        if (null != ctx.windowSpecification().partitionClause()) {
-            CollectionValue<ExpressionSegment> value = (CollectionValue<ExpressionSegment>) visit(ctx.windowSpecification().partitionClause().exprList());
+        setWindowSpecification(ctx.windowSpecification(), result);
+        return result;
+    }
+    
+    private WindowItemSegment createWindowItem(final WindowSpecificationContext ctx) {
+        WindowItemSegment result = new WindowItemSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex());
+        if (null != ctx.existingWindowName()) {
+            result.setWindowName(new IdentifierValue(ctx.existingWindowName().colId().getText()));
+        }
+        setWindowSpecification(ctx, result);
+        return result;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private void setWindowSpecification(final WindowSpecificationContext ctx, final WindowItemSegment result) {
+        if (null != ctx.partitionClause()) {
+            CollectionValue<ExpressionSegment> value = (CollectionValue<ExpressionSegment>) visit(ctx.partitionClause().exprList());
             result.setPartitionListSegments(value.getValue());
         }
-        if (null != ctx.windowSpecification().sortClause()) {
-            OrderBySegment orderBySegment = (OrderBySegment) visit(ctx.windowSpecification().sortClause());
+        if (null != ctx.sortClause()) {
+            OrderBySegment orderBySegment = (OrderBySegment) visit(ctx.sortClause());
             result.setOrderBySegment(orderBySegment);
         }
-        if (null != ctx.windowSpecification().frameClause()) {
-            result.setFrameClause(new CommonExpressionSegment(ctx.windowSpecification().frameClause().start.getStartIndex(), ctx.windowSpecification().frameClause().stop.getStopIndex(),
-                    ctx.windowSpecification().frameClause().getText()));
+        if (null != ctx.frameClause()) {
+            result.setFrameClause(new CommonExpressionSegment(ctx.frameClause().start.getStartIndex(), ctx.frameClause().stop.getStopIndex(), ctx.frameClause().getText()));
         }
-        return result;
     }
     
     @Override

--- a/parser/sql/engine/dialect/opengauss/src/test/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitorTest.java
+++ b/parser/sql/engine/dialect/opengauss/src/test/java/org/apache/shardingsphere/sql/parser/engine/opengauss/visitor/statement/OpenGaussStatementVisitorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.engine.opengauss.visitor.statement;
+
+import org.apache.shardingsphere.sql.parser.engine.api.CacheOption;
+import org.apache.shardingsphere.sql.parser.engine.api.SQLParserEngine;
+import org.apache.shardingsphere.sql.parser.engine.api.SQLStatementVisitorEngine;
+import org.apache.shardingsphere.sql.parser.engine.core.ParseASTNode;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenGaussStatementVisitorTest {
+    
+    @Test
+    void assertVisitWindowAggregationProjection() {
+        String sql = "select pg_catalog.max(ref_0.c36) over (partition by ref_0.c39 order by ref_0.vkey desc) as c_5 from t24 as ref_0";
+        SelectStatement statement = parseSelectStatement(sql);
+        ProjectionSegment projection = statement.getProjections().getProjections().iterator().next();
+        assertThat(projection, isA(AggregationProjectionSegment.class));
+        AggregationProjectionSegment aggregationProjection = (AggregationProjectionSegment) projection;
+        assertThat(aggregationProjection.getExpression(), is("pg_catalog.max(ref_0.c36) over (partition by ref_0.c39 order by ref_0.vkey desc)"));
+        assertThat(aggregationProjection.getAliasName().orElse(null), is("c_5"));
+        assertTrue(aggregationProjection.getWindow().isPresent());
+        WindowItemSegment windowItem = aggregationProjection.getWindow().get();
+        assertThat(windowItem.getOrderBySegment().getOrderByItems().size(), is(1));
+    }
+    
+    private SelectStatement parseSelectStatement(final String sql) {
+        ParseASTNode parseASTNode = new SQLParserEngine("openGauss", new CacheOption(128, 1024L)).parse(sql, false);
+        return (SelectStatement) new SQLStatementVisitorEngine("openGauss").visit(parseASTNode);
+    }
+}

--- a/parser/sql/engine/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/engine/postgresql/visitor/statement/PostgreSQLStatementVisitor.java
+++ b/parser/sql/engine/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/engine/postgresql/visitor/statement/PostgreSQLStatementVisitor.java
@@ -81,6 +81,7 @@ import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.Na
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.NullsOrderContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.NumberLiteralsContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.OptOnConflictContext;
+import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.OverClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.OuterJoinTypeContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.OwnerContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.ParameterMarkerContext;
@@ -117,6 +118,7 @@ import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.Wh
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.WindowClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.WindowDefinitionContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.WindowDefinitionListContext;
+import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.WindowSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.WithClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParserBaseVisitor;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.AggregationType;
@@ -463,7 +465,60 @@ public abstract class PostgreSQLStatementVisitor extends PostgreSQLStatementPars
         if (null != ctx.functionExprCommonSubexpr()) {
             return visit(ctx.functionExprCommonSubexpr());
         }
-        return visit(ctx.funcApplication());
+        ASTNode result = visit(ctx.funcApplication());
+        return null == ctx.overClause() ? result : appendWindow(ctx, result);
+    }
+    
+    private ASTNode appendWindow(final FuncExprContext ctx, final ASTNode node) {
+        WindowItemSegment window = (WindowItemSegment) visit(ctx.overClause());
+        if (node instanceof AggregationDistinctProjectionSegment) {
+            AggregationDistinctProjectionSegment result = createAggregationDistinctSegmentWithWindow(ctx, (AggregationDistinctProjectionSegment) node, window);
+            return result;
+        }
+        if (node instanceof AggregationProjectionSegment) {
+            AggregationProjectionSegment result = createAggregationSegmentWithWindow(ctx, (AggregationProjectionSegment) node, window);
+            return result;
+        }
+        if (node instanceof FunctionSegment) {
+            FunctionSegment result = createFunctionSegmentWithWindow(ctx, (FunctionSegment) node, window);
+            return result;
+        }
+        return node;
+    }
+    
+    private AggregationDistinctProjectionSegment createAggregationDistinctSegmentWithWindow(final FuncExprContext ctx, final AggregationDistinctProjectionSegment segment,
+                                                                                            final WindowItemSegment window) {
+        AggregationDistinctProjectionSegment result = new AggregationDistinctProjectionSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), segment.getType(), getOriginalText(ctx),
+                segment.getDistinctInnerExpression(), segment.getSeparator().orElse(null));
+        result.getParameters().addAll(segment.getParameters());
+        result.setWindow(window);
+        return result;
+    }
+    
+    private AggregationProjectionSegment createAggregationSegmentWithWindow(final FuncExprContext ctx, final AggregationProjectionSegment segment, final WindowItemSegment window) {
+        AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), segment.getType(), getOriginalText(ctx),
+                segment.getSeparator().orElse(null));
+        result.getParameters().addAll(segment.getParameters());
+        result.setWindow(window);
+        return result;
+    }
+    
+    private FunctionSegment createFunctionSegmentWithWindow(final FuncExprContext ctx, final FunctionSegment segment, final WindowItemSegment window) {
+        FunctionSegment result = new FunctionSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), segment.getFunctionName(), getOriginalText(ctx));
+        result.setOwner(segment.getOwner());
+        result.getParameters().addAll(segment.getParameters());
+        result.setWindow(window);
+        return result;
+    }
+    
+    @Override
+    public ASTNode visitOverClause(final OverClauseContext ctx) {
+        if (null != ctx.windowSpecification()) {
+            return createWindowItem(ctx.windowSpecification());
+        }
+        WindowItemSegment result = new WindowItemSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex());
+        result.setWindowName(new IdentifierValue(ctx.colId().getText()));
+        return result;
     }
     
     @Override
@@ -1071,24 +1126,36 @@ public abstract class PostgreSQLStatementVisitor extends PostgreSQLStatementPars
         windowItems.add((WindowItemSegment) visit(ctx.windowDefinition()));
     }
     
-    @SuppressWarnings("unchecked")
     @Override
     public ASTNode visitWindowDefinition(final WindowDefinitionContext ctx) {
         WindowItemSegment result = new WindowItemSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex());
         result.setWindowName(new IdentifierValue(ctx.colId().getText()));
-        if (null != ctx.windowSpecification().partitionClause()) {
-            CollectionValue<ExpressionSegment> value = (CollectionValue<ExpressionSegment>) visit(ctx.windowSpecification().partitionClause().exprList());
+        setWindowSpecification(ctx.windowSpecification(), result);
+        return result;
+    }
+    
+    private WindowItemSegment createWindowItem(final WindowSpecificationContext ctx) {
+        WindowItemSegment result = new WindowItemSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex());
+        if (null != ctx.existingWindowName()) {
+            result.setWindowName(new IdentifierValue(ctx.existingWindowName().colId().getText()));
+        }
+        setWindowSpecification(ctx, result);
+        return result;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private void setWindowSpecification(final WindowSpecificationContext ctx, final WindowItemSegment result) {
+        if (null != ctx.partitionClause()) {
+            CollectionValue<ExpressionSegment> value = (CollectionValue<ExpressionSegment>) visit(ctx.partitionClause().exprList());
             result.setPartitionListSegments(value.getValue());
         }
-        if (null != ctx.windowSpecification().sortClause()) {
-            OrderBySegment orderBySegment = (OrderBySegment) visit(ctx.windowSpecification().sortClause());
+        if (null != ctx.sortClause()) {
+            OrderBySegment orderBySegment = (OrderBySegment) visit(ctx.sortClause());
             result.setOrderBySegment(orderBySegment);
         }
-        if (null != ctx.windowSpecification().frameClause()) {
-            result.setFrameClause(new CommonExpressionSegment(ctx.windowSpecification().frameClause().start.getStartIndex(), ctx.windowSpecification().frameClause().stop.getStopIndex(),
-                    ctx.windowSpecification().frameClause().getText()));
+        if (null != ctx.frameClause()) {
+            result.setFrameClause(new CommonExpressionSegment(ctx.frameClause().start.getStartIndex(), ctx.frameClause().stop.getStopIndex(), ctx.frameClause().getText()));
         }
-        return result;
     }
     
     @Override

--- a/parser/sql/engine/dialect/postgresql/src/test/java/org/apache/shardingsphere/sql/parser/engine/postgresql/visitor/statement/PostgreSQLStatementVisitorTest.java
+++ b/parser/sql/engine/dialect/postgresql/src/test/java/org/apache/shardingsphere/sql/parser/engine/postgresql/visitor/statement/PostgreSQLStatementVisitorTest.java
@@ -23,6 +23,9 @@ import org.apache.shardingsphere.sql.parser.engine.api.SQLStatementVisitorEngine
 import org.apache.shardingsphere.sql.parser.engine.core.ParseASTNode;
 import org.apache.shardingsphere.sql.parser.statement.core.extractor.TableExtractor;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.NotExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.AggregationProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WindowItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +34,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -49,5 +53,24 @@ class PostgreSQLStatementVisitorTest {
         Collection<String> rewriteTableNames = tableExtractor.getRewriteTables().stream()
                 .map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList());
         assertThat(rewriteTableNames, hasItems("t17", "t23", "t22"));
+    }
+    
+    @Test
+    void assertVisitWindowAggregationProjection() {
+        String sql = "select pg_catalog.max(ref_0.c36) over (partition by ref_0.c39 order by ref_0.vkey desc) as c_5 from t24 as ref_0";
+        SelectStatement statement = parseSelectStatement(sql);
+        ProjectionSegment projection = statement.getProjections().getProjections().iterator().next();
+        assertThat(projection, isA(AggregationProjectionSegment.class));
+        AggregationProjectionSegment aggregationProjection = (AggregationProjectionSegment) projection;
+        assertThat(aggregationProjection.getExpression(), is("pg_catalog.max(ref_0.c36) over (partition by ref_0.c39 order by ref_0.vkey desc)"));
+        assertThat(aggregationProjection.getAliasName().orElse(null), is("c_5"));
+        assertTrue(aggregationProjection.getWindow().isPresent());
+        WindowItemSegment windowItem = aggregationProjection.getWindow().get();
+        assertThat(windowItem.getOrderBySegment().getOrderByItems().size(), is(1));
+    }
+    
+    private SelectStatement parseSelectStatement(final String sql) {
+        ParseASTNode parseASTNode = new SQLParserEngine("PostgreSQL", new CacheOption(128, 1024L)).parse(sql, false);
+        return (SelectStatement) new SQLStatementVisitorEngine("PostgreSQL").visit(parseASTNode);
     }
 }


### PR DESCRIPTION
Fixes #38642.

## Summary

This PR fixes PostgreSQL window aggregate queries on empty sharded tables returning one `NULL` row instead of zero rows.

For a query like:

```sql
select pg_catalog.max(ref_0.c36) over (partition by ref_0.c39 order by ref_0.vkey desc) as c_5
from t24 as ref_0;
```

PostgreSQL should return zero rows when the input table is empty, because window functions produce one result per input row.

## Root Cause

PostgreSQL `OVER` clauses were not preserved on parsed aggregate projection segments. As a result, `max(...) over (...)` was bound as a normal aggregate projection, causing the sharding merge layer to use the aggregate merge path.

For empty routed results, `GroupByMemoryMergedResult` synthesizes one aggregate row, which is correct for plain aggregate queries like `select max(...) from t24`, but incorrect for window aggregate queries.

## Changes

- Preserve PostgreSQL `OVER` clauses on function and aggregate projection segments.
- Bind windowed aggregate projection segments as expression projections instead of aggregate projections.
- Add regression coverage for PostgreSQL window aggregate parsing.
- Add binder coverage for windowed aggregate projection classification.
- Add sharding merge coverage to ensure empty window aggregate results stay empty.

## Tests

```bash
./mvnw -pl parser/sql/engine/dialect/postgresql -am -DskipITs -Dtest=PostgreSQLStatementVisitorTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl infra/binder/core -am -DskipITs -Dtest=ProjectionEngineTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl features/sharding/core -am -DskipITs -Dtest=GroupByMemoryMergedResultTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -Pcheck -pl infra/binder/core,parser/sql/engine/dialect/postgresql,features/sharding/core -DskipTests -DskipITs spotless:check
./mvnw -Pcheck -pl infra/binder/core,parser/sql/engine/dialect/postgresql,features/sharding/core -DskipTests -DskipITs validate
```
