### PR TITLE
Reset proxy backend executor across repeated ShardingSphereProxy lifecycles

### DIFF
--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/context/BackendExecutorContext.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/context/BackendExecutorContext.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.proxy.backend.context;
 
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.executor.kernel.ExecutorEngine;
@@ -27,13 +26,11 @@ import org.apache.shardingsphere.infra.executor.kernel.ExecutorEngine;
  * Backend executor context.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-@Getter
 public final class BackendExecutorContext {
     
     private static final BackendExecutorContext INSTANCE = new BackendExecutorContext();
     
-    private final ExecutorEngine executorEngine = ExecutorEngine.createExecutorEngineWithSize(
-            ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getProps().<Integer>getValue(ConfigurationPropertyKey.KERNEL_EXECUTOR_SIZE));
+    private volatile ExecutorEngine executorEngine;
     
     /**
      * Get executor context instance.
@@ -42,5 +39,37 @@ public final class BackendExecutorContext {
      */
     public static BackendExecutorContext getInstance() {
         return INSTANCE;
+    }
+    
+    /**
+     * Initialize backend executor context.
+     */
+    public synchronized void init() {
+        close();
+        executorEngine = ExecutorEngine.createExecutorEngineWithSize(
+                ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getProps().<Integer>getValue(ConfigurationPropertyKey.KERNEL_EXECUTOR_SIZE));
+    }
+    
+    /**
+     * Get executor engine.
+     *
+     * @return executor engine
+     */
+    public synchronized ExecutorEngine getExecutorEngine() {
+        if (null == executorEngine) {
+            init();
+        }
+        return executorEngine;
+    }
+    
+    /**
+     * Close backend executor context.
+     */
+    public synchronized void close() {
+        if (null == executorEngine) {
+            return;
+        }
+        executorEngine.close();
+        executorEngine = null;
     }
 }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/context/BackendExecutorContext.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/context/BackendExecutorContext.java
