### PR TITLE
Support parsing Doris RECOVER syntax for database, table, and partition

### DIFF
--- a/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
+++ b/parser/sql/engine/core/src/main/java/org/apache/shardingsphere/sql/parser/engine/core/database/visitor/SQLVisitorRule.java
@@ -595,6 +595,8 @@ public enum SQLVisitorRule {
     
     ADMIN_CLEAN_TRASH("AdminCleanTrash", SQLStatementType.DAL),
     
+    RECOVER("Recover", SQLStatementType.DAL),
+    
     CLEAN_ALL_PROFILE("CleanAllProfile", SQLStatementType.DAL),
     
     PLAN_REPLAYER_PLAY("PlanReplayerPlay", SQLStatementType.DAL),

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DALStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/imports/doris/DALStatement.g4
@@ -883,6 +883,22 @@ cancelLoadWhereCondition
     | STATE EQ_ string_
     ;
 
+recover
+    : RECOVER (recoverDatabase | recoverTable | recoverPartition)
+    ;
+
+recoverDatabase
+    : DATABASE databaseName NUMBER_? (AS databaseName)?
+    ;
+
+recoverTable
+    : TABLE tableName NUMBER_? (AS identifier)?
+    ;
+
+recoverPartition
+    : PARTITION partitionName NUMBER_? FROM tableName
+    ;
+
 show
     : showDatabases
     | showDatabase

--- a/parser/sql/engine/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
+++ b/parser/sql/engine/dialect/doris/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/DorisStatement.g4
@@ -173,6 +173,7 @@ execute
     | cancelLoadStatement
     | cleanAllProfile
     | planReplayerPlay
+    | recover
     // TODO consider refactor following sytax to SEMI_? EOF
     ) (SEMI_ EOF? | EOF)
     | EOF

--- a/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDALStatementVisitor.java
+++ b/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDALStatementVisitor.java
@@ -181,6 +181,10 @@ import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.BackupT
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CancelBackupContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CancelLoadStatementContext;
 import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.CancelLoadWhereConditionContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RecoverContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RecoverDatabaseContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RecoverPartitionContext;
+import org.apache.shardingsphere.sql.parser.autogen.DorisStatementParser.RecoverTableContext;
 import org.apache.shardingsphere.sql.parser.engine.doris.visitor.statement.DorisStatementVisitor;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.BackupTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.CacheTableIndexSegment;
@@ -234,6 +238,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.value.literal.impl.Te
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminCleanTrashStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCleanAllProfileStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisPlanReplayerPlayStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisRecoverStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminSetReplicaStatusStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminSetReplicaVersionStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminCopyTabletStatement;
@@ -1701,5 +1706,49 @@ public final class DorisDALStatementVisitor extends DorisStatementVisitor implem
             result.setConditionValue(SQLUtils.getExactlyValue(condCtx.string_().getText()));
         }
         return result;
+    }
+    
+    @Override
+    public ASTNode visitRecover(final RecoverContext ctx) {
+        DorisRecoverStatement result = new DorisRecoverStatement(getDatabaseType());
+        if (null != ctx.recoverDatabase()) {
+            visitRecoverDatabase(ctx.recoverDatabase(), result);
+        } else if (null != ctx.recoverTable()) {
+            visitRecoverTable(ctx.recoverTable(), result);
+        } else {
+            visitRecoverPartition(ctx.recoverPartition(), result);
+        }
+        return result;
+    }
+    
+    private void visitRecoverDatabase(final RecoverDatabaseContext ctx, final DorisRecoverStatement statement) {
+        statement.setObjectType(DorisRecoverStatement.RecoverObjectType.DATABASE);
+        statement.setDatabase((DatabaseSegment) visit(ctx.databaseName(0)));
+        if (null != ctx.NUMBER_()) {
+            statement.setObjectId(Long.parseLong(ctx.NUMBER_().getText()));
+        }
+        if (null != ctx.AS()) {
+            statement.setNewName(((DatabaseSegment) visit(ctx.databaseName(1))).getIdentifier().getValue());
+        }
+    }
+    
+    private void visitRecoverTable(final RecoverTableContext ctx, final DorisRecoverStatement statement) {
+        statement.setObjectType(DorisRecoverStatement.RecoverObjectType.TABLE);
+        statement.setTable((SimpleTableSegment) visit(ctx.tableName()));
+        if (null != ctx.NUMBER_()) {
+            statement.setObjectId(Long.parseLong(ctx.NUMBER_().getText()));
+        }
+        if (null != ctx.AS()) {
+            statement.setNewName(((IdentifierValue) visit(ctx.identifier())).getValue());
+        }
+    }
+    
+    private void visitRecoverPartition(final RecoverPartitionContext ctx, final DorisRecoverStatement statement) {
+        statement.setObjectType(DorisRecoverStatement.RecoverObjectType.PARTITION);
+        statement.setPartitionName(((PartitionSegment) visit(ctx.partitionName())).getName().getValue());
+        if (null != ctx.NUMBER_()) {
+            statement.setObjectId(Long.parseLong(ctx.NUMBER_().getText()));
+        }
+        statement.setTable((SimpleTableSegment) visit(ctx.tableName()));
     }
 }

