### PR TITLE
Normalize actual table/view name with identifier in SchemaMetaDataUtils for different database type

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilder.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilder.java
@@ -69,8 +69,9 @@ public final class GenericSchemaBuilder {
      * @throws SQLException SQL exception
      */
     public static Map<String, ShardingSphereSchema> build(final Collection<String> tableNames, final DatabaseType protocolType, final GenericSchemaBuilderMaterial material) throws SQLException {
-        Map<String, SchemaMetaData> result = loadSchemas(tableNames, material);
-        if (!isSameProtocolAndStorageTypes(protocolType, material.getStorageUnits())) {
+        boolean isSameProtocolAndStorageTypes = isSameProtocolAndStorageTypes(protocolType, material.getStorageUnits());
+        Map<String, SchemaMetaData> result = loadSchemas(tableNames, material, isSameProtocolAndStorageTypes);
+        if (!isSameProtocolAndStorageTypes) {
             result = translate(result, protocolType, material);
         }
         return revise(result, material, protocolType);
@@ -84,8 +85,9 @@ public final class GenericSchemaBuilder {
         return result;
     }
     
-    private static Map<String, SchemaMetaData> loadSchemas(final Collection<String> tableNames, final GenericSchemaBuilderMaterial material) throws SQLException {
-        Collection<MetaDataLoaderMaterial> materials = SchemaMetaDataUtils.getMetaDataLoaderMaterials(tableNames, material);
+    private static Map<String, SchemaMetaData> loadSchemas(final Collection<String> tableNames, final GenericSchemaBuilderMaterial material,
+                                                           final boolean isSameProtocolAndStorageTypes) throws SQLException {
+        Collection<MetaDataLoaderMaterial> materials = SchemaMetaDataUtils.getMetaDataLoaderMaterials(tableNames, material, isSameProtocolAndStorageTypes);
         return materials.isEmpty() ? Collections.emptyMap() : MetaDataLoader.load(materials);
     }
     

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtils.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtils.java
@@ -22,7 +22,6 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.GlobalDataSourceRegistry;
 import org.apache.shardingsphere.database.connector.core.metadata.data.loader.MetaDataLoaderMaterial;
-import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
@@ -33,6 +32,7 @@ import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.datanode.UnsupportedActualDataNodeStructureException;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
 import org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilderMaterial;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 
 import javax.sql.DataSource;
 import java.util.ArrayList;
@@ -56,9 +56,11 @@ public final class SchemaMetaDataUtils {
      *
      * @param tableNames table name collection
      * @param material material
+     * @param isSameProtocolAndStorageTypes whether protocol and storage types are the same
      * @return meta data loader materials
      */
-    public static Collection<MetaDataLoaderMaterial> getMetaDataLoaderMaterials(final Collection<String> tableNames, final GenericSchemaBuilderMaterial material) {
+    public static Collection<MetaDataLoaderMaterial> getMetaDataLoaderMaterials(final Collection<String> tableNames, final GenericSchemaBuilderMaterial material,
+                                                                                final boolean isSameProtocolAndStorageTypes) {
         Map<String, Collection<String>> dataSourceTableGroups = new LinkedHashMap<>();
         Collection<DatabaseType> unsupportedThreeTierStorageStructureDatabaseTypes = getUnsupportedThreeTierStorageStructureDatabaseTypes(material.getStorageUnits().values());
         DataNodes dataNodes = new DataNodes(material.getRules());
@@ -76,20 +78,27 @@ public final class SchemaMetaDataUtils {
         for (Entry<String, Collection<String>> entry : dataSourceTableGroups.entrySet()) {
             DatabaseType storageType = material.getStorageUnits().get(entry.getKey()).getStorageType();
             String defaultSchemaName = new DatabaseTypeRegistry(storageType).getDefaultSchemaName(material.getDefaultSchemaName());
-            result.addAll(buildMaterials(material, entry.getKey(), entry.getValue(), storageType, defaultSchemaName, loadTableMetadataBatchSize));
+            result.addAll(buildMaterials(material, entry.getKey(), entry.getValue(), storageType, defaultSchemaName, loadTableMetadataBatchSize, isSameProtocolAndStorageTypes));
         }
         return result;
     }
     
     private static Collection<MetaDataLoaderMaterial> buildMaterials(final GenericSchemaBuilderMaterial material, final String dataSourceName, final Collection<String> actualTableNames,
-                                                                     final DatabaseType storageType, final String defaultSchemaName, final int loadTableMetadataBatchSize) {
+                                                                     final DatabaseType storageType, final String defaultSchemaName, final int loadTableMetadataBatchSize,
+                                                                     final boolean isSameProtocolAndStorageTypes) {
         Collection<MetaDataLoaderMaterial> result = new LinkedList<>();
         DataSource dataSource = getDataSource(material, dataSourceName);
-        IdentifierCaseRule tableIdentifierRule = material.getIdentifierContext().getRule(IdentifierScope.TABLE);
         for (List<String> each : Lists.partition(new ArrayList<>(actualTableNames), loadTableMetadataBatchSize)) {
-            result.add(new MetaDataLoaderMaterial(each.stream().map(tableIdentifierRule::normalize).collect(Collectors.toList()), dataSourceName, dataSource, storageType, defaultSchemaName));
+            result.add(new MetaDataLoaderMaterial(normalize(each, material.getIdentifierContext(), isSameProtocolAndStorageTypes), dataSourceName, dataSource, storageType, defaultSchemaName));
         }
         return result;
+    }
+    
+    private static Collection<String> normalize(final Collection<String> tableNames, final DatabaseIdentifierContext identifierContext, final boolean isSameProtocolAndStorageTypes) {
+        if (isSameProtocolAndStorageTypes) {
+            return tableNames;
+        }
+        return tableNames.stream().map(each -> identifierContext.getRule(IdentifierScope.TABLE).normalize(each)).collect(Collectors.toList());
     }
     
     private static DataSource getDataSource(final GenericSchemaBuilderMaterial material, final String dataSourceName) {

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtilsTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtilsTest.java
@@ -82,7 +82,7 @@ class SchemaMetaDataUtilsTest {
                                           final List<List<String>> expectedActualTableNames, final List<String> expectedDefaultSchemaNames) {
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits, Collections.singleton(mockDataNodeRule(dataNodes)), props, defaultSchemaName,
                 DatabaseIdentifierContextFactory.createDefault());
-        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material));
+        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material, true));
         assertThat(actual.size(), is(expectedStorageUnitNames.size()));
         for (int i = 0; i < actual.size(); i++) {
             assertThat(actual.get(i).getStorageUnitName(), is(expectedStorageUnitNames.get(i)));
@@ -100,7 +100,7 @@ class SchemaMetaDataUtilsTest {
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits,
                 Collections.singleton(mockDataNodeRule(Collections.singleton(new DataNode("ds.foo_db", "foo_db", "foo_tbl")))),
                 createProperties(Boolean.FALSE, null), "foo_db", DatabaseIdentifierContextFactory.createDefault());
-        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material));
+        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material, true));
         assertThat(actual.size(), is(1));
         assertThat(actual.get(0).getStorageUnitName(), is("ds.foo_db"));
         assertThat(actual.get(0).getDataSource(), is(dataSource));
@@ -118,7 +118,7 @@ class SchemaMetaDataUtilsTest {
                 Collections.singleton(mockDataNodeRule(Collections.singleton(new DataNode("ds.foo_db", "foo_db", "foo_tbl")))),
                 createProperties(Boolean.FALSE, null), "foo_db", DatabaseIdentifierContextFactory.createDefault());
         UnsupportedActualDataNodeStructureException actual = assertThrows(UnsupportedActualDataNodeStructureException.class,
-                () -> SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material));
+                () -> SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material, true));
         assertThat(actual.getMessage(), is("Can not support 3-tier structure for actual data node 'ds.foo_db.foo_tbl' with JDBC 'jdbc:mock'."));
     }
     
