### PR TITLE
Fix unload all single table

### DIFF
--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/persist/metadata/DatabaseMetaDataPersistFacade.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/persist/metadata/DatabaseMetaDataPersistFacade.java
@@ -165,4 +165,16 @@ public final class DatabaseMetaDataPersistFacade {
             }
         });
     }
+    
+    /**
+     * Persist reload database by unload single table.
+     *
+     * @param databaseName database name
+     * @param reloadDatabase reload database
+     * @param currentDatabase current database
+     */
+    public void persistReloadDatabaseByUnloadSingleTable(final String databaseName, final ShardingSphereDatabase reloadDatabase, final ShardingSphereDatabase currentDatabase) {
+        Collection<ShardingSphereSchema> toBeAlteredSchemasWithTablesDropped = GenericSchemaManager.getToBeAlteredSchemasWithTablesDropped(reloadDatabase, currentDatabase);
+        toBeAlteredSchemasWithTablesDropped.forEach(each -> table.drop(databaseName, each.getName(), each.getAllTables()));
+    }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/metadata/DatabaseMetaDataPersistFacadeTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/metadata/DatabaseMetaDataPersistFacadeTest.java
@@ -126,6 +126,15 @@ class DatabaseMetaDataPersistFacadeTest {
     }
     
     @Test
+    void assertPersistReloadDatabaseByUnloadSingleTable() {
+        when(GenericSchemaManager.getToBeAlteredSchemasWithTablesDropped(any(), any()))
+                .thenReturn(Collections.singleton(new ShardingSphereSchema("Foo_Dropped", mock(DatabaseType.class))));
+        databaseMetaDataFacade.persistReloadDatabaseByUnloadSingleTable("foo_db", mock(ShardingSphereDatabase.class), mock(ShardingSphereDatabase.class));
+        verify(tableMetaDataService).drop(eq("foo_db"), eq("Foo_Dropped"), anyCollection());
+        verify(tableMetaDataService, never()).persist(anyString(), anyString(), anyCollection());
+    }
+    
+    @Test
     void assertRenameSchemaWithEmptySchema() {
         ShardingSphereDatabase database = createDatabase("foo_db", Collections.singleton(new ShardingSphereSchema("foo_schema", mock(DatabaseType.class))));
         databaseMetaDataFacade.renameSchema(createMetaData(database), database, "foo_schema", "bar_schema");

--- a/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistService.java
+++ b/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistService.java
@@ -208,26 +208,33 @@ public final class ClusterMetaDataManagerPersistService implements MetaDataManag
         if (null == toBeRemovedRuleItemConfig) {
             return;
         }
-        Collection<String> needReloadTables = getNeedReloadTables(database, toBeRemovedRuleItemConfig);
         MetaDataContexts originalMetaDataContexts = new MetaDataContexts(metaDataContextManager.getMetaDataContexts().getMetaData(), metaDataContextManager.getMetaDataContexts().getStatistics());
+        if (toBeRemovedRuleItemConfig instanceof SingleRuleConfiguration) {
+            removeSingleRuleConfiguration(database, toBeRemovedRuleItemConfig, originalMetaDataContexts);
+            return;
+        }
+        Collection<String> needReloadTables = toBeRemovedRuleItemConfig.getLogicTableNames();
         metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleItemConfig));
         metaDataPersistFacade.getDatabaseMetaDataFacade().persistAlteredTables(database.getName(), getReloadedMetaDataContexts(originalMetaDataContexts), needReloadTables);
     }
     
-    private Collection<String> getNeedReloadTables(final ShardingSphereDatabase originalDatabase, final RuleConfiguration toBeAlteredRuleConfig) {
-        if (toBeAlteredRuleConfig instanceof SingleRuleConfiguration) {
-            Collection<String> originalSingleTables = originalDatabase.getRuleMetaData().getSingleRule(SingleRule.class).getConfiguration().getLogicTableNames();
-            return toBeAlteredRuleConfig.getLogicTableNames().stream().filter(each -> !originalSingleTables.contains(each)).collect(Collectors.toList());
-        }
-        return toBeAlteredRuleConfig.getLogicTableNames();
-    }
-    
     @Override
     public void removeRuleConfiguration(final ShardingSphereDatabase database, final RuleConfiguration toBeRemovedRuleConfig, final String ruleType) {
-        Collection<String> needReloadTables = getNeedReloadTables(database, toBeRemovedRuleConfig);
         MetaDataContexts originalMetaDataContexts = new MetaDataContexts(metaDataContextManager.getMetaDataContexts().getMetaData(), metaDataContextManager.getMetaDataContexts().getStatistics());
+        if (toBeRemovedRuleConfig instanceof SingleRuleConfiguration) {
+            removeSingleRuleConfiguration(database, toBeRemovedRuleConfig, originalMetaDataContexts);
+            return;
+        }
+        Collection<String> needReloadTables = toBeRemovedRuleConfig.getLogicTableNames();
         metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), ruleType);
         metaDataPersistFacade.getDatabaseMetaDataFacade().persistAlteredTables(database.getName(), getReloadedMetaDataContexts(originalMetaDataContexts), needReloadTables);