--- a/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisRecoverStatement.java
+++ b/parser/sql/statement/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/statement/doris/dal/DorisRecoverStatement.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.doris.dal;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.DatabaseSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.DALStatement;
+
+/**
+ * Recover statement for Doris.
+ */
+@Getter
+@Setter
+public final class DorisRecoverStatement extends DALStatement {
+    
+    private RecoverObjectType objectType;
+    
+    private DatabaseSegment database;
+    
+    private SimpleTableSegment table;
+    
+    private String partitionName;
+    
+    private Long objectId;
+    
+    private String newName;
+    
+    public DorisRecoverStatement(final DatabaseType databaseType) {
+        super(databaseType);
+    }
+    
+    public enum RecoverObjectType {
+        DATABASE, TABLE, PARTITION
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/DorisDALStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/DorisDALStatementAssert.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.Un
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminCleanTrashStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisCleanAllProfileStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisPlanReplayerPlayStatement;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisRecoverStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminCopyTabletStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminSetReplicaStatusStatement;
 import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisAdminSetReplicaVersionStatement;
@@ -57,6 +58,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAsse
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisAdminCleanTrashStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisCleanAllProfileStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisPlanReplayerPlayStatementAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisRecoverStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisAdminCopyTabletStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisAdminSetReplicaStatusStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type.DorisAdminSetReplicaVersionStatementAssert;
@@ -91,6 +93,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.S
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminCleanTrashStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCleanAllProfileStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisPlanReplayerPlayStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisRecoverStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminCopyTabletStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminSetReplicaStatusStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminSetReplicaVersionStatementTestCase;
@@ -182,6 +185,8 @@ public final class DorisDALStatementAssert {
             DorisShowEncryptKeysStatementAssert.assertIs(assertContext, (DorisShowEncryptKeysStatement) actual, (DorisShowEncryptKeysStatementTestCase) expected);
         } else if (actual instanceof DorisAdminCleanTrashStatement) {
             DorisAdminCleanTrashStatementAssert.assertIs(assertContext, (DorisAdminCleanTrashStatement) actual, (DorisAdminCleanTrashStatementTestCase) expected);
+        } else if (actual instanceof DorisRecoverStatement) {
+            DorisRecoverStatementAssert.assertIs(assertContext, (DorisRecoverStatement) actual, (DorisRecoverStatementTestCase) expected);
         } else if (actual instanceof DorisShowTrashStatement) {
             DorisShowTrashStatementAssert.assertIs(assertContext, (DorisShowTrashStatement) actual, (DorisShowTrashStatementTestCase) expected);
         } else if (actual instanceof DorisShowLoadStatement) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/type/DorisRecoverStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/dal/dialect/doris/type/DorisRecoverStatementAssert.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dal.dialect.doris.type;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.statement.doris.dal.DorisRecoverStatement;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.database.DatabaseAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.table.TableAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisRecoverStatementTestCase;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Recover statement assert for Doris.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DorisRecoverStatementAssert {
+    
+    /**
+     * Assert recover statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual recover statement
+     * @param expected expected recover statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final DorisRecoverStatement actual, final DorisRecoverStatementTestCase expected) {
+        assertThat(assertContext.getText("Recover object type does not match: "), actual.getObjectType().name(), is(expected.getObjectType()));
+        assertDatabase(assertContext, actual, expected);
+        assertTable(assertContext, actual, expected);
+        assertThat(assertContext.getText("Partition name does not match: "), actual.getPartitionName(), is(expected.getPartitionName()));
+        assertThat(assertContext.getText("Object id does not match: "), actual.getObjectId(), is(expected.getObjectId()));
+        assertThat(assertContext.getText("New name does not match: "), actual.getNewName(), is(expected.getNewName()));
+    }
+    
+    private static void assertDatabase(final SQLCaseAssertContext assertContext, final DorisRecoverStatement actual, final DorisRecoverStatementTestCase expected) {
+        if (null == expected.getDatabase()) {
+            assertNull(actual.getDatabase(), assertContext.getText("Actual database should not exist."));
+        } else {
+            assertNotNull(actual.getDatabase(), assertContext.getText("Actual database should exist."));
+            DatabaseAssert.assertIs(assertContext, actual.getDatabase(), expected.getDatabase());
+        }
+    }
+    
+    private static void assertTable(final SQLCaseAssertContext assertContext, final DorisRecoverStatement actual, final DorisRecoverStatementTestCase expected) {
+        if (null == expected.getTable()) {
+            assertNull(actual.getTable(), assertContext.getText("Actual table should not exist."));
+        } else {
+            assertNotNull(actual.getTable(), assertContext.getText("Actual table should exist."));
+            TableAssert.assertIs(assertContext, actual.getTable(), expected.getTable());
+        }
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/RootSQLParserTestCases.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminCleanTrashStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisCleanAllProfileStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisPlanReplayerPlayStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisRecoverStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminCopyTabletStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminSetReplicaStatusStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris.DorisAdminSetReplicaVersionStatementTestCase;
@@ -792,6 +793,9 @@ public final class RootSQLParserTestCases {
     
     @XmlElement(name = "admin-clean-trash")
     private final List<DorisAdminCleanTrashStatementTestCase> adminCleanTrashTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "doris-recover")
+    private final List<DorisRecoverStatementTestCase> dorisRecoverTestCases = new LinkedList<>();
     
     @XmlElement(name = "clean-all-profile")
     private final List<DorisCleanAllProfileStatementTestCase> cleanAllProfileTestCases = new LinkedList<>();

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/dialect/doris/DorisRecoverStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/dal/dialect/doris/DorisRecoverStatementTestCase.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.dal.dialect.doris;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.database.ExpectedDatabase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedSimpleTable;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * Recover statement test case for Doris.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@Setter
+public final class DorisRecoverStatementTestCase extends SQLParserTestCase {
+    
+    @XmlAttribute(name = "object-type")
+    private String objectType;
+    
+    @XmlElement(name = "database")
+    private ExpectedDatabase database;
+    
+    @XmlElement(name = "table")
+    private ExpectedSimpleTable table;
+    
+    @XmlAttribute(name = "partition-name")
+    private String partitionName;
+    
+    @XmlAttribute(name = "object-id")
+    private Long objectId;
+    
+    @XmlAttribute(name = "new-name")
+    private String newName;
+}

--- a/test/it/parser/src/main/resources/case/dal/recover.xml
+++ b/test/it/parser/src/main/resources/case/dal/recover.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <doris-recover sql-case-id="recover_database" object-type="DATABASE">
+        <database name="example_db" start-index="17" stop-index="26" />
+    </doris-recover>
+
+    <doris-recover sql-case-id="recover_database_with_id" object-type="DATABASE" object-id="10001">
+        <database name="example_db" start-index="17" stop-index="26" />
+    </doris-recover>
+
+    <doris-recover sql-case-id="recover_database_as_new_name" object-type="DATABASE" new-name="new_db">
+        <database name="example_db" start-index="17" stop-index="26" />
+    </doris-recover>
+
+    <doris-recover sql-case-id="recover_table" object-type="TABLE">
+        <table name="example_tbl" start-index="14" stop-index="24" />
+    </doris-recover>
+
+    <doris-recover sql-case-id="recover_table_with_db" object-type="TABLE">
+        <table name="example_tbl" start-index="14" stop-index="35">
+            <owner name="example_db" start-index="14" stop-index="23" />
+        </table>
+    </doris-recover>
+
+    <doris-recover sql-case-id="recover_table_with_id" object-type="TABLE" object-id="20002">
+        <table name="example_tbl" start-index="14" stop-index="35">
+            <owner name="example_db" start-index="14" stop-index="23" />
+        </table>
+    </doris-recover>
+
+    <doris-recover sql-case-id="recover_table_as_new_name" object-type="TABLE" object-id="20002" new-name="new_tbl">
+        <table name="example_tbl" start-index="14" stop-index="35">
+            <owner name="example_db" start-index="14" stop-index="23" />
+        </table>
+    </doris-recover>
+
+    <doris-recover sql-case-id="recover_partition" object-type="PARTITION" partition-name="p1">
+        <table name="example_tbl" start-index="26" stop-index="36" />
+    </doris-recover>
+
+    <doris-recover sql-case-id="recover_partition_with_db" object-type="PARTITION" partition-name="p1">
+        <table name="example_tbl" start-index="26" stop-index="47">
+            <owner name="example_db" start-index="26" stop-index="35" />
+        </table>
+    </doris-recover>
+
+    <doris-recover sql-case-id="recover_partition_with_id" object-type="PARTITION" partition-name="p1" object-id="30003">
+        <table name="example_tbl" start-index="32" stop-index="53">
+            <owner name="example_db" start-index="32" stop-index="41" />
+        </table>
+    </doris-recover>
+</sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dal/recover.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/recover.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="recover_database" value="RECOVER DATABASE example_db" db-types="Doris" />
+    <sql-case id="recover_database_with_id" value="RECOVER DATABASE example_db 10001" db-types="Doris" />
+    <sql-case id="recover_database_as_new_name" value="RECOVER DATABASE example_db AS new_db" db-types="Doris" />
+    <sql-case id="recover_table" value="RECOVER TABLE example_tbl" db-types="Doris" />
+    <sql-case id="recover_table_with_db" value="RECOVER TABLE example_db.example_tbl" db-types="Doris" />
+    <sql-case id="recover_table_with_id" value="RECOVER TABLE example_db.example_tbl 20002" db-types="Doris" />
+    <sql-case id="recover_table_as_new_name" value="RECOVER TABLE example_db.example_tbl 20002 AS new_tbl" db-types="Doris" />
+    <sql-case id="recover_partition" value="RECOVER PARTITION p1 FROM example_tbl" db-types="Doris" />
+    <sql-case id="recover_partition_with_db" value="RECOVER PARTITION p1 FROM example_db.example_tbl" db-types="Doris" />
+    <sql-case id="recover_partition_with_id" value="RECOVER PARTITION p1 30003 FROM example_db.example_tbl" db-types="Doris" />
+</sql-cases>


### PR DESCRIPTION
## Problem

Doris ships a `RECOVER` administration statement that brings a dropped database, table, or partition back from the recycle bin, optionally with the original object id and/or a renamed target. None of the variants listed in #31503 are accepted by the current Doris parser:

```
RECOVER DATABASE example_db
RECOVER DATABASE example_db 10001
RECOVER DATABASE example_db AS new_db
RECOVER TABLE example_db.example_tbl
RECOVER TABLE example_db.example_tbl 20002
RECOVER TABLE example_db.example_tbl 20002 AS new_tbl
RECOVER PARTITION p1 FROM example_tbl
RECOVER PARTITION p1 FROM example_db.example_tbl
RECOVER PARTITION p1 30003 FROM example_db.example_tbl
```

## Root Cause

`DALStatement.g4` for the Doris dialect has no rule for `RECOVER` outside of XA transactions, so each form fails ANTLR parsing before any visitor runs.

## Fix

- Add `recover`, `recoverDatabase`, `recoverTable`, and `recoverPartition` rules to the Doris `DALStatement.g4`, allowing the optional numeric id and the optional `AS new_name` tail for database/table forms, and `PARTITION name [id] FROM [db.]table` for the partition form.
- Wire the new alternative into the top-level `execute` rule of `DorisStatement.g4`.
- Introduce `DorisRecoverStatement` (object type, database/table segment, partition name, optional id, optional new name) and the matching `visitRecover` logic in `DorisDALStatementVisitor`.
- Register the SPI entry in `SQLVisitorRule` and the assert/test-case glue (`DorisRecoverStatementAssert`, `DorisRecoverStatementTestCase`, `DorisDALStatementAssert`, `RootSQLParserTestCases`).

## Tests Added

- `test/it/parser/src/main/resources/sql/supported/dal/recover.xml` covering the nine Doris syntaxes from #31503 plus a partition variant without the database-qualified table.
- `test/it/parser/src/main/resources/case/dal/recover.xml` with the matching assertions.
- `InternalDorisParserIT` runs cleanly: 1250 tests pass after the change.

## Fixes

Refs #31503