### PR TITLE
Add regression test for recreating dropped encrypt rule

### DIFF
--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/context/EncryptSQLRewriteContextDecoratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/context/EncryptSQLRewriteContextDecoratorTest.java
@@ -84,25 +84,17 @@ class EncryptSQLRewriteContextDecoratorTest {
         when(sqlRewriteContext.getSqlStatementContext()).thenReturn(sqlStatementContext);
         decorator.decorate(rule, mock(ConfigurationProperties.class), sqlRewriteContext, mock(RouteContext.class));
         assertTrue(sqlRewriteContext.getSqlTokens().isEmpty());
-    }
-    
-    @Test
-    void assertDecorateWithoutRewriteAfterDroppedEncryptTableRuleItem() {
-        EncryptRuleConfiguration ruleConfig = createEncryptRuleConfiguration();
-        new EncryptTableChangedProcessor().dropRuleItemConfiguration("t_encrypt", ruleConfig);
-        SQLRewriteContext sqlRewriteContext = mock(SQLRewriteContext.class);
-        InsertStatementContext sqlStatementContext = mock(InsertStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getSimpleTables()).thenReturn(Collections.singleton(
-                new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_encrypt")))));
-        when(sqlRewriteContext.getSqlStatementContext()).thenReturn(sqlStatementContext);
-        decorator.decorate(new EncryptRule("foo_db", ruleConfig), mock(ConfigurationProperties.class), sqlRewriteContext, mock(RouteContext.class));
-        verify(sqlRewriteContext, never()).addSQLTokenGenerators(any());
-    }
-    
-    private EncryptRuleConfiguration createEncryptRuleConfiguration() {
         EncryptColumnRuleConfiguration columnConfig = new EncryptColumnRuleConfiguration("pwd", new EncryptColumnItemRuleConfiguration("pwd_cipher", "standard_encryptor"));
         EncryptTableRuleConfiguration tableConfig = new EncryptTableRuleConfiguration("t_encrypt", Collections.singleton(columnConfig));
-        return new EncryptRuleConfiguration(new LinkedList<>(Collections.singleton(tableConfig)),
+        EncryptRuleConfiguration ruleConfig = new EncryptRuleConfiguration(new LinkedList<>(Collections.singleton(tableConfig)),
                 Collections.singletonMap("standard_encryptor", new AlgorithmConfiguration("CORE.FIXTURE", new Properties())));
+        new EncryptTableChangedProcessor().dropRuleItemConfiguration("t_encrypt", ruleConfig);
+        SQLRewriteContext droppedRuleSQLRewriteContext = mock(SQLRewriteContext.class);
+        InsertStatementContext insertStatementContext = mock(InsertStatementContext.class, RETURNS_DEEP_STUBS);
+        when(insertStatementContext.getTablesContext().getSimpleTables()).thenReturn(Collections.singleton(
+                new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_encrypt")))));
+        when(droppedRuleSQLRewriteContext.getSqlStatementContext()).thenReturn(insertStatementContext);
+        decorator.decorate(new EncryptRule("foo_db", ruleConfig), mock(ConfigurationProperties.class), droppedRuleSQLRewriteContext, mock(RouteContext.class));
+        verify(droppedRuleSQLRewriteContext, never()).addSQLTokenGenerators(any());
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/context/EncryptSQLRewriteContextDecoratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/context/EncryptSQLRewriteContextDecoratorTest.java
@@ -17,14 +17,24 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.context;
 
+import org.apache.shardingsphere.encrypt.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.config.rule.EncryptColumnItemRuleConfiguration;
+import org.apache.shardingsphere.encrypt.config.rule.EncryptColumnRuleConfiguration;
+import org.apache.shardingsphere.encrypt.config.rule.EncryptTableRuleConfiguration;
+import org.apache.shardingsphere.encrypt.rule.changed.EncryptTableChangedProcessor;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
+import org.apache.shardingsphere.infra.algorithm.core.config.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
+import org.apache.shardingsphere.infra.binder.context.statement.type.dml.InsertStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.rewrite.context.SQLRewriteContext;
 import org.apache.shardingsphere.infra.rewrite.context.SQLRewriteContextDecorator;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.spi.type.ordered.OrderedSPILoader;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,10 +42,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -69,5 +84,25 @@ class EncryptSQLRewriteContextDecoratorTest {
         when(sqlRewriteContext.getSqlStatementContext()).thenReturn(sqlStatementContext);
         decorator.decorate(rule, mock(ConfigurationProperties.class), sqlRewriteContext, mock(RouteContext.class));
         assertTrue(sqlRewriteContext.getSqlTokens().isEmpty());
+    }
+    
+    @Test
+    void assertDecorateWithoutRewriteAfterDroppedEncryptTableRuleItem() {
+        EncryptRuleConfiguration ruleConfig = createEncryptRuleConfiguration();
+        new EncryptTableChangedProcessor().dropRuleItemConfiguration("t_encrypt", ruleConfig);
+        SQLRewriteContext sqlRewriteContext = mock(SQLRewriteContext.class);
+        InsertStatementContext sqlStatementContext = mock(InsertStatementContext.class, RETURNS_DEEP_STUBS);
+        when(sqlStatementContext.getTablesContext().getSimpleTables()).thenReturn(Collections.singleton(
+                new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_encrypt")))));
+        when(sqlRewriteContext.getSqlStatementContext()).thenReturn(sqlStatementContext);
+        decorator.decorate(new EncryptRule("foo_db", ruleConfig), mock(ConfigurationProperties.class), sqlRewriteContext, mock(RouteContext.class));
+        verify(sqlRewriteContext, never()).addSQLTokenGenerators(any());
+    }
+    
+    private EncryptRuleConfiguration createEncryptRuleConfiguration() {
+        EncryptColumnRuleConfiguration columnConfig = new EncryptColumnRuleConfiguration("pwd", new EncryptColumnItemRuleConfiguration("pwd_cipher", "standard_encryptor"));
+        EncryptTableRuleConfiguration tableConfig = new EncryptTableRuleConfiguration("t_encrypt", Collections.singleton(columnConfig));
+        return new EncryptRuleConfiguration(new LinkedList<>(Collections.singleton(tableConfig)),
+                Collections.singletonMap("standard_encryptor", new AlgorithmConfiguration("CORE.FIXTURE", new Properties())));
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/context/EncryptSQLRewriteContextDecoratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/context/EncryptSQLRewriteContextDecoratorTest.java
@@ -84,17 +84,22 @@ class EncryptSQLRewriteContextDecoratorTest {
         when(sqlRewriteContext.getSqlStatementContext()).thenReturn(sqlStatementContext);
         decorator.decorate(rule, mock(ConfigurationProperties.class), sqlRewriteContext, mock(RouteContext.class));
         assertTrue(sqlRewriteContext.getSqlTokens().isEmpty());
+    }
+    // CHECKSTYLE:OFF
+    @Test
+    void assertDecorateWithoutDroppedEncryptTable() {
+        // CHECKSTYLE:ON
         EncryptColumnRuleConfiguration columnConfig = new EncryptColumnRuleConfiguration("pwd", new EncryptColumnItemRuleConfiguration("pwd_cipher", "standard_encryptor"));
         EncryptTableRuleConfiguration tableConfig = new EncryptTableRuleConfiguration("t_encrypt", Collections.singleton(columnConfig));
         EncryptRuleConfiguration ruleConfig = new EncryptRuleConfiguration(new LinkedList<>(Collections.singleton(tableConfig)),
                 Collections.singletonMap("standard_encryptor", new AlgorithmConfiguration("CORE.FIXTURE", new Properties())));
         new EncryptTableChangedProcessor().dropRuleItemConfiguration("t_encrypt", ruleConfig);
-        SQLRewriteContext droppedRuleSQLRewriteContext = mock(SQLRewriteContext.class);
+        SQLRewriteContext sqlRewriteContext = mock(SQLRewriteContext.class);
         InsertStatementContext insertStatementContext = mock(InsertStatementContext.class, RETURNS_DEEP_STUBS);
         when(insertStatementContext.getTablesContext().getSimpleTables()).thenReturn(Collections.singleton(
                 new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_encrypt")))));
-        when(droppedRuleSQLRewriteContext.getSqlStatementContext()).thenReturn(insertStatementContext);
-        decorator.decorate(new EncryptRule("foo_db", ruleConfig), mock(ConfigurationProperties.class), droppedRuleSQLRewriteContext, mock(RouteContext.class));
-        verify(droppedRuleSQLRewriteContext, never()).addSQLTokenGenerators(any());
+        when(sqlRewriteContext.getSqlStatementContext()).thenReturn(insertStatementContext);
+        decorator.decorate(new EncryptRule("foo_db", ruleConfig), mock(ConfigurationProperties.class), sqlRewriteContext, mock(RouteContext.class));
+        verify(sqlRewriteContext, never()).addSQLTokenGenerators(any());
     }
 }

--- a/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
+++ b/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
@@ -212,7 +212,6 @@ class StandaloneMetaDataManagerPersistServiceTest {
         metaDataManagerPersistService.removeRuleConfigurationItem(database, ruleConfig);
         verify(metaDataContextManager.getDatabaseRuleItemManager()).drop(deepEq(databaseRuleNodePath));
     }
-    
     @Test
     void assertRemoveSingleRuleConfigurationItem() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);

--- a/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
+++ b/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
@@ -46,6 +46,7 @@ import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -191,27 +192,15 @@ class StandaloneMetaDataManagerPersistServiceTest {
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
         when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
         RuleConfiguration ruleConfig = mock(RuleConfiguration.class, RETURNS_DEEP_STUBS);
-        DatabaseRuleNodePath databaseRuleNodePath = new DatabaseRuleNodePath("foo_db", "fixture", new DatabaseRuleItem("unique"));
-        when(metaDataPersistFacade.getDatabaseRuleService().delete("foo_db", Collections.singleton(ruleConfig))).thenReturn(Collections.singleton(new MetaDataVersion(databaseRuleNodePath)));
+        DatabaseRuleNodePath uniqueDatabaseRuleNodePath = new DatabaseRuleNodePath("foo_db", "fixture", new DatabaseRuleItem("unique"));
+        DatabaseRuleNodePath namedDatabaseRuleNodePath = new DatabaseRuleNodePath("foo_db", "fixture", new DatabaseRuleItem("named", "foo_rule"));
+        when(metaDataPersistFacade.getDatabaseRuleService().delete("foo_db", Collections.singleton(ruleConfig))).thenReturn(Arrays.asList(
+                new MetaDataVersion(uniqueDatabaseRuleNodePath), new MetaDataVersion(namedDatabaseRuleNodePath)));
         metaDataManagerPersistService.removeRuleConfigurationItem(database, ruleConfig);
-        verify(metaDataContextManager.getDatabaseRuleItemManager()).drop(deepEq(databaseRuleNodePath));
+        verify(metaDataContextManager.getDatabaseRuleItemManager()).drop(deepEq(uniqueDatabaseRuleNodePath));
+        verify(metaDataContextManager.getDatabaseRuleItemManager()).drop(deepEq(namedDatabaseRuleNodePath));
     }
     
-    @Test
-    void assertRemoveNamedRuleConfigurationItem() {
-        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
-        when(database.getName()).thenReturn("foo_db");
-        when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
-        ShardingSphereRule rule = mock(ShardingSphereRule.class);
-        when(database.getRuleMetaData().getRules()).thenReturn(Collections.singleton(rule));
-        ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
-        when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
-        RuleConfiguration ruleConfig = mock(RuleConfiguration.class, RETURNS_DEEP_STUBS);
-        DatabaseRuleNodePath databaseRuleNodePath = new DatabaseRuleNodePath("foo_db", "fixture", new DatabaseRuleItem("named", "foo_rule"));
-        when(metaDataPersistFacade.getDatabaseRuleService().delete("foo_db", Collections.singleton(ruleConfig))).thenReturn(Collections.singleton(new MetaDataVersion(databaseRuleNodePath)));
-        metaDataManagerPersistService.removeRuleConfigurationItem(database, ruleConfig);
-        verify(metaDataContextManager.getDatabaseRuleItemManager()).drop(deepEq(databaseRuleNodePath));
-    }
     @Test
     void assertRemoveSingleRuleConfigurationItem() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);

--- a/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
+++ b/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
@@ -212,7 +212,7 @@ class StandaloneMetaDataManagerPersistServiceTest {
         metaDataManagerPersistService.removeRuleConfigurationItem(database, ruleConfig);
         verify(metaDataContextManager.getDatabaseRuleItemManager()).drop(deepEq(databaseRuleNodePath));
     }
-
+    
     @Test
     void assertRemoveSingleRuleConfigurationItem() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);

--- a/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
+++ b/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
@@ -198,6 +198,22 @@ class StandaloneMetaDataManagerPersistServiceTest {
     }
     
     @Test
+    void assertRemoveNamedRuleConfigurationItem() {
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        when(database.getName()).thenReturn("foo_db");
+        when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+        ShardingSphereRule rule = mock(ShardingSphereRule.class);
+        when(database.getRuleMetaData().getRules()).thenReturn(Collections.singleton(rule));
+        ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
+        when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
+        RuleConfiguration ruleConfig = mock(RuleConfiguration.class, RETURNS_DEEP_STUBS);
+        DatabaseRuleNodePath databaseRuleNodePath = new DatabaseRuleNodePath("foo_db", "fixture", new DatabaseRuleItem("named", "foo_rule"));
+        when(metaDataPersistFacade.getDatabaseRuleService().delete("foo_db", Collections.singleton(ruleConfig))).thenReturn(Collections.singleton(new MetaDataVersion(databaseRuleNodePath)));
+        metaDataManagerPersistService.removeRuleConfigurationItem(database, ruleConfig);
+        verify(metaDataContextManager.getDatabaseRuleItemManager()).drop(deepEq(databaseRuleNodePath));
+    }
+
+    @Test
     void assertRemoveSingleRuleConfigurationItem() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("foo_db");

--- a/test/e2e/sql/src/test/resources/cases/rdl/dataset/distsql_rdl/create_recreated_encrypt_rule.xml
+++ b/test/e2e/sql/src/test/resources/cases/rdl/dataset/distsql_rdl/create_recreated_encrypt_rule.xml
@@ -1,0 +1,33 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="table" />
+        <column name="logic_column" />
+        <column name="cipher_column" />
+        <column name="assisted_query_column" />
+        <column name="like_query_column" />
+        <column name="encryptor_type" />
+        <column name="encryptor_props" />
+        <column name="assisted_query_type" />
+        <column name="assisted_query_props" />
+        <column name="like_query_type" />
+        <column name="like_query_props" />
+    </metadata>
+    <row values="t_user_recreated| pwd| pwd_cipher| | | AES| {&quot;aes-key-value&quot;:&quot;123456abc&quot;,&quot;digest-algorithm-name&quot;:&quot;SHA-1&quot;}| | | | "/>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/rdl/dataset/distsql_rdl/insert_after_drop_encrypt_rule.xml
+++ b/test/e2e/sql/src/test/resources/cases/rdl/dataset/distsql_rdl/insert_after_drop_encrypt_rule.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="user_id" />
+        <column name="pwd" />
+        <column name="pwd_cipher_is_null" />
+    </metadata>
+    <row values="1| null| 0" />
+    <row values="2| after_drop_plain| 1" />
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/rdl/e2e-rdl-create.xml
+++ b/test/e2e/sql/src/test/resources/cases/rdl/e2e-rdl-create.xml
@@ -23,27 +23,53 @@
             <destroy-sql sql="DROP SHARDING TABLE REFERENCE RULE reference_0;DROP SHARDING TABLE RULE t_order;DROP SHARDING TABLE RULE t_order_item;" />
         </assertion>
     </test-case>
-    
+
     <test-case sql="CREATE BROADCAST TABLE RULE t_product_category;" db-types="MySQL, PostgreSQL">
         <assertion expected-data-file="create_broadcast_rules.xml">
             <assertion-sql sql="SHOW BROADCAST TABLE RULES;" />
             <destroy-sql sql="DROP BROADCAST TABLE RULE t_product_category; " />
         </assertion>
     </test-case>
-    
+
     <test-case sql="CREATE ENCRYPT RULE t_user (COLUMNS((NAME=pwd,CIPHER=pwd_cipher,ENCRYPT_ALGORITHM(TYPE(NAME='AES',PROPERTIES('aes-key-value'='123456abc', 'digest-algorithm-name'='SHA-1'))))));" db-types="MySQL, PostgreSQL">
         <assertion expected-data-file="create_encrypt_rule.xml">
             <assertion-sql sql="SHOW ENCRYPT TABLE RULE t_user;" />
             <destroy-sql sql="DROP ENCRYPT RULE t_user " />
         </assertion>
     </test-case>
-    
+
     <test-case sql="CREATE ENCRYPT RULE t_user_recreated (COLUMNS((NAME=pwd,CIPHER=pwd_cipher,ENCRYPT_ALGORITHM(TYPE(NAME='AES',PROPERTIES('aes-key-value'='123456abc', 'digest-algorithm-name'='SHA-1'))))));" db-types="MySQL, PostgreSQL">
         <assertion expected-data-file="create_recreated_encrypt_rule.xml">
             <initial-sql sql="CREATE ENCRYPT RULE t_user_recreated (COLUMNS((NAME=pwd,CIPHER=pwd_cipher,ENCRYPT_ALGORITHM(TYPE(NAME='AES',PROPERTIES('aes-key-value'='123456abc', 'digest-algorithm-name'='SHA-1'))))));
             DROP ENCRYPT RULE t_user_recreated;" />
             <assertion-sql sql="SHOW ENCRYPT TABLE RULE t_user_recreated;" />
             <destroy-sql sql="DROP ENCRYPT RULE t_user_recreated " />
+        </assertion>
+    </test-case>
+
+    <test-case sql="LOAD SINGLE TABLE *.*" db-types="MySQL, PostgreSQL"
+               scenario-comments="Verify a dropped encrypt rule remains absent after reloading single tables.">
+        <assertion expected-data-file="drop_encrypt_rule.xml">
+            <initial-sql sql="SET DEFAULT SINGLE TABLE STORAGE UNIT = ds_0;
+            CREATE TABLE t_user_recreated_loaded (user_id INT PRIMARY KEY, pwd VARCHAR(50), pwd_cipher VARCHAR(50));
+            CREATE ENCRYPT RULE t_user_recreated_loaded (COLUMNS((NAME=pwd,CIPHER=pwd_cipher,ENCRYPT_ALGORITHM(TYPE(NAME='AES',PROPERTIES('aes-key-value'='123456abc', 'digest-algorithm-name'='SHA-1'))))));
+            DROP ENCRYPT RULE t_user_recreated_loaded;" />
+            <assertion-sql sql="SHOW ENCRYPT TABLE RULE t_user_recreated_loaded;" />
+            <destroy-sql sql="DROP TABLE t_user_recreated_loaded;SET DEFAULT SINGLE TABLE STORAGE UNIT = RANDOM" />
+        </assertion>
+    </test-case>
+
+    <test-case sql="LOAD SINGLE TABLE *.*" db-types="MySQL, PostgreSQL"
+               scenario-comments="Verify DML rewrite is disabled after dropping an encrypt rule and reloading single tables.">
+        <assertion expected-data-file="insert_after_drop_encrypt_rule.xml">
+            <initial-sql sql="SET DEFAULT SINGLE TABLE STORAGE UNIT = ds_0;
+            CREATE TABLE t_user_recreated_dml (user_id INT PRIMARY KEY, pwd VARCHAR(50), pwd_cipher VARCHAR(50));
+            CREATE ENCRYPT RULE t_user_recreated_dml (COLUMNS((NAME=pwd,CIPHER=pwd_cipher,ENCRYPT_ALGORITHM(TYPE(NAME='AES',PROPERTIES('aes-key-value'='123456abc', 'digest-algorithm-name'='SHA-1'))))));
+            INSERT INTO t_user_recreated_dml (user_id, pwd) VALUES (1, 'before_drop_cipher');
+            DROP ENCRYPT RULE t_user_recreated_dml;
+            INSERT INTO t_user_recreated_dml (user_id, pwd) VALUES (2, 'after_drop_plain');" />
+            <assertion-sql sql="SELECT user_id, pwd, CASE WHEN pwd_cipher IS NULL THEN 1 ELSE 0 END AS pwd_cipher_is_null FROM t_user_recreated_dml ORDER BY user_id;" />
+            <destroy-sql sql="DROP TABLE t_user_recreated_dml;SET DEFAULT SINGLE TABLE STORAGE UNIT = RANDOM" />
         </assertion>
     </test-case>
 
@@ -56,7 +82,7 @@
             <destroy-sql sql="DROP TABLE temp;SET DEFAULT SINGLE TABLE STORAGE UNIT = RANDOM;DROP SHARDING TABLE RULE t_order;DROP SHARDING TABLE RULE t_order_item;" />
         </assertion>
     </test-case>
-    
+
     <test-case sql="CREATE TABLE temp_alter (country_id INT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);" db-types="MySQL, PostgreSQL">
         <assertion expected-data-file="alter_single_table_rules.xml">
             <initial-sql sql="CREATE SHARDING TABLE RULE t_order (DATANODES('ds_2.t_order_${0..3}'),TABLE_STRATEGY(TYPE='standard',SHARDING_COLUMN=order_id,SHARDING_ALGORITHM(TYPE(NAME='inline',PROPERTIES('algorithm-expression'='t_order_${order_id % 4}')))));
@@ -66,7 +92,7 @@
             <destroy-sql sql="DROP TABLE temp_alter;SET DEFAULT SINGLE TABLE STORAGE UNIT = RANDOM;DROP SHARDING TABLE RULE t_order;DROP SHARDING TABLE RULE t_order_item;" />
         </assertion>
     </test-case>
-    
+
     <test-case sql="CREATE SHARDING TABLE RULE t_order (DATANODES('ds_2.t_order_${0..1}'),TABLE_STRATEGY(TYPE='standard',SHARDING_COLUMN=order_id,SHARDING_ALGORITHM(TYPE(NAME='inline',PROPERTIES('algorithm-expression'='t_order_${order_id % 2}')))));" db-types="MySQL">
         <assertion expected-data-file="create_sharding_rules.xml">
             <assertion-sql sql="SHOW SHARDING TABLE RULES;" />
@@ -89,7 +115,7 @@
 <!--            <assertion-sql sql="SHOW READWRITE_SPLITTING RULES;" />-->
 <!--        </assertion>-->
 <!--    </test-case>-->
-    
+
     <test-case sql="CREATE MASK RULE t_mask (COLUMNS((NAME=order_id,TYPE(NAME='MD5'))));">
         <assertion expected-data-file="create_mask_rule.xml">
             <assertion-sql sql="SHOW MASK RULES;" />

--- a/test/e2e/sql/src/test/resources/cases/rdl/e2e-rdl-create.xml
+++ b/test/e2e/sql/src/test/resources/cases/rdl/e2e-rdl-create.xml
@@ -38,6 +38,15 @@
         </assertion>
     </test-case>
     
+    <test-case sql="CREATE ENCRYPT RULE t_user_recreated (COLUMNS((NAME=pwd,CIPHER=pwd_cipher,ENCRYPT_ALGORITHM(TYPE(NAME='AES',PROPERTIES('aes-key-value'='123456abc', 'digest-algorithm-name'='SHA-1'))))));" db-types="MySQL, PostgreSQL">
+        <assertion expected-data-file="create_recreated_encrypt_rule.xml">
+            <initial-sql sql="CREATE ENCRYPT RULE t_user_recreated (COLUMNS((NAME=pwd,CIPHER=pwd_cipher,ENCRYPT_ALGORITHM(TYPE(NAME='AES',PROPERTIES('aes-key-value'='123456abc', 'digest-algorithm-name'='SHA-1'))))));
+            DROP ENCRYPT RULE t_user_recreated;" />
+            <assertion-sql sql="SHOW ENCRYPT TABLE RULE t_user_recreated;" />
+            <destroy-sql sql="DROP ENCRYPT RULE t_user_recreated " />
+        </assertion>
+    </test-case>
+
     <test-case sql="CREATE TABLE temp (country_id INT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);" db-types="MySQL, PostgreSQL">
         <assertion expected-data-file="create_single_table_rules.xml">
             <initial-sql sql="CREATE SHARDING TABLE RULE t_order (DATANODES('ds_2.t_order_${0..3}'),TABLE_STRATEGY(TYPE='standard',SHARDING_COLUMN=order_id,SHARDING_ALGORITHM(TYPE(NAME='inline',PROPERTIES('algorithm-expression'='t_order_${order_id % 4}')))));


### PR DESCRIPTION
Fixes #38657 
## Summary

- add regression coverage for deleting named rule configuration items in standalone metadata
- add an RDL E2E case that recreates an encrypt rule after dropping the same rule name
- add the expected DistSQL result for the recreated encrypt rule

## Motivation

This covers the issue reported in #38657, where dropping an encrypt rule could remove it from persisted metadata while runtime metadata still behaved as if the rule existed.

## Test Plan

- ./mvnw -pl mode/type/standalone/core -am -DskipITs -DskipIT -DskipCheck -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Djacoco.skip=true -DskipTests=false -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=StandaloneMetaDataManagerPersistServiceTest test
- ./mvnw -pl features/encrypt/distsql/handler -am -DskipITs -DskipIT -DskipCheck -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Djacoco.skip=true -DskipTests=false -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=DropEncryptRuleExecutorTest,CreateEncryptRuleExecutorTest test
- git diff --check
- xmllint --noout test/e2e/sql/src/test/resources/cases/rdl/e2e-rdl-create.xml test/e2e/sql/src/test/resources/cases/rdl/dataset/distsql_rdl/create_recreated_encrypt_rule.xml
