### PR TITLE
Minor refactor EncryptPredicateColumnTokenGenerator, EncryptPredicateParameterRewriter and EncryptPredicateValueTokenGenerator

### DIFF
--- a/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/option/OracleFunctionOption.java
+++ b/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/option/OracleFunctionOption.java
@@ -30,8 +30,8 @@ public final class OracleFunctionOption implements DialectFunctionOption {
     
     // TODO remove ROWNUM_ and ROW_NUMBER, move DAY to anthor method @duanzhengqiang
     private static final Collection<String> UNPARENTHESIZED_FUNCTION_NAMES = new CaseInsensitiveSet<>(Arrays.asList(
-            "CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER", "CURRVAL", "DAY", "DBTIMEZONE", "LEVEL", "LOCALTIME", "LOCALTIMESTAMP",
-            "NEXTVAL", "ORA_ROWSCN", "ROWID", "ROWNUM", "ROWNUM_", "ROW_NUMBER", "SESSIONTIMEZONE", "SESSION_USER", "SYSDATE", "SYSTIMESTAMP", "UID", "USER"));
+            "CONNECT_BY_ISCYCLE", "CONNECT_BY_ISLEAF", "CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER", "CURRVAL", "DAY", "DBTIMEZONE", "LEVEL", "LOCALTIME",
+            "LOCALTIMESTAMP", "NEXTVAL", "ORA_ROWSCN", "ROWID", "ROWNUM", "ROWNUM_", "ROW_NUMBER", "SESSIONTIMEZONE", "SESSION_USER", "SYSDATE", "SYSTIMESTAMP", "UID", "USER"));
     
     @Override
     public String getIfNullFunctionName() {

--- a/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/option/OracleFunctionOptionTest.java
+++ b/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/option/OracleFunctionOptionTest.java
@@ -34,6 +34,8 @@ class OracleFunctionOptionTest {
     
     @Test
     void assertGetUnparenthesizedFunctionNames() {
+        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("CONNECT_BY_ISCYCLE"));
+        assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("CONNECT_BY_ISLEAF"));
         assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("CURRENT_DATE"));
         assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("CURRENT_TIME"));
         assertTrue(functionOption.getUnparenthesizedFunctionNames().contains("CURRENT_TIMESTAMP"));

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/checker/sql/predicate/EncryptPredicateColumnSupportedChecker.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/checker/sql/predicate/EncryptPredicateColumnSupportedChecker.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.encrypt.checker.sql.predicate;
 
 import org.apache.shardingsphere.encrypt.checker.cryptographic.JoinConditionsEncryptorChecker;
+import org.apache.shardingsphere.encrypt.constant.EncryptConstants;
 import org.apache.shardingsphere.encrypt.exception.metadata.MissingMatchedEncryptQueryAlgorithmException;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.table.EncryptTable;
