### PR TITLE
Refactor metadata reload flow and fix related tests

### DIFF
--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
@@ -159,7 +159,7 @@ public final class ContextManager implements AutoCloseable {
                 metaDataContextManager.getResourceSwitchManager().switchByAlterStorageUnit(database.getResourceMetaData(), dataSourcePoolProps, isInstanceConnectionEnabled);
         Collection<RuleConfiguration> ruleConfigs = persistServiceFacade.getMetaDataFacade().getDatabaseRuleService().load(database.getName());
         ShardingSphereDatabase changedDatabase = new MetaDataContextsFactory(persistServiceFacade.getMetaDataFacade(), computeNodeInstanceContext)
-                .createChangedDatabase(database.getName(), false, switchingResource, ruleConfigs, metaDataContexts);
+                .createChangedDatabaseByRebuild(database.getName(), switchingResource, ruleConfigs, metaDataContexts);
         metaDataContexts.getMetaData().putDatabase(changedDatabase);
         ConfigurationProperties props = new ConfigurationProperties(persistServiceFacade.getMetaDataFacade().getPropsService().load());
         Collection<RuleConfiguration> globalRuleConfigs = persistServiceFacade.getMetaDataFacade().getGlobalRuleService().load();

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/factory/MetaDataContextsFactory.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/factory/MetaDataContextsFactory.java
@@ -88,15 +88,13 @@ public final class MetaDataContextsFactory {
      * Create meta data contexts by switch resource.
      *
      * @param databaseName database name
-     * @param isLoadSchemasFromRegisterCenter is load schemas from register center or not
      * @param switchingResource switching resource
      * @param originalMetaDataContexts original meta data contexts
      * @return meta data contexts
-     * @throws SQLException SQL exception
      */
-    public MetaDataContexts createBySwitchResource(final String databaseName, final boolean isLoadSchemasFromRegisterCenter,
-                                                   final SwitchingResource switchingResource, final MetaDataContexts originalMetaDataContexts) throws SQLException {
-        ShardingSphereDatabase changedDatabase = createChangedDatabase(databaseName, isLoadSchemasFromRegisterCenter, switchingResource, null, originalMetaDataContexts);
+    public MetaDataContexts createBySwitchResource(final String databaseName, final SwitchingResource switchingResource,
+                                                   final MetaDataContexts originalMetaDataContexts) {
+        ShardingSphereDatabase changedDatabase = createChangedDatabase(databaseName, switchingResource, null, originalMetaDataContexts);
         ConfigurationProperties props = originalMetaDataContexts.getMetaData().getProps();
         ShardingSphereMetaData clonedMetaData = cloneMetaData(originalMetaDataContexts.getMetaData(), changedDatabase);
         RuleMetaData changedGlobalMetaData = new RuleMetaData(
@@ -111,15 +109,13 @@ public final class MetaDataContextsFactory {
      * Create meta data contexts by alter rule.
      *
      * @param databaseName database name
-     * @param isLoadSchemasFromRegisterCenter is load schemas from register center or not
      * @param ruleConfigs rule configs
      * @param originalMetaDataContexts original meta data contexts
      * @return meta data contexts
-     * @throws SQLException SQL exception
      */
-    public MetaDataContexts createByAlterRule(final String databaseName, final boolean isLoadSchemasFromRegisterCenter,
-                                              final Collection<RuleConfiguration> ruleConfigs, final MetaDataContexts originalMetaDataContexts) throws SQLException {
-        ShardingSphereDatabase changedDatabase = createChangedDatabase(databaseName, isLoadSchemasFromRegisterCenter, null, ruleConfigs, originalMetaDataContexts);
+    public MetaDataContexts createByAlterRule(final String databaseName, final Collection<RuleConfiguration> ruleConfigs,
+                                              final MetaDataContexts originalMetaDataContexts) {
+        ShardingSphereDatabase changedDatabase = createChangedDatabase(databaseName, null, ruleConfigs, originalMetaDataContexts);
         ShardingSphereMetaData clonedMetaData = cloneMetaData(originalMetaDataContexts.getMetaData(), changedDatabase);
         ConfigurationProperties props = originalMetaDataContexts.getMetaData().getProps();
         RuleMetaData changedGlobalMetaData = new RuleMetaData(
@@ -138,40 +134,20 @@ public final class MetaDataContextsFactory {
         return result;
     }
     
-    /**
-     * Create changed database.
-     *
-     * @param databaseName database name
-     * @param isLoadSchemasFromRegisterCenter is load schemas from register center or not
-     * @param switchingResource switching resource
-     * @param ruleConfigs rule configurations
-     * @param originalMetaDataContext original meta data contexts
-     * @return changed database
-     * @throws SQLException SQL exception
-     */
-    public ShardingSphereDatabase createChangedDatabase(final String databaseName, final boolean isLoadSchemasFromRegisterCenter,
-                                                        final SwitchingResource switchingResource, final Collection<RuleConfiguration> ruleConfigs,
-                                                        final MetaDataContexts originalMetaDataContext) throws SQLException {
+    private ShardingSphereDatabase createChangedDatabase(final String databaseName, final SwitchingResource switchingResource, final Collection<RuleConfiguration> ruleConfigs,
+                                                         final MetaDataContexts originalMetaDataContext) {
         ShardingSphereDatabase database = originalMetaDataContext.getMetaData().getDatabase(databaseName);
         ResourceMetaData effectiveResourceMetaData = getEffectiveResourceMetaData(database, switchingResource);
         Collection<RuleConfiguration> toBeCreatedRuleConfigs = null == ruleConfigs ? database.getRuleMetaData().getConfigurations() : ruleConfigs;
         DatabaseConfiguration toBeCreatedDatabaseConfig = getDatabaseConfiguration(effectiveResourceMetaData, switchingResource, toBeCreatedRuleConfigs, originalMetaDataContext);
-        return createChangedDatabase(database.getName(), isLoadSchemasFromRegisterCenter, toBeCreatedDatabaseConfig, originalMetaDataContext);
+        return createChangedDatabaseByLoad(database.getName(), toBeCreatedDatabaseConfig, originalMetaDataContext);
     }
     
-    private ShardingSphereDatabase createChangedDatabase(final String databaseName, final boolean isLoadSchemasFromRegisterCenter, final DatabaseConfiguration databaseConfig,
-                                                         final MetaDataContexts originalMetaDataContext) throws SQLException {
+    private ShardingSphereDatabase createChangedDatabaseByLoad(final String databaseName, final DatabaseConfiguration databaseConfig, final MetaDataContexts originalMetaDataContext) {
         ConfigurationProperties props = originalMetaDataContext.getMetaData().getProps();
         DatabaseType protocolType = DatabaseTypeEngine.getProtocolType(databaseConfig, props);
-        return isLoadSchemasFromRegisterCenter
-                ? createFromRegisterCenter(databaseName, protocolType, databaseConfig, originalMetaDataContext)
-                : ShardingSphereDatabaseFactory.create(databaseName, protocolType, databaseConfig, props, instanceContext);
-    }
-    
-    private ShardingSphereDatabase createFromRegisterCenter(final String databaseName, final DatabaseType protocolType, final DatabaseConfiguration databaseConfig,
-                                                            final MetaDataContexts originalMetaDataContext) {
         Collection<ShardingSphereSchema> schemas = persistFacade.getDatabaseMetaDataFacade().getSchema().load(databaseName, protocolType);
-        boolean persistSchemasEnabled = originalMetaDataContext.getMetaData().getProps().getValue(ConfigurationPropertyKey.PERSIST_SCHEMAS_TO_REPOSITORY_ENABLED);
+        boolean persistSchemasEnabled = props.getValue(ConfigurationPropertyKey.PERSIST_SCHEMAS_TO_REPOSITORY_ENABLED);
         if (!persistSchemasEnabled) {
             for (ShardingSphereSchema schema : schemas) {
                 if (originalMetaDataContext.getMetaData().getDatabase(databaseName).containsSchema(schema.getName())) {
@@ -180,7 +156,33 @@ public final class MetaDataContextsFactory {
                 }
             }
         }
-        return ShardingSphereDatabaseFactory.create(databaseName, protocolType, databaseConfig, originalMetaDataContext.getMetaData().getProps(), instanceContext, schemas);
+        return ShardingSphereDatabaseFactory.create(databaseName, protocolType, databaseConfig, props, instanceContext, schemas);
+    }
+    
+    /**
+     * Create changed database by reloading schema from data sources.
+     *
+     * @param databaseName database name
+     * @param switchingResource switching resource
+     * @param ruleConfigs rule configurations
+     * @param originalMetaDataContext original meta data contexts
+     * @return changed database
+     * @throws SQLException SQL exception
+     */
+    public ShardingSphereDatabase createChangedDatabaseByRebuild(final String databaseName, final SwitchingResource switchingResource, final Collection<RuleConfiguration> ruleConfigs,
+                                                                 final MetaDataContexts originalMetaDataContext) throws SQLException {
+        ShardingSphereDatabase database = originalMetaDataContext.getMetaData().getDatabase(databaseName);
+        ResourceMetaData effectiveResourceMetaData = getEffectiveResourceMetaData(database, switchingResource);
+        Collection<RuleConfiguration> toBeCreatedRuleConfigs = null == ruleConfigs ? database.getRuleMetaData().getConfigurations() : ruleConfigs;
+        DatabaseConfiguration toBeCreatedDatabaseConfig = getDatabaseConfiguration(effectiveResourceMetaData, switchingResource, toBeCreatedRuleConfigs, originalMetaDataContext);
+        return createChangedDatabaseByRebuild(databaseName, toBeCreatedDatabaseConfig, originalMetaDataContext);
+    }
+    
+    private ShardingSphereDatabase createChangedDatabaseByRebuild(final String databaseName, final DatabaseConfiguration databaseConfig,
+                                                                  final MetaDataContexts originalMetaDataContext) throws SQLException {
+        ConfigurationProperties props = originalMetaDataContext.getMetaData().getProps();
+        DatabaseType protocolType = DatabaseTypeEngine.getProtocolType(databaseConfig, props);
+        return ShardingSphereDatabaseFactory.create(databaseName, protocolType, databaseConfig, props, instanceContext);
     }
     
     private ResourceMetaData getEffectiveResourceMetaData(final ShardingSphereDatabase database, final SwitchingResource switchingResource) {

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/manager/resource/StorageUnitManager.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/manager/resource/StorageUnitManager.java
@@ -64,7 +64,7 @@ public final class StorageUnitManager {
             closeStaleRules(database);
             boolean isInstanceConnectionEnabled = metaDataContexts.getMetaData().getTemporaryProps().<Boolean>getValue(TemporaryConfigurationPropertyKey.INSTANCE_CONNECTION_ENABLED);
             SwitchingResource switchingResource = resourceSwitchManager.switchByRegisterStorageUnit(database.getResourceMetaData(), propsMap, isInstanceConnectionEnabled);
-            buildNewMetaDataContext(databaseName, switchingResource, true);
+            buildNewMetaDataContext(databaseName, switchingResource);
         } catch (final SQLException ex) {
             log.error("Alter database: {} register storage unit failed.", databaseName, ex);
         }
@@ -82,7 +82,7 @@ public final class StorageUnitManager {
             closeStaleRules(database);
             boolean isInstanceConnectionEnabled = metaDataContexts.getMetaData().getTemporaryProps().<Boolean>getValue(TemporaryConfigurationPropertyKey.INSTANCE_CONNECTION_ENABLED);
             SwitchingResource switchingResource = resourceSwitchManager.switchByAlterStorageUnit(database.getResourceMetaData(), propsMap, isInstanceConnectionEnabled);
-            buildNewMetaDataContext(databaseName, switchingResource, true);
+            buildNewMetaDataContext(databaseName, switchingResource);
         } catch (final SQLException ex) {
             log.error("Alter database: {} alter storage unit failed.", databaseName, ex);
         }
@@ -99,15 +99,15 @@ public final class StorageUnitManager {
         try {
             closeStaleRules(database);
             SwitchingResource switchingResource = resourceSwitchManager.switchByUnregisterStorageUnit(database.getResourceMetaData(), Collections.singleton(storageUnitName));
-            buildNewMetaDataContext(databaseName, switchingResource, false);
+            buildNewMetaDataContext(databaseName, switchingResource);
         } catch (final SQLException ex) {
             log.error("Alter database: {} register storage unit failed.", databaseName, ex);
         }
     }
     
-    private void buildNewMetaDataContext(final String databaseName, final SwitchingResource switchingResource, final boolean isLoadSchemasFromRegisterCenter) throws SQLException {
+    private void buildNewMetaDataContext(final String databaseName, final SwitchingResource switchingResource) throws SQLException {
         MetaDataContexts reloadMetaDataContexts = new MetaDataContextsFactory(metaDataPersistFacade, computeNodeInstanceContext).createBySwitchResource(
-                databaseName, isLoadSchemasFromRegisterCenter, switchingResource, metaDataContexts);
+                databaseName, switchingResource, metaDataContexts);
         metaDataContexts.update(reloadMetaDataContexts);
         metaDataContexts.getMetaData().putDatabase(buildDatabase(reloadMetaDataContexts.getMetaData().getDatabase(databaseName), reloadMetaDataContexts.getMetaData().getProps()));
         switchingResource.closeStaleDataSources();

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/manager/rule/DatabaseRuleConfigurationManager.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/manager/rule/DatabaseRuleConfigurationManager.java
@@ -93,7 +93,7 @@ public final class DatabaseRuleConfigurationManager {
     }
     
     private void refreshMetadata(final String databaseName, final Collection<RuleConfiguration> ruleConfigs, final Collection<ShardingSphereRule> toBeRemovedRules) throws SQLException {
-        metaDataContexts.update(new MetaDataContextsFactory(metaDataPersistFacade, computeNodeInstanceContext).createByAlterRule(databaseName, false, ruleConfigs, metaDataContexts));
+        metaDataContexts.update(new MetaDataContextsFactory(metaDataPersistFacade, computeNodeInstanceContext).createByAlterRule(databaseName, ruleConfigs, metaDataContexts));
         closeOriginalRules(toBeRemovedRules);
     }
     

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/manager/ContextManagerTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/manager/ContextManagerTest.java
@@ -200,7 +200,7 @@ class ContextManagerTest {
                 MockedStatic<GlobalRulesBuilder> globalRulesBuilder = mockStatic(GlobalRulesBuilder.class);
                 MockedStatic<ShardingSphereStatisticsFactory> statisticsFactory = mockStatic(ShardingSphereStatisticsFactory.class);
                 MockedConstruction<MetaDataContextsFactory> ignored = mockConstruction(MetaDataContextsFactory.class,
-                        (mock, context) -> when(mock.createChangedDatabase("foo_db", false, switchingResource, Collections.emptyList(), metaDataContexts)).thenReturn(database))) {
+                        (mock, context) -> when(mock.createChangedDatabaseByRebuild("foo_db", switchingResource, Collections.emptyList(), metaDataContexts)).thenReturn(database))) {
             genericSchemaManager.when(() -> GenericSchemaManager.getToBeDroppedSchemaNames(any(ShardingSphereDatabase.class), any(ShardingSphereDatabase.class)))
                     .thenReturn(Collections.singleton("foo_schema"));
             globalRulesBuilder.when(() -> GlobalRulesBuilder.buildRules(anyCollection(), anyCollection(), any(ConfigurationProperties.class))).thenReturn(Collections.emptyList());
@@ -220,7 +220,7 @@ class ContextManagerTest {
         setMetaDataContextManager(metaDataContextManager);
         try (
                 MockedConstruction<MetaDataContextsFactory> ignored = mockConstruction(MetaDataContextsFactory.class,
-                        (mock, context) -> when(mock.createChangedDatabase("foo_db", false, switchingResource, Collections.emptyList(), metaDataContexts)).thenThrow(SQLException.class))) {
+                        (mock, context) -> when(mock.createChangedDatabaseByRebuild("foo_db", switchingResource, Collections.emptyList(), metaDataContexts)).thenThrow(SQLException.class))) {
             contextManager.reloadDatabase(database);
             verify(metaDataContexts, never()).update(any());
         }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/factory/MetaDataContextsFactoryTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/factory/MetaDataContextsFactoryTest.java
@@ -118,6 +118,7 @@ class MetaDataContextsFactoryTest {
         when(DatabaseTypeEngine.getProtocolType(any(DatabaseConfiguration.class), any(ConfigurationProperties.class))).thenReturn(databaseType);
         when(DatabaseTypeFactory.get(anyString())).thenReturn(databaseType);
         when(metaDataPersistFacade.getRepository()).thenReturn(repository);
+        when(metaDataPersistFacade.getDatabaseMetaDataFacade().getSchema().load(anyString(), any(DatabaseType.class))).thenReturn(Collections.emptyList());
     }
     
     private ShardingSphereDatabase createDatabaseFromConfiguration(final String databaseName, final DatabaseType protocolType,
@@ -170,7 +171,7 @@ class MetaDataContextsFactoryTest {
         Map<StorageNode, DataSource> newDataSources = Collections.singletonMap(new StorageNode("new_ds"), new MockedDataSource());
         SwitchingResource switchingResource = new SwitchingResource(newDataSources, Collections.singletonMap(staleNode, new MockedDataSource()),
                 Collections.singleton("stale_ds"), createDataSourcePoolPropertiesMap("active_ds", "new_ds"));
-        MetaDataContexts actual = new MetaDataContextsFactory(metaDataPersistFacade, mock()).createBySwitchResource("foo_db", false, switchingResource, originalMetaDataContexts);
+        MetaDataContexts actual = new MetaDataContextsFactory(metaDataPersistFacade, mock()).createBySwitchResource("foo_db", switchingResource, originalMetaDataContexts);
         ResourceMetaData actualResourceMetaData = actual.getMetaData().getDatabase("foo_db").getResourceMetaData();
         assertFalse(actualResourceMetaData.getDataSources().containsKey(staleNode));
         assertTrue(actualResourceMetaData.getDataSources().containsKey(activeNode));
@@ -189,7 +190,7 @@ class MetaDataContextsFactoryTest {
                 new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()));
         MetaDataContexts originalMetaDataContexts = new MetaDataContexts(metaData, new ShardingSphereStatistics());
         SwitchingResource switchingResource = new SwitchingResource(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList(), createDataSourcePoolPropertiesMap("foo_ds"));
-        MetaDataContexts actual = new MetaDataContextsFactory(metaDataPersistFacade, mock()).createBySwitchResource("foo_db", false, switchingResource, originalMetaDataContexts);
+        MetaDataContexts actual = new MetaDataContextsFactory(metaDataPersistFacade, mock()).createBySwitchResource("foo_db", switchingResource, originalMetaDataContexts);
         ResourceMetaData actualResourceMetaData = actual.getMetaData().getDatabase("foo_db").getResourceMetaData();
         assertTrue(actualResourceMetaData.getDataSources().containsKey(new StorageNode("foo_ds")));
         assertTrue(actualResourceMetaData.getStorageUnits().containsKey("foo_ds"));
@@ -207,7 +208,7 @@ class MetaDataContextsFactoryTest {
                 new ConfigurationProperties(PropertiesBuilder.build(new Property(ConfigurationPropertyKey.PERSIST_SCHEMAS_TO_REPOSITORY_ENABLED.getKey(), Boolean.FALSE.toString()))));
         MetaDataContexts originalMetaDataContexts = new MetaDataContexts(metaData, new ShardingSphereStatistics());
         MetaDataContexts actual = new MetaDataContextsFactory(metaDataPersistFacade, mock())
-                .createByAlterRule("foo_db", true, Collections.singleton(new MockedRuleConfiguration("alter_rule")), originalMetaDataContexts);
+                .createByAlterRule("foo_db", Collections.singleton(new MockedRuleConfiguration("alter_rule")), originalMetaDataContexts);
         ShardingSphereSchema mergedSchema = loadedSchemas.stream().filter(each -> "foo_schema".equals(each.getName())).findFirst().orElseThrow(IllegalStateException::new);
         assertThat(mergedSchema.getAllTables().size(), is(2));
         ShardingSphereSchema untouchedSchema = loadedSchemas.stream().filter(each -> "new_schema".equals(each.getName())).findFirst().orElseThrow(IllegalStateException::new);
@@ -226,7 +227,7 @@ class MetaDataContextsFactoryTest {
         Collection<ShardingSphereSchema> loadedSchemas = Collections.singleton(createSchemaWithTable("persisted_schema", "persisted_table"));
         when(metaDataPersistFacade.getDatabaseMetaDataFacade().getSchema().load("foo_db", databaseType)).thenReturn(loadedSchemas);
         MetaDataContexts actual = new MetaDataContextsFactory(metaDataPersistFacade, mock())
-                .createByAlterRule("foo_db", true, Collections.singleton(new MockedRuleConfiguration("persist_rule")), originalMetaDataContexts);
+                .createByAlterRule("foo_db", Collections.singleton(new MockedRuleConfiguration("persist_rule")), originalMetaDataContexts);
         ShardingSphereSchema persistedSchema = loadedSchemas.iterator().next();
         assertThat(persistedSchema.getAllTables().size(), is(1));
         assertTrue(actual.getMetaData().containsDatabase("foo_db"));

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/resource/StorageUnitManagerTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/resource/StorageUnitManagerTest.java
@@ -74,7 +74,7 @@ class StorageUnitManagerTest {
         when(reloadMetaDataContexts.getMetaData().getDatabase(DATABASE_NAME)).thenReturn(reloadDatabase);
         try (
                 MockedConstruction<MetaDataContextsFactory> ignored = mockConstruction(MetaDataContextsFactory.class,
-                        (mock, context) -> when(mock.createBySwitchResource(DATABASE_NAME, true, switchingResource, metaDataContexts)).thenReturn(reloadMetaDataContexts))) {
+                        (mock, context) -> when(mock.createBySwitchResource(DATABASE_NAME, switchingResource, metaDataContexts)).thenReturn(reloadMetaDataContexts))) {
             createManager(metaDataContexts, resourceSwitchManager).register(DATABASE_NAME, Collections.emptyMap());
         }
         verify(metaDataContexts).update(any(MetaDataContexts.class));
@@ -106,7 +106,7 @@ class StorageUnitManagerTest {
         when(reloadDatabase.getAllSchemas()).thenReturn(Collections.singleton(new ShardingSphereSchema("foo_schema", mock(DatabaseType.class))));
         try (
                 MockedConstruction<MetaDataContextsFactory> ignored = mockConstruction(MetaDataContextsFactory.class,
-                        (mock, context) -> when(mock.createBySwitchResource(DATABASE_NAME, true, switchingResource, metaDataContexts)).thenReturn(reloadMetaDataContexts))) {
+                        (mock, context) -> when(mock.createBySwitchResource(DATABASE_NAME, switchingResource, metaDataContexts)).thenReturn(reloadMetaDataContexts))) {
             createManager(metaDataContexts, resourceSwitchManager).alter(DATABASE_NAME, Collections.emptyMap());
         }
         verify(metaDataContexts).update(any(MetaDataContexts.class));
@@ -137,7 +137,7 @@ class StorageUnitManagerTest {
         when(reloadDatabase.getAllSchemas()).thenReturn(Collections.singleton(new ShardingSphereSchema("foo_schema", mock(DatabaseType.class))));
         try (
                 MockedConstruction<MetaDataContextsFactory> ignored = mockConstruction(MetaDataContextsFactory.class,
-                        (mock, context) -> when(mock.createBySwitchResource(DATABASE_NAME, false, switchingResource, metaDataContexts)).thenReturn(reloadMetaDataContexts))) {
+                        (mock, context) -> when(mock.createBySwitchResource(DATABASE_NAME, switchingResource, metaDataContexts)).thenReturn(reloadMetaDataContexts))) {
             createManager(metaDataContexts, resourceSwitchManager).unregister(DATABASE_NAME, "ds_0");
         }
         verify(metaDataContexts).update(any(MetaDataContexts.class));

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/rule/DatabaseRuleConfigurationManagerTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/rule/DatabaseRuleConfigurationManagerTest.java
@@ -76,10 +76,13 @@ class DatabaseRuleConfigurationManagerTest {
         when(metaDataContexts.getMetaData().getDatabase(DATABASE_NAME).getRuleMetaData()).thenReturn(ruleMetaData);
         try (
                 MockedConstruction<MetaDataContextsFactory> ignored = mockConstruction(MetaDataContextsFactory.class,
-                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), eq(false), any(Collection.class), eq(metaDataContexts))).thenReturn(mock(MetaDataContexts.class)))) {
+                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME),
+                                any(Collection.class), eq(metaDataContexts))).thenReturn(mock(MetaDataContexts.class)))) {
             new DatabaseRuleConfigurationManager(metaDataContexts, mock(), mock()).refresh(DATABASE_NAME, ruleConfig);
-            verify(ignored.constructed().iterator().next()).createByAlterRule(eq(DATABASE_NAME), eq(false),
-                    argThat(actual -> 2 == actual.size() && actual.contains(ruleConfig) && actual.contains(otherRuleConfig)), eq(metaDataContexts));
+            verify(ignored.constructed().iterator().next()).createByAlterRule(
+                    eq(DATABASE_NAME),
+                    argThat(actual -> 2 == actual.size() && actual.contains(ruleConfig) && actual.contains(otherRuleConfig)),
+                    eq(metaDataContexts));
             verify((PartialRuleUpdateSupported) closableRule).updateConfiguration(ruleConfig);
             verify(metaDataContexts).update(any(MetaDataContexts.class));
             assertDoesNotThrow(() -> verify((AutoCloseable) closableRule).close());
@@ -108,9 +111,9 @@ class DatabaseRuleConfigurationManagerTest {
         when(metaDataContexts.getMetaData().getDatabase(DATABASE_NAME).getRuleMetaData()).thenReturn(ruleMetaData);
         try (
                 MockedConstruction<MetaDataContextsFactory> ignored = mockConstruction(MetaDataContextsFactory.class,
-                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), eq(false), any(Collection.class), eq(metaDataContexts))).thenReturn(mock(MetaDataContexts.class)))) {
+                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), any(Collection.class), eq(metaDataContexts))).thenReturn(mock(MetaDataContexts.class)))) {
             new DatabaseRuleConfigurationManager(metaDataContexts, mock(), mock()).refresh(DATABASE_NAME, ruleConfig);
-            verify(ignored.constructed().iterator().next()).createByAlterRule(eq(DATABASE_NAME), eq(false), argThat(Collection::isEmpty), eq(metaDataContexts));
+            verify(ignored.constructed().iterator().next()).createByAlterRule(eq(DATABASE_NAME), argThat(Collection::isEmpty), eq(metaDataContexts));
             verify((PartialRuleUpdateSupported) partialRule, never()).partialUpdate(ruleConfig);
             verify((PartialRuleUpdateSupported) partialRule, never()).updateConfiguration(ruleConfig);
             verify(metaDataContexts).update(any(MetaDataContexts.class));
@@ -129,10 +132,12 @@ class DatabaseRuleConfigurationManagerTest {
         when(metaDataContexts.getMetaData().getDatabase(DATABASE_NAME).getRuleMetaData()).thenReturn(ruleMetaData);
         try (
                 MockedConstruction<MetaDataContextsFactory> ignored = mockConstruction(MetaDataContextsFactory.class,
-                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), eq(false), any(Collection.class), eq(metaDataContexts))).thenReturn(mock(MetaDataContexts.class)))) {
+                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), any(Collection.class), eq(metaDataContexts))).thenReturn(mock(MetaDataContexts.class)))) {
             new DatabaseRuleConfigurationManager(metaDataContexts, mock(), mock()).refresh(DATABASE_NAME, ruleConfig);
-            verify(ignored.constructed().iterator().next()).createByAlterRule(eq(DATABASE_NAME), eq(false),
-                    argThat(actual -> 1 == actual.size() && actual.contains(ruleConfig)), eq(metaDataContexts));
+            verify(ignored.constructed().iterator().next()).createByAlterRule(
+                    eq(DATABASE_NAME),
+                    argThat(actual -> 1 == actual.size() && actual.contains(ruleConfig)),
+                    eq(metaDataContexts));
             verify(metaDataContexts).update(any(MetaDataContexts.class));
             verify(updater).updateConfiguration(ruleConfig);
         }
