### PR TITLE
Pipeline: Support MySQL 8.4 binlog position initialization

### DIFF
--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/incremental/binlog/position/MySQLIncrementalPositionManager.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/incremental/binlog/position/MySQLIncrementalPositionManager.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.data.pipeline.core.ingest.position.DialectIncre
 
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -30,6 +31,10 @@ import java.sql.SQLException;
  * Incremental position manager for MySQL.
  */
 public final class MySQLIncrementalPositionManager implements DialectIncrementalPositionManager {
+    
+    private static final String SHOW_MASTER_STATUS_SQL = "SHOW MASTER STATUS";
+    
+    private static final String SHOW_BINARY_LOG_STATUS_SQL = "SHOW BINARY LOG STATUS";
     
     @Override
     public MySQLBinlogPosition init(final String data) {
@@ -40,13 +45,25 @@ public final class MySQLIncrementalPositionManager implements DialectIncremental
     
     @Override
     public MySQLBinlogPosition init(final DataSource dataSource, final String slotNameSuffix) throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            return getBinlogPosition(connection);
+        }
+    }
+    
+    private MySQLBinlogPosition getBinlogPosition(final Connection connection) throws SQLException {
+        String sql = getShowBinaryLogStatusSQL(connection);
         try (
-                Connection connection = dataSource.getConnection();
-                PreparedStatement preparedStatement = connection.prepareStatement("SHOW MASTER STATUS");
+                PreparedStatement preparedStatement = connection.prepareStatement(sql);
                 ResultSet resultSet = preparedStatement.executeQuery()) {
             resultSet.next();
             return new MySQLBinlogPosition(resultSet.getString(1), resultSet.getLong(2));
         }
+    }
+    
+    private String getShowBinaryLogStatusSQL(final Connection connection) throws SQLException {
+        DatabaseMetaData databaseMetaData = connection.getMetaData();
+        int majorVersion = databaseMetaData.getDatabaseMajorVersion();
+        return majorVersion > 8 || 8 == majorVersion && databaseMetaData.getDatabaseMinorVersion() >= 4 ? SHOW_BINARY_LOG_STATUS_SQL : SHOW_MASTER_STATUS_SQL;
     }
     
     @Override

--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/incremental/binlog/position/MySQLIncrementalPositionManager.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/incremental/binlog/position/MySQLIncrementalPositionManager.java
@@ -32,6 +32,8 @@ import java.sql.SQLException;
  */
 public final class MySQLIncrementalPositionManager implements DialectIncrementalPositionManager {
     
+    private static final String MYSQL_DATABASE_PRODUCT_NAME = "MySQL";
+    
     private static final String SHOW_MASTER_STATUS_SQL = "SHOW MASTER STATUS";
     
     private static final String SHOW_BINARY_LOG_STATUS_SQL = "SHOW BINARY LOG STATUS";
@@ -51,7 +53,7 @@ public final class MySQLIncrementalPositionManager implements DialectIncremental
     }
     
     private MySQLBinlogPosition getBinlogPosition(final Connection connection) throws SQLException {
-        String sql = getShowBinaryLogStatusSQL(connection);
+        String sql = getShowBinlogStatusSQL(connection);
         try (
                 PreparedStatement preparedStatement = connection.prepareStatement(sql);
                 ResultSet resultSet = preparedStatement.executeQuery()) {
@@ -60,10 +62,17 @@ public final class MySQLIncrementalPositionManager implements DialectIncremental
         }
     }
     