@@ -82,8 +83,7 @@ public final class EncryptPredicateColumnSupportedChecker implements SupportedSQ
     
     private boolean isLikeColumnSegment(final Collection<ExpressionSegment> expressions, final ColumnSegment targetColumnSegment) {
         for (ExpressionSegment each : expressions) {
-            if (each instanceof BinaryOperationExpression
-                    && ("LIKE".equalsIgnoreCase(((BinaryOperationExpression) each).getOperator()) || "NOT LIKE".equalsIgnoreCase(((BinaryOperationExpression) each).getOperator()))
+            if (each instanceof BinaryOperationExpression && EncryptConstants.LIKE_OPERATORS.contains(((BinaryOperationExpression) each).getOperator())
                     && isSameColumnSegment(((BinaryOperationExpression) each).getLeft(), targetColumnSegment)) {
                 return true;
             }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/constant/EncryptConstants.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/constant/EncryptConstants.java
@@ -30,5 +30,7 @@ import java.util.Collection;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class EncryptConstants {
     
+    public static final Collection<String> LIKE_OPERATORS = new CaseInsensitiveSet<>(Arrays.asList("LIKE", "NOT LIKE"));
+    
     public static final Collection<String> SUPPORTED_BINARY_OPERATORS = new CaseInsensitiveSet<>(Arrays.asList("=", "<>", "!=", ">", "<", ">=", "<=", "IS", "LIKE", "NOT LIKE"));
 }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/rewriter/EncryptPredicateParameterRewriter.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/rewriter/EncryptPredicateParameterRewriter.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.encrypt.rewrite.parameter.rewriter;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.encrypt.constant.EncryptConstants;
 import org.apache.shardingsphere.encrypt.exception.metadata.MissingMatchedEncryptQueryAlgorithmException;
 import org.apache.shardingsphere.encrypt.rewrite.condition.EncryptCondition;
 import org.apache.shardingsphere.encrypt.rewrite.condition.EncryptConditionValues;
@@ -86,7 +87,7 @@ public final class EncryptPredicateParameterRewriter implements ParameterRewrite
     }
     
     private boolean containsLikeOperator(final EncryptBinaryCondition encryptCondition) {
-        return "LIKE".equalsIgnoreCase(encryptCondition.getOperator()) || "NOT LIKE".equalsIgnoreCase(encryptCondition.getOperator());
+        return EncryptConstants.LIKE_OPERATORS.contains(encryptCondition.getOperator());
     }
     
     private void encryptParameters(final ParameterBuilder paramBuilder, final Map<Integer, Integer> positionIndexes, final List<Object> encryptValues) {

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateColumnTokenGenerator.java
@@ -22,6 +22,7 @@ import lombok.Setter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
+import org.apache.shardingsphere.encrypt.constant.EncryptConstants;
 import org.apache.shardingsphere.encrypt.enums.EncryptDerivedColumnSuffix;
 import org.apache.shardingsphere.encrypt.exception.metadata.MissingMatchedEncryptQueryAlgorithmException;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
@@ -46,6 +47,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.Co
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.ColumnSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
@@ -88,9 +90,10 @@ public final class EncryptPredicateColumnTokenGenerator implements CollectionSQL
     private Collection<SQLToken> generateSQLTokens(final SQLStatement sqlStatement, final ExpressionSegment expression) {
         Collection<SQLToken> result = new LinkedList<>();
         for (ColumnSegment each : ColumnExtractor.extract(expression)) {
-            Optional<EncryptTable> encryptTable = rule.findEncryptTable(each.getColumnBoundInfo().getOriginalTable().getValue());
-            if (encryptTable.isPresent() && encryptTable.get().isEncryptColumn(each.getColumnBoundInfo().getOriginalColumn().getValue())) {
-                EncryptColumn encryptColumn = encryptTable.get().getEncryptColumn(each.getColumnBoundInfo().getOriginalColumn().getValue());
+            ColumnSegmentBoundInfo columnBoundInfo = each.getColumnBoundInfo();
+            Optional<EncryptTable> encryptTable = rule.findEncryptTable(columnBoundInfo.getOriginalTable().getValue());
+            if (encryptTable.isPresent() && encryptTable.get().isEncryptColumn(columnBoundInfo.getOriginalColumn().getValue())) {
+                EncryptColumn encryptColumn = encryptTable.get().getEncryptColumn(columnBoundInfo.getOriginalColumn().getValue());
                 result.addAll(buildSubstitutableColumnNameTokens(encryptColumn, each, expression, sqlStatement.getDatabaseType(), encryptTable.get().getTable()));
             }
         }
@@ -128,8 +131,7 @@ public final class EncryptPredicateColumnTokenGenerator implements CollectionSQL
     }
     
     private boolean isIncludeLike(final ExpressionSegment expression) {
-        return expression instanceof BinaryOperationExpression && ("LIKE".equalsIgnoreCase(((BinaryOperationExpression) expression).getOperator())
-                || "NOT LIKE".equalsIgnoreCase(((BinaryOperationExpression) expression).getOperator()));
+        return expression instanceof BinaryOperationExpression && EncryptConstants.LIKE_OPERATORS.contains(((BinaryOperationExpression) expression).getOperator());
     }
     
     private Collection<Projection> createColumnProjections(final String actualColumnName, final ColumnSegment columnSegment, final EncryptDerivedColumnSuffix derivedColumnSuffix,

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateValueTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/predicate/EncryptPredicateValueTokenGenerator.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
+import org.apache.shardingsphere.encrypt.constant.EncryptConstants;
 import org.apache.shardingsphere.encrypt.exception.metadata.MissingMatchedEncryptQueryAlgorithmException;
 import org.apache.shardingsphere.encrypt.rewrite.condition.EncryptCondition;
 import org.apache.shardingsphere.encrypt.rewrite.condition.EncryptConditionValues;
@@ -111,8 +112,7 @@ public final class EncryptPredicateValueTokenGenerator implements CollectionSQLT
         String columnName = encryptCondition.getColumnSegment().getColumnBoundInfo().getOriginalColumn().getValue();
         EncryptColumn encryptColumn = encryptTable.getEncryptColumn(columnName);
         String tableName = encryptCondition.getColumnSegment().getColumnBoundInfo().getOriginalTable().getValue();
-        if (encryptCondition instanceof EncryptBinaryCondition && ("LIKE".equalsIgnoreCase(((EncryptBinaryCondition) encryptCondition).getOperator())
-                || "NOT LIKE".equalsIgnoreCase(((EncryptBinaryCondition) encryptCondition).getOperator()))) {
+        if (encryptCondition instanceof EncryptBinaryCondition && EncryptConstants.LIKE_OPERATORS.contains(((EncryptBinaryCondition) encryptCondition).getOperator())) {
             return getLikeQueryEncryptedValues(schemaName, encryptCondition, originalValues, encryptColumn, tableName, columnName);
         }
         return encryptColumn.getAssistedQuery()


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Minor refactor EncryptPredicateColumnTokenGenerator, EncryptPredicateParameterRewriter and EncryptPredicateValueTokenGenerator

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