@@ -149,10 +154,12 @@ class DatabaseRuleConfigurationManagerTest {
         when(metaDataContexts.getMetaData().getDatabase(DATABASE_NAME).getRuleMetaData()).thenReturn(ruleMetaData);
         try (
                 MockedConstruction<MetaDataContextsFactory> ignored = mockConstruction(MetaDataContextsFactory.class,
-                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), eq(false), any(Collection.class), eq(metaDataContexts))).thenReturn(mock(MetaDataContexts.class)))) {
+                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), any(Collection.class), eq(metaDataContexts))).thenReturn(mock(MetaDataContexts.class)))) {
             new DatabaseRuleConfigurationManager(metaDataContexts, mock(), mock()).refresh(DATABASE_NAME, ruleConfig);
-            verify(ignored.constructed().iterator().next()).createByAlterRule(eq(DATABASE_NAME), eq(false),
-                    argThat(actual -> 2 == actual.size() && actual.contains(ruleConfig) && actual.contains(otherRuleConfig)), eq(metaDataContexts));
+            verify(ignored.constructed().iterator().next()).createByAlterRule(
+                    eq(DATABASE_NAME),
+                    argThat(actual -> 2 == actual.size() && actual.contains(ruleConfig) && actual.contains(otherRuleConfig)),
+                    eq(metaDataContexts));
             verify(metaDataContexts).update(any(MetaDataContexts.class));
         }
     }
