### PR TITLE
Make unquoted schema lookup case-insensitive for PostgresSQL

### DIFF
--- a/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/identifier/OpenGaussIdentifierCaseRuleProvider.java
+++ b/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/identifier/OpenGaussIdentifierCaseRuleProvider.java
@@ -19,9 +19,13 @@ package org.apache.shardingsphere.database.connector.opengauss.metadata.identifi
 
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleProvider;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleProviderContext;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSet;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSets;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -33,7 +37,10 @@ public final class OpenGaussIdentifierCaseRuleProvider implements IdentifierCase
     @Override
     public Optional<IdentifierCaseRuleSet> provide(final IdentifierCaseRuleProviderContext context) {
         Objects.requireNonNull(context, "context cannot be null.");
-        return Optional.of(IdentifierCaseRuleSets.newLowerCaseRuleSet());
+        IdentifierCaseRuleSet lowerCaseRuleSet = IdentifierCaseRuleSets.newLowerCaseRuleSet();
+        Map<IdentifierScope, IdentifierCaseRule> scopedRules = new EnumMap<>(IdentifierScope.class);
+        scopedRules.put(IdentifierScope.SCHEMA, IdentifierCaseRuleSets.newInsensitiveRuleSet().getRule(IdentifierScope.SCHEMA));
+        return Optional.of(new IdentifierCaseRuleSet(lowerCaseRuleSet.getRule(IdentifierScope.TABLE), scopedRules));
     }
     
     @Override