-    private String getShowBinaryLogStatusSQL(final Connection connection) throws SQLException {
+    private String getShowBinlogStatusSQL(final Connection connection) throws SQLException {
         DatabaseMetaData databaseMetaData = connection.getMetaData();
+        return isShowBinaryLogStatusSupported(databaseMetaData) ? SHOW_BINARY_LOG_STATUS_SQL : SHOW_MASTER_STATUS_SQL;
+    }
+    
+    private boolean isShowBinaryLogStatusSupported(final DatabaseMetaData databaseMetaData) throws SQLException {
+        if (!MYSQL_DATABASE_PRODUCT_NAME.equals(databaseMetaData.getDatabaseProductName())) {
+            return false;
+        }
         int majorVersion = databaseMetaData.getDatabaseMajorVersion();
-        return majorVersion > 8 || 8 == majorVersion && databaseMetaData.getDatabaseMinorVersion() >= 4 ? SHOW_BINARY_LOG_STATUS_SQL : SHOW_MASTER_STATUS_SQL;
+        return majorVersion > 8 || 8 == majorVersion && databaseMetaData.getDatabaseMinorVersion() >= 4;
     }
     
     @Override

--- a/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/incremental/binlog/position/MySQLIncrementalPositionManagerTest.java
+++ b/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/incremental/binlog/position/MySQLIncrementalPositionManagerTest.java
@@ -40,6 +40,10 @@ import static org.mockito.Mockito.when;
 
 class MySQLIncrementalPositionManagerTest {
     
+    private static final String MYSQL_DATABASE_PRODUCT_NAME = "MySQL";
+    
+    private static final String MARIADB_DATABASE_PRODUCT_NAME = "MariaDB";
+    
     private static final String SHOW_MASTER_STATUS_SQL = "SHOW MASTER STATUS";
     
     private static final String SHOW_BINARY_LOG_STATUS_SQL = "SHOW BINARY LOG STATUS";
@@ -66,29 +70,35 @@ class MySQLIncrementalPositionManagerTest {
     
     @Test
     void assertInitWithDataSourceByShowMasterStatus() throws SQLException {
-        assertInitWithDataSource(8, 3, SHOW_MASTER_STATUS_SQL);
+        assertInitWithDataSource(MYSQL_DATABASE_PRODUCT_NAME, 8, 3, SHOW_MASTER_STATUS_SQL);
     }
     
     @Test
     void assertInitWithDataSourceByShowBinaryLogStatus() throws SQLException {
-        assertInitWithDataSource(8, 4, SHOW_BINARY_LOG_STATUS_SQL);
+        assertInitWithDataSource(MYSQL_DATABASE_PRODUCT_NAME, 8, 4, SHOW_BINARY_LOG_STATUS_SQL);
     }
     
     @Test
     void assertInitWithDataSourceByShowBinaryLogStatusForHigherMajorVersion() throws SQLException {
-        assertInitWithDataSource(9, 0, SHOW_BINARY_LOG_STATUS_SQL);
+        assertInitWithDataSource(MYSQL_DATABASE_PRODUCT_NAME, 9, 0, SHOW_BINARY_LOG_STATUS_SQL);
     }
     
-    private void assertInitWithDataSource(final int majorVersion, final int minorVersion, final String expectedStatusSQL) throws SQLException {
+    @Test
+    void assertInitWithDataSourceByShowMasterStatusForMariaDB() throws SQLException {
+        assertInitWithDataSource(MARIADB_DATABASE_PRODUCT_NAME, 11, 4, SHOW_MASTER_STATUS_SQL);
+    }
+    
+    private void assertInitWithDataSource(final String productName, final int majorVersion, final int minorVersion, final String expectedStatusSQL) throws SQLException {
         Connection connection = mock(Connection.class);
-        MySQLBinlogPosition actual = (MySQLBinlogPosition) incrementalPositionManager.init(createDataSource(connection, majorVersion, minorVersion, expectedStatusSQL), "");
+        MySQLBinlogPosition actual = (MySQLBinlogPosition) incrementalPositionManager.init(createDataSource(connection, productName, majorVersion, minorVersion, expectedStatusSQL), "");
         assertThat(actual.getFilename(), is(LOG_FILE_NAME));
         assertThat(actual.getPosition(), is(LOG_POSITION));
         verify(connection).prepareStatement(expectedStatusSQL);
     }
     
-    private DataSource createDataSource(final Connection connection, final int majorVersion, final int minorVersion, final String expectedStatusSQL) throws SQLException {
+    private DataSource createDataSource(final Connection connection, final String productName, final int majorVersion, final int minorVersion, final String expectedStatusSQL) throws SQLException {
         DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+        when(databaseMetaData.getDatabaseProductName()).thenReturn(productName);
         when(databaseMetaData.getDatabaseMajorVersion()).thenReturn(majorVersion);
         when(databaseMetaData.getDatabaseMinorVersion()).thenReturn(minorVersion);
         when(connection.getMetaData()).thenReturn(databaseMetaData);

--- a/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/incremental/binlog/position/MySQLIncrementalPositionManagerTest.java
+++ b/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/incremental/binlog/position/MySQLIncrementalPositionManagerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -34,9 +35,14 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MySQLIncrementalPositionManagerTest {
+    
+    private static final String SHOW_MASTER_STATUS_SQL = "SHOW MASTER STATUS";
+    
+    private static final String SHOW_BINARY_LOG_STATUS_SQL = "SHOW BINARY LOG STATUS";
     
     private static final String LOG_FILE_NAME = "binlog-000001";
     
@@ -59,16 +65,35 @@ class MySQLIncrementalPositionManagerTest {
     }
     
     @Test
-    void assertInitWithDataSource() throws SQLException {
-        MySQLBinlogPosition actual = (MySQLBinlogPosition) incrementalPositionManager.init(createDataSource(), "");
-        assertThat(actual.getFilename(), is(LOG_FILE_NAME));
-        assertThat(actual.getPosition(), is(LOG_POSITION));
+    void assertInitWithDataSourceByShowMasterStatus() throws SQLException {
+        assertInitWithDataSource(8, 3, SHOW_MASTER_STATUS_SQL);
     }
     
-    DataSource createDataSource() throws SQLException {
+    @Test
+    void assertInitWithDataSourceByShowBinaryLogStatus() throws SQLException {
+        assertInitWithDataSource(8, 4, SHOW_BINARY_LOG_STATUS_SQL);
+    }
+    
+    @Test
+    void assertInitWithDataSourceByShowBinaryLogStatusForHigherMajorVersion() throws SQLException {
+        assertInitWithDataSource(9, 0, SHOW_BINARY_LOG_STATUS_SQL);
+    }
+    
+    private void assertInitWithDataSource(final int majorVersion, final int minorVersion, final String expectedStatusSQL) throws SQLException {
         Connection connection = mock(Connection.class);
+        MySQLBinlogPosition actual = (MySQLBinlogPosition) incrementalPositionManager.init(createDataSource(connection, majorVersion, minorVersion, expectedStatusSQL), "");
+        assertThat(actual.getFilename(), is(LOG_FILE_NAME));
+        assertThat(actual.getPosition(), is(LOG_POSITION));
+        verify(connection).prepareStatement(expectedStatusSQL);
+    }
+    
+    private DataSource createDataSource(final Connection connection, final int majorVersion, final int minorVersion, final String expectedStatusSQL) throws SQLException {
+        DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+        when(databaseMetaData.getDatabaseMajorVersion()).thenReturn(majorVersion);
+        when(databaseMetaData.getDatabaseMinorVersion()).thenReturn(minorVersion);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
         PreparedStatement positionStatement = mockPositionStatement();
-        when(connection.prepareStatement("SHOW MASTER STATUS")).thenReturn(positionStatement);
+        when(connection.prepareStatement(expectedStatusSQL)).thenReturn(positionStatement);
         return new MockedDataSource(connection);
     }
     


### PR DESCRIPTION

Changes proposed in this pull request:
  - Pipeline: Support MySQL 8.4 binlog position initialization

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