@@ -167,10 +174,12 @@ class DatabaseRuleConfigurationManagerTest {
         when(metaDataContexts.getMetaData().getDatabase(DATABASE_NAME).getRuleMetaData()).thenReturn(ruleMetaData);
         try (
                 MockedConstruction<MetaDataContextsFactory> ignored = mockConstruction(MetaDataContextsFactory.class,
-                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), eq(false), any(Collection.class), eq(metaDataContexts))).thenReturn(mock(MetaDataContexts.class)))) {
+                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), any(Collection.class), eq(metaDataContexts))).thenReturn(mock(MetaDataContexts.class)))) {
             new DatabaseRuleConfigurationManager(metaDataContexts, mock(), mock()).refresh(DATABASE_NAME, ruleConfig);
-            verify(ignored.constructed().iterator().next()).createByAlterRule(eq(DATABASE_NAME), eq(false),
-                    argThat(actual -> 1 == actual.size() && actual.contains(ruleConfig)), eq(metaDataContexts));
+            verify(ignored.constructed().iterator().next()).createByAlterRule(
+                    eq(DATABASE_NAME),
+                    argThat(actual -> 1 == actual.size() && actual.contains(ruleConfig)),
+                    eq(metaDataContexts));
             verify(metaDataContexts).update(any(MetaDataContexts.class));
         }
     }
