### PR TITLE
Refactor EncryptAlterTableTokenGenerator and EncryptCreateTableTokenGenerator

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/ddl/EncryptAlterTableTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/ddl/EncryptAlterTableTokenGenerator.java
@@ -30,7 +30,6 @@ import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptColumnToken;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.column.EncryptColumn;
 import org.apache.shardingsphere.encrypt.rule.column.item.AssistedQueryColumnItem;
-import org.apache.shardingsphere.encrypt.rule.column.item.CipherColumnItem;
 import org.apache.shardingsphere.encrypt.rule.column.item.LikeQueryColumnItem;
 import org.apache.shardingsphere.encrypt.rule.table.EncryptTable;
 import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
@@ -82,8 +81,7 @@ public final class EncryptAlterTableTokenGenerator implements CollectionSQLToken
     @Override
     public Collection<SQLToken> generateSQLTokens(final CommonSQLStatementContext sqlStatementContext) {
         AlterTableStatement sqlStatement = (AlterTableStatement) sqlStatementContext.getSqlStatement();
-        String tableName = sqlStatement.getTable().getTableName().getIdentifier().getValue();
-        EncryptTable encryptTable = rule.getEncryptTable(tableName);
+        EncryptTable encryptTable = rule.getEncryptTable(sqlStatement.getTable().getTableName().getIdentifier().getValue());
         Collection<SQLToken> result = new LinkedList<>(getAddColumnTokens(encryptTable, sqlStatement.getAddColumnDefinitions(), sqlStatementContext));
         result.addAll(getModifyColumnTokens(encryptTable, sqlStatement.getModifyColumnDefinitions()));
         result.addAll(getChangeColumnTokens(encryptTable, sqlStatement.getChangeColumnDefinitions()));
@@ -120,20 +118,13 @@ public final class EncryptAlterTableTokenGenerator implements CollectionSQLToken
     
     private Collection<SQLToken> getAddColumnTokens(final EncryptColumn encryptColumn, final AddColumnDefinitionSegment addColumnDefinitionSegment,
                                                     final ColumnDefinitionSegment columnDefinitionSegment, final SQLStatement sqlStatement, final String tableName) {
+        DatabaseType databaseType = sqlStatement.getDatabaseType();
         Collection<SQLToken> result = new LinkedList<>();
         result.add(new RemoveToken(columnDefinitionSegment.getStartIndex(), columnDefinitionSegment.getStopIndex()));
-        result.add(new EncryptColumnToken(columnDefinitionSegment.getStopIndex() + 1, columnDefinitionSegment.getStopIndex(),
-                createFirstAddColumnName(sqlStatement.getDatabaseType(), encryptColumn.getCipher().getName()),
-                appendCipherColumnDefault(EncryptColumnDataType.DEFAULT_DATA_TYPE, encryptColumn.getCipher(), tableName, columnDefinitionSegment)));
-        encryptColumn.getAssistedQuery().map(optional -> new EncryptColumnToken(addColumnDefinitionSegment.getStopIndex() + 1,
-                addColumnDefinitionSegment.getStopIndex(), createDerivedAddColumnName(sqlStatement.getDatabaseType(), optional.getName()),
-                appendAssistedQueryDefault(EncryptColumnDataType.DEFAULT_DATA_TYPE, optional, tableName, columnDefinitionSegment)))
-                .ifPresent(result::add);
-        encryptColumn.getLikeQuery().map(optional -> new EncryptColumnToken(addColumnDefinitionSegment.getStopIndex() + 1,
-                addColumnDefinitionSegment.getStopIndex(), createDerivedAddColumnName(sqlStatement.getDatabaseType(), optional.getName()),
-                appendLikeQueryDefault(EncryptColumnDataType.DEFAULT_DATA_TYPE, optional, tableName, columnDefinitionSegment)))
-                .ifPresent(result::add);
-        createAddColumnClauseCloseToken(sqlStatement.getDatabaseType(), addColumnDefinitionSegment).ifPresent(result::add);
+        result.add(createFirstAddColumnToken(encryptColumn, columnDefinitionSegment, tableName, databaseType));
+        addAssistedQueryAddColumnToken(result, encryptColumn, addColumnDefinitionSegment, columnDefinitionSegment, tableName, databaseType);
+        addLikeQueryAddColumnToken(result, encryptColumn, addColumnDefinitionSegment, columnDefinitionSegment, tableName, databaseType);
+        createAddColumnClauseCloseToken(databaseType, addColumnDefinitionSegment).ifPresent(result::add);
         return result;
     }
     
@@ -157,25 +148,50 @@ public final class EncryptAlterTableTokenGenerator implements CollectionSQLToken
                 : Optional.empty();
     }
     