@@ -129,7 +129,7 @@ class SchemaMetaDataUtilsTest {
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits, Collections.singleton(
                 mockDataNodeRule(Arrays.asList(new DataNode("ds_0.foo_tbl_0"), new DataNode("ds_0.foo_tbl_1"), new DataNode("ds_0.foo_tbl_2")))),
                 createProperties(Boolean.TRUE, 2), "foo_db", DatabaseIdentifierContextFactory.createDefault());
-        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material));
+        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material, true));
         assertThat(actual.size(), is(2));
         assertThat(actual.get(0).getStorageUnitName(), is("ds_0"));
         assertThat(new ArrayList<>(actual.get(0).getActualTableNames()), is(Arrays.asList("foo_tbl_0", "foo_tbl_1")));
@@ -144,7 +144,7 @@ class SchemaMetaDataUtilsTest {
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits,
                 Collections.singleton(mockDataNodeRule(Collections.singleton(new DataNode("ds_0.t_user")))), props, "foo_db",
                 DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, new ResourceMetaData(Collections.emptyMap(), storageUnits), props));
-        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material));
+        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material, false));
         assertThat(actual.size(), is(1));
         assertThat(new ArrayList<>(actual.get(0).getActualTableNames()), is(Collections.singletonList("T_USER")));
     }
@@ -158,7 +158,7 @@ class SchemaMetaDataUtilsTest {
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(storageUnits, Collections.singleton(
                 mockDataNodeRule(Arrays.asList(new DataNode("ds_mysql.t_order"), new DataNode("ds_oracle.t_user")))), props, "foo_db",
                 DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, new ResourceMetaData(Collections.emptyMap(), storageUnits), props));
-        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material));
+        List<MetaDataLoaderMaterial> actual = new ArrayList<>(SchemaMetaDataUtils.getMetaDataLoaderMaterials(Collections.singleton("foo_tbl"), material, false));
         assertThat(actual.size(), is(2));
         assertThat(actual.get(0).getStorageUnitName(), is("ds_mysql"));
         assertThat(new ArrayList<>(actual.get(0).getActualTableNames()), is(Collections.singletonList("t_order")));


### PR DESCRIPTION

Changes proposed in this pull request:
  - Normalize actual table/view name with identifier in SchemaMetaDataUtils for different database type

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