@@ -185,8 +194,8 @@ class DatabaseRuleConfigurationManagerTest {
         when(metaDataContexts.getMetaData().getDatabase(DATABASE_NAME).getRuleMetaData()).thenReturn(ruleMetaData);
         try (
                 MockedConstruction<MetaDataContextsFactory> ignored = mockConstruction(MetaDataContextsFactory.class,
-                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), eq(false), any(Collection.class), eq(metaDataContexts))).thenThrow(SQLException.class))) {
-            assertThrows(SQLException.class, () -> new DatabaseRuleConfigurationManager(metaDataContexts, mock(), mock()).refresh(DATABASE_NAME, ruleConfig));
+                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), any(Collection.class), eq(metaDataContexts))).thenThrow(new RuntimeException("mocked")))) {
+            assertThrows(RuntimeException.class, () -> new DatabaseRuleConfigurationManager(metaDataContexts, mock(), mock()).refresh(DATABASE_NAME, ruleConfig));
         }
     }
     
@@ -203,7 +212,7 @@ class DatabaseRuleConfigurationManagerTest {
         when(metaDataContexts.getMetaData().getDatabase(DATABASE_NAME).getRuleMetaData()).thenReturn(ruleMetaData);
         try (
                 MockedConstruction<MetaDataContextsFactory> ignored = mockConstruction(MetaDataContextsFactory.class,
-                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), eq(false), any(Collection.class), eq(metaDataContexts))).thenReturn(mock(MetaDataContexts.class)))) {
+                        (mock, context) -> when(mock.createByAlterRule(eq(DATABASE_NAME), any(Collection.class), eq(metaDataContexts))).thenReturn(mock(MetaDataContexts.class)))) {
             assertThrows(Exception.class, () -> new DatabaseRuleConfigurationManager(metaDataContexts, mock(), mock()).refresh(DATABASE_NAME, ruleConfig));
         }
     }

