### PR TITLE
Handle MySQL lower_case_table_names=0 in identifier rules

### DIFF
--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProvider.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProvider.java
@@ -46,8 +46,7 @@ public final class MySQLIdentifierCaseRuleProvider implements IdentifierCaseRule
         if (null == context.getDataSource()) {
             return Optional.empty();
         }
-        try {
-            Connection connection = context.getDataSource().getConnection();
+        try (Connection connection = context.getDataSource().getConnection()) {
             if (null == connection) {
                 return Optional.empty();
             }

--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProvider.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProvider.java
@@ -19,13 +19,17 @@ package org.apache.shardingsphere.database.connector.mysql.metadata.identifier;
 
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleProvider;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleProviderContext;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSet;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSets;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -42,18 +46,33 @@ public final class MySQLIdentifierCaseRuleProvider implements IdentifierCaseRule
         if (null == context.getDataSource()) {
             return Optional.empty();
         }
-        try (
-                Connection connection = context.getDataSource().getConnection();
-                PreparedStatement preparedStatement = connection.prepareStatement(QUERY_LOWER_CASE_TABLE_NAMES);
-                ResultSet resultSet = preparedStatement.executeQuery()) {
-            return resultSet.next() ? createRuleSet(resultSet.getInt(1)) : Optional.empty();
+        try {
+            Connection connection = context.getDataSource().getConnection();
+            if (null == connection) {
+                return Optional.empty();
+            }
+            try (
+                    PreparedStatement preparedStatement = connection.prepareStatement(QUERY_LOWER_CASE_TABLE_NAMES);
+                    ResultSet resultSet = preparedStatement.executeQuery()) {
+                return resultSet.next() ? createRuleSet(resultSet.getInt(1)) : Optional.empty();
+            }
         } catch (final SQLException ignored) {
             return Optional.empty();
         }
     }
     
     private Optional<IdentifierCaseRuleSet> createRuleSet(final int lowerCaseTableNames) {
-        return 1 == lowerCaseTableNames || 2 == lowerCaseTableNames ? Optional.of(IdentifierCaseRuleSets.newMySQLInsensitiveRuleSet()) : Optional.empty();
+        if (1 == lowerCaseTableNames || 2 == lowerCaseTableNames) {
+            return Optional.of(IdentifierCaseRuleSets.newMySQLInsensitiveRuleSet());
+        }
+        if (0 == lowerCaseTableNames) {
+            Map<IdentifierScope, IdentifierCaseRule> scopedRules = new EnumMap<>(IdentifierScope.class);
+            scopedRules.put(IdentifierScope.SCHEMA, IdentifierCaseRuleSets.newSensitiveRuleSet().getRule(IdentifierScope.SCHEMA));
+            scopedRules.put(IdentifierScope.TABLE, IdentifierCaseRuleSets.newSensitiveRuleSet().getRule(IdentifierScope.TABLE));
+            scopedRules.put(IdentifierScope.VIEW, IdentifierCaseRuleSets.newSensitiveRuleSet().getRule(IdentifierScope.VIEW));
+            return Optional.of(new IdentifierCaseRuleSet(IdentifierCaseRuleSets.newInsensitiveRuleSet().getRule(IdentifierScope.TABLE), scopedRules));
+        }
+        return Optional.empty();
     }
     
     @Override

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProviderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProviderTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.database.enums
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleProvider;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleProviderContext;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSet;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.LookupMode;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
@@ -95,7 +96,9 @@ class MySQLIdentifierCaseRuleProviderTest {
     private static Stream<Arguments> provideArguments() throws SQLException {
         return Stream.of(
                 Arguments.of("null_data_source", new IdentifierCaseRuleProviderContext(DATABASE_TYPE, null), null, null, null),
-                Arguments.of("lower_case_table_names_0", new IdentifierCaseRuleProviderContext(DATABASE_TYPE, mockDataSource(true, 0)), null, null, null),
+                Arguments.of("null_connection", new IdentifierCaseRuleProviderContext(DATABASE_TYPE, mockNullConnectionDataSource()), null, null, null),
+                Arguments.of("lower_case_table_names_0", new IdentifierCaseRuleProviderContext(DATABASE_TYPE, mockDataSource(true, 0)),
+                        LookupMode.EXACT, LookupMode.EXACT, Boolean.FALSE),
                 Arguments.of("lower_case_table_names_1", new IdentifierCaseRuleProviderContext(DATABASE_TYPE, mockDataSource(true, 1)),
                         LookupMode.NORMALIZED, LookupMode.NORMALIZED, Boolean.TRUE),
                 Arguments.of("lower_case_table_names_2", new IdentifierCaseRuleProviderContext(DATABASE_TYPE, mockDataSource(true, 2)),
@@ -104,12 +107,27 @@ class MySQLIdentifierCaseRuleProviderTest {
                 Arguments.of("sql_exception", new IdentifierCaseRuleProviderContext(DATABASE_TYPE, mockFailingDataSource()), null, null, null));
     }
     
+    @Test
+    void assertProvideWithLowerCaseTableNamesZeroUsesScopedRules() throws SQLException {
+        IdentifierCaseRuleProviderContext context = new IdentifierCaseRuleProviderContext(DATABASE_TYPE, mockDataSource(true, 0));
+        IdentifierCaseRuleSet actual = provider.provide(context).orElseThrow(AssertionError::new);
+        assertThat(actual.getRule(IdentifierScope.SCHEMA).matches("foo_schema", "FOO_SCHEMA", QuoteCharacter.NONE), is(Boolean.FALSE));
+        assertThat(actual.getRule(IdentifierScope.TABLE).matches("foo_tbl", "FOO_TBL", QuoteCharacter.NONE), is(Boolean.FALSE));
+        assertThat(actual.getRule(IdentifierScope.VIEW).matches("foo_view", "FOO_VIEW", QuoteCharacter.NONE), is(Boolean.FALSE));
+        assertThat(actual.getRule(IdentifierScope.COLUMN).matches("foo_col", "FOO_COL", QuoteCharacter.NONE), is(Boolean.TRUE));
+        assertThat(actual.getRule(IdentifierScope.INDEX).matches("foo_idx", "FOO_IDX", QuoteCharacter.NONE), is(Boolean.TRUE));
+    }
+    
     private static DataSource mockDataSource(final boolean hasResultSetRow, final int lowerCaseTableNames) throws SQLException {
         return new FixtureDataSource(hasResultSetRow, lowerCaseTableNames);
     }
     
     private static DataSource mockFailingDataSource() throws SQLException {
         return new FailingFixtureDataSource();
+    }
+    
+    private static DataSource mockNullConnectionDataSource() {
+        return new NullConnectionFixtureDataSource();
     }
     
     private static Object getDefaultValue(final Class<?> returnType) {
@@ -226,6 +244,52 @@ class MySQLIdentifierCaseRuleProviderTest {
         @Override
         public Connection getConnection(final String username, final String password) throws SQLException {
             throw new SQLException("expected");
+        }
+        
+        @Override
+        public <T> T unwrap(final Class<T> iface) {
+            return null;
+        }
+        
+        @Override
+        public boolean isWrapperFor(final Class<?> iface) {
+            return false;
+        }
+        
+        @Override
+        public PrintWriter getLogWriter() {
+            return null;
+        }
+        
+        @Override
+        public void setLogWriter(final PrintWriter out) {
+        }
+        
+        @Override
+        public void setLoginTimeout(final int seconds) {
+        }
+        
+        @Override
+        public int getLoginTimeout() {
+            return 0;
+        }
+        
+        @Override
+        public Logger getParentLogger() {
+            return Logger.getGlobal();
+        }
+    }
+    
+    private static final class NullConnectionFixtureDataSource implements DataSource {
+        
+        @Override
+        public Connection getConnection() {
+            return null;
+        }
+        
+        @Override
+        public Connection getConnection(final String username, final String password) {
+            return null;
         }
         
         @Override

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
@@ -78,7 +78,7 @@ public final class DatabaseIdentifierContextFactory {
     public static DatabaseIdentifierContext create(final DatabaseType protocolType, final ResourceMetaData resourceMetaData, final ConfigurationProperties props) {
         ConfigurationProperties actualProps = getProps(props);
         IdentifierCaseRuleResolver resolver = new IdentifierCaseRuleResolver();
-        IdentifierCaseRuleSet protocolRuleSet = resolver.resolve(protocolType, actualProps, null);
+        IdentifierCaseRuleSet protocolRuleSet = resolver.resolve(protocolType, actualProps, getFirstDataSource(resourceMetaData));
         Optional<DatabaseType> storageDatabaseType = getIdentifierRuleDatabaseType(resourceMetaData);
         IdentifierCaseRuleSet storageRuleSet = resolver.resolve(storageDatabaseType.orElse(protocolType), actualProps, getFirstDataSource(resourceMetaData));
         IdentifierCaseRuleSet scopeAwareRuleSet = createScopeAwareRuleSet(protocolRuleSet, storageRuleSet);
@@ -110,7 +110,7 @@ public final class DatabaseIdentifierContextFactory {
     public static void refresh(final DatabaseIdentifierContext identifierContext, final DatabaseType protocolType, final ResourceMetaData resourceMetaData, final ConfigurationProperties props) {
         ConfigurationProperties actualProps = getProps(props);
         IdentifierCaseRuleResolver resolver = new IdentifierCaseRuleResolver();
-        IdentifierCaseRuleSet protocolRuleSet = resolver.resolve(protocolType, actualProps, null);
+        IdentifierCaseRuleSet protocolRuleSet = resolver.resolve(protocolType, actualProps, getFirstDataSource(resourceMetaData));
         Optional<DatabaseType> storageDatabaseType = getIdentifierRuleDatabaseType(resourceMetaData);
         IdentifierCaseRuleSet storageRuleSet = resolver.resolve(storageDatabaseType.orElse(protocolType), actualProps, getFirstDataSource(resourceMetaData));
         identifierContext.refresh(createScopeAwareRuleSet(protocolRuleSet, storageRuleSet), isHeterogeneous(protocolType, getStorageDatabaseTypes(resourceMetaData)));

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
@@ -137,7 +137,7 @@ public final class DatabaseIdentifierContextFactory {
             }
             scopedRules.put(each, IdentifierScope.SCHEMA == each ? protocolRuleSet.getRule(each) : storageRuleSet.getRule(each));
         }
-        scopedRules.put(IdentifierScope.LOGICAL_TABLE, protocolRuleSet.getRule(IdentifierScope.TABLE));
+        scopedRules.put(IdentifierScope.LOGICAL_TABLE, protocolRuleSet.getRule(IdentifierScope.LOGICAL_TABLE));
         return new IdentifierCaseRuleSet(storageRuleSet.getRule(IdentifierScope.TABLE), scopedRules);
     }
     

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -384,7 +384,7 @@ class DatabaseIdentifierContextFactoryTest {
     
     private static Stream<Arguments> createWithSupportedDatabaseSchemaLookupArguments() {
         return Stream.of(
-                createInsensitiveQuotedExactLookupArguments("mysql schema", MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, "foo_schema", "`"),
+                createNormalizedLookupArguments("mysql schema", MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, "foo_schema", "`"),
                 createLowerCaseLookupArguments("postgresql schema", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
                 createLowerCaseLookupArguments("openGauss schema", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
                 createUpperCaseLookupArguments("oracle schema", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_schema", "\""))
@@ -441,7 +441,7 @@ class DatabaseIdentifierContextFactoryTest {
     
     private static Stream<Arguments> createWithMixedStoredCaseSchemaLookupArguments() {
         return Stream.of(
-                createInsensitiveQuotedExactMixedLookupArguments("mysql schema", MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, "foo_schema", "`"),
+                createNormalizedMixedLookupArguments("mysql schema", MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, "foo_schema", "`"),
                 createLowerCaseMixedLookupArguments("postgresql schema", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
                 createLowerCaseMixedLookupArguments("openGauss schema", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
                 createUpperCaseMixedLookupArguments("oracle schema", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_schema", "\""))

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -76,6 +76,8 @@ class DatabaseIdentifierContextFactoryTest {
     
     private static final ResourceMetaData MYSQL_QUOTED_INSENSITIVE_RESOURCE_META_DATA = createResourceMetaDataWithMySQLLowerCaseTableNames(2);
     
+    private static final ResourceMetaData MYSQL_SENSITIVE_STORAGE_RESOURCE_META_DATA = createResourceMetaDataWithMySQLLowerCaseTableNames(0);
+    
     private static final ResourceMetaData POSTGRESQL_RESOURCE_META_DATA = createResourceMetaDataWithStorageUrls("jdbc:postgresql://localhost:5432/foo_db");
     
     private static final ResourceMetaData OPEN_GAUSS_RESOURCE_META_DATA = createResourceMetaDataWithStorageUrls("jdbc:opengauss://localhost:5432/foo_db");
@@ -178,6 +180,36 @@ class DatabaseIdentifierContextFactoryTest {
         assertTrue(actual.isHeterogeneousTableLookupEnabled());
         assertTrue(actualLogicalTableRule.matches("t_order", "T_ORDER", QuoteCharacter.NONE));
         assertTrue(actualTableRule.matches("T_ORDER", "t_order", QuoteCharacter.NONE));
+    }
+    
+    @Test
+    void assertCreateUsesInsensitiveRuleForLogicalTableWhenMySQLLowerCaseTableNamesIsZero() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, MYSQL_SENSITIVE_STORAGE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        IdentifierCaseRule actualLogicalTableRule = actual.getRule(IdentifierScope.LOGICAL_TABLE);
+        IdentifierCaseRule actualTableRule = actual.getRule(IdentifierScope.TABLE);
+        assertTrue(actualLogicalTableRule.matches("t_order", "T_ORDER", QuoteCharacter.NONE));
+        assertFalse(actualTableRule.matches("t_order", "T_ORDER", QuoteCharacter.NONE));
+    }
+    
+    @Test
+    void assertRefreshUsesInsensitiveRuleForLogicalTableWhenMySQLLowerCaseTableNamesIsZero() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.createDefault();
+        DatabaseIdentifierContextFactory.refresh(actual, MYSQL_DATABASE_TYPE, MYSQL_SENSITIVE_STORAGE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        IdentifierCaseRule actualLogicalTableRule = actual.getRule(IdentifierScope.LOGICAL_TABLE);
+        IdentifierCaseRule actualTableRule = actual.getRule(IdentifierScope.TABLE);
+        assertTrue(actualLogicalTableRule.matches("t_order", "T_ORDER", QuoteCharacter.NONE));
+        assertFalse(actualTableRule.matches("t_order", "T_ORDER", QuoteCharacter.NONE));
+    }
+    
+    @Test
+    void assertCreateKeepsPostgreSQLLogicalTableRuleWithResourceMetadata() {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        IdentifierCaseRule actualLogicalTableRule = actual.getRule(IdentifierScope.LOGICAL_TABLE);
+        IdentifierCaseRule actualTableRule = actual.getRule(IdentifierScope.TABLE);
+        assertTrue(actualLogicalTableRule.matches("t_order", "T_ORDER", QuoteCharacter.NONE));
+        assertTrue(actualTableRule.matches("t_order", "T_ORDER", QuoteCharacter.NONE));
+        assertFalse(actualLogicalTableRule.matches("T_ORDER", "t_order", QuoteCharacter.NONE));
+        assertFalse(actualTableRule.matches("T_ORDER", "t_order", QuoteCharacter.NONE));
     }
     
     @Test

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/MySQLAdminExecutorCreatorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/MySQLAdminExecutorCreatorTest.java
@@ -73,6 +73,7 @@ import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockS
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.sql.Connection;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -287,7 +288,7 @@ class MySQLAdminExecutorCreatorTest {
     
     @Test
     void assertCreateWithOtherSelectStatementForDatabaseName() {
-        ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource()));
+        ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds", new MockedDataSource(mock(Connection.class, RETURNS_DEEP_STUBS))));
         ShardingSphereDatabase database =
                 new ShardingSphereDatabase("db_0", databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         initProxyContext(Collections.singleton(database));
@@ -306,7 +307,7 @@ class MySQLAdminExecutorCreatorTest {
     
     @Test
     void assertCreateWithOtherSelectStatementForNullDatabaseName() {
-        ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds_0", new MockedDataSource()));
+        ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds_0", new MockedDataSource(mock(Connection.class, RETURNS_DEEP_STUBS))));
         ShardingSphereDatabase database =
                 new ShardingSphereDatabase("db_0", databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         initProxyContext(Collections.singleton(database));
@@ -420,7 +421,7 @@ class MySQLAdminExecutorCreatorTest {
     
     @Test
     void assertCreateWithNoFromAndMultiProjectionsSkipsAdmin() {
-        ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds_0", new MockedDataSource()));
+        ResourceMetaData resourceMetaData = new ResourceMetaData(Collections.singletonMap("ds_0", new MockedDataSource(mock(Connection.class, RETURNS_DEEP_STUBS))));
         ShardingSphereDatabase database =
                 new ShardingSphereDatabase("db_0", databaseType, resourceMetaData, mock(RuleMetaData.class), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         initProxyContext(Collections.singleton(database));

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/select/SelectInformationSchemataExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/select/SelectInformationSchemataExecutorTest.java
@@ -51,6 +51,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -68,6 +69,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -185,8 +187,21 @@ class SelectInformationSchemataExecutorTest {
         Connection result = mock(Connection.class, RETURNS_DEEP_STUBS);
         when(result.getMetaData().getURL()).thenReturn("jdbc:mysql://localhost:3306/foo_ds");
         when(result.getCatalog()).thenReturn("foo_ds");
+        PreparedStatement lowerCasePreparedStatement = mock(PreparedStatement.class, RETURNS_DEEP_STUBS);
+        PreparedStatement queryPreparedStatement = mock(PreparedStatement.class, RETURNS_DEEP_STUBS);
         ResultSet resultSet = mockResultSet(expectedResultSetMap);
-        when(result.prepareStatement(any(String.class)).executeQuery()).thenReturn(resultSet);
+        ResultSet lowerCaseResultSet = mockLowerCaseResultSet();
+        when(lowerCasePreparedStatement.executeQuery()).thenReturn(lowerCaseResultSet);
+        when(queryPreparedStatement.executeQuery()).thenReturn(resultSet);
+        when(result.prepareStatement(any(String.class))).thenReturn(queryPreparedStatement);
+        when(result.prepareStatement(eq("SELECT @@lower_case_table_names"))).thenReturn(lowerCasePreparedStatement);
+        return result;
+    }
+    
+    private ResultSet mockLowerCaseResultSet() throws SQLException {
+        ResultSet result = mock(ResultSet.class, RETURNS_DEEP_STUBS);
+        when(result.next()).thenReturn(true);
+        when(result.getInt(1)).thenReturn(1);
         return result;
     }
     


### PR DESCRIPTION

Changes proposed in this pull request:

## Description
This PR adds explicit handling for MySQL `lower_case_table_names=0` in identifier case-rule resolution.

### Changes
- Update `MySQLIdentifierCaseRuleProvider`:
  - `SCHEMA/TABLE/VIEW` are case-sensitive when `lower_case_table_names=0`.
  - Other scopes (for example `COLUMN/INDEX`) remain case-insensitive.
- Keep existing behavior for `lower_case_table_names=1/2`.
- Add null-connection guard in provider (`getConnection()` may return `null`).
- Update `DatabaseIdentifierContextFactory` to resolve protocol rules with datasource context when `ResourceMetaData` is available.
- Fix related tests:
  - `MySQLIdentifierCaseRuleProviderTest`
  - `DatabaseIdentifierContextFactoryTest`
  - `SelectInformationSchemataExecutorTest` (stubbing order / matcher override issue)
  - `MySQLAdminExecutorCreatorTest` (remove unnecessary default datasource stubbing paths)
- Fix Checkstyle indentation in `try-with-resources`.

### Why
Previously, `lower_case_table_names=0` was not modeled precisely and could fall back to insensitive behavior.
This PR makes MySQL `0` behavior explicit for schema/table/view lookup while keeping logical database handling unchanged.

### Test
 All exit code 0
```
./mvnw -pl infra/common -DskipITs -Dspotless.skip=true -Dtest=DatabaseIdentifierContextFactoryTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl infra/common -DskipITs -Dspotless.skip=true -Dtest=DatabaseIdentifierContextFactoryTest#assertCreateKeepsPostgreSQLLogicalTableRuleWithResourceMetadata -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl database/connector/dialect/mysql -am -DskipITs -Dspotless.skip=true -Dtest=MySQLIdentifierCaseRuleProviderTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl infra/common -am -DskipITs -Dspotless.skip=true -Dtest=SchemaMetaDataUtilsTest#assertGetMetaDataLoaderMaterialsNormalizeActualTableNamesByTableScope+DatabaseIdentifierContextFactoryTest -Dsurefire.failIfNoSpecifiedTests=false test
```
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