+    }
+    
+    private void removeSingleRuleConfiguration(final ShardingSphereDatabase database, final RuleConfiguration toBeRemovedRuleItemConfig, final MetaDataContexts originalMetaDataContexts) {
+        metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleItemConfig));
+        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(database.getName(),
+                getReloadedMetaDataContexts(originalMetaDataContexts).getMetaData().getDatabase(database.getName()),
+                originalMetaDataContexts.getMetaData().getDatabase(database.getName()));
     }
     
     @Override

--- a/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistServiceTest.java
+++ b/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistServiceTest.java
@@ -47,7 +47,6 @@ import java.util.Properties;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -179,19 +178,32 @@ class ClusterMetaDataManagerPersistServiceTest {
         ruleConfig.setTables(Collections.singleton("ds_0.t_order"));
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
         when(database.getName()).thenReturn("foo_db");
-        SingleRule singleRule = mock(SingleRule.class);
-        when(singleRule.getConfiguration()).thenReturn(new SingleRuleConfiguration());
-        when(database.getRuleMetaData()).thenReturn(new RuleMetaData(Collections.singleton(singleRule)));
         metaDataManagerPersistService.removeRuleConfigurationItem(database, ruleConfig);
         verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", Collections.singleton(ruleConfig));
-        verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).persistAlteredTables(eq("foo_db"), any(), argThat(actual -> 1 == actual.size() && actual.contains("t_order")));
+        verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).persistReloadDatabaseByUnloadSingleTable(eq("foo_db"), any(), any());
+        verify(metaDataPersistFacade.getDatabaseMetaDataFacade(), never()).persistAlteredTables(eq("foo_db"), any(), any());
     }
     
     @Test
     void assertRemoveRuleConfiguration() {
-        metaDataManagerPersistService.removeRuleConfiguration(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
-                mock(RuleConfiguration.class), "fixtureRule");
+        RuleConfiguration ruleConfig = mock(RuleConfiguration.class);
+        when(ruleConfig.getLogicTableNames()).thenReturn(Collections.singleton("t_order"));
+        metaDataManagerPersistService.removeRuleConfiguration(
+                new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())), ruleConfig, "fixtureRule");
         verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", "fixtureRule");
+        verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).persistAlteredTables(eq("foo_db"), any(), eq(Collections.singleton("t_order")));
+    }
+    
+    @Test
+    void assertRemoveSingleRuleConfiguration() {
+        SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration();
+        ruleConfig.setTables(Collections.singleton("ds_0.t_order"));
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
+        when(database.getName()).thenReturn("foo_db");
+        metaDataManagerPersistService.removeRuleConfiguration(database, ruleConfig, "SINGLE");
+        verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", Collections.singleton(ruleConfig));
+        verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).persistReloadDatabaseByUnloadSingleTable(eq("foo_db"), any(), any());
+        verify(metaDataPersistFacade.getDatabaseRuleService(), never()).delete("foo_db", "SINGLE");
     }
     
     @Test

--- a/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistService.java
+++ b/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistService.java
@@ -234,6 +234,14 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
         if (null == toBeRemovedRuleItemConfig) {
             return;
         }
+        if (toBeRemovedRuleItemConfig instanceof SingleRuleConfiguration) {
+            Collection<MetaDataVersion> metaDataVersions = metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleItemConfig));
+            removeRuleItem(database.getName(), metaDataVersions);
+            metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(
+                    database.getName(), metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase(database.getName()), database);
+            clearServicesCache();
+            return;
+        }
         Collection<String> needReloadTables = getNeedReloadTables(database, toBeRemovedRuleItemConfig);
         Collection<MetaDataVersion> metaDataVersions = metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleItemConfig));
         removeRuleItem(database.getName(), metaDataVersions);
@@ -267,6 +275,14 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
     
     @Override
     public void removeRuleConfiguration(final ShardingSphereDatabase database, final RuleConfiguration toBeRemovedRuleConfig, final String ruleType) {
+        if (toBeRemovedRuleConfig instanceof SingleRuleConfiguration) {
+            metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), ruleType);
+            metaDataContextManager.getDatabaseRuleItemManager().drop(new DatabaseRuleNodePath(database.getName(), ruleType, null));
+            metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(
+                    database.getName(), metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase(database.getName()), database);
+            clearServicesCache();
+            return;
+        }
         Collection<String> needReloadTables = getNeedReloadTables(database, toBeRemovedRuleConfig);
         metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), ruleType);
         metaDataContextManager.getDatabaseRuleItemManager().drop(new DatabaseRuleNodePath(database.getName(), ruleType, null));