--- a/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistService.java
+++ b/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistService.java
@@ -21,8 +21,12 @@ import lombok.SneakyThrows;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
+import org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilder;
+import org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilderMaterial;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereView;
 import org.apache.shardingsphere.infra.metadata.statistics.DatabaseStatistics;
@@ -42,6 +46,7 @@ import org.apache.shardingsphere.single.rule.SingleRule;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -155,11 +160,11 @@ public final class ClusterMetaDataManagerPersistService implements MetaDataManag
     
     private void afterStorageUnitsAltered(final String databaseName, final MetaDataContexts originalMetaDataContexts) {
         MetaDataContexts reloadMetaDataContexts = getReloadedMetaDataContexts(originalMetaDataContexts);
+        ShardingSphereDatabase reloadedDatabase = rebuildDatabaseSchemaIndex(databaseName, reloadMetaDataContexts);
         Optional.ofNullable(reloadMetaDataContexts.getStatistics().getDatabaseStatistics(databaseName))
                 .ifPresent(optional -> optional.getSchemaStatisticsMap().forEach((schemaName, schemaStatistics) -> metaDataPersistFacade.getStatisticsService()
                         .persist(originalMetaDataContexts.getMetaData().getDatabase(databaseName), schemaName, schemaStatistics)));
-        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(databaseName, reloadMetaDataContexts.getMetaData().getDatabase(databaseName),
-                originalMetaDataContexts.getMetaData().getDatabase(databaseName));
+        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(databaseName, reloadedDatabase, originalMetaDataContexts.getMetaData().getDatabase(databaseName));
     }
     
     @Override