@@ -32,6 +32,8 @@ public final class BackendExecutorContext {
     
     private volatile ExecutorEngine executorEngine;
     
+    private LifecycleState lifecycleState = LifecycleState.UNINITIALIZED;
+    
     /**
      * Get executor context instance.
      *
@@ -45,19 +47,29 @@ public final class BackendExecutorContext {
      * Initialize backend executor context.
      */
     public synchronized void init() {
-        close();
+        if (null != executorEngine) {
+            executorEngine.close();
+        }
         executorEngine = ExecutorEngine.createExecutorEngineWithSize(
                 ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getProps().<Integer>getValue(ConfigurationPropertyKey.KERNEL_EXECUTOR_SIZE));
+        lifecycleState = LifecycleState.RUNNING;
     }
     
     /**
      * Get executor engine.
      *
      * @return executor engine
+     * @throws IllegalStateException backend executor is unavailable in current lifecycle state
      */
     public synchronized ExecutorEngine getExecutorEngine() {
         if (null == executorEngine) {
+            if (LifecycleState.CLOSED == lifecycleState) {
+                throw new IllegalStateException(String.format("Backend executor engine is unavailable in `%s` lifecycle state.", lifecycleState));
+            }
             init();
+        }
+        if (LifecycleState.RUNNING != lifecycleState) {
+            throw new IllegalStateException(String.format("Backend executor engine is unavailable in `%s` lifecycle state.", lifecycleState));
         }
         return executorEngine;
     }
@@ -66,10 +78,27 @@ public final class BackendExecutorContext {
      * Close backend executor context.
      */
     public synchronized void close() {
-        if (null == executorEngine) {
-            return;
+        if (null != executorEngine) {
+            executorEngine.close();
+            executorEngine = null;
         }
-        executorEngine.close();
-        executorEngine = null;
+        lifecycleState = LifecycleState.UNINITIALIZED;
+    }
+    
+    /**
+     * Shutdown backend executor context.
+     */
+    public synchronized void shutdown() {
+        close();
+        lifecycleState = LifecycleState.CLOSED;
+    }
+    
+    private enum LifecycleState {
+        
+        UNINITIALIZED,
+        
+        RUNNING,
+        
+        CLOSED
     }
 }

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/context/BackendExecutorContextTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/context/BackendExecutorContextTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.proxy.backend.context;
 
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.executor.kernel.ExecutorEngine;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
@@ -26,14 +27,19 @@ import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.internal.configuration.plugins.Plugins;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Properties;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -42,11 +48,38 @@ import static org.mockito.Mockito.when;
 @StaticMockSettings(ProxyContext.class)
 class BackendExecutorContextTest {
     
+    @AfterEach
+    void tearDown() {
+        BackendExecutorContext.getInstance().close();
+    }
+    
     @Test
-    void assertGetInstance() {
+    void assertGetExecutorEngine() {
         ContextManager contextManager = mockContextManager();
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
-        assertThat(BackendExecutorContext.getInstance().getExecutorEngine(), is(BackendExecutorContext.getInstance().getExecutorEngine()));
+        ExecutorEngine actual = BackendExecutorContext.getInstance().getExecutorEngine();
+        assertThat(actual, is(BackendExecutorContext.getInstance().getExecutorEngine()));
+    }
+    
+    @Test
+    void assertInit() {
+        ContextManager contextManager = mockContextManager();
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        BackendExecutorContext.getInstance().init();
+        ExecutorEngine actual = BackendExecutorContext.getInstance().getExecutorEngine();
+        BackendExecutorContext.getInstance().init();
+        assertThat(BackendExecutorContext.getInstance().getExecutorEngine(), is(not(actual)));
+    }
+    
+    @Test
+    void assertClose() throws ReflectiveOperationException {
+        ContextManager contextManager = mockContextManager();
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        BackendExecutorContext.getInstance().init();
+        BackendExecutorContext.getInstance().close();
+        Field executorEngineField = BackendExecutorContext.class.getDeclaredField("executorEngine");
+        ExecutorEngine executorEngine = (ExecutorEngine) Plugins.getMemberAccessor().get(executorEngineField, BackendExecutorContext.getInstance());
+        assertNull(executorEngine);
     }
     
     private ContextManager mockContextManager() {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/context/BackendExecutorContextTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/context/BackendExecutorContextTest.java
@@ -30,16 +30,14 @@ import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockS
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.internal.configuration.plugins.Plugins;
 
-import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -57,6 +55,7 @@ class BackendExecutorContextTest {
     void assertGetExecutorEngine() {
         ContextManager contextManager = mockContextManager();
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        BackendExecutorContext.getInstance().init();
         ExecutorEngine actual = BackendExecutorContext.getInstance().getExecutorEngine();
         assertThat(actual, is(BackendExecutorContext.getInstance().getExecutorEngine()));
     }
@@ -67,19 +66,28 @@ class BackendExecutorContextTest {
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         BackendExecutorContext.getInstance().init();
         ExecutorEngine actual = BackendExecutorContext.getInstance().getExecutorEngine();
+        BackendExecutorContext.getInstance().close();
         BackendExecutorContext.getInstance().init();
         assertThat(BackendExecutorContext.getInstance().getExecutorEngine(), is(not(actual)));
     }
     
     @Test
-    void assertClose() throws ReflectiveOperationException {
+    void assertClose() {
         ContextManager contextManager = mockContextManager();
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         BackendExecutorContext.getInstance().init();
         BackendExecutorContext.getInstance().close();
-        Field executorEngineField = BackendExecutorContext.class.getDeclaredField("executorEngine");
-        ExecutorEngine executorEngine = (ExecutorEngine) Plugins.getMemberAccessor().get(executorEngineField, BackendExecutorContext.getInstance());
-        assertNull(executorEngine);
+        ExecutorEngine actual = BackendExecutorContext.getInstance().getExecutorEngine();
+        assertThat(actual, is(BackendExecutorContext.getInstance().getExecutorEngine()));
+    }
+    
+    @Test
+    void assertShutdown() {
+        ContextManager contextManager = mockContextManager();
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        BackendExecutorContext.getInstance().init();
+        BackendExecutorContext.getInstance().shutdown();
+        assertThrows(IllegalStateException.class, () -> BackendExecutorContext.getInstance().getExecutorEngine());
     }
     
     private ContextManager mockContextManager() {

--- a/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializer.java
+++ b/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializer.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.mode.manager.builder.ContextManagerBuilderParam
 import org.apache.shardingsphere.proxy.backend.config.ProxyConfiguration;
 import org.apache.shardingsphere.proxy.backend.config.YamlProxyConfiguration;
 import org.apache.shardingsphere.proxy.backend.config.yaml.swapper.YamlProxyConfigurationSwapper;
+import org.apache.shardingsphere.proxy.backend.context.BackendExecutorContext;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.version.ShardingSphereProxyVersion;
 
@@ -51,6 +52,7 @@ public final class BootstrapInitializer {
         ProxyConfiguration proxyConfig = new YamlProxyConfigurationSwapper().swap(yamlConfig);
         ContextManager contextManager = createContextManager(proxyConfig, modeConfig, port);
         ProxyContext.init(contextManager);
+        BackendExecutorContext.getInstance().init();
         ShardingSphereProxyVersion.setVersion(contextManager);
     }
     

--- a/proxy/bootstrap/src/test/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializerTest.java
+++ b/proxy/bootstrap/src/test/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializerTest.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.mode.manager.builder.ContextManagerBuilderParam
 import org.apache.shardingsphere.proxy.backend.config.YamlProxyConfiguration;
 import org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyDatabaseConfiguration;
 import org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfiguration;
+import org.apache.shardingsphere.proxy.backend.context.BackendExecutorContext;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.version.ShardingSphereProxyVersion;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
@@ -56,7 +57,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(AutoMockExtension.class)
-@StaticMockSettings({ProxyContext.class, ShardingSphereProxyVersion.class})
+@StaticMockSettings({BackendExecutorContext.class, ProxyContext.class, ShardingSphereProxyVersion.class})
 class BootstrapInitializerTest {
     
     private final Map<Class<?>, Object> originalRegisteredServices = new HashMap<>(2, 1F);
@@ -90,6 +91,7 @@ class BootstrapInitializerTest {
         ArgumentCaptor<ContextManagerBuilderParameter> paramCaptor = ArgumentCaptor.forClass(ContextManagerBuilderParameter.class);
         verify(instanceMetaDataBuilder).build(3307, "");
         verify(contextManagerBuilder).build(paramCaptor.capture(), any(EventBusContext.class));
+        verify(BackendExecutorContext.getInstance()).init();
         ContextManagerBuilderParameter actualParameter = paramCaptor.getValue();
         ModeConfiguration actualModeConfig = actualParameter.getModeConfiguration();
         assertThat(actualModeConfig.getType(), is("Standalone"));
@@ -118,6 +120,7 @@ class BootstrapInitializerTest {
         ArgumentCaptor<ContextManagerBuilderParameter> paramCaptor = ArgumentCaptor.forClass(ContextManagerBuilderParameter.class);
         verify(instanceMetaDataBuilder).build(3307, "");
         verify(contextManagerBuilder).build(paramCaptor.capture(), any(EventBusContext.class));
+        verify(BackendExecutorContext.getInstance()).init();
         ContextManagerBuilderParameter actualParameter = paramCaptor.getValue();
         assertThat(actualParameter.getModeConfiguration().getType(), is("Cluster"));
         assertThat(actualParameter.getDatabaseConfigs().size(), is(1));

--- a/proxy/bootstrap/src/test/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializerTest.java
+++ b/proxy/bootstrap/src/test/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializerTest.java
@@ -53,6 +53,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -129,6 +130,23 @@ class BootstrapInitializerTest {
         assertTrue(actualParameter.getProps().isEmpty());
         assertTrue(actualParameter.getLabels().isEmpty());
         assertThat(actualParameter.getInstanceMetaData(), is(instanceMetaData));
+    }
+    
+    @Test
+    void assertInitWithRepeatedLifecycle() throws SQLException, ReflectiveOperationException {
+        InstanceMetaDataBuilder instanceMetaDataBuilder = mock(InstanceMetaDataBuilder.class);
+        InstanceMetaData instanceMetaData = mock(InstanceMetaData.class);
+        registerSingletonService(InstanceMetaDataBuilder.class, instanceMetaDataBuilder);
+        ContextManagerBuilder contextManagerBuilder = mock(ContextManagerBuilder.class);
+        when(instanceMetaDataBuilder.getType()).thenReturn("Proxy");
+        when(instanceMetaDataBuilder.build(3307, "")).thenReturn(instanceMetaData);
+        when(contextManagerBuilder.isDefault()).thenReturn(true);
+        registerSingletonService(ContextManagerBuilder.class, contextManagerBuilder);
+        BootstrapInitializer bootstrapInitializer = new BootstrapInitializer();
+        bootstrapInitializer.init(createYamlProxyConfiguration(null), 3307);
+        BackendExecutorContext.getInstance().shutdown();
+        bootstrapInitializer.init(createYamlProxyConfiguration(null), 3307);
+        verify(BackendExecutorContext.getInstance(), times(2)).init();
     }
     
     private YamlProxyConfiguration createYamlProxyConfiguration(final YamlModeConfiguration modeConfig) {

--- a/proxy/frontend/core/src/main/java/org/apache/shardingsphere/proxy/frontend/ShardingSphereProxy.java
+++ b/proxy/frontend/core/src/main/java/org/apache/shardingsphere/proxy/frontend/ShardingSphereProxy.java
@@ -168,7 +168,7 @@ public final class ShardingSphereProxy {
         }
         bossGroup.shutdownGracefully();
         workerGroup.shutdownGracefully();
-        BackendExecutorContext.getInstance().getExecutorEngine().close();
+        BackendExecutorContext.getInstance().close();
         ProxyContext.getInstance().getContextManager().close();
         isClosed = true;
     }

--- a/proxy/frontend/core/src/main/java/org/apache/shardingsphere/proxy/frontend/ShardingSphereProxy.java
+++ b/proxy/frontend/core/src/main/java/org/apache/shardingsphere/proxy/frontend/ShardingSphereProxy.java
@@ -168,7 +168,7 @@ public final class ShardingSphereProxy {
         }
         bossGroup.shutdownGracefully();
         workerGroup.shutdownGracefully();
-        BackendExecutorContext.getInstance().close();
+        BackendExecutorContext.getInstance().shutdown();
         ProxyContext.getInstance().getContextManager().close();
         isClosed = true;
     }


### PR DESCRIPTION
Fixes #38664 .

Changes proposed in this pull request:
  - Reset proxy backend executor across repeated ShardingSphereProxy lifecycles .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