--- a/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistService.java
+++ b/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistService.java
@@ -235,11 +235,7 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
             return;
         }
         if (toBeRemovedRuleItemConfig instanceof SingleRuleConfiguration) {
-            Collection<MetaDataVersion> metaDataVersions = metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleItemConfig));
-            removeRuleItem(database.getName(), metaDataVersions);
-            metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(
-                    database.getName(), metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase(database.getName()), database);
-            clearServicesCache();
+            removeSingleRuleConfiguration(database, toBeRemovedRuleItemConfig);
             return;
         }
         Collection<String> needReloadTables = getNeedReloadTables(database, toBeRemovedRuleItemConfig);
@@ -276,17 +272,21 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
     @Override
     public void removeRuleConfiguration(final ShardingSphereDatabase database, final RuleConfiguration toBeRemovedRuleConfig, final String ruleType) {
         if (toBeRemovedRuleConfig instanceof SingleRuleConfiguration) {
-            metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), ruleType);
-            metaDataContextManager.getDatabaseRuleItemManager().drop(new DatabaseRuleNodePath(database.getName(), ruleType, null));
-            metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(
-                    database.getName(), metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase(database.getName()), database);
-            clearServicesCache();
+            removeSingleRuleConfiguration(database, toBeRemovedRuleConfig);
             return;
         }
         Collection<String> needReloadTables = getNeedReloadTables(database, toBeRemovedRuleConfig);
         metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), ruleType);
         metaDataContextManager.getDatabaseRuleItemManager().drop(new DatabaseRuleNodePath(database.getName(), ruleType, null));
         persistAndAlterSchemaTables(database, needReloadTables);
+        clearServicesCache();
+    }
+    
+    private void removeSingleRuleConfiguration(final ShardingSphereDatabase database, final RuleConfiguration toBeRemovedRuleConfig) {
+        Collection<MetaDataVersion> metaDataVersions = metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleConfig));
+        removeRuleItem(database.getName(), metaDataVersions);
+        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(
+                database.getName(), metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase(database.getName()), database);
         clearServicesCache();
     }
     

--- a/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistService.java
+++ b/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistService.java
@@ -235,7 +235,11 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
             return;
         }
         if (toBeRemovedRuleItemConfig instanceof SingleRuleConfiguration) {
-            removeSingleRuleConfiguration(database, toBeRemovedRuleItemConfig);
+            Collection<MetaDataVersion> metaDataVersions = metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleItemConfig));
+            removeRuleItem(database.getName(), metaDataVersions);
+            metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(
+                    database.getName(), metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase(database.getName()), database);
+            clearServicesCache();
             return;
         }
         Collection<String> needReloadTables = getNeedReloadTables(database, toBeRemovedRuleItemConfig);
@@ -272,21 +276,17 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
     @Override
     public void removeRuleConfiguration(final ShardingSphereDatabase database, final RuleConfiguration toBeRemovedRuleConfig, final String ruleType) {
         if (toBeRemovedRuleConfig instanceof SingleRuleConfiguration) {
-            removeSingleRuleConfiguration(database, toBeRemovedRuleConfig);
+            metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), ruleType);
+            metaDataContextManager.getDatabaseRuleItemManager().drop(new DatabaseRuleNodePath(database.getName(), ruleType, null));
+            metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(
+                    database.getName(), metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase(database.getName()), database);
+            clearServicesCache();
             return;
         }
         Collection<String> needReloadTables = getNeedReloadTables(database, toBeRemovedRuleConfig);
         metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), ruleType);
         metaDataContextManager.getDatabaseRuleItemManager().drop(new DatabaseRuleNodePath(database.getName(), ruleType, null));
         persistAndAlterSchemaTables(database, needReloadTables);
-        clearServicesCache();
-    }
-    
-    private void removeSingleRuleConfiguration(final ShardingSphereDatabase database, final RuleConfiguration toBeRemovedRuleConfig) {
-        Collection<MetaDataVersion> metaDataVersions = metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleConfig));
-        removeRuleItem(database.getName(), metaDataVersions);
-        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(
-                database.getName(), metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase(database.getName()), database);
         clearServicesCache();
     }
     

--- a/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
+++ b/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
@@ -198,10 +198,35 @@ class StandaloneMetaDataManagerPersistServiceTest {
     }
     
     @Test