@@ -169,8 +174,8 @@ public final class ClusterMetaDataManagerPersistService implements MetaDataManag
             MetaDataContexts originalMetaDataContexts = new MetaDataContexts(metaDataContextManager.getMetaDataContexts().getMetaData(), metaDataContextManager.getMetaDataContexts().getStatistics());
             metaDataPersistFacade.getDataSourceUnitService().delete(database.getName(), each);
             MetaDataContexts reloadMetaDataContexts = getReloadedMetaDataContexts(originalMetaDataContexts);
-            metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(databaseName, reloadMetaDataContexts.getMetaData().getDatabase(databaseName),
-                    originalMetaDataContexts.getMetaData().getDatabase(databaseName));
+            ShardingSphereDatabase reloadedDatabase = rebuildDatabaseSchemaIndex(databaseName, reloadMetaDataContexts);
+            metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(databaseName, reloadedDatabase, originalMetaDataContexts.getMetaData().getDatabase(databaseName));
             DatabaseStatistics databaseStatistics = reloadMetaDataContexts.getStatistics().getDatabaseStatistics(database.getName());
             if (null != databaseStatistics) {
                 for (Entry<String, SchemaStatistics> entry : databaseStatistics.getSchemaStatisticsMap().entrySet()) {
@@ -199,8 +204,8 @@ public final class ClusterMetaDataManagerPersistService implements MetaDataManag
         MetaDataContexts originalMetaDataContexts = new MetaDataContexts(metaDataContextManager.getMetaDataContexts().getMetaData(), metaDataContextManager.getMetaDataContexts().getStatistics());
         metaDataPersistFacade.getDatabaseRuleService().persist(database.getName(), Collections.singleton(toBeAlteredRuleConfig));
         MetaDataContexts reloadMetaDataContexts = getReloadedMetaDataContexts(originalMetaDataContexts);
-        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(
-                database.getName(), reloadMetaDataContexts.getMetaData().getDatabase(database.getName()), originalMetaDataContexts.getMetaData().getDatabase(database.getName()));
+        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(database.getName(), rebuildDatabaseSchemaIndex(database.getName(), reloadMetaDataContexts),
+                originalMetaDataContexts.getMetaData().getDatabase(database.getName()));
     }
     
     @Override
@@ -257,5 +262,15 @@ public final class ClusterMetaDataManagerPersistService implements MetaDataManag
         RetryExecutor retryExecutor = new RetryExecutor(30000L, 1000L);
         ShardingSpherePreconditions.checkState(retryExecutor.execute(arg -> metaDataContextManager.getMetaDataContexts() != arg, originalMetaDataContexts), ReloadMetaDataContextFailedException::new);
         return metaDataContextManager.getMetaDataContexts();
+    }
+    
+    @SneakyThrows
+    private ShardingSphereDatabase rebuildDatabaseSchemaIndex(final String databaseName, final MetaDataContexts reloadMetaDataContexts) {
+        ShardingSphereDatabase database = reloadMetaDataContexts.getMetaData().getDatabase(databaseName);
+        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(database.getResourceMetaData().getStorageUnits(), database.getRuleMetaData().getRules(),
+                reloadMetaDataContexts.getMetaData().getProps(), new DatabaseTypeRegistry(database.getProtocolType()).getDefaultSchemaName(databaseName), database.getIdentifierContext());
+        Collection<ShardingSphereSchema> schemas = new LinkedList<>(GenericSchemaBuilder.build(database.getProtocolType(), material).values());
+        return new ShardingSphereDatabase(database.getName(), database.getProtocolType(), database.getResourceMetaData(),
+                database.getRuleMetaData(), schemas, reloadMetaDataContexts.getMetaData().getProps());
     }
 }

--- a/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistServiceTest.java
+++ b/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/persist/service/ClusterMetaDataManagerPersistServiceTest.java
@@ -20,11 +20,16 @@ package org.apache.shardingsphere.mode.manager.cluster.persist.service;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 
 import lombok.SneakyThrows;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
+import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
+import org.apache.shardingsphere.infra.rule.attribute.RuleAttributes;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mode.manager.cluster.persist.coordinator.database.ClusterDatabaseListenerCoordinatorType;
 import org.apache.shardingsphere.mode.manager.cluster.persist.coordinator.database.ClusterDatabaseListenerPersistCoordinator;
 import org.apache.shardingsphere.mode.metadata.manager.MetaDataContextManager;
