### PR TITLE
Use case-insensitive set to create logical tables for single rule

### DIFF
--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/attribute/SingleTableMapperRuleAttribute.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/rule/attribute/SingleTableMapperRuleAttribute.java
@@ -17,12 +17,12 @@
 
 package org.apache.shardingsphere.single.rule.attribute;
 
+import com.cedarsoftware.util.CaseInsensitiveSet;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.rule.attribute.table.TableMapperRuleAttribute;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 
 /**
  * Single table mapper rule attribute.
@@ -36,7 +36,7 @@ public final class SingleTableMapperRuleAttribute implements TableMapperRuleAttr
     }
     
     private Collection<String> createLogicalTableNames(final Collection<Collection<DataNode>> singleTableDataNodes) {
-        Collection<String> result = new LinkedHashSet<>(singleTableDataNodes.size(), 1F);
+        Collection<String> result = new CaseInsensitiveSet<>(singleTableDataNodes.size(), 1F);
         singleTableDataNodes.forEach(each -> result.add(each.iterator().next().getTableName()));
         return result;
     }

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/attribute/SingleTableMapperRuleAttributeTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/attribute/SingleTableMapperRuleAttributeTest.java
@@ -41,7 +41,7 @@ class SingleTableMapperRuleAttributeTest {
         SingleTableMapperRuleAttribute actual = new SingleTableMapperRuleAttribute(Arrays.asList(
                 Collections.singleton(new DataNode("foo_ds", "public", "Test3")),
                 Collections.singleton(new DataNode("foo_ds", "public", "test3"))));
-        assertThat(new LinkedList<>(actual.getLogicTableNames()), is(Arrays.asList("Test3", "test3")));
+        assertThat(new LinkedList<>(actual.getLogicTableNames()), is(Collections.singletonList("Test3")));
     }
     
     @Test


### PR DESCRIPTION

Changes proposed in this pull request:
  - Use case-insensitive set to create logical tables for single rule

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