+    void assertRemoveSingleRuleConfigurationItem() {
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        when(database.getName()).thenReturn("foo_db");
+        SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration();
+        ruleConfig.setTables(Collections.singleton("ds_0.t_order"));
+        DatabaseRuleNodePath databaseRuleNodePath = new DatabaseRuleNodePath("foo_db", "single", new DatabaseRuleItem("unique"));
+        when(metaDataPersistFacade.getDatabaseRuleService().delete("foo_db", Collections.singleton(ruleConfig))).thenReturn(Collections.singleton(new MetaDataVersion(databaseRuleNodePath)));
+        metaDataManagerPersistService.removeRuleConfigurationItem(database, ruleConfig);
+        verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", Collections.singleton(ruleConfig));
+        verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).persistReloadDatabaseByUnloadSingleTable(eq("foo_db"), any(), eq(database));
+        verify(metaDataPersistFacade.getDatabaseMetaDataFacade(), never()).persistAlteredTables(eq("foo_db"), any(), any());
+    }
+    
+    @Test
     void assertRemoveRuleConfiguration() {
         metaDataManagerPersistService.removeRuleConfiguration(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
                 mock(RuleConfiguration.class), "foo_rule");
         verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", "foo_rule");
+    }
+    
+    @Test
+    void assertRemoveSingleRuleConfiguration() {
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        when(database.getName()).thenReturn("foo_db");
+        SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration();
+        ruleConfig.setTables(Collections.singleton("ds_0.t_order"));
+        metaDataManagerPersistService.removeRuleConfiguration(database, ruleConfig, "SINGLE");
+        verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", "SINGLE");
+        verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).persistReloadDatabaseByUnloadSingleTable(eq("foo_db"), any(), eq(database));
     }
     
     @Test

--- a/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
+++ b/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
@@ -224,12 +224,9 @@ class StandaloneMetaDataManagerPersistServiceTest {
         when(database.getName()).thenReturn("foo_db");
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration();
         ruleConfig.setTables(Collections.singleton("ds_0.t_order"));
-        DatabaseRuleNodePath databaseRuleNodePath = new DatabaseRuleNodePath("foo_db", "single", new DatabaseRuleItem("unique"));
-        when(metaDataPersistFacade.getDatabaseRuleService().delete("foo_db", Collections.singleton(ruleConfig))).thenReturn(Collections.singleton(new MetaDataVersion(databaseRuleNodePath)));
         metaDataManagerPersistService.removeRuleConfiguration(database, ruleConfig, "SINGLE");
-        verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", Collections.singleton(ruleConfig));
+        verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", "SINGLE");
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).persistReloadDatabaseByUnloadSingleTable(eq("foo_db"), any(), eq(database));
-        verify(metaDataPersistFacade.getDatabaseRuleService(), never()).delete("foo_db", "SINGLE");
     }
     
     @Test

--- a/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
+++ b/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
@@ -224,9 +224,12 @@ class StandaloneMetaDataManagerPersistServiceTest {
         when(database.getName()).thenReturn("foo_db");
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration();
         ruleConfig.setTables(Collections.singleton("ds_0.t_order"));
+        DatabaseRuleNodePath databaseRuleNodePath = new DatabaseRuleNodePath("foo_db", "single", new DatabaseRuleItem("unique"));
+        when(metaDataPersistFacade.getDatabaseRuleService().delete("foo_db", Collections.singleton(ruleConfig))).thenReturn(Collections.singleton(new MetaDataVersion(databaseRuleNodePath)));
         metaDataManagerPersistService.removeRuleConfiguration(database, ruleConfig, "SINGLE");
-        verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", "SINGLE");
+        verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", Collections.singleton(ruleConfig));
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).persistReloadDatabaseByUnloadSingleTable(eq("foo_db"), any(), eq(database));
+        verify(metaDataPersistFacade.getDatabaseRuleService(), never()).delete("foo_db", "SINGLE");
     }
     
     @Test


### PR DESCRIPTION


Changes proposed in this pull request:
  - Fix unload all single table

This PR fixes an issue in UNLOAD SINGLE TABLE * handling.

When unloading all single tables, the single table rule was removed, but the corresponding table metadata was not dropped correctly.
As a result, rule state and metadata state became inconsistent.

### Root Cause
The remove flow for SingleRuleConfiguration only removed the rule configuration and did not execute the full table-drop reconciliation path for the unloaded single tables.

### Fix
- Add a dedicated remove path for SingleRuleConfiguration:
  - delete the single rule config
  - then trigger metadata reconciliation via persistReloadDatabaseByUnloadSingleTable(...)
- Apply this behavior consistently so unloading single tables removes both:
  - the single table rule entries
  - the related table metadata entries
  
### Test
- Added/updated tests to verify that for single-rule removal:
  - persistReloadDatabaseByUnloadSingleTable(...) is invoked
  - the generic altered-table path is not incorrectly used for this scenario
  
### Expected Result
After UNLOAD SINGLE TABLE *, both rule and metadata are removed consistently, with no stale table metadata left behind.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