@@ -156,10 +161,15 @@ class ClusterMetaDataManagerPersistServiceTest {
     
     @Test
     void assertAlterRuleConfiguration() {
-        RuleConfiguration ruleConfig = new SingleRuleConfiguration();
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, Answers.RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("foo_db");
-        when(metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase("foo_db")).thenReturn(database);
+        when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
+        ShardingSphereRule rule = mock(ShardingSphereRule.class);
+        when(rule.getAttributes()).thenReturn(new RuleAttributes());
+        when(database.getRuleMetaData().getRules()).thenReturn(Collections.singleton(rule));
+        ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
+        when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
+        RuleConfiguration ruleConfig = new SingleRuleConfiguration();
         metaDataManagerPersistService.alterRuleConfiguration(database, ruleConfig);
         verify(metaDataPersistFacade.getDatabaseRuleService()).persist("foo_db", Collections.singleton(ruleConfig));
         verify(metaDataPersistFacade.getDatabaseMetaDataFacade()).persistReloadDatabase(eq("foo_db"), any(), any());

--- a/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistService.java
+++ b/mode/type/standalone/core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistService.java
@@ -17,12 +17,17 @@
 
 package org.apache.shardingsphere.mode.manager.standalone.persist.service;
 
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.datasource.pool.props.domain.DataSourcePoolProperties;
 import org.apache.shardingsphere.infra.exception.external.sql.type.wrapper.SQLWrapperException;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
+import org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilder;
+import org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilderMaterial;
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereView;
 import org.apache.shardingsphere.infra.rule.scope.GlobalRule;
@@ -46,6 +51,7 @@ import org.apache.shardingsphere.single.rule.SingleRule;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -158,7 +164,7 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
     private void afterStorageUnitsRegistered(final String databaseName, final MetaDataContexts originalMetaDataContexts,
                                              final Map<String, DataSourcePoolProperties> toBeRegisteredProps) {
         metaDataContextManager.getStorageUnitManager().register(databaseName, toBeRegisteredProps);
-        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(databaseName, metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase(databaseName),
+        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(databaseName, rebuildDatabaseSchemaIndex(databaseName, metaDataContextManager.getMetaDataContexts()),
                 originalMetaDataContexts.getMetaData().getDatabase(databaseName));
         refreshGlobalRules(GlobalRuleChangedType.DATABASE_CHANGED);
     }
@@ -173,7 +179,7 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
     
     private void afterStorageUnitsAltered(final String databaseName, final MetaDataContexts originalMetaDataContexts, final Map<String, DataSourcePoolProperties> toBeRegisteredProps) {
         metaDataContextManager.getStorageUnitManager().alter(databaseName, toBeRegisteredProps);
-        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(databaseName, metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase(databaseName),
+        metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(databaseName, rebuildDatabaseSchemaIndex(databaseName, metaDataContextManager.getMetaDataContexts()),
                 originalMetaDataContexts.getMetaData().getDatabase(databaseName));
         refreshGlobalRules(GlobalRuleChangedType.DATABASE_CHANGED);
     }
@@ -181,10 +187,12 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
     @Override
     public void unregisterStorageUnits(final ShardingSphereDatabase database, final Collection<String> toBeDroppedStorageUnitNames) {
         for (String each : getToBeDroppedResourceNames(database.getName(), toBeDroppedStorageUnitNames)) {
+            MetaDataContexts originalMetaDataContexts = new MetaDataContexts(metaDataContextManager.getMetaDataContexts().getMetaData(), metaDataContextManager.getMetaDataContexts().getStatistics());
             metaDataPersistFacade.getDataSourceUnitService().delete(database.getName(), each);
             metaDataContextManager.getStorageUnitManager().unregister(database.getName(), each);
             MetaDataContexts reloadMetaDataContexts = metaDataContextManager.getMetaDataContexts();
-            metaDataPersistFacade.getDatabaseMetaDataFacade().unregisterStorageUnits(database.getName(), reloadMetaDataContexts);
+            metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabase(database.getName(), rebuildDatabaseSchemaIndex(database.getName(), reloadMetaDataContexts),
+                    originalMetaDataContexts.getMetaData().getDatabase(database.getName()));
         }
         clearServicesCache();
     }
@@ -237,8 +245,9 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
         if (toBeRemovedRuleItemConfig instanceof SingleRuleConfiguration) {
             Collection<MetaDataVersion> metaDataVersions = metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), Collections.singleton(toBeRemovedRuleItemConfig));
             removeRuleItem(database.getName(), metaDataVersions);
+            ShardingSphereDatabase reloadedDatabase = rebuildDatabaseSchemaIndex(database.getName(), metaDataContextManager.getMetaDataContexts());
             metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(
-                    database.getName(), metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase(database.getName()), database);
+                    database.getName(), reloadedDatabase, database);
             clearServicesCache();
             return;
         }
@@ -278,8 +287,9 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
         if (toBeRemovedRuleConfig instanceof SingleRuleConfiguration) {
             metaDataPersistFacade.getDatabaseRuleService().delete(database.getName(), ruleType);
             metaDataContextManager.getDatabaseRuleItemManager().drop(new DatabaseRuleNodePath(database.getName(), ruleType, null));
+            ShardingSphereDatabase reloadedDatabase = rebuildDatabaseSchemaIndex(database.getName(), metaDataContextManager.getMetaDataContexts());
             metaDataPersistFacade.getDatabaseMetaDataFacade().persistReloadDatabaseByUnloadSingleTable(
-                    database.getName(), metaDataContextManager.getMetaDataContexts().getMetaData().getDatabase(database.getName()), database);
+                    database.getName(), reloadedDatabase, database);
             clearServicesCache();
             return;
         }
@@ -314,8 +324,27 @@ public final class StandaloneMetaDataManagerPersistService implements MetaDataMa
     }
     
     private void persistAndAlterSchemaTables(final ShardingSphereDatabase database, final Collection<String> needReloadTables) {
+        MetaDataContexts reloadedMetaDataContexts = createMetaDataContextsWithRebuiltDatabase(database.getName(), metaDataContextManager.getMetaDataContexts());
         Map<String, Collection<ShardingSphereTable>> schemaAndTablesMap = metaDataPersistFacade.getDatabaseMetaDataFacade().persistAlteredTables(
-                database.getName(), metaDataContextManager.getMetaDataContexts(), needReloadTables);
+                database.getName(), reloadedMetaDataContexts, needReloadTables);
         alterSchemaTables(database, schemaAndTablesMap);
+    }
+    
+    @SneakyThrows(SQLException.class)
+    private ShardingSphereDatabase rebuildDatabaseSchemaIndex(final String databaseName, final MetaDataContexts metaDataContexts) {
+        ShardingSphereDatabase database = metaDataContexts.getMetaData().getDatabase(databaseName);
+        GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(database.getResourceMetaData().getStorageUnits(), database.getRuleMetaData().getRules(),
+                metaDataContexts.getMetaData().getProps(), new DatabaseTypeRegistry(database.getProtocolType()).getDefaultSchemaName(databaseName), database.getIdentifierContext());
+        Collection<ShardingSphereSchema> schemas = new LinkedList<>(GenericSchemaBuilder.build(database.getProtocolType(), material).values());
+        return new ShardingSphereDatabase(database.getName(), database.getProtocolType(), database.getResourceMetaData(), database.getRuleMetaData(), schemas,
+                metaDataContexts.getMetaData().getProps());
+    }
+    
+    private MetaDataContexts createMetaDataContextsWithRebuiltDatabase(final String databaseName, final MetaDataContexts metaDataContexts) {
+        ShardingSphereMetaData metaData = metaDataContexts.getMetaData();
+        ShardingSphereMetaData clonedMetaData = new ShardingSphereMetaData(
+                metaData.getAllDatabases(), metaData.getGlobalResourceMetaData(), metaData.getGlobalRuleMetaData(), metaData.getProps(), metaData.getProtocolType());
+        clonedMetaData.putDatabase(rebuildDatabaseSchemaIndex(databaseName, metaDataContexts));
+        return new MetaDataContexts(clonedMetaData, metaDataContexts.getStatistics());
     }
 }

--- a/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
+++ b/mode/type/standalone/core/src/test/java/org/apache/shardingsphere/mode/manager/standalone/persist/service/StandaloneMetaDataManagerPersistServiceTest.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
+import org.apache.shardingsphere.infra.rule.attribute.RuleAttributes;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mode.metadata.manager.MetaDataContextManager;
 import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade;