--- a/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/identifier/OpenGaussIdentifierCaseRuleProviderTest.java
+++ b/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/identifier/OpenGaussIdentifierCaseRuleProviderTest.java
@@ -48,9 +48,14 @@ class OpenGaussIdentifierCaseRuleProviderTest {
     
     @Test
     void assertProvide() {
-        IdentifierCaseRule actual = provider.provide(new IdentifierCaseRuleProviderContext(databaseType, null)).orElseThrow(AssertionError::new).getRule(IdentifierScope.TABLE);
-        assertThat(actual.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
-        assertTrue(actual.matches("foo", "FOO", QuoteCharacter.NONE));
-        assertFalse(actual.matches("Foo", "foo", QuoteCharacter.NONE));
+        IdentifierCaseRuleProviderContext context = new IdentifierCaseRuleProviderContext(databaseType, null);
+        IdentifierCaseRule tableRule = provider.provide(context).orElseThrow(AssertionError::new).getRule(IdentifierScope.TABLE);
+        assertThat(tableRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
+        assertTrue(tableRule.matches("foo", "FOO", QuoteCharacter.NONE));
+        assertFalse(tableRule.matches("Foo", "foo", QuoteCharacter.NONE));
+        IdentifierCaseRule schemaRule = provider.provide(context).orElseThrow(AssertionError::new).getRule(IdentifierScope.SCHEMA);
+        assertThat(schemaRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
+        assertTrue(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.NONE));
+        assertFalse(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.QUOTE));
     }
 }

--- a/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/identifier/PostgreSQLIdentifierCaseRuleProvider.java
+++ b/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/identifier/PostgreSQLIdentifierCaseRuleProvider.java
@@ -20,8 +20,12 @@ package org.apache.shardingsphere.database.connector.postgresql.metadata.identif
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleProvider;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleProviderContext;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSet;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSets;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -33,7 +37,10 @@ public final class PostgreSQLIdentifierCaseRuleProvider implements IdentifierCas
     @Override
     public Optional<IdentifierCaseRuleSet> provide(final IdentifierCaseRuleProviderContext context) {
         Objects.requireNonNull(context, "context cannot be null.");
-        return Optional.of(IdentifierCaseRuleSets.newLowerCaseRuleSet());
+        IdentifierCaseRuleSet lowerCaseRuleSet = IdentifierCaseRuleSets.newLowerCaseRuleSet();
+        Map<IdentifierScope, IdentifierCaseRule> scopedRules = new EnumMap<>(IdentifierScope.class);
+        scopedRules.put(IdentifierScope.SCHEMA, IdentifierCaseRuleSets.newInsensitiveRuleSet().getRule(IdentifierScope.SCHEMA));
+        return Optional.of(new IdentifierCaseRuleSet(lowerCaseRuleSet.getRule(IdentifierScope.TABLE), scopedRules));
     }
     
     @Override

--- a/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/identifier/PostgreSQLIdentifierCaseRuleProviderTest.java
+++ b/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/identifier/PostgreSQLIdentifierCaseRuleProviderTest.java
@@ -48,9 +48,14 @@ class PostgreSQLIdentifierCaseRuleProviderTest {
     
     @Test
     void assertProvide() {
-        IdentifierCaseRule actual = provider.provide(new IdentifierCaseRuleProviderContext(databaseType, null)).orElseThrow(AssertionError::new).getRule(IdentifierScope.TABLE);
-        assertThat(actual.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
-        assertTrue(actual.matches("foo", "FOO", QuoteCharacter.NONE));
-        assertFalse(actual.matches("Foo", "foo", QuoteCharacter.NONE));
+        IdentifierCaseRuleProviderContext context = new IdentifierCaseRuleProviderContext(databaseType, null);
+        IdentifierCaseRule tableRule = provider.provide(context).orElseThrow(AssertionError::new).getRule(IdentifierScope.TABLE);
+        assertThat(tableRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
+        assertTrue(tableRule.matches("foo", "FOO", QuoteCharacter.NONE));
+        assertFalse(tableRule.matches("Foo", "foo", QuoteCharacter.NONE));
+        IdentifierCaseRule schemaRule = provider.provide(context).orElseThrow(AssertionError::new).getRule(IdentifierScope.SCHEMA);
+        assertThat(schemaRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
+        assertTrue(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.NONE));
+        assertFalse(schemaRule.matches("UPPER_SCHEMA", "upper_schema", QuoteCharacter.QUOTE));
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -417,8 +417,8 @@ class DatabaseIdentifierContextFactoryTest {
     private static Stream<Arguments> createWithSupportedDatabaseSchemaLookupArguments() {
         return Stream.of(
                 createNormalizedLookupArguments("mysql schema", MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, "foo_schema", "`"),
-                createLowerCaseLookupArguments("postgresql schema", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
-                createLowerCaseLookupArguments("openGauss schema", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
+                createInsensitiveQuotedExactLookupArguments("postgresql schema", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
+                createInsensitiveQuotedExactLookupArguments("openGauss schema", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
                 createUpperCaseLookupArguments("oracle schema", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_schema", "\""))
                 .flatMap(each -> each);
     }
@@ -474,8 +474,8 @@ class DatabaseIdentifierContextFactoryTest {
     private static Stream<Arguments> createWithMixedStoredCaseSchemaLookupArguments() {
         return Stream.of(
                 createNormalizedMixedLookupArguments("mysql schema", MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, "foo_schema", "`"),
-                createLowerCaseMixedLookupArguments("postgresql schema", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
-                createLowerCaseMixedLookupArguments("openGauss schema", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
+                createInsensitiveQuotedExactMixedLookupArguments("postgresql schema", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
+                createInsensitiveQuotedExactMixedLookupArguments("openGauss schema", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
                 createUpperCaseMixedLookupArguments("oracle schema", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_schema", "\""))
                 .flatMap(each -> each);
     }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Make unquoted schema lookup case-insensitive for PostgresSQL

**PR Title**  
Refine PostgreSQL/openGauss schema identifier rules: case-insensitive unquoted lookup with exact quoted match

**PR Description**  
## Summary
This PR adjusts schema identifier matching for PostgreSQL and openGauss to support mixed-case stored schema names while preserving quoted-identifier semantics.

## Changes
- Updated PostgreSQL identifier case rule provider:
  - Override `IdentifierScope.SCHEMA` with `newInsensitiveRuleSet().getRule(IdentifierScope.SCHEMA)`.
  - Keep other scopes on the existing lower-case rule set.
- Updated openGauss identifier case rule provider with the same schema-scope override.
- Updated related unit tests to reflect the new schema behavior.

## Behavior After Change
For **schema** identifiers in PostgreSQL/openGauss:
- Unquoted lookup is case-insensitive (`LookupMode.NORMALIZED`).
- Quoted lookup remains exact (`LookupMode.EXACT` behavior for quoted identifiers).

Other identifier scopes (table/column/view/etc.) keep their previous behavior.

## Why
Previously, PostgreSQL/openGauss schema rules filtered unquoted candidates by lower-case stored names.  
That could fail when schema metadata was stored in upper-case or mixed-case forms.  
This change ensures unquoted schema lookup can still resolve those names, while quoted lookup remains strict.

## Verification
Executed:
- `./mvnw -pl database/connector/dialect/postgresql,database/connector/dialect/opengauss -am -DskipITs -Dspotless.skip=true -Dtest=PostgreSQLIdentifierCaseRuleProviderTest,OpenGaussIdentifierCaseRuleProviderTest test -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw -pl infra/common -DskipITs -Dspotless.skip=true -Dtest=DatabaseIdentifierContextFactoryTest test -Dsurefire.failIfNoSpecifiedTests=false`

All passed.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
