### PR TITLE
Fix Proxy backend executor lifecycle after repeated startup and shutdown

### DIFF
--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/context/BackendExecutorContext.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/context/BackendExecutorContext.java
@@ -45,11 +45,12 @@ public final class BackendExecutorContext {
     
     /**
      * Initialize backend executor context.
+     *
+     * <p>The proxy bootstrap lifecycle uses this method to create a fresh backend executor.
+     * It may explicitly restore the context from the closed state for repeated proxy lifecycles in the same JVM.</p>
      */
     public synchronized void init() {
-        if (null != executorEngine) {
-            executorEngine.close();
-        }
+        closeExecutorEngine();
         executorEngine = ExecutorEngine.createExecutorEngineWithSize(
                 ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getProps().<Integer>getValue(ConfigurationPropertyKey.KERNEL_EXECUTOR_SIZE));
         lifecycleState = LifecycleState.RUNNING;
@@ -75,22 +76,20 @@ public final class BackendExecutorContext {
     }
     
     /**
-     * Close backend executor context.
+     * Shutdown backend executor context.
+     *
+     * <p>After shutdown, request-side executor lookup is rejected until the next explicit lifecycle initialization.</p>
      */
-    public synchronized void close() {
+    public synchronized void shutdown() {
+        closeExecutorEngine();
+        lifecycleState = LifecycleState.CLOSED;
+    }
+    
+    private void closeExecutorEngine() {
         if (null != executorEngine) {
             executorEngine.close();
             executorEngine = null;
         }
-        lifecycleState = LifecycleState.UNINITIALIZED;
-    }
-    
-    /**
-     * Shutdown backend executor context.
-     */
-    public synchronized void shutdown() {
-        close();
-        lifecycleState = LifecycleState.CLOSED;
     }
     
     private enum LifecycleState {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/DatabaseProxyConnectorFactoryTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/DatabaseProxyConnectorFactoryTest.java
@@ -33,9 +33,11 @@ import org.apache.shardingsphere.infra.session.query.QueryContext;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
+import org.apache.shardingsphere.proxy.backend.context.BackendExecutorContext;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -62,6 +64,11 @@ class DatabaseProxyConnectorFactoryTest {
     
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
     
+    @AfterEach
+    void tearDown() {
+        BackendExecutorContext.getInstance().shutdown();
+    }
+    
     @Test
     void assertNewDatabaseProxyConnectorWithoutParameter() {
         ProxyDatabaseConnectionManager databaseConnectionManager = mock(ProxyDatabaseConnectionManager.class, RETURNS_DEEP_STUBS);
@@ -75,7 +82,7 @@ class DatabaseProxyConnectorFactoryTest {
         when(metaData.getDatabase("foo_db")).thenReturn(database);
         QueryContext queryContext = new QueryContext(sqlStatementContext, "schemaName", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), metaData);
         ContextManager contextManager = mockContextManager(database);
-        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        initBackendExecutorContext(contextManager);
         DatabaseProxyConnector engine = DatabaseProxyConnectorFactory.newInstance(queryContext, databaseConnectionManager, false);
         assertThat(engine, isA(DatabaseProxyConnector.class));
     }
@@ -98,7 +105,7 @@ class DatabaseProxyConnectorFactoryTest {
         when(metaData.containsDatabase("foo_db")).thenReturn(true);
         when(metaData.getDatabase("foo_db")).thenReturn(database);
         ContextManager contextManager = mockContextManager(database);
-        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        initBackendExecutorContext(contextManager);
         assertThat(DatabaseProxyConnectorFactory.newInstance(
                 new QueryContext(sqlStatementContext, "schemaName", Collections.emptyList(), new HintValueContext(), mockConnectionContext(), metaData), databaseConnectionManager, false),
                 isA(DatabaseProxyConnector.class));
@@ -116,9 +123,14 @@ class DatabaseProxyConnectorFactoryTest {
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
         QueryContext queryContext = new QueryContext(sqlStatementContext, "schemaName", parameters, new HintValueContext(), mockConnectionContext(), metaData);
         ContextManager contextManager = mockContextManager(database);
-        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        initBackendExecutorContext(contextManager);
         DatabaseProxyConnector connector = DatabaseProxyConnectorFactory.newInstance(queryContext, databaseConnectionManager, preferPreparedStatement);
         assertThat((JDBCDriverType) Plugins.getMemberAccessor().get(connector.getClass().getDeclaredField("driverType"), connector), is(expected));
+    }
+    
+    private void initBackendExecutorContext(final ContextManager contextManager) {
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        BackendExecutorContext.getInstance().init();
     }
     
     private ContextManager mockContextManager(final ShardingSphereDatabase database) {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxySQLExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/ProxySQLExecutorTest.java
@@ -51,6 +51,7 @@ import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.executor.ProxyJDBCExecutor;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.statement.JDBCBackendStatement;
 import org.apache.shardingsphere.proxy.backend.connector.sane.DialectSaneQueryResultEngine;
+import org.apache.shardingsphere.proxy.backend.context.BackendExecutorContext;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.sql.parser.statement.core.enums.TransactionIsolationLevel;
@@ -71,6 +72,7 @@ import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockS
 import org.apache.shardingsphere.transaction.api.TransactionType;
 import org.apache.shardingsphere.transaction.rule.TransactionRule;
 import org.apache.shardingsphere.transaction.spi.TransactionHook;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -185,6 +187,12 @@ class ProxySQLExecutorTest {
         when(contextManager.getDatabase("foo_db")).thenReturn(database);
         when(contextManager.getDatabaseType()).thenReturn(fixtureDatabaseType);
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        BackendExecutorContext.getInstance().init();
+    }
+    
+    @AfterEach
+    void tearDown() {
+        BackendExecutorContext.getInstance().shutdown();
     }
     
     @Test

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
@@ -73,6 +73,7 @@ import org.apache.shardingsphere.parser.rule.SQLParserRule;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.fixture.QueryHeaderBuilderFixture;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.statement.JDBCBackendStatement;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.transaction.ProxyBackendTransactionManager;
+import org.apache.shardingsphere.proxy.backend.context.BackendExecutorContext;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeaderBuilder;
@@ -92,6 +93,7 @@ import org.apache.shardingsphere.sqlfederation.engine.SQLFederationEngine;
 import org.apache.shardingsphere.sqlfederation.rule.SQLFederationRule;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.infra.framework.extension.mock.StaticMockSettings;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -160,6 +162,12 @@ class StandardDatabaseProxyConnectorTest {
         when(databaseConnectionManager.getConnectionSession().getUsedDatabaseName()).thenReturn("foo_db");
         ContextManager contextManager = mockContextManager();
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        BackendExecutorContext.getInstance().init();
+    }
+    
+    @AfterEach
+    void tearDown() {
+        BackendExecutorContext.getInstance().shutdown();
     }
     
     private ContextManager mockContextManager() {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/context/BackendExecutorContextTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/context/BackendExecutorContextTest.java
@@ -48,7 +48,7 @@ class BackendExecutorContextTest {
     
     @AfterEach
     void tearDown() {
-        BackendExecutorContext.getInstance().close();
+        BackendExecutorContext.getInstance().shutdown();
     }
     
     @Test
@@ -66,19 +66,8 @@ class BackendExecutorContextTest {
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         BackendExecutorContext.getInstance().init();
         ExecutorEngine actual = BackendExecutorContext.getInstance().getExecutorEngine();
-        BackendExecutorContext.getInstance().close();
         BackendExecutorContext.getInstance().init();
         assertThat(BackendExecutorContext.getInstance().getExecutorEngine(), is(not(actual)));
-    }
-    
-    @Test
-    void assertClose() {
-        ContextManager contextManager = mockContextManager();
-        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
-        BackendExecutorContext.getInstance().init();
-        BackendExecutorContext.getInstance().close();
-        ExecutorEngine actual = BackendExecutorContext.getInstance().getExecutorEngine();
-        assertThat(actual, is(BackendExecutorContext.getInstance().getExecutorEngine()));
     }
     
     @Test
@@ -88,6 +77,18 @@ class BackendExecutorContextTest {
         BackendExecutorContext.getInstance().init();
         BackendExecutorContext.getInstance().shutdown();
         assertThrows(IllegalStateException.class, () -> BackendExecutorContext.getInstance().getExecutorEngine());
+    }
+    
+    @Test
+    void assertInitAfterShutdown() {
+        ContextManager contextManager = mockContextManager();
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        BackendExecutorContext.getInstance().init();
+        final ExecutorEngine actual = BackendExecutorContext.getInstance().getExecutorEngine();
+        BackendExecutorContext.getInstance().shutdown();
+        assertThrows(IllegalStateException.class, () -> BackendExecutorContext.getInstance().getExecutorEngine());
+        BackendExecutorContext.getInstance().init();
+        assertThat(BackendExecutorContext.getInstance().getExecutorEngine(), is(not(actual)));
     }
     
     private ContextManager mockContextManager() {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rul/PreviewExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rul/PreviewExecutorTest.java
@@ -58,6 +58,7 @@ import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.parser.rule.SQLParserRule;
 import org.apache.shardingsphere.parser.rule.builder.DefaultSQLParserRuleConfigurationBuilder;
 import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
+import org.apache.shardingsphere.proxy.backend.context.BackendExecutorContext;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.cursor.CursorNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
@@ -66,6 +67,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.attribute.t
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sqlfederation.context.SQLFederationContext;
 import org.apache.shardingsphere.sqlfederation.engine.SQLFederationEngine;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
@@ -108,6 +110,12 @@ class PreviewExecutorTest {
     void setUp() {
         contextManager = mockContextManager();
         ProxyContext.init(contextManager);
+        BackendExecutorContext.getInstance().init();
+    }
+    
+    @AfterEach
+    void tearDown() {
+        BackendExecutorContext.getInstance().shutdown();
     }
     
     private ContextManager mockContextManager() {

--- a/proxy/bootstrap/src/test/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializerTest.java
+++ b/proxy/bootstrap/src/test/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializerTest.java
@@ -133,7 +133,7 @@ class BootstrapInitializerTest {
     }
     
     @Test
-    void assertInitWithRepeatedLifecycle() throws SQLException, ReflectiveOperationException {
+    void assertInitWithRepeatedBootstrap() throws SQLException, ReflectiveOperationException {
         InstanceMetaDataBuilder instanceMetaDataBuilder = mock(InstanceMetaDataBuilder.class);
         InstanceMetaData instanceMetaData = mock(InstanceMetaData.class);
         registerSingletonService(InstanceMetaDataBuilder.class, instanceMetaDataBuilder);

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLMultiStatementsProxyBackendHandlerTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLMultiStatementsProxyBackendHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.executor.kernel.ExecutorEngine;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMode;
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.jdbc.StatementOption;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -35,6 +36,7 @@ import org.apache.shardingsphere.parser.rule.SQLParserRule;
 import org.apache.shardingsphere.parser.rule.builder.DefaultSQLParserRuleConfigurationBuilder;
 import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.statement.JDBCBackendStatement;
+import org.apache.shardingsphere.proxy.backend.context.BackendExecutorContext;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.MultiStatementsUpdateResponseHeader;
@@ -63,6 +65,8 @@ import java.util.Properties;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -82,7 +86,7 @@ class MySQLMultiStatementsProxyBackendHandlerTest {
         ConnectionSession connectionSession = mockConnectionSession();
         UpdateStatement expectedStatement = mock(UpdateStatement.class);
         ContextManager contextManager = mockContextManager();
-        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        initBackendExecutorContext(contextManager);
         ResponseHeader actual = new MySQLMultiStatementsProxyBackendHandler(connectionSession, expectedStatement, sql).execute();
         assertThat(actual, isA(MultiStatementsUpdateResponseHeader.class));
         MultiStatementsUpdateResponseHeader actualHeader = (MultiStatementsUpdateResponseHeader) actual;
@@ -103,12 +107,29 @@ class MySQLMultiStatementsProxyBackendHandlerTest {
     }
     
     @Test
+    void assertExecuteAfterRepeatedProxyLifecycle() throws SQLException {
+        final String sql = "UPDATE t SET v=v+1 WHERE id=1;UPDATE t SET v=v+1 WHERE id=2;UPDATE t SET v=v+1 WHERE id=3";
+        final ConnectionSession connectionSession = mockConnectionSession();
+        final UpdateStatement expectedStatement = mock(UpdateStatement.class);
+        ContextManager contextManager = mockContextManager();
+        initBackendExecutorContext(contextManager);
+        final ExecutorEngine previousExecutorEngine = BackendExecutorContext.getInstance().getExecutorEngine();
+        BackendExecutorContext.getInstance().shutdown();
+        assertThrows(IllegalStateException.class, () -> BackendExecutorContext.getInstance().getExecutorEngine());
+        BackendExecutorContext.getInstance().init();
+        assertThat(BackendExecutorContext.getInstance().getExecutorEngine(), is(not(previousExecutorEngine)));
+        ResponseHeader actual = new MySQLMultiStatementsProxyBackendHandler(connectionSession, expectedStatement, sql).execute();
+        assertThat(actual, isA(MultiStatementsUpdateResponseHeader.class));
+        assertThat(((MultiStatementsUpdateResponseHeader) actual).getUpdateResponseHeaders().size(), is(3));
+    }
+    
+    @Test
     void assertExecuteWithSpecifiedDatabaseName() throws SQLException {
         String sql = "UPDATE foo_db.t SET v=v+1 WHERE id=1;UPDATE foo_db.t SET v=v+1 WHERE id=2;UPDATE foo_db.t SET v=v+1 WHERE id=3";
         ConnectionSession connectionSession = mockConnectionSession();
         UpdateStatement expectedStatement = mock(UpdateStatement.class);
         ContextManager contextManager = mockContextManager();
-        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        initBackendExecutorContext(contextManager);
         ResponseHeader actual = new MySQLMultiStatementsProxyBackendHandler(connectionSession, expectedStatement, sql).execute();
         assertThat(actual, isA(MultiStatementsUpdateResponseHeader.class));
         MultiStatementsUpdateResponseHeader actualHeader = (MultiStatementsUpdateResponseHeader) actual;
@@ -135,7 +156,7 @@ class MySQLMultiStatementsProxyBackendHandlerTest {
         ConnectionSession connectionSession = mockConnectionSession();
         UpdateStatement expectedStatement = mock(UpdateStatement.class);
         ContextManager contextManager = mockContextManager();
-        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        initBackendExecutorContext(contextManager);
         ResponseHeader actual = new MySQLMultiStatementsProxyBackendHandler(connectionSession, expectedStatement, sql).execute();
         assertThat(actual, isA(MultiStatementsUpdateResponseHeader.class));
         MultiStatementsUpdateResponseHeader actualHeader = (MultiStatementsUpdateResponseHeader) actual;
@@ -153,6 +174,11 @@ class MySQLMultiStatementsProxyBackendHandlerTest {
         assertThat(responseHeader.getUpdateCount(), is(1L));
         assertThat(responseHeader.getLastInsertId(), is(0L));
         assertThat(responseHeader.getSqlStatement(), is(expectedStatement));
+    }
+    
+    private void initBackendExecutorContext(final ContextManager contextManager) {
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        BackendExecutorContext.getInstance().init();
     }
     
     private ConnectionSession mockConnectionSession() throws SQLException {

--- a/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PostgreSQLBatchedStatementsExecutorTest.java
+++ b/proxy/frontend/dialect/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PostgreSQLBatchedStatementsExecutorTest.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.infra.binder.context.statement.type.dml.InsertS
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.UpdateStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.executor.kernel.ExecutorEngine;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionContext;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMode;
@@ -41,6 +42,7 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
 import org.apache.shardingsphere.proxy.backend.connector.jdbc.statement.JDBCBackendStatement;
+import org.apache.shardingsphere.proxy.backend.context.BackendExecutorContext;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.SetAssignmentSegment;
@@ -73,7 +75,9 @@ import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -115,7 +119,7 @@ class PostgreSQLBatchedStatementsExecutorTest {
                 new HintValueContext(), Arrays.asList(PostgreSQLBinaryColumnType.INT4, PostgreSQLBinaryColumnType.VARCHAR), Arrays.asList(0, 1));
         List<List<Object>> parameterSets = Arrays.asList(Arrays.asList(1, new PostgreSQLTypeUnspecifiedSQLParameter("foo")),
                 Arrays.asList(2, new PostgreSQLTypeUnspecifiedSQLParameter("bar")), Arrays.asList(3, new PostgreSQLTypeUnspecifiedSQLParameter("baz")));
-        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        initBackendExecutorContext(contextManager);
         PostgreSQLBatchedStatementsExecutor actual = new PostgreSQLBatchedStatementsExecutor(connectionSession, postgresqlPreparedStatement, parameterSets);
         prepareExecutionUnitParameters(actual, parameterSets);
         int actualUpdated = actual.executeBatch();
@@ -126,6 +130,32 @@ class PostgreSQLBatchedStatementsExecutorTest {
             inOrder.verify(preparedStatement).setObject(2, each.get(1).toString());
             inOrder.verify(preparedStatement).addBatch();
         }
+    }
+    
+    @Test
+    void assertExecuteBatchAfterRepeatedProxyLifecycle() throws SQLException {
+        Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
+        when(connection.getMetaData().getURL()).thenReturn("jdbc:postgresql://127.0.0.1/db");
+        when(databaseConnectionManager.getConnections(any(), nullable(String.class), anyInt(), anyInt(), any(ConnectionMode.class))).thenReturn(Collections.singletonList(connection));
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(preparedStatement.getConnection()).thenReturn(connection);
+        when(preparedStatement.executeBatch()).thenReturn(new int[]{1, 1, 1});
+        when(backendStatement.createStorageResource(any(ExecutionUnit.class), eq(connection), anyInt(), any(ConnectionMode.class), any(StatementOption.class), nullable(DatabaseType.class)))
+                .thenReturn(preparedStatement);
+        ContextManager contextManager = mockContextManager(databaseType);
+        initBackendExecutorContext(contextManager);
+        final ExecutorEngine previousExecutorEngine = BackendExecutorContext.getInstance().getExecutorEngine();
+        BackendExecutorContext.getInstance().shutdown();
+        assertThrows(IllegalStateException.class, () -> BackendExecutorContext.getInstance().getExecutorEngine());
+        BackendExecutorContext.getInstance().init();
+        assertThat(BackendExecutorContext.getInstance().getExecutorEngine(), is(not(previousExecutorEngine)));
+        PostgreSQLServerPreparedStatement postgresqlPreparedStatement = new PostgreSQLServerPreparedStatement("INSERT INTO t (id, col) VALUES (?, ?)", mockInsertStatementContext(),
+                new HintValueContext(), Arrays.asList(PostgreSQLBinaryColumnType.INT4, PostgreSQLBinaryColumnType.VARCHAR), Arrays.asList(0, 1));
+        List<List<Object>> parameterSets = Arrays.asList(Arrays.asList(1, new PostgreSQLTypeUnspecifiedSQLParameter("foo")),
+                Arrays.asList(2, new PostgreSQLTypeUnspecifiedSQLParameter("bar")), Arrays.asList(3, new PostgreSQLTypeUnspecifiedSQLParameter("baz")));
+        PostgreSQLBatchedStatementsExecutor actual = new PostgreSQLBatchedStatementsExecutor(mockConnectionSession(), postgresqlPreparedStatement, parameterSets);
+        prepareExecutionUnitParameters(actual, parameterSets);
+        assertThat(actual.executeBatch(), is(3));
     }
     
     @Test
@@ -143,7 +173,7 @@ class PostgreSQLBatchedStatementsExecutorTest {
         PostgreSQLServerPreparedStatement postgresqlPreparedStatement = new PostgreSQLServerPreparedStatement("UPDATE t SET col = ? WHERE id = ?", mockUpdateStatementContext(),
                 new HintValueContext(), Arrays.asList(PostgreSQLBinaryColumnType.INT4, PostgreSQLBinaryColumnType.VARCHAR), Arrays.asList(0, 1));
         List<List<Object>> parameterSets = Collections.singletonList(Arrays.asList(10, "foo"));
-        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        initBackendExecutorContext(contextManager);
         PostgreSQLBatchedStatementsExecutor actual = new PostgreSQLBatchedStatementsExecutor(connectionSession, postgresqlPreparedStatement, parameterSets);
         prepareExecutionUnitParameters(actual, parameterSets);
         try {
@@ -165,7 +195,7 @@ class PostgreSQLBatchedStatementsExecutorTest {
     @Test
     void assertCreateExecutorWithoutParameterSets() throws ReflectiveOperationException {
         ContextManager contextManager = mockContextManager(databaseType);
-        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        initBackendExecutorContext(contextManager);
         ConnectionSession connectionSession = mockConnectionSession();
         PostgreSQLServerPreparedStatement postgresqlPreparedStatement = new PostgreSQLServerPreparedStatement("INSERT INTO t (id, col) VALUES (?, ?)", mockInsertStatementContext(),
                 new HintValueContext(), Arrays.asList(PostgreSQLBinaryColumnType.INT4, PostgreSQLBinaryColumnType.VARCHAR), Arrays.asList(0, 1));
@@ -182,7 +212,7 @@ class PostgreSQLBatchedStatementsExecutorTest {
     @Test
     void assertPrepareForRestOfParametersWithoutParameterAware() throws ReflectiveOperationException {
         ContextManager contextManager = mockContextManager(databaseType);
-        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        initBackendExecutorContext(contextManager);
         ConnectionSession connectionSession = mockConnectionSession();
         PostgreSQLServerPreparedStatement postgresqlPreparedStatement = new PostgreSQLServerPreparedStatement("UPDATE t SET col = ? WHERE id = ?", mockUpdateStatementContext(),
                 new HintValueContext(), Arrays.asList(PostgreSQLBinaryColumnType.INT4, PostgreSQLBinaryColumnType.VARCHAR), Arrays.asList(0, 1));
@@ -192,6 +222,11 @@ class PostgreSQLBatchedStatementsExecutorTest {
                 .get(PostgreSQLBatchedStatementsExecutor.class.getDeclaredField("executionUnitParams"), actual);
         int actualParamGroups = executionUnitParams.values().stream().mapToInt(List::size).sum();
         assertThat(actualParamGroups, is(2));
+    }
+    
+    private void initBackendExecutorContext(final ContextManager contextManager) {
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        BackendExecutorContext.getInstance().init();
     }
     
     private InsertStatementContext mockInsertStatementContext() {


### PR DESCRIPTION
Related to #38665

## Background

  Commit `7a75e3931f6d404af7ee299c0112d997a0e22230`(#38665) improved the Proxy backend executor lifecycle, but it still left several follow-up issues around repeated Proxy startup and shutdown flows.

  The remaining concern was that `BackendExecutorContext` could still be reinitialized from request-side execution paths after shutdown. In practice, this made the lifecycle boundary ambiguous:

  - `shutdown()` closed the executor, but later `getExecutorEngine()` could still lazily initialize a new executor.
  - Request execution paths could revive the backend executor after Proxy shutdown instead of requiring an explicit lifecycle startup.
  - Repeated Proxy lifecycle scenarios were not covered by near-production frontend execution tests.
  - Some tests depended on singleton state left by other tests, which made the lifecycle behavior easier to regress.

  ## Changes

  This PR tightens the `BackendExecutorContext` lifecycle semantics.

  ### Backend executor lifecycle

  - Makes `shutdown()` close the current executor and move the context into the `CLOSED` state.
  - Prevents `getExecutorEngine()` from lazily creating a new executor when the lifecycle state is `CLOSED`.
  - Keeps explicit `init()` as the only supported way to move from a closed lifecycle into a running lifecycle again.
  - Replaces the old close-style helper flow with an internal executor close helper so lifecycle state changes stay explicit.

  The intended lifecycle behavior is now:

  - `UNINITIALIZED -> RUNNING`: explicit `init()` creates the executor.
  - `RUNNING -> RUNNING`: repeated `init()` replaces the old executor with a fresh one.
  - `RUNNING -> CLOSED`: `shutdown()` closes the executor and marks the context closed.
  - `CLOSED -> getExecutorEngine()`: rejected with `IllegalStateException`.
  - `CLOSED -> RUNNING`: only allowed through explicit `init()`.

  ### Tests

  This PR adds and updates tests for the lifecycle and affected execution paths:

  - Covers repeated `BackendExecutorContext.init()` replacing the executor.
  - Covers `shutdown()` rejecting later request-side executor access.
  - Covers explicit `init()` after `shutdown()` creating a fresh executor.
  - Initializes and shuts down `BackendExecutorContext` explicitly in `ProxySQLExecutorTest` to avoid singleton state leakage between tests.
  - Adds a PostgreSQL batched statements repeated Proxy lifecycle test.
  - Adds a MySQL multi-statements adjacent repeated Proxy lifecycle test.
  - Updates bootstrap lifecycle test naming to reflect repeated bootstrap behavior.

  ## Impact

  This change makes the Proxy backend executor lifecycle stricter and more predictable.

  After Proxy shutdown, request execution paths can no longer accidentally recreate the backend executor. A new executor can still be created for a repeated Proxy startup, but only through the explicit lifecycle initialization path.

  This reduces the risk of accepting work after shutdown and makes repeated Proxy lifecycle behavior easier to reason about and test.

  No SQL behavior, configuration format, protocol packet format, SPI contract, or dependency is changed.