@@ -161,8 +162,9 @@ class StandaloneMetaDataManagerPersistServiceTest {
     void assertAlterRuleConfiguration() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("foo_db");
-        when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+        when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
         ShardingSphereRule rule = mock(ShardingSphereRule.class);
+        when(rule.getAttributes()).thenReturn(new RuleAttributes());
         when(database.getRuleMetaData().getRules()).thenReturn(Collections.singleton(rule));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
         when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
@@ -185,8 +187,9 @@ class StandaloneMetaDataManagerPersistServiceTest {
     void assertRemoveRuleConfigurationItem() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("foo_db");
-        when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "FIXTURE"));
+        when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
         ShardingSphereRule rule = mock(ShardingSphereRule.class);
+        when(rule.getAttributes()).thenReturn(new RuleAttributes());
         when(database.getRuleMetaData().getRules()).thenReturn(Collections.singleton(rule));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
         when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
@@ -201,6 +204,12 @@ class StandaloneMetaDataManagerPersistServiceTest {
     void assertRemoveSingleRuleConfigurationItem() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("foo_db");
+        when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
+        ShardingSphereRule rule = mock(ShardingSphereRule.class);
+        when(rule.getAttributes()).thenReturn(new RuleAttributes());
+        when(database.getRuleMetaData().getRules()).thenReturn(Collections.singleton(rule));
+        ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
+        when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration();
         ruleConfig.setTables(Collections.singleton("ds_0.t_order"));
         DatabaseRuleNodePath databaseRuleNodePath = new DatabaseRuleNodePath("foo_db", "single", new DatabaseRuleItem("unique"));
@@ -213,8 +222,15 @@ class StandaloneMetaDataManagerPersistServiceTest {
     
     @Test
     void assertRemoveRuleConfiguration() {
-        metaDataManagerPersistService.removeRuleConfiguration(new ShardingSphereDatabase("foo_db", mock(), mock(), mock(), Collections.emptyList(), new ConfigurationProperties(new Properties())),
-                mock(RuleConfiguration.class), "foo_rule");
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        when(database.getName()).thenReturn("foo_db");
+        when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
+        ShardingSphereRule rule = mock(ShardingSphereRule.class);
+        when(rule.getAttributes()).thenReturn(new RuleAttributes());
+        when(database.getRuleMetaData().getRules()).thenReturn(Collections.singleton(rule));
+        ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
+        when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
+        metaDataManagerPersistService.removeRuleConfiguration(database, mock(RuleConfiguration.class), "foo_rule");
         verify(metaDataPersistFacade.getDatabaseRuleService()).delete("foo_db", "foo_rule");
     }
     
@@ -222,6 +238,12 @@ class StandaloneMetaDataManagerPersistServiceTest {
     void assertRemoveSingleRuleConfiguration() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getName()).thenReturn("foo_db");
+        when(database.getProtocolType()).thenReturn(TypedSPILoader.getService(DatabaseType.class, "MySQL"));
+        ShardingSphereRule rule = mock(ShardingSphereRule.class);
+        when(rule.getAttributes()).thenReturn(new RuleAttributes());
+        when(database.getRuleMetaData().getRules()).thenReturn(Collections.singleton(rule));
+        ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), mock(), mock(), new ConfigurationProperties(new Properties()));
+        when(metaDataContextManager.getMetaDataContexts().getMetaData()).thenReturn(metaData);
         SingleRuleConfiguration ruleConfig = new SingleRuleConfiguration();
         ruleConfig.setTables(Collections.singleton("ds_0.t_order"));
         metaDataManagerPersistService.removeRuleConfiguration(database, ruleConfig, "SINGLE");


### PR DESCRIPTION

Changes proposed in this pull request:

This PR refines metadata reload and persistence behavior after storage unit/rule changes, and updates related tests in `mode/core`, `mode/type/cluster/core`, and `mode/type/standalone/core`.

## Motivation
The previous reload flow could persist schema/table metadata too early in some paths.  
If step-1 operations failed (for example during storage-unit unload), in-memory schema tables and registry-persisted schema tables could become inconsistent across nodes.

This PR enforces a safer sequencing:
1. apply storage/rule changes,
2. rebuild schema index from updated runtime metadata,
3. compare old/new schema tables and persist deltas in the second stage.

## Main Functional Changes

### 1) Core metadata reload flow (`mode/core`)
- Refined `MetaDataContextsFactory` related rebuild entry points.
- Removed/cleaned obsolete checked-exception behavior on changed-database creation path.
- Kept `ContextManager` reload call-site semantics that still require the non-registry direct reload behavior (the existing `false` path expectation).

### 2) Cluster persistence path (`mode/type/cluster/core`)
- In `ClusterMetaDataManagerPersistService`, adjusted persistence behavior to rely on rebuilt schema index in the reload stage instead of unsafe direct full-database persistence ordering.
- Ensured schema/table persistence is aligned with post-update rebuild results.

### 3) Standalone persistence path (`mode/type/standalone/core`)
- Aligned standalone behavior with the same staged schema persistence principle.
- `StandaloneMetaDataManagerPersistService` uses rebuilt schema index in reload-related persistence paths consistently.

## Test Fixes

### `mode/core` tests
- Updated exception expectations after checked-exception path cleanup.
- Fixed tests around metadata/rule refresh:
  - `MetaDataContextsFactoryTest`
  - `DatabaseRuleConfigurationManagerTest`
  - related `ContextManager` / `StorageUnitManager` tests impacted by reload semantics.

### `mode/type/standalone/core` tests
- Fixed `StandaloneMetaDataManagerPersistServiceTest` for schema-index rebuild prerequisites:
  - added valid protocol type in mock database where needed,
  - added rule attributes stubs (`RuleAttributes`) where rebuild path requires them,
  - replaced fragile deep-stub metadata path with concrete `ShardingSphereMetaData` + `ConfigurationProperties` in affected cases.

### `mode/type/cluster/core` tests
- Fixed `ClusterMetaDataManagerPersistServiceTest.assertAlterRuleConfiguration`:
  - provided protocol type (`MySQL`) for schema rebuild,
  - provided non-null rule attributes,
  - provided concrete metadata props context to avoid NPE during schema rebuild material creation.

## Behavior/Consistency Impact
- Reduces risk of divergence between:
  - in-memory schema/table metadata of running nodes, and
  - registry-persisted schema/table metadata loaded by newly started nodes.
- Keeps rule/storage update + metadata persistence ordering deterministic.

## Verification
Targeted tests executed for impacted areas, including:
- `DatabaseRuleConfigurationManagerTest`
- `MetaDataContextsFactoryTest`
- `StandaloneMetaDataManagerPersistServiceTest`
- `StandaloneContextManagerBuilderTest`
- `StandalonePersistServiceFacadeBuilderTest`
- `StandaloneProcessPersistServiceTest`
- `ClusterMetaDataManagerPersistServiceTest#assertAlterRuleConfiguration`

All targeted runs passed in the validated environment after fixes.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
