### PR TITLE
Refactor table identifier lookup for heterogeneous databases with LOGICAL_TABLE scope fallback

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierScope.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierScope.java
@@ -28,6 +28,8 @@ public enum IdentifierScope {
     
     TABLE,
     
+    LOGICAL_TABLE,
+    
     VIEW,
     
     COLUMN,

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchema.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchema.java
@@ -54,6 +54,9 @@ public final class ShardingSphereSchema {
     private IdentifierIndex<ShardingSphereTable> tableIndex;
     
     @Getter(AccessLevel.NONE)
+    private IdentifierIndex<ShardingSphereTable> logicalTableIndex;
+    
+    @Getter(AccessLevel.NONE)
     private IdentifierIndex<ShardingSphereView> viewIndex;
     
     /**
@@ -69,6 +72,7 @@ public final class ShardingSphereSchema {
         this.protocolType = protocolType;
         identifierContext = DatabaseIdentifierContextFactory.createDefault();
         tableIndex = new IdentifierIndex<>(identifierContext, IdentifierScope.TABLE);
+        logicalTableIndex = null;
         viewIndex = new IdentifierIndex<>(identifierContext, IdentifierScope.VIEW);
         tableIndex.rebuild(Collections.emptyMap());
         viewIndex.rebuild(Collections.emptyMap());
@@ -109,6 +113,12 @@ public final class ShardingSphereSchema {
      * @return table
      */
     private Optional<ShardingSphereTable> findTable(final IdentifierValue tableName) {
+        if (null != logicalTableIndex) {
+            Optional<ShardingSphereTable> logicalMatchedTable = logicalTableIndex.find(tableName);
+            if (logicalMatchedTable.isPresent()) {
+                return logicalMatchedTable;
+            }
+        }
         return tableIndex.find(tableName);
     }
     
@@ -160,6 +170,9 @@ public final class ShardingSphereSchema {
     public void putTable(final ShardingSphereTable table) {
         refreshTableIdentifierContext(table);
         tableIndex.put(table.getName(), table);
+        if (null != logicalTableIndex) {
+            logicalTableIndex.put(table.getName(), table);
+        }
     }
     
     /**
@@ -173,6 +186,9 @@ public final class ShardingSphereSchema {
             return;
         }
         tableIndex.remove(table.getName());
+        if (null != logicalTableIndex) {
+            logicalTableIndex.remove(table.getName());
+        }
     }
     
     /**
@@ -266,9 +282,14 @@ public final class ShardingSphereSchema {
         final Collection<ShardingSphereView> views = new LinkedList<>(viewIndex.getAll());
         this.identifierContext = identifierContext;
         tableIndex = new IdentifierIndex<>(identifierContext, IdentifierScope.TABLE);
+        logicalTableIndex = createLogicalTableIndex(identifierContext);
         viewIndex = new IdentifierIndex<>(identifierContext, IdentifierScope.VIEW);
         tables.forEach(this::refreshTableIdentifierContext);
-        tableIndex.rebuild(createTableMap(tables));
+        Map<String, ShardingSphereTable> tableMap = createTableMap(tables);
+        tableIndex.rebuild(tableMap);
+        if (null != logicalTableIndex) {
+            logicalTableIndex.rebuild(tableMap);
+        }
         viewIndex.rebuild(createViewMap(views));
     }
     
@@ -344,5 +365,12 @@ public final class ShardingSphereSchema {
     private Map<String, ShardingSphereView> createViewMap(final Collection<ShardingSphereView> views) {
         return views.stream().collect(Collectors.toMap(ShardingSphereView::getName, each -> each, (oldValue, currentValue) -> currentValue,
                 () -> new LinkedHashMap<>(views.size(), 1F)));
+    }
+    
+    private IdentifierIndex<ShardingSphereTable> createLogicalTableIndex(final DatabaseIdentifierContext context) {
+        if (!context.isHeterogeneousTableLookupEnabled()) {
+            return null;
+        }
+        return new IdentifierIndex<>(context, IdentifierScope.LOGICAL_TABLE);
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchema.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchema.java
@@ -113,13 +113,14 @@ public final class ShardingSphereSchema {
      * @return table
      */
     private Optional<ShardingSphereTable> findTable(final IdentifierValue tableName) {
-        if (null != logicalTableIndex) {
-            Optional<ShardingSphereTable> logicalMatchedTable = logicalTableIndex.find(tableName);
-            if (logicalMatchedTable.isPresent()) {
-                return logicalMatchedTable;
-            }
+        Optional<ShardingSphereTable> physicalMatchedTable = tableIndex.find(tableName);
+        if (physicalMatchedTable.isPresent()) {
+            return physicalMatchedTable;
         }
-        return tableIndex.find(tableName);
+        if (null == logicalTableIndex) {
+            return Optional.empty();
+        }
+        return logicalTableIndex.find(tableName);
     }
     
     /**

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContext.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.metadata.identifier;
 
+import lombok.Getter;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSet;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
@@ -30,8 +31,16 @@ public final class DatabaseIdentifierContext {
     
     private volatile IdentifierCaseRuleSet ruleSet;
     
+    @Getter
+    private volatile boolean heterogeneousTableLookupEnabled;
+    
     public DatabaseIdentifierContext(final IdentifierCaseRuleSet ruleSet) {
+        this(ruleSet, false);
+    }
+    
+    public DatabaseIdentifierContext(final IdentifierCaseRuleSet ruleSet, final boolean heterogeneousTableLookupEnabled) {
         this.ruleSet = Objects.requireNonNull(ruleSet, "ruleSet cannot be null.");
+        this.heterogeneousTableLookupEnabled = heterogeneousTableLookupEnabled;
     }
     
     /**
@@ -51,5 +60,16 @@ public final class DatabaseIdentifierContext {
      */
     public synchronized void refresh(final IdentifierCaseRuleSet ruleSet) {
         this.ruleSet = Objects.requireNonNull(ruleSet, "ruleSet cannot be null.");
+    }
+    
+    /**
+     * Refresh identifier context.
+     *
+     * @param ruleSet identifier case rule set
+     * @param heterogeneousTableLookupEnabled heterogeneous table lookup enabled or not
+     */
+    public synchronized void refresh(final IdentifierCaseRuleSet ruleSet, final boolean heterogeneousTableLookupEnabled) {
+        this.ruleSet = Objects.requireNonNull(ruleSet, "ruleSet cannot be null.");
+        this.heterogeneousTableLookupEnabled = heterogeneousTableLookupEnabled;
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
@@ -30,6 +30,7 @@ import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUn
 
 import javax.sql.DataSource;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -81,7 +82,7 @@ public final class DatabaseIdentifierContextFactory {
         Optional<DatabaseType> storageDatabaseType = getIdentifierRuleDatabaseType(resourceMetaData);
         IdentifierCaseRuleSet storageRuleSet = resolver.resolve(storageDatabaseType.orElse(protocolType), actualProps, getFirstDataSource(resourceMetaData));
         IdentifierCaseRuleSet scopeAwareRuleSet = createScopeAwareRuleSet(protocolRuleSet, storageRuleSet);
-        return new DatabaseIdentifierContext(scopeAwareRuleSet, isHeterogeneous(protocolType, storageDatabaseType));
+        return new DatabaseIdentifierContext(scopeAwareRuleSet, isHeterogeneous(protocolType, getStorageDatabaseTypes(resourceMetaData)));
     }
     
     /**
@@ -112,7 +113,7 @@ public final class DatabaseIdentifierContextFactory {
         IdentifierCaseRuleSet protocolRuleSet = resolver.resolve(protocolType, actualProps, null);
         Optional<DatabaseType> storageDatabaseType = getIdentifierRuleDatabaseType(resourceMetaData);
         IdentifierCaseRuleSet storageRuleSet = resolver.resolve(storageDatabaseType.orElse(protocolType), actualProps, getFirstDataSource(resourceMetaData));
-        identifierContext.refresh(createScopeAwareRuleSet(protocolRuleSet, storageRuleSet), isHeterogeneous(protocolType, storageDatabaseType));
+        identifierContext.refresh(createScopeAwareRuleSet(protocolRuleSet, storageRuleSet), isHeterogeneous(protocolType, getStorageDatabaseTypes(resourceMetaData)));
     }
     
     private static ConfigurationProperties getProps(final ConfigurationProperties props) {
@@ -141,18 +142,23 @@ public final class DatabaseIdentifierContextFactory {
     }
     
     private static Optional<DatabaseType> getIdentifierRuleDatabaseType(final ResourceMetaData resourceMetaData) {
+        Collection<DatabaseType> storageDatabaseTypes = getStorageDatabaseTypes(resourceMetaData);
+        return storageDatabaseTypes.stream().findFirst();
+    }
+    
+    private static Collection<DatabaseType> getStorageDatabaseTypes(final ResourceMetaData resourceMetaData) {
         if (null == resourceMetaData || null == resourceMetaData.getStorageUnits() || resourceMetaData.getStorageUnits().isEmpty()) {
-            return Optional.empty();
+            return Collections.emptyList();
         }
         Collection<DatabaseType> storageDatabaseTypes = new LinkedHashSet<>(resourceMetaData.getStorageUnits().size(), 1F);
         for (StorageUnit each : resourceMetaData.getStorageUnits().values()) {
             storageDatabaseTypes.add(each.getStorageType());
         }
-        return storageDatabaseTypes.stream().findFirst();
+        return storageDatabaseTypes;
     }
     
-    private static boolean isHeterogeneous(final DatabaseType protocolType, final Optional<DatabaseType> storageDatabaseType) {
-        return storageDatabaseType.filter(optional -> null != optional.getType() && null != protocolType && null != protocolType.getType())
-                .map(optional -> !protocolType.getType().equalsIgnoreCase(optional.getType())).orElse(false);
+    private static boolean isHeterogeneous(final DatabaseType protocolType, final Collection<DatabaseType> storageDatabaseTypes) {
+        return null != protocolType && null != protocolType.getType() && storageDatabaseTypes.stream()
+                .anyMatch(each -> null != each && null != each.getType() && !protocolType.getType().equalsIgnoreCase(each.getType()));
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
@@ -62,7 +62,8 @@ public final class DatabaseIdentifierContextFactory {
         ConfigurationProperties actualProps = getProps(props);
         IdentifierCaseRuleResolver resolver = new IdentifierCaseRuleResolver();
         IdentifierCaseRuleSet protocolRuleSet = resolver.resolve(protocolType, actualProps, null);
-        return new DatabaseIdentifierContext(createScopeAwareRuleSet(protocolRuleSet, protocolRuleSet));
+        IdentifierCaseRuleSet scopeAwareRuleSet = createScopeAwareRuleSet(protocolRuleSet, protocolRuleSet);
+        return new DatabaseIdentifierContext(scopeAwareRuleSet, false);
     }
     
     /**
@@ -74,7 +75,13 @@ public final class DatabaseIdentifierContextFactory {
      * @return identifier context
      */
     public static DatabaseIdentifierContext create(final DatabaseType protocolType, final ResourceMetaData resourceMetaData, final ConfigurationProperties props) {
-        return new DatabaseIdentifierContext(createRuleSet(protocolType, resourceMetaData, getProps(props)));
+        ConfigurationProperties actualProps = getProps(props);
+        IdentifierCaseRuleResolver resolver = new IdentifierCaseRuleResolver();
+        IdentifierCaseRuleSet protocolRuleSet = resolver.resolve(protocolType, actualProps, null);
+        Optional<DatabaseType> storageDatabaseType = getIdentifierRuleDatabaseType(resourceMetaData);
+        IdentifierCaseRuleSet storageRuleSet = resolver.resolve(storageDatabaseType.orElse(protocolType), actualProps, getFirstDataSource(resourceMetaData));
+        IdentifierCaseRuleSet scopeAwareRuleSet = createScopeAwareRuleSet(protocolRuleSet, storageRuleSet);
+        return new DatabaseIdentifierContext(scopeAwareRuleSet, isHeterogeneous(protocolType, storageDatabaseType));
     }
     
     /**
@@ -88,7 +95,7 @@ public final class DatabaseIdentifierContextFactory {
         ConfigurationProperties actualProps = getProps(props);
         IdentifierCaseRuleResolver resolver = new IdentifierCaseRuleResolver();
         IdentifierCaseRuleSet protocolRuleSet = resolver.resolve(protocolType, actualProps, null);
-        identifierContext.refresh(createScopeAwareRuleSet(protocolRuleSet, protocolRuleSet));
+        identifierContext.refresh(createScopeAwareRuleSet(protocolRuleSet, protocolRuleSet), false);
     }
     
     /**
@@ -100,7 +107,12 @@ public final class DatabaseIdentifierContextFactory {
      * @param props configuration properties
      */
     public static void refresh(final DatabaseIdentifierContext identifierContext, final DatabaseType protocolType, final ResourceMetaData resourceMetaData, final ConfigurationProperties props) {
-        identifierContext.refresh(createRuleSet(protocolType, resourceMetaData, getProps(props)));
+        ConfigurationProperties actualProps = getProps(props);
+        IdentifierCaseRuleResolver resolver = new IdentifierCaseRuleResolver();
+        IdentifierCaseRuleSet protocolRuleSet = resolver.resolve(protocolType, actualProps, null);
+        Optional<DatabaseType> storageDatabaseType = getIdentifierRuleDatabaseType(resourceMetaData);
+        IdentifierCaseRuleSet storageRuleSet = resolver.resolve(storageDatabaseType.orElse(protocolType), actualProps, getFirstDataSource(resourceMetaData));
+        identifierContext.refresh(createScopeAwareRuleSet(protocolRuleSet, storageRuleSet), isHeterogeneous(protocolType, storageDatabaseType));
     }
     
     private static ConfigurationProperties getProps(final ConfigurationProperties props) {
@@ -114,12 +126,6 @@ public final class DatabaseIdentifierContextFactory {
         return resourceMetaData.getStorageUnits().values().iterator().next().getDataSource();
     }
     
-    private static IdentifierCaseRuleSet createRuleSet(final DatabaseType protocolType, final ResourceMetaData resourceMetaData, final ConfigurationProperties props) {
-        IdentifierCaseRuleResolver resolver = new IdentifierCaseRuleResolver();
-        DatabaseType resolvedDatabaseType = getIdentifierRuleDatabaseType(resourceMetaData).orElse(protocolType);
-        return createScopeAwareRuleSet(resolver.resolve(protocolType, props, null), resolver.resolve(resolvedDatabaseType, props, getFirstDataSource(resourceMetaData)));
-    }
-    
     private static IdentifierCaseRuleSet createScopeAwareRuleSet(final IdentifierCaseRuleSet protocolRuleSet, final IdentifierCaseRuleSet storageRuleSet) {
         IdentifierCaseRuleSet databaseRuleSet = IdentifierCaseRuleSets.newInsensitiveRuleSet();
         Map<IdentifierScope, IdentifierCaseRule> scopedRules = new EnumMap<>(IdentifierScope.class);
@@ -130,6 +136,7 @@ public final class DatabaseIdentifierContextFactory {
             }
             scopedRules.put(each, IdentifierScope.SCHEMA == each ? protocolRuleSet.getRule(each) : storageRuleSet.getRule(each));
         }
+        scopedRules.put(IdentifierScope.LOGICAL_TABLE, protocolRuleSet.getRule(IdentifierScope.TABLE));
         return new IdentifierCaseRuleSet(storageRuleSet.getRule(IdentifierScope.TABLE), scopedRules);
     }
     
@@ -142,5 +149,10 @@ public final class DatabaseIdentifierContextFactory {
             storageDatabaseTypes.add(each.getStorageType());
         }
         return storageDatabaseTypes.stream().findFirst();
+    }
+    
+    private static boolean isHeterogeneous(final DatabaseType protocolType, final Optional<DatabaseType> storageDatabaseType) {
+        return storageDatabaseType.filter(optional -> null != optional.getType() && null != protocolType && null != protocolType.getType())
+                .map(optional -> !protocolType.getType().equalsIgnoreCase(optional.getType())).orElse(false);
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchemaIdentifierTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchemaIdentifierTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -117,5 +118,17 @@ class ShardingSphereSchemaIdentifierTest {
         schema.refreshIdentifierContext(context);
         assertTrue(schema.containsTable("FOO_TBL"));
         assertThat(schema.getTable("FOO_TBL"), is(table));
+    }
+    
+    @Test
+    void assertGetTablePrioritizesPhysicalTableIndexWhenBothIndexesCanMatch() {
+        ShardingSphereTable lowerCaseTable = new ShardingSphereTable("foo_tbl", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        ShardingSphereTable upperCaseTable = new ShardingSphereTable("FOO_TBL", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        ShardingSphereSchema schema = new ShardingSphereSchema("foo_schema", postgreSQLDatabaseType, Arrays.asList(lowerCaseTable, upperCaseTable), Collections.emptyList());
+        Map<IdentifierScope, IdentifierCaseRule> scopedRules = new EnumMap<>(IdentifierScope.class);
+        scopedRules.put(IdentifierScope.LOGICAL_TABLE, IdentifierCaseRuleSets.newLowerCaseRuleSet().getRule(IdentifierScope.TABLE));
+        DatabaseIdentifierContext context = new DatabaseIdentifierContext(new IdentifierCaseRuleSet(IdentifierCaseRuleSets.newUpperCaseRuleSet().getRule(IdentifierScope.TABLE), scopedRules), true);
+        schema.refreshIdentifierContext(context);
+        assertThat(schema.getTable("FOO_TBL"), is(upperCaseTable));
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchemaIdentifierTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchemaIdentifierTest.java
@@ -18,12 +18,17 @@
 package org.apache.shardingsphere.infra.metadata.database.schema.model;
 
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSets;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSet;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -100,5 +105,17 @@ class ShardingSphereSchemaIdentifierTest {
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_schema", postgreSQLDatabaseType, Collections.singleton(table), Collections.emptyList());
         schema.refreshIdentifierContext(new DatabaseIdentifierContext(IdentifierCaseRuleSets.newLowerCaseRuleSet()));
         assertFalse(schema.getTable("foo_tbl").containsColumn("FOO_COL"));
+    }
+    
+    @Test
+    void assertContainsTableByLogicalTableIndexWhenHeterogeneousLookupEnabled() {
+        ShardingSphereTable table = new ShardingSphereTable("foo_tbl", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        ShardingSphereSchema schema = new ShardingSphereSchema("foo_schema", postgreSQLDatabaseType, Collections.singleton(table), Collections.emptyList());
+        Map<IdentifierScope, IdentifierCaseRule> scopedRules = new EnumMap<>(IdentifierScope.class);
+        scopedRules.put(IdentifierScope.LOGICAL_TABLE, IdentifierCaseRuleSets.newLowerCaseRuleSet().getRule(IdentifierScope.TABLE));
+        DatabaseIdentifierContext context = new DatabaseIdentifierContext(new IdentifierCaseRuleSet(IdentifierCaseRuleSets.newUpperCaseRuleSet().getRule(IdentifierScope.TABLE), scopedRules), true);
+        schema.refreshIdentifierContext(context);
+        assertTrue(schema.containsTable("FOO_TBL"));
+        assertThat(schema.getTable("FOO_TBL"), is(table));
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -82,6 +82,12 @@ class DatabaseIdentifierContextFactoryTest {
     
     private static final ResourceMetaData ORACLE_RESOURCE_META_DATA = createResourceMetaDataWithStorageUrls("jdbc:oracle:thin:@localhost:1521:xe");
     
+    private static final ResourceMetaData MYSQL_ORACLE_MIXED_RESOURCE_META_DATA = createResourceMetaDataWithStorageUrls(
+            "jdbc:mysql://localhost:3306/foo_db", "jdbc:oracle:thin:@localhost:1521:xe");
+    
+    private static final ResourceMetaData ORACLE_MYSQL_MIXED_RESOURCE_META_DATA = createResourceMetaDataWithStorageUrls(
+            "jdbc:oracle:thin:@localhost:1521:xe", "jdbc:mysql://localhost:3306/foo_db");
+    
     @Test
     void assertCreateDefault() {
         DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.createDefault();
@@ -185,6 +191,29 @@ class DatabaseIdentifierContextFactoryTest {
         DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.createDefault();
         DatabaseIdentifierContextFactory.refresh(actual, MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
         assertFalse(actual.isHeterogeneousTableLookupEnabled());
+    }
+    
+    @Test
+    void assertCreateEnablesHeterogeneousLookupWhenAnyStorageTypeDiffersFromProtocolEvenIfFirstMatches() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, MYSQL_ORACLE_MIXED_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        assertTrue(actual.isHeterogeneousTableLookupEnabled());
+    }
+    
+    @Test
+    void assertRefreshEnablesHeterogeneousLookupWhenAnyStorageTypeDiffersFromProtocolEvenIfFirstMatches() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.createDefault();
+        DatabaseIdentifierContextFactory.refresh(actual, MYSQL_DATABASE_TYPE, MYSQL_ORACLE_MIXED_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        assertTrue(actual.isHeterogeneousTableLookupEnabled());
+    }
+    
+    @Test
+    void assertCreateEnablesHeterogeneousLookupRegardlessOfStorageUnitIterationOrder() {
+        DatabaseIdentifierContext mysqlFirstActual = DatabaseIdentifierContextFactory.create(
+                MYSQL_DATABASE_TYPE, MYSQL_ORACLE_MIXED_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        DatabaseIdentifierContext oracleFirstActual = DatabaseIdentifierContextFactory.create(
+                MYSQL_DATABASE_TYPE, ORACLE_MYSQL_MIXED_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        assertTrue(mysqlFirstActual.isHeterogeneousTableLookupEnabled());
+        assertTrue(oracleFirstActual.isHeterogeneousTableLookupEnabled());
     }
     
     @Test

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -174,6 +174,19 @@ class DatabaseIdentifierContextFactoryTest {
     }
     
     @Test
+    void assertCreateDisablesHeterogeneousLookupWhenProtocolAndStorageAreHomogeneous() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        assertThat(actual.isHeterogeneousTableLookupEnabled(), is(false));
+    }
+    
+    @Test
+    void assertRefreshDisablesHeterogeneousLookupWhenProtocolAndStorageAreHomogeneous() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.createDefault();
+        DatabaseIdentifierContextFactory.refresh(actual, MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        assertThat(actual.isHeterogeneousTableLookupEnabled(), is(false));
+    }
+    
+    @Test
     void assertCreateUsesInsensitiveRuleForDatabaseScope() {
         DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(ORACLE_DATABASE_TYPE,
                 createConfigurationProperties(MetadataIdentifierCaseSensitivity.SENSITIVE));

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -57,6 +57,7 @@ import java.util.logging.Logger;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DatabaseIdentifierContextFactoryTest {
@@ -176,14 +177,14 @@ class DatabaseIdentifierContextFactoryTest {
     @Test
     void assertCreateDisablesHeterogeneousLookupWhenProtocolAndStorageAreHomogeneous() {
         DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
-        assertThat(actual.isHeterogeneousTableLookupEnabled(), is(false));
+        assertFalse(actual.isHeterogeneousTableLookupEnabled());
     }
     
     @Test
     void assertRefreshDisablesHeterogeneousLookupWhenProtocolAndStorageAreHomogeneous() {
         DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.createDefault();
         DatabaseIdentifierContextFactory.refresh(actual, MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
-        assertThat(actual.isHeterogeneousTableLookupEnabled(), is(false));
+        assertFalse(actual.isHeterogeneousTableLookupEnabled());
     }
     
     @Test

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -153,6 +153,27 @@ class DatabaseIdentifierContextFactoryTest {
     }
     
     @Test
+    void assertCreateUsesProtocolRuleForLogicalTableAndEnablesHeterogeneousLookup() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        IdentifierCaseRule actualLogicalTableRule = actual.getRule(IdentifierScope.LOGICAL_TABLE);
+        IdentifierCaseRule actualTableRule = actual.getRule(IdentifierScope.TABLE);
+        assertTrue(actual.isHeterogeneousTableLookupEnabled());
+        assertTrue(actualLogicalTableRule.matches("t_order", "T_ORDER", QuoteCharacter.NONE));
+        assertTrue(actualTableRule.matches("T_ORDER", "t_order", QuoteCharacter.NONE));
+    }
+    
+    @Test
+    void assertRefreshUsesProtocolRuleForLogicalTableAndEnablesHeterogeneousLookup() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.createDefault();
+        DatabaseIdentifierContextFactory.refresh(actual, MYSQL_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        IdentifierCaseRule actualLogicalTableRule = actual.getRule(IdentifierScope.LOGICAL_TABLE);
+        IdentifierCaseRule actualTableRule = actual.getRule(IdentifierScope.TABLE);
+        assertTrue(actual.isHeterogeneousTableLookupEnabled());
+        assertTrue(actualLogicalTableRule.matches("t_order", "T_ORDER", QuoteCharacter.NONE));
+        assertTrue(actualTableRule.matches("T_ORDER", "t_order", QuoteCharacter.NONE));
+    }
+    
+    @Test
     void assertCreateUsesInsensitiveRuleForDatabaseScope() {
         DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(ORACLE_DATABASE_TYPE,
                 createConfigurationProperties(MetadataIdentifierCaseSensitivity.SENSITIVE));


### PR DESCRIPTION


Changes proposed in this pull request:
 
## Root Cause, Repro, and Fix Mapping

### Root Cause
In heterogeneous protocol/storage deployments, table identifier matching mixed two semantics:
- logical table names should follow **protocol-side** identifier rules
- physical/storage table names should follow **storage-side** identifier rules

The previous lookup flow could not consistently satisfy both, which caused metadata lookup mismatches in cross-database case rules.

### Trigger Condition
- Protocol database type differs from storage database type (for example MySQL protocol + Oracle storage).
- Logical table name and actual storage table names differ in case normalization behavior.

### Failure Path
1. Metadata is loaded from storage-side objects (physical table names).
2. Lookup uses a single table matching rule path.
3. In heterogeneous case-rule combinations, one side (logical or physical) can be missed.

### Expected vs Actual (before fix)
- **Expected**: both logical-table lookup and physical-table lookup should be resolvable without requiring caller-side table-type awareness.
- **Actual**: one side could fail depending on active case rule interpretation.

## Minimal Repro Scenario

1. Use heterogeneous topology:
- Protocol: MySQL
- Storage: Oracle

2. Table shape:
- Logical table: `sbtest`
- Physical tables: `SBTEST_0`, `SBTEST_1`

3. Behavior before fix:
- Storage metadata loading follows Oracle physical naming.
- Logical lookup under protocol semantics can mismatch physical-index-only resolution.

4. Behavior after fix:
- Physical index remains storage-rule-based.
- Logical fallback index is protocol-rule-based and enabled only for heterogeneous mode.

## Fix Mapping (code -> risk point -> test)

1. Lookup precedence correction
- Code: `ShardingSphereSchema#findTable`
- Change: physical index first, logical fallback second.
- Risk addressed: same-name collision/shadowing should not override physical match.
- Test: `ShardingSphereSchemaIdentifierTest#assertGetTablePrioritizesPhysicalTableIndexWhenBothIndexesCanMatch`

2. Heterogeneous-only fallback enablement
- Code: `DatabaseIdentifierContextFactory` / `DatabaseIdentifierContext`
- Change: heterogeneous flag controls logical fallback index initialization.
- Risk addressed: avoid behavior/perf impact in homogeneous deployments.
- Tests:
  - `DatabaseIdentifierContextFactoryTest#assertCreateDisablesHeterogeneousLookupWhenProtocolAndStorageAreHomogeneous`
  - `DatabaseIdentifierContextFactoryTest#assertRefreshDisablesHeterogeneousLookupWhenProtocolAndStorageAreHomogeneous`

3. Protocol-vs-storage scope wiring
- Code: `IdentifierScope.LOGICAL_TABLE` + scope-aware rule set wiring
- Change: LOGICAL_TABLE follows protocol TABLE rule; TABLE keeps storage rule.
- Risk addressed: logical and physical lookups use correct semantics in heterogeneous mode.
- Tests:
  - `DatabaseIdentifierContextFactoryTest#assertCreateUsesProtocolRuleForLogicalTableAndEnablesHeterogeneousLookup`
  - `DatabaseIdentifierContextFactoryTest#assertRefreshUsesProtocolRuleForLogicalTableAndEnablesHeterogeneousLookup`

## Blast Radius Validation

### Target scenario
- Heterogeneous protocol/storage lookup behavior is covered by newly added identifier-context and schema tests.

### Non-target scenario (shared path safety)
- Homogeneous protocol/storage path verified to keep fallback disabled.
- This confirms no unnecessary logical-fallback activation on non-target paths.

### Disabled-path validation
- Verified by:
  - `assertCreateDisablesHeterogeneousLookupWhenProtocolAndStorageAreHomogeneous`
  - `assertRefreshDisablesHeterogeneousLookupWhenProtocolAndStorageAreHomogeneous`

## Pre-Merge Verification Evidence

### Local verification commands
```bash
./mvnw -pl infra/common -am -DskipITs -Dspotless.skip=true -Dtest=ShardingSphereSchemaIdentifierTest,DatabaseIdentifierContextFactoryTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl infra/common -am -DskipITs -Dspotless.skip=true -Dtest=DatabaseIdentifierContextFactoryTest -Dsurefire.failIfNoSpecifiedTests=false test
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