+    private EncryptColumnToken createFirstAddColumnToken(final EncryptColumn encryptColumn, final ColumnDefinitionSegment columnDefinitionSegment,
+                                                         final String tableName, final DatabaseType databaseType) {
+        String columnName = createFirstAddColumnName(databaseType, encryptColumn.getCipher().getName());
+        String columnDefinition = getCipherAddColumnDefinition(encryptColumn, columnDefinitionSegment, tableName);
+        return new EncryptColumnToken(columnDefinitionSegment.getStopIndex() + 1, columnDefinitionSegment.getStopIndex(), columnName, columnDefinition);
+    }
+    
+    private EncryptColumnToken createDerivedAddColumnToken(final AddColumnDefinitionSegment addColumnDefinitionSegment, final String columnName, final String dataType,
+                                                           final DatabaseType databaseType) {
+        return new EncryptColumnToken(addColumnDefinitionSegment.getStopIndex() + 1, addColumnDefinitionSegment.getStopIndex(), createDerivedAddColumnName(databaseType, columnName), dataType);
+    }
+    
+    private void addAssistedQueryAddColumnToken(final Collection<SQLToken> result, final EncryptColumn encryptColumn, final AddColumnDefinitionSegment addColumnDefinitionSegment,
+                                                final ColumnDefinitionSegment columnDefinitionSegment, final String tableName, final DatabaseType databaseType) {
+        encryptColumn.getAssistedQuery().ifPresent(item -> result.add(createDerivedAddColumnToken(
+                addColumnDefinitionSegment, item.getName(), getAssistedQueryAddColumnDefinition(item, columnDefinitionSegment, tableName), databaseType)));
+    }
+    
+    private String getAssistedQueryAddColumnDefinition(final AssistedQueryColumnItem item, final ColumnDefinitionSegment columnDefinitionSegment, final String tableName) {
+        String dataType = EncryptColumnDataType.DEFAULT_DATA_TYPE;
+        return appendEncryptedDefault(dataType, columnDefinitionSegment,
+                plainValue -> item.encrypt("", "", tableName, columnDefinitionSegment.getColumnName().getIdentifier().getValue(), plainValue));
+    }
+    
+    private void addLikeQueryAddColumnToken(final Collection<SQLToken> result, final EncryptColumn encryptColumn, final AddColumnDefinitionSegment addColumnDefinitionSegment,
+                                            final ColumnDefinitionSegment columnDefinitionSegment, final String tableName, final DatabaseType databaseType) {
+        encryptColumn.getLikeQuery().ifPresent(item -> result.add(createDerivedAddColumnToken(
+                addColumnDefinitionSegment, item.getName(), getLikeQueryAddColumnDefinition(item, columnDefinitionSegment, tableName), databaseType)));
+    }
+    
+    private String getLikeQueryAddColumnDefinition(final LikeQueryColumnItem item, final ColumnDefinitionSegment columnDefinitionSegment, final String tableName) {
+        String dataType = EncryptColumnDataType.DEFAULT_DATA_TYPE;
+        return appendEncryptedDefault(dataType, columnDefinitionSegment,
+                plainValue -> item.encrypt("", "", tableName, columnDefinitionSegment.getColumnName().getIdentifier().getValue(), plainValue));
+    }
+    
+    private String getCipherAddColumnDefinition(final EncryptColumn encryptColumn, final ColumnDefinitionSegment columnDefinitionSegment, final String tableName) {
+        String dataType = EncryptColumnDataType.DEFAULT_DATA_TYPE;
+        return appendEncryptedDefault(dataType, columnDefinitionSegment,
+                plainValue -> encryptColumn.getCipher().encrypt("", "", tableName, columnDefinitionSegment.getColumnName().getIdentifier().getValue(), plainValue));
+    }
+    
     private boolean isContainsParenthesesOnColumnsClause(final DatabaseType databaseType) {
         return new DatabaseTypeRegistry(databaseType).getDialectDatabaseMetaData().getAlterTableOption().map(DialectAlterTableOption::isContainsParenthesesOnColumnsClause).orElse(false);
-    }
-    
-    private String appendCipherColumnDefault(final String dataType, final CipherColumnItem cipherColumnItem, final String tableName, final ColumnDefinitionSegment columnDefinitionSegment) {
-        return appendEncryptedDefault(dataType, columnDefinitionSegment,
-                plainValue -> cipherColumnItem.encrypt("", "", tableName, columnDefinitionSegment.getColumnName().getIdentifier().getValue(), plainValue));
-    }
-    
-    private String appendAssistedQueryDefault(final String dataType, final AssistedQueryColumnItem assistedQueryColumnItem, final String tableName,
-                                              final ColumnDefinitionSegment columnDefinitionSegment) {
-        return appendEncryptedDefault(dataType, columnDefinitionSegment,
-                plainValue -> assistedQueryColumnItem.encrypt("", "", tableName, columnDefinitionSegment.getColumnName().getIdentifier().getValue(), plainValue));
-    }
-    
-    private String appendLikeQueryDefault(final String dataType, final LikeQueryColumnItem likeQueryColumnItem, final String tableName,
-                                          final ColumnDefinitionSegment columnDefinitionSegment) {
-        return appendEncryptedDefault(dataType, columnDefinitionSegment,
-                plainValue -> likeQueryColumnItem.encrypt("", "", tableName, columnDefinitionSegment.getColumnName().getIdentifier().getValue(), plainValue));
     }
     
     private String appendEncryptedDefault(final String dataType, final ColumnDefinitionSegment columnDefinitionSegment, final Function<Object, Object> encryptor) {
@@ -300,15 +316,23 @@ public final class EncryptAlterTableTokenGenerator implements CollectionSQLToken
     private Collection<SQLToken> getColumnTokens(final EncryptColumn previousEncryptColumn, final EncryptColumn encryptColumn, final ChangeColumnDefinitionSegment segment) {
         Collection<SQLToken> result = new LinkedList<>();
         result.add(new RemoveToken(segment.getColumnDefinition().getColumnName().getStartIndex(), segment.getColumnDefinition().getStopIndex()));
-        result.add(new EncryptColumnToken(segment.getColumnDefinition().getStopIndex() + 1, segment.getColumnDefinition().getStopIndex(), encryptColumn.getCipher().getName(),
-                EncryptColumnDataType.DEFAULT_DATA_TYPE));
-        previousEncryptColumn.getAssistedQuery().map(optional -> new EncryptColumnToken(segment.getStopIndex() + 1, segment.getStopIndex(),
-                ", CHANGE COLUMN " + optional.getName() + " " + encryptColumn.getAssistedQuery().map(AssistedQueryColumnItem::getName).orElse(""), EncryptColumnDataType.DEFAULT_DATA_TYPE))
-                .ifPresent(result::add);
-        previousEncryptColumn.getLikeQuery().map(optional -> new EncryptColumnToken(segment.getStopIndex() + 1, segment.getStopIndex(),
-                ", CHANGE COLUMN " + optional.getName() + " " + encryptColumn.getLikeQuery().map(LikeQueryColumnItem::getName).orElse(""), EncryptColumnDataType.DEFAULT_DATA_TYPE))
-                .ifPresent(result::add);
+        String cipherDataType = EncryptColumnDataType.DEFAULT_DATA_TYPE;
+        result.add(new EncryptColumnToken(segment.getColumnDefinition().getStopIndex() + 1, segment.getColumnDefinition().getStopIndex(),
+                encryptColumn.getCipher().getName(), cipherDataType));
+        previousEncryptColumn.getAssistedQuery().ifPresent(item -> {
+            String dataType = EncryptColumnDataType.DEFAULT_DATA_TYPE;
+            result.add(createChangedDerivedColumnToken(item.getName(), encryptColumn.getAssistedQuery().map(AssistedQueryColumnItem::getName).orElse(""), dataType, segment));
+        });
+        previousEncryptColumn.getLikeQuery().ifPresent(item -> {
+            String dataType = EncryptColumnDataType.DEFAULT_DATA_TYPE;
+            result.add(createChangedDerivedColumnToken(item.getName(), encryptColumn.getLikeQuery().map(LikeQueryColumnItem::getName).orElse(""), dataType, segment));
+        });
         return result;
+    }
+    
+    private EncryptColumnToken createChangedDerivedColumnToken(final String previousColumnName, final String currentColumnName, final String dataType,
+                                                               final ChangeColumnDefinitionSegment segment) {
+        return new EncryptColumnToken(segment.getStopIndex() + 1, segment.getStopIndex(), ", CHANGE COLUMN " + previousColumnName + " " + currentColumnName, dataType);
     }
     
     private List<SQLToken> getDropColumnTokens(final EncryptTable encryptTable, final Collection<DropColumnDefinitionSegment> segments) {

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/ddl/EncryptCreateTableTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/ddl/EncryptCreateTableTokenGenerator.java
@@ -21,7 +21,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.encrypt.constant.EncryptColumnDataType;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.column.EncryptColumn;
-import org.apache.shardingsphere.encrypt.rule.column.item.CipherColumnItem;
 import org.apache.shardingsphere.encrypt.rule.table.EncryptTable;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.CommonSQLStatementContext;
@@ -53,41 +52,44 @@ public final class EncryptCreateTableTokenGenerator implements CollectionSQLToke
     
     @Override
     public Collection<SQLToken> generateSQLTokens(final CommonSQLStatementContext sqlStatementContext) {
-        Collection<SQLToken> result = new LinkedList<>();
         CreateTableStatement sqlStatement = (CreateTableStatement) sqlStatementContext.getSqlStatement();
-        String tableName = sqlStatement.getTable().getTableName().getIdentifier().getValue();
-        EncryptTable encryptTable = rule.getEncryptTable(tableName);
         List<ColumnDefinitionSegment> columns = new ArrayList<>(sqlStatement.getColumnDefinitions());
+        EncryptTable encryptTable = rule.getEncryptTable(sqlStatement.getTable().getTableName().getIdentifier().getValue());
+        Collection<SQLToken> result = new LinkedList<>();
         for (int index = 0; index < columns.size(); index++) {
-            ColumnDefinitionSegment each = columns.get(index);
-            String columnName = each.getColumnName().getIdentifier().getValue();
-            if (encryptTable.isEncryptColumn(columnName)) {
-                result.add(getSubstituteColumnToken(encryptTable.getEncryptColumn(columnName), each, columns, index));
-            }
+            getSubstituteColumnToken(encryptTable, columns, index).ifPresent(result::add);
         }
         return result;
     }
     
-    private SQLToken getSubstituteColumnToken(final EncryptColumn encryptColumn, final ColumnDefinitionSegment column, final List<ColumnDefinitionSegment> columns, final int index) {
-        Collection<SQLToken> columnDefinitionTokens = new LinkedList<>();
-        columnDefinitionTokens.add(getCipherColumnToken(encryptColumn, column));
-        getAssistedQueryColumnToken(encryptColumn, column).ifPresent(columnDefinitionTokens::add);
-        getLikeQueryColumnToken(encryptColumn, column).ifPresent(columnDefinitionTokens::add);
+    private Optional<SQLToken> getSubstituteColumnToken(final EncryptTable encryptTable, final List<ColumnDefinitionSegment> columns, final int index) {
+        ColumnDefinitionSegment column = columns.get(index);
+        String columnName = column.getColumnName().getIdentifier().getValue();
+        if (!encryptTable.isEncryptColumn(columnName)) {
+            return Optional.empty();
+        }
         boolean lastColumn = columns.size() - 1 == index;
         int columnStopIndex = lastColumn ? column.getStopIndex() : columns.get(index + 1).getStartIndex() - 1;
-        return new SubstituteColumnDefinitionToken(column.getStartIndex(), columnStopIndex, lastColumn, columnDefinitionTokens);
+        return Optional.of(new SubstituteColumnDefinitionToken(column.getStartIndex(), columnStopIndex, lastColumn,
+                createColumnDefinitionTokens(encryptTable.getEncryptColumn(columnName), column)));
     }
     
-    private SQLToken getCipherColumnToken(final EncryptColumn encryptColumn, final ColumnDefinitionSegment column) {
-        CipherColumnItem cipherColumnItem = encryptColumn.getCipher();
-        return new ColumnDefinitionToken(cipherColumnItem.getName(), EncryptColumnDataType.DEFAULT_DATA_TYPE, column.getStartIndex());
+    private Collection<SQLToken> createColumnDefinitionTokens(final EncryptColumn encryptColumn, final ColumnDefinitionSegment column) {
+        Collection<SQLToken> result = new LinkedList<>();
+        String cipherDataType = EncryptColumnDataType.DEFAULT_DATA_TYPE;
+        result.add(createColumnDefinitionToken(encryptColumn.getCipher().getName(), cipherDataType, column.getStartIndex()));
+        encryptColumn.getAssistedQuery().ifPresent(item -> {
+            String dataType = EncryptColumnDataType.DEFAULT_DATA_TYPE;
+            result.add(createColumnDefinitionToken(item.getName(), dataType, column.getStartIndex()));
+        });
+        encryptColumn.getLikeQuery().ifPresent(item -> {
+            String dataType = EncryptColumnDataType.DEFAULT_DATA_TYPE;
+            result.add(createColumnDefinitionToken(item.getName(), dataType, column.getStartIndex()));
+        });
+        return result;
     }
     
-    private Optional<? extends SQLToken> getAssistedQueryColumnToken(final EncryptColumn encryptColumn, final ColumnDefinitionSegment column) {
-        return encryptColumn.getAssistedQuery().map(optional -> new ColumnDefinitionToken(optional.getName(), EncryptColumnDataType.DEFAULT_DATA_TYPE, column.getStartIndex()));
-    }
-    
-    private Optional<? extends SQLToken> getLikeQueryColumnToken(final EncryptColumn encryptColumn, final ColumnDefinitionSegment column) {
-        return encryptColumn.getLikeQuery().map(optional -> new ColumnDefinitionToken(optional.getName(), EncryptColumnDataType.DEFAULT_DATA_TYPE, column.getStartIndex()));
+    private ColumnDefinitionToken createColumnDefinitionToken(final String columnName, final String dataType, final int startIndex) {
+        return new ColumnDefinitionToken(columnName, dataType, startIndex);
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/ddl/EncryptAlterTableTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/ddl/EncryptAlterTableTokenGeneratorTest.java
@@ -125,8 +125,13 @@ class EncryptAlterTableTokenGeneratorTest {
     }
     
     private SQLStatement createAddColumnStatement() {
+        return createAddColumnStatement(false);
+    }
+    
+    private SQLStatement createAddColumnStatement(final boolean notNull) {
         ColumnDefinitionSegment columnDefinitionSegment = new ColumnDefinitionSegment(
-                33, 67, new ColumnSegment(33, 50, new IdentifierValue("certificate_number")), new DataTypeSegment(), false, false, "");
+                33, 67, new ColumnSegment(33, 50, new IdentifierValue("certificate_number")), new DataTypeSegment(), false, notNull,
+                notNull ? "certificate_number VARCHAR(10) DEFAULT 'foo' NOT NULL" : "");
         return AlterTableStatement.builder().databaseType(databaseType)
                 .table(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_encrypt"))))
                 .addColumnDefinition(new AddColumnDefinitionSegment(22, 67, Collections.singleton(columnDefinitionSegment))).build();

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/ddl/EncryptCreateTableTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/ddl/EncryptCreateTableTokenGeneratorTest.java
@@ -48,6 +48,7 @@ import java.util.Iterator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -102,6 +103,10 @@ class EncryptCreateTableTokenGeneratorTest {
         ColumnDefinitionToken likeToken = (ColumnDefinitionToken) actualIterator.next();
         assertThat(likeToken.toString(), is("like_certificate_number VARCHAR(4000)"));
         assertThat(likeToken.getStartIndex(), is(25));
+        assertThat(token.toString(), is("cipher_certificate_number VARCHAR(4000), assisted_certificate_number VARCHAR(4000), like_certificate_number VARCHAR(4000)"));
+        assertThat(token.getStartIndex(), is(25));
+        assertThat(token.getStopIndex(), is(78));
+        assertTrue(((SubstituteColumnDefinitionToken) token).isLastColumn());
     }
     
     private CreateTableStatement createCreateTableStatement() {

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/ddl/EncryptCreateTableTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/ddl/EncryptCreateTableTokenGeneratorTest.java
@@ -33,6 +33,7 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.column.ColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.DataTypeSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.TableSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.table.CreateTableStatement;
@@ -44,10 +45,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -102,18 +102,20 @@ class EncryptCreateTableTokenGeneratorTest {
         ColumnDefinitionToken likeToken = (ColumnDefinitionToken) actualIterator.next();
         assertThat(likeToken.toString(), is("like_certificate_number VARCHAR(4000)"));
         assertThat(likeToken.getStartIndex(), is(25));
-        assertThat(token.toString(), is("cipher_certificate_number VARCHAR(4000), assisted_certificate_number VARCHAR(4000), like_certificate_number VARCHAR(4000)"));
-        assertThat(token.getStartIndex(), is(25));
-        assertThat(token.getStopIndex(), is(78));
-        assertTrue(((SubstituteColumnDefinitionToken) token).isLastColumn());
     }
     
     private CreateTableStatement createCreateTableStatement() {
+        return createCreateTableStatement(false);
+    }
+    
+    private CreateTableStatement createCreateTableStatement(final boolean notNull) {
+        SimpleTableSegment tableSegment = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_encrypt")));
+        tableSegment.getTableName().setTableBoundInfo(new TableSegmentBoundInfo(null, new IdentifierValue("default")));
         return CreateTableStatement.builder()
                 .databaseType(databaseType)
-                .table(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_encrypt"))))
+                .table(tableSegment)
                 .columnDefinitions(Collections.singleton(
-                        new ColumnDefinitionSegment(25, 78, new ColumnSegment(25, 42, new IdentifierValue("certificate_number")), new DataTypeSegment(), false, false, "")))
+                        new ColumnDefinitionSegment(25, 78, new ColumnSegment(25, 42, new IdentifierValue("certificate_number")), new DataTypeSegment(), false, notNull, "")))
                 .build();
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Refactor EncryptAlterTableTokenGenerator and EncryptCreateTableTokenGenerator

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
