### PR TITLE
Map MySQL YEAR column to protocol type 0x0d so yearIsDateType driver property takes effect

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 1. Mode: Fix rule metadata not removed from memory after dropping rules in Etcd cluster mode - [#38561](https://github.com/apache/shardingsphere/pull/38561)
 1. Pipeline: Fix MySQL JSON literal decoding in migration - [#38622](https://github.com/apache/shardingsphere/pull/38622)
 1. Pipeline: Fix MySQL zero-value temporal binlog decoding with fractional precision in migration - [#35531](https://github.com/apache/shardingsphere/issues/35531)
+1. Proxy: Map MySQL YEAR column to protocol type 0x0d so the yearIsDateType driver property takes effect - [#38697](https://github.com/apache/shardingsphere/pull/38697)
 1. Sharding: Support ORDER BY MySQL VARBINARY column by wrapping byte[] values in a Comparable adapter - [#38699](https://github.com/apache/shardingsphere/pull/38699)
 
 ### Enhancements

--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/data/model/ColumnMetaData.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/data/model/ColumnMetaData.java
@@ -44,4 +44,11 @@ public final class ColumnMetaData {
     private final boolean unsigned;
     
     private final boolean nullable;
+    
+    private final String columnTypeName;
+    
+    public ColumnMetaData(final String name, final int dataType, final boolean primaryKey, final boolean generated, final boolean caseSensitive,
+                          final boolean visible, final boolean unsigned, final boolean nullable) {
+        this(name, dataType, primaryKey, generated, caseSensitive, visible, unsigned, nullable, null);
+    }
 }

--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/jdbcurl/MySQLDefaultQueryPropertiesProvider.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/jdbcurl/MySQLDefaultQueryPropertiesProvider.java
@@ -38,6 +38,7 @@ public final class MySQLDefaultQueryPropertiesProvider implements DialectDefault
         result.setProperty("netTimeoutForStreamingResults", "0");
         result.setProperty("tinyInt1isBit", Boolean.FALSE.toString());
         result.setProperty("useSSL", Boolean.FALSE.toString());
+        result.setProperty("yearIsDateType", Boolean.FALSE.toString());
         result.setProperty("zeroDateTimeBehavior", "round");
         return result;
     }

--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoader.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoader.java
@@ -159,7 +159,8 @@ public final class MySQLMetaDataLoader implements DialectMetaDataLoader {
         boolean visible = !"INVISIBLE".equalsIgnoreCase(extra);
         boolean unsigned = resultSet.getString("COLUMN_TYPE").toUpperCase().contains("UNSIGNED");
         boolean nullable = "YES".equals(resultSet.getString("IS_NULLABLE"));
-        return new ColumnMetaData(columnName, DataTypeRegistry.getDataType(getDatabaseType(), dataType).orElse(Types.OTHER), primaryKey, generated, caseSensitive, visible, unsigned, nullable);
+        return new ColumnMetaData(columnName, DataTypeRegistry.getDataType(getDatabaseType(), dataType).orElse(Types.OTHER), primaryKey, generated, caseSensitive, visible, unsigned, nullable,
+                dataType);
     }
     
     private String getTableMetaDataSQL(final Collection<String> tables) {

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/jdbcurl/MySQLDefaultQueryPropertiesProviderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/jdbcurl/MySQLDefaultQueryPropertiesProviderTest.java
@@ -49,6 +49,7 @@ class MySQLDefaultQueryPropertiesProviderTest {
                 new Property("netTimeoutForStreamingResults", "0"),
                 new Property("tinyInt1isBit", Boolean.FALSE.toString()),
                 new Property("useSSL", Boolean.FALSE.toString()),
+                new Property("yearIsDateType", Boolean.FALSE.toString()),
                 new Property("zeroDateTimeBehavior", "round"));
         assertThat(actual, is(expected));
     }

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoaderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoaderTest.java
@@ -192,15 +192,15 @@ class MySQLMetaDataLoaderTest {
         assertThat(actualTableMetaData.getName(), is("tbl"));
         assertThat(actualTableMetaData.getColumns().size(), is(9));
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
-        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("id", Types.INTEGER, true, true, true, true, false, false));
-        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("name", Types.VARCHAR, false, false, false, false, false, true));
-        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("doc", Types.LONGVARCHAR, false, false, false, true, false, true));
-        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("geo", Types.BINARY, false, false, false, true, false, true));
-        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("t_year", Types.DATE, false, false, false, true, false, true));
-        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("pg", Types.BINARY, false, false, false, true, false, true));
-        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("mpg", Types.BINARY, false, false, false, true, false, true));
-        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("pt", Types.BINARY, false, false, false, true, false, true));
-        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("mpt", Types.BINARY, false, false, false, true, false, true));
+        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("id", Types.INTEGER, true, true, true, true, false, false, "int"));
+        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("name", Types.VARCHAR, false, false, false, false, false, true, "varchar"));
+        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("doc", Types.LONGVARCHAR, false, false, false, true, false, true, "json"));
+        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("geo", Types.BINARY, false, false, false, true, false, true, "geometry"));
+        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("t_year", Types.DATE, false, false, false, true, false, true, "year"));
+        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("pg", Types.BINARY, false, false, false, true, false, true, "polygon"));
+        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("mpg", Types.BINARY, false, false, false, true, false, true, "multipolygon"));
+        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("pt", Types.BINARY, false, false, false, true, false, true, "point"));
+        assertColumnMetaData(columnsIterator.next(), new ColumnMetaData("mpt", Types.BINARY, false, false, false, true, false, true, "multipoint"));
         assertIndexMetaData(actualTableMetaData.getIndexes(), expectedCompositeIndexExists);
         assertConstraintMetaData(actualTableMetaData.getConstraints(), expectedConstraintExists);
     }
@@ -214,6 +214,7 @@ class MySQLMetaDataLoaderTest {
         assertThat(actual.isVisible(), is(expected.isVisible()));
         assertThat(actual.isUnsigned(), is(expected.isUnsigned()));
         assertThat(actual.isNullable(), is(expected.isNullable()));
+        assertThat(actual.getColumnTypeName(), is(expected.getColumnTypeName()));
     }
     
     private void assertIndexMetaData(final Collection<IndexMetaData> actualIndexMetaData, final boolean expectedCompositeIndexExists) {

--- a/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLBinaryColumnType.java
+++ b/database/protocol/dialect/mysql/src/main/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLBinaryColumnType.java
@@ -147,6 +147,31 @@ public enum MySQLBinaryColumnType implements BinaryColumnType {
     }
     
     /**
+     * Value of JDBC type.
+     *
+     * @param jdbcType JDBC type
+     * @param columnTypeName column type name
+     * @return column type enum
+     */
+    public static MySQLBinaryColumnType valueOfJDBCType(final int jdbcType, final String columnTypeName) {
+        if (isYear(jdbcType, columnTypeName)) {
+            return YEAR;
+        }
+        return valueOfJDBCType(jdbcType);
+    }
+    
+    /**
+     * Check if MySQL YEAR type.
+     *
+     * @param jdbcType JDBC type
+     * @param columnTypeName column type name
+     * @return whether is MySQL YEAR
+     */
+    public static boolean isYear(final int jdbcType, final String columnTypeName) {
+        return Types.DATE == jdbcType && "YEAR".equalsIgnoreCase(columnTypeName);
+    }
+    
+    /**
      * Value of.
      *
      * @param value value

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLBinaryColumnTypeTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLBinaryColumnTypeTest.java
@@ -23,7 +23,9 @@ import java.sql.Types;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MySQLBinaryColumnTypeTest {
     
@@ -57,6 +59,27 @@ class MySQLBinaryColumnTypeTest {
         assertThrows(IllegalArgumentException.class, () -> MySQLBinaryColumnType.valueOfJDBCType(9999));
     }
     
+    @Test
+    void assertValueOfJDBCTypeForYear() {
+        assertThat(MySQLBinaryColumnType.valueOfJDBCType(Types.DATE, "YEAR"), is(MySQLBinaryColumnType.YEAR));
+        assertThat(MySQLBinaryColumnType.valueOfJDBCType(Types.DATE, "year"), is(MySQLBinaryColumnType.YEAR));
+    }
+
+    @Test
+    void assertValueOfJDBCTypeForDate() {
+        assertThat(MySQLBinaryColumnType.valueOfJDBCType(Types.DATE, "DATE"), is(MySQLBinaryColumnType.DATE));
+        assertThat(MySQLBinaryColumnType.valueOfJDBCType(Types.DATE, null), is(MySQLBinaryColumnType.DATE));
+    }
+
+    @Test
+    void assertIsYear() {
+        assertTrue(MySQLBinaryColumnType.isYear(Types.DATE, "YEAR"));
+        assertTrue(MySQLBinaryColumnType.isYear(Types.DATE, "year"));
+        assertFalse(MySQLBinaryColumnType.isYear(Types.DATE, "DATE"));
+        assertFalse(MySQLBinaryColumnType.isYear(Types.DATE, null));
+        assertFalse(MySQLBinaryColumnType.isYear(Types.INTEGER, "YEAR"));
+    }
+
     @Test
     void assertValueOf() {
         assertThat(MySQLBinaryColumnType.valueOf(MySQLBinaryColumnType.DECIMAL.getValue()), is(MySQLBinaryColumnType.DECIMAL));

--- a/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLBinaryColumnTypeTest.java
+++ b/database/protocol/dialect/mysql/src/test/java/org/apache/shardingsphere/database/protocol/mysql/constant/MySQLBinaryColumnTypeTest.java
@@ -64,13 +64,13 @@ class MySQLBinaryColumnTypeTest {
         assertThat(MySQLBinaryColumnType.valueOfJDBCType(Types.DATE, "YEAR"), is(MySQLBinaryColumnType.YEAR));
         assertThat(MySQLBinaryColumnType.valueOfJDBCType(Types.DATE, "year"), is(MySQLBinaryColumnType.YEAR));
     }
-
+    
     @Test
     void assertValueOfJDBCTypeForDate() {
         assertThat(MySQLBinaryColumnType.valueOfJDBCType(Types.DATE, "DATE"), is(MySQLBinaryColumnType.DATE));
         assertThat(MySQLBinaryColumnType.valueOfJDBCType(Types.DATE, null), is(MySQLBinaryColumnType.DATE));
     }
-
+    
     @Test
     void assertIsYear() {
         assertTrue(MySQLBinaryColumnType.isYear(Types.DATE, "YEAR"));
@@ -79,7 +79,7 @@ class MySQLBinaryColumnTypeTest {
         assertFalse(MySQLBinaryColumnType.isYear(Types.DATE, null));
         assertFalse(MySQLBinaryColumnType.isYear(Types.INTEGER, "YEAR"));
     }
-
+    
     @Test
     void assertValueOf() {
         assertThat(MySQLBinaryColumnType.valueOf(MySQLBinaryColumnType.DECIMAL.getValue()), is(MySQLBinaryColumnType.DECIMAL));

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/metadata/reviser/ShardingMetaDataReviseEntryTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/metadata/reviser/ShardingMetaDataReviseEntryTest.java
@@ -17,8 +17,12 @@
 
 package org.apache.shardingsphere.sharding.metadata.reviser;
 
+import org.apache.shardingsphere.database.connector.core.metadata.data.model.ColumnMetaData;
+import org.apache.shardingsphere.database.connector.core.metadata.data.model.TableMetaData;
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstanceContext;
+import org.apache.shardingsphere.infra.metadata.database.schema.reviser.table.TableMetaDataReviseEngine;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.metadata.reviser.column.ShardingColumnGeneratedReviser;
@@ -30,7 +34,9 @@ import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.test.infra.fixture.jdbc.MockedDataSource;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Types;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
@@ -78,6 +84,19 @@ class ShardingMetaDataReviseEntryTest {
         Optional<ShardingSchemaTableAggregationReviser> schemaTableAggregationReviser = reviseEntry.getSchemaTableAggregationReviser(new ConfigurationProperties(null));
         assertTrue(schemaTableAggregationReviser.isPresent());
         assertThat(schemaTableAggregationReviser.get().getClass(), is(ShardingSchemaTableAggregationReviser.class));
+    }
+    
+    @Test
+    void assertReviseKeepsYearColumnTypeNameThroughShardingPath() {
+        ColumnMetaData yearColumn = new ColumnMetaData("t_year", Types.DATE, false, false, false, true, false, true, "YEAR");
+        TableMetaData original = new TableMetaData("t_order", Collections.singleton(yearColumn), Collections.emptyList(), Collections.emptyList(), TableType.TABLE);
+        TableMetaData revised = new TableMetaDataReviseEngine<>(rule, reviseEntry).revise(original);
+        Iterator<ColumnMetaData> columns = revised.getColumns().iterator();
+        assertTrue(columns.hasNext());
+        ColumnMetaData revisedColumn = columns.next();
+        assertThat(revisedColumn.getName(), is("t_year"));
+        assertThat(revisedColumn.getDataType(), is(Types.DATE));
+        assertThat(revisedColumn.getColumnTypeName(), is("YEAR"));
     }
     
     private ShardingRule createShardingRule() {

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereColumn.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereColumn.java
@@ -46,8 +46,15 @@ public final class ShardingSphereColumn {
     
     private final boolean nullable;
     
+    private final String columnTypeName;
+    
+    public ShardingSphereColumn(final String name, final int dataType, final boolean primaryKey, final boolean generated, final boolean caseSensitive,
+                                final boolean visible, final boolean unsigned, final boolean nullable) {
+        this(name, dataType, primaryKey, generated, caseSensitive, visible, unsigned, nullable, null);
+    }
+    
     public ShardingSphereColumn(final ColumnMetaData columnMetaData) {
         this(columnMetaData.getName(), columnMetaData.getDataType(), columnMetaData.isPrimaryKey(), columnMetaData.isGenerated(),
-                columnMetaData.isCaseSensitive(), columnMetaData.isVisible(), columnMetaData.isUnsigned(), columnMetaData.isNullable());
+                columnMetaData.isCaseSensitive(), columnMetaData.isVisible(), columnMetaData.isUnsigned(), columnMetaData.isNullable(), columnMetaData.getColumnTypeName());
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/column/ColumnReviseEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/column/ColumnReviseEngine.java
@@ -56,7 +56,8 @@ public final class ColumnReviseEngine<T extends ShardingSphereRule> {
             }
             String name = nameReviser.isPresent() ? nameReviser.get().revise(each.getName()) : each.getName();
             boolean generated = generatedReviser.map(optional -> optional.revise(each)).orElseGet(each::isGenerated);
-            result.add(new ColumnMetaData(name, each.getDataType(), each.isPrimaryKey(), generated, each.isCaseSensitive(), each.isVisible(), each.isUnsigned(), each.isNullable()));
+            result.add(new ColumnMetaData(name, each.getDataType(), each.isPrimaryKey(), generated, each.isCaseSensitive(), each.isVisible(), each.isUnsigned(), each.isNullable(),
+                    each.getColumnTypeName()));
         }
         return result;
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/schema/pojo/YamlShardingSphereColumn.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/schema/pojo/YamlShardingSphereColumn.java
@@ -43,4 +43,6 @@ public final class YamlShardingSphereColumn implements YamlConfiguration {
     private boolean unsigned;
     
     private boolean nullable;
+    
+    private String columnTypeName;
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/schema/swapper/YamlColumnSwapper.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/schema/swapper/YamlColumnSwapper.java
@@ -37,12 +37,13 @@ public final class YamlColumnSwapper implements YamlConfigurationSwapper<YamlSha
         result.setVisible(data.isVisible());
         result.setUnsigned(data.isUnsigned());
         result.setNullable(data.isNullable());
+        result.setColumnTypeName(data.getColumnTypeName());
         return result;
     }
     
     @Override
     public ShardingSphereColumn swapToObject(final YamlShardingSphereColumn yamlConfig) {
-        return new ShardingSphereColumn(yamlConfig.getName(), yamlConfig.getDataType(),
-                yamlConfig.isPrimaryKey(), yamlConfig.isGenerated(), yamlConfig.isCaseSensitive(), yamlConfig.isVisible(), yamlConfig.isUnsigned(), yamlConfig.isNullable());
+        return new ShardingSphereColumn(yamlConfig.getName(), yamlConfig.getDataType(), yamlConfig.isPrimaryKey(), yamlConfig.isGenerated(),
+                yamlConfig.isCaseSensitive(), yamlConfig.isVisible(), yamlConfig.isUnsigned(), yamlConfig.isNullable(), yamlConfig.getColumnTypeName());
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/column/ColumnReviseEngineTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/column/ColumnReviseEngineTest.java
@@ -63,4 +63,16 @@ class ColumnReviseEngineTest {
         assertFalse(revisedColumn.isUnsigned());
         assertFalse(revisedColumn.isNullable());
     }
+    
+    @Test
+    void assertReviseKeepsColumnTypeName() {
+        String tableName = "foo_tbl";
+        when(reviseEntry.getColumnExistedReviser(rule, tableName)).thenReturn(Optional.empty());
+        when(reviseEntry.getColumnNameReviser(rule, tableName)).thenReturn(Optional.empty());
+        when(reviseEntry.getColumnGeneratedReviser(rule, tableName)).thenReturn(Optional.empty());
+        ColumnMetaData yearColumn = new ColumnMetaData("t_year", java.sql.Types.DATE, false, false, false, true, false, true, "YEAR");
+        Collection<ColumnMetaData> actual = new ColumnReviseEngine<>(rule, reviseEntry).revise(tableName, Collections.singleton(yearColumn));
+        assertThat(actual.size(), is(1));
+        assertThat(actual.iterator().next().getColumnTypeName(), is("YEAR"));
+    }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/yaml/schema/swapper/YamlColumnSwapperTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/yaml/schema/swapper/YamlColumnSwapperTest.java
@@ -32,7 +32,7 @@ class YamlColumnSwapperTest {
     
     @Test
     void assertSwapToYamlConfiguration() {
-        ShardingSphereColumn column = new ShardingSphereColumn("id", 1, true, false, true, true, false, false);
+        ShardingSphereColumn column = new ShardingSphereColumn("id", 1, true, false, true, true, false, false, "int");
         YamlShardingSphereColumn actual = swapper.swapToYamlConfiguration(column);
         assertThat(actual.getName(), is("id"));
         assertThat(actual.getDataType(), is(1));
@@ -42,6 +42,7 @@ class YamlColumnSwapperTest {
         assertTrue(actual.isVisible());
         assertFalse(actual.isUnsigned());
         assertFalse(actual.isNullable());
+        assertThat(actual.getColumnTypeName(), is("int"));
     }
     
     @Test
@@ -55,6 +56,7 @@ class YamlColumnSwapperTest {
         yamlColumn.setVisible(false);
         yamlColumn.setUnsigned(true);
         yamlColumn.setNullable(true);
+        yamlColumn.setColumnTypeName("year");
         ShardingSphereColumn actual = swapper.swapToObject(yamlColumn);
         assertThat(actual.getName(), is("id"));
         assertThat(actual.getDataType(), is(2));
@@ -64,5 +66,6 @@ class YamlColumnSwapperTest {
         assertFalse(actual.isVisible());
         assertTrue(actual.isUnsigned());
         assertTrue(actual.isNullable());
+        assertThat(actual.getColumnTypeName(), is("year"));
     }
 }

--- a/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutor.java
+++ b/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutor.java
@@ -50,6 +50,7 @@ import org.apache.shardingsphere.proxy.frontend.mysql.command.ServerStatusFlagCa
 import org.apache.shardingsphere.proxy.frontend.mysql.command.query.binary.MySQLServerPreparedStatement;
 import org.apache.shardingsphere.proxy.frontend.mysql.command.query.builder.ResponsePacketBuilder;
 
+import java.sql.Date;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -154,9 +155,14 @@ public final class MySQLComStmtExecuteExecutor implements QueryCommandExecutor {
     private BinaryRow createBinaryRow(final QueryResponseRow queryResponseRow) {
         List<BinaryCell> result = new ArrayList<>(queryResponseRow.getCells().size());
         for (QueryResponseCell each : queryResponseRow.getCells()) {
-            result.add(new BinaryCell(MySQLBinaryColumnType.valueOfJDBCType(each.getJdbcType()), each.getData()));
+            MySQLBinaryColumnType columnType = MySQLBinaryColumnType.valueOfJDBCType(each.getJdbcType(), each.getColumnTypeName().orElse(null));
+            result.add(new BinaryCell(columnType, adjustValueForBinaryColumnType(columnType, each.getData())));
         }
         return new BinaryRow(result);
+    }
+    
+    private Object adjustValueForBinaryColumnType(final MySQLBinaryColumnType columnType, final Object value) {
+        return MySQLBinaryColumnType.YEAR == columnType && value instanceof Date ? ((Date) value).toLocalDate().getYear() : value;
     }
     
     @Override

--- a/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutor.java
+++ b/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutor.java
@@ -162,7 +162,13 @@ public final class MySQLComStmtExecuteExecutor implements QueryCommandExecutor {
     }
     
     private Object adjustValueForBinaryColumnType(final MySQLBinaryColumnType columnType, final Object value) {
-        return MySQLBinaryColumnType.YEAR == columnType && value instanceof Date ? ((Date) value).toLocalDate().getYear() : value;
+        if (MySQLBinaryColumnType.YEAR != columnType) {
+            return value;
+        }
+        if (value instanceof Date) {
+            return ((Date) value).toLocalDate().getYear();
+        }
+        return value instanceof Number ? ((Number) value).intValue() : value;
     }
     
     @Override

--- a/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
+++ b/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
@@ -142,7 +142,7 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
             if (null != column) {
                 int columnDefinitionFlag = calculateColumnDefinitionFlag(column);
                 result.add(createMySQLColumnDefinition41PacketByCache(characterSet, columnPacketCache, column, columnDefinitionFlag));
-                MySQLBinaryColumnType columnType = MySQLBinaryColumnType.valueOfJDBCType(column.getDataType());
+                MySQLBinaryColumnType columnType = MySQLBinaryColumnType.valueOfJDBCType(column.getDataType(), column.getColumnTypeName());
                 paramColumnDefinitionFlags.add(columnDefinitionFlag);
                 parameterColumnTypes.add(columnType);
             } else {
@@ -166,7 +166,8 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
         if (null != cachedPacket) {
             return cachedPacket;
         }
-        MySQLColumnDefinition41Packet result = createMySQLColumnDefinition41Packet(characterSet, columnDefinitionFlag, MySQLBinaryColumnType.valueOfJDBCType(column.getDataType()));
+        MySQLColumnDefinition41Packet result =
+                createMySQLColumnDefinition41Packet(characterSet, columnDefinitionFlag, MySQLBinaryColumnType.valueOfJDBCType(column.getDataType(), column.getColumnTypeName()));
         columnPacketCache.put(column, result);
         return result;
     }
@@ -202,7 +203,8 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
             ColumnProjection columnProjection = (ColumnProjection) each;
             result.add(Optional.ofNullable(schema.getTable(columnProjection.getOriginalTable().getValue()))
                     .map(table -> table.getColumn(columnProjection.getOriginalColumn().getValue()))
-                    .map(column -> createMySQLColumnDefinition41Packet(characterSet, calculateColumnDefinitionFlag(column), MySQLBinaryColumnType.valueOfJDBCType(column.getDataType())))
+                    .map(column -> createMySQLColumnDefinition41Packet(characterSet, calculateColumnDefinitionFlag(column),
+                            MySQLBinaryColumnType.valueOfJDBCType(column.getDataType(), column.getColumnTypeName())))
                     .orElseGet(() -> createMySQLColumnDefinition41Packet(characterSet, 0, MySQLBinaryColumnType.VAR_STRING)));
         }
         return result;

--- a/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLProjectionMetadataResolver.java
+++ b/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLProjectionMetadataResolver.java
@@ -95,7 +95,8 @@ public final class MySQLProjectionMetadataResolver {
     private static MySQLColumnDefinition41Packet createMySQLColumnDefinition41Packet(final QueryHeader queryHeader, final int characterSet) {
         int actualCharacterSet = BINARY_TYPES.contains(queryHeader.getColumnType()) ? MySQLCharacterSets.BINARY.getId() : characterSet;
         return new MySQLColumnDefinition41Packet(actualCharacterSet, getColumnDefinitionFlag(queryHeader), queryHeader.getSchema(), queryHeader.getTable(), queryHeader.getTable(),
-                queryHeader.getColumnLabel(), queryHeader.getColumnName(), queryHeader.getColumnLength(), MySQLBinaryColumnType.valueOfJDBCType(queryHeader.getColumnType()),
+                queryHeader.getColumnLabel(), queryHeader.getColumnName(), queryHeader.getColumnLength(),
+                MySQLBinaryColumnType.valueOfJDBCType(queryHeader.getColumnType(), queryHeader.getColumnTypeName()),
                 queryHeader.getDecimals(), false);
     }
     

--- a/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/builder/ResponsePacketBuilder.java
+++ b/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/builder/ResponsePacketBuilder.java
@@ -66,7 +66,8 @@ public final class ResponsePacketBuilder {
         for (QueryHeader each : queryHeaders) {
             int characterSet = BINARY_TYPES.contains(each.getColumnType()) ? MySQLCharacterSets.BINARY.getId() : sessionCharacterSet;
             result.add(new MySQLColumnDefinition41Packet(characterSet, getColumnDefinitionFlag(each), each.getSchema(), each.getTable(), each.getTable(),
-                    each.getColumnLabel(), each.getColumnName(), each.getColumnLength(), MySQLBinaryColumnType.valueOfJDBCType(each.getColumnType()), each.getDecimals(), false));
+                    each.getColumnLabel(), each.getColumnName(), each.getColumnLength(),
+                    MySQLBinaryColumnType.valueOfJDBCType(each.getColumnType(), each.getColumnTypeName()), each.getDecimals(), false));
         }
         result.add(new MySQLEofPacket(statusFlags));
         return result;

--- a/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutor.java
+++ b/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutor.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory;
 import org.apache.shardingsphere.proxy.backend.handler.ProxySQLComQueryParser;
+import org.apache.shardingsphere.proxy.backend.response.data.QueryResponseCell;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.query.QueryResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.MultiStatementsUpdateResponseHeader;
@@ -44,9 +45,14 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.In
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.UpdateStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.util.MultiSQLSplitter;
 
+import java.sql.Date;
 import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * COM_QUERY command packet executor for MySQL.
@@ -130,7 +136,19 @@ public final class MySQLComQueryPacketExecutor implements QueryCommandExecutor {
     
     @Override
     public MySQLPacket getQueryRowPacket() throws SQLException {
-        return new MySQLTextResultSetRowPacket(proxyBackendHandler.getRowData().getData());
+        Collection<QueryResponseCell> cells = proxyBackendHandler.getRowData().getCells();
+        List<Object> result = new ArrayList<>(cells.size());
+        for (QueryResponseCell each : cells) {
+            result.add(adjustValueForTextColumnType(each));
+        }
+        return new MySQLTextResultSetRowPacket(result);
+    }
+    
+    private Object adjustValueForTextColumnType(final QueryResponseCell cell) {
+        Object data = cell.getData();
+        return Types.DATE == cell.getJdbcType() && "YEAR".equalsIgnoreCase(cell.getColumnTypeName().orElse(null)) && data instanceof Date
+                ? String.format(Locale.ROOT, "%04d", ((Date) data).toLocalDate().getYear())
+                : data;
     }
     
     @Override

--- a/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutor.java
+++ b/proxy/frontend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutor.java
@@ -146,9 +146,16 @@ public final class MySQLComQueryPacketExecutor implements QueryCommandExecutor {
     
     private Object adjustValueForTextColumnType(final QueryResponseCell cell) {
         Object data = cell.getData();
-        return Types.DATE == cell.getJdbcType() && "YEAR".equalsIgnoreCase(cell.getColumnTypeName().orElse(null)) && data instanceof Date
-                ? String.format(Locale.ROOT, "%04d", ((Date) data).toLocalDate().getYear())
-                : data;
+        if (Types.DATE != cell.getJdbcType() || !"YEAR".equalsIgnoreCase(cell.getColumnTypeName().orElse(null))) {
+            return data;
+        }
+        if (data instanceof Number) {
+            return String.format(Locale.ROOT, "%04d", ((Number) data).intValue());
+        }
+        if (data instanceof Date) {
+            return String.format(Locale.ROOT, "%04d", ((Date) data).toLocalDate().getYear());
+        }
+        return data;
     }
     
     @Override

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutorTest.java
@@ -218,6 +218,28 @@ class MySQLComStmtExecuteExecutorTest {
     }
     
     @Test
+    void assertYearColumnFromShortValueEncodedAsShort() throws SQLException {
+        MySQLComStmtExecutePacket packet = mock(MySQLComStmtExecutePacket.class);
+        when(packet.getStatementId()).thenReturn(1);
+        QueryHeader yearHeader = mock(QueryHeader.class);
+        when(yearHeader.getColumnTypeName()).thenReturn("YEAR");
+        when(yearHeader.getColumnType()).thenReturn(Types.DATE);
+        when(proxyBackendHandler.execute()).thenReturn(new QueryResponseHeader(Collections.singletonList(yearHeader)));
+        when(proxyBackendHandler.next()).thenReturn(true, false);
+        when(proxyBackendHandler.getRowData()).thenReturn(new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.DATE, Short.valueOf((short) 1925), "YEAR"))));
+        when(ProxyBackendHandlerFactory.newInstance(eq(databaseType), any(QueryContext.class), eq(connectionSession), anyBoolean())).thenReturn(proxyBackendHandler);
+        MySQLComStmtExecuteExecutor executor = new MySQLComStmtExecuteExecutor(packet, connectionSession);
+        executor.execute();
+        assertTrue(executor.next());
+        MySQLPacket rowPacket = executor.getQueryRowPacket();
+        ByteBuf buffer = Unpooled.buffer();
+        rowPacket.write(new MySQLPacketPayload(buffer, StandardCharsets.UTF_8));
+        assertThat(buffer.readUnsignedByte(), is((short) 0x00));
+        assertThat(buffer.readUnsignedByte(), is((short) 0x00));
+        assertThat(buffer.readShortLE(), is((short) 1925));
+    }
+    
+    @Test
     void assertDateColumnNotAdjustedAsYear() throws SQLException {
         MySQLComStmtExecutePacket packet = mock(MySQLComStmtExecutePacket.class);
         when(packet.getStatementId()).thenReturn(1);

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutorTest.java
@@ -17,7 +17,10 @@
 
 package org.apache.shardingsphere.proxy.frontend.mysql.command.query.binary.execute;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.database.protocol.mysql.payload.MySQLPacketPayload;
 import org.apache.shardingsphere.database.exception.mysql.exception.UnsupportedPreparedStatementException;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCharacterSets;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLBinaryColumnType;
@@ -77,6 +80,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.nio.charset.StandardCharsets;
+import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Arrays;
@@ -188,6 +193,54 @@ class MySQLComStmtExecuteExecutorTest {
         assertThat(actualQueryRowPacket, isA(MySQLBinaryResultSetRowPacket.class));
         executor.close();
         verify(proxyBackendHandler).close();
+    }
+    
+    @Test
+    void assertYearColumnEncodedAsShortFromDate() throws SQLException {
+        MySQLComStmtExecutePacket packet = mock(MySQLComStmtExecutePacket.class);
+        when(packet.getStatementId()).thenReturn(1);
+        QueryHeader yearHeader = mock(QueryHeader.class);
+        when(yearHeader.getColumnTypeName()).thenReturn("YEAR");
+        when(yearHeader.getColumnType()).thenReturn(Types.DATE);
+        when(proxyBackendHandler.execute()).thenReturn(new QueryResponseHeader(Collections.singletonList(yearHeader)));
+        when(proxyBackendHandler.next()).thenReturn(true, false);
+        when(proxyBackendHandler.getRowData()).thenReturn(new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.DATE, Date.valueOf("1925-01-01"), "YEAR"))));
+        when(ProxyBackendHandlerFactory.newInstance(eq(databaseType), any(QueryContext.class), eq(connectionSession), anyBoolean())).thenReturn(proxyBackendHandler);
+        MySQLComStmtExecuteExecutor executor = new MySQLComStmtExecuteExecutor(packet, connectionSession);
+        executor.execute();
+        assertTrue(executor.next());
+        MySQLPacket rowPacket = executor.getQueryRowPacket();
+        ByteBuf buffer = Unpooled.buffer();
+        rowPacket.write(new MySQLPacketPayload(buffer, StandardCharsets.UTF_8));
+        assertThat(buffer.readUnsignedByte(), is((short) 0x00));
+        assertThat(buffer.readUnsignedByte(), is((short) 0x00));
+        assertThat(buffer.readShortLE(), is((short) 1925));
+    }
+    
+    @Test
+    void assertDateColumnNotAdjustedAsYear() throws SQLException {
+        MySQLComStmtExecutePacket packet = mock(MySQLComStmtExecutePacket.class);
+        when(packet.getStatementId()).thenReturn(1);
+        QueryHeader dateHeader = mock(QueryHeader.class);
+        when(dateHeader.getColumnTypeName()).thenReturn("DATE");
+        when(dateHeader.getColumnType()).thenReturn(Types.DATE);
+        when(proxyBackendHandler.execute()).thenReturn(new QueryResponseHeader(Collections.singletonList(dateHeader)));
+        when(proxyBackendHandler.next()).thenReturn(true, false);
+        Date payloadDate = Date.valueOf("2025-05-25");
+        when(proxyBackendHandler.getRowData()).thenReturn(new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.DATE, payloadDate, "DATE"))));
+        when(ProxyBackendHandlerFactory.newInstance(eq(databaseType), any(QueryContext.class), eq(connectionSession), anyBoolean())).thenReturn(proxyBackendHandler);
+        MySQLComStmtExecuteExecutor executor = new MySQLComStmtExecuteExecutor(packet, connectionSession);
+        executor.execute();
+        assertTrue(executor.next());
+        MySQLPacket rowPacket = executor.getQueryRowPacket();
+        ByteBuf buffer = Unpooled.buffer();
+        rowPacket.write(new MySQLPacketPayload(buffer, StandardCharsets.UTF_8));
+        assertThat(buffer.readUnsignedByte(), is((short) 0x00));
+        assertThat(buffer.readUnsignedByte(), is((short) 0x00));
+        assertThat(buffer.readUnsignedByte(), is((short) 4));
+        assertThat(buffer.readShortLE(), is((short) 2025));
+        assertThat(buffer.readUnsignedByte(), is((short) 5));
+        assertThat(buffer.readUnsignedByte(), is((short) 25));
     }
     
     @Test

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutorTest.java
@@ -240,6 +240,50 @@ class MySQLComStmtExecuteExecutorTest {
     }
     
     @Test
+    void assertYearColumnFromShortZeroValueEncodedAsShortZero() throws SQLException {
+        MySQLComStmtExecutePacket packet = mock(MySQLComStmtExecutePacket.class);
+        when(packet.getStatementId()).thenReturn(1);
+        QueryHeader yearHeader = mock(QueryHeader.class);
+        when(yearHeader.getColumnTypeName()).thenReturn("YEAR");
+        when(yearHeader.getColumnType()).thenReturn(Types.DATE);
+        when(proxyBackendHandler.execute()).thenReturn(new QueryResponseHeader(Collections.singletonList(yearHeader)));
+        when(proxyBackendHandler.next()).thenReturn(true, false);
+        when(proxyBackendHandler.getRowData()).thenReturn(new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.DATE, Short.valueOf((short) 0), "YEAR"))));
+        when(ProxyBackendHandlerFactory.newInstance(eq(databaseType), any(QueryContext.class), eq(connectionSession), anyBoolean())).thenReturn(proxyBackendHandler);
+        MySQLComStmtExecuteExecutor executor = new MySQLComStmtExecuteExecutor(packet, connectionSession);
+        executor.execute();
+        assertTrue(executor.next());
+        MySQLPacket rowPacket = executor.getQueryRowPacket();
+        ByteBuf buffer = Unpooled.buffer();
+        rowPacket.write(new MySQLPacketPayload(buffer, StandardCharsets.UTF_8));
+        assertThat(buffer.readUnsignedByte(), is((short) 0x00));
+        assertThat(buffer.readUnsignedByte(), is((short) 0x00));
+        assertThat(buffer.readShortLE(), is((short) 0));
+    }
+    
+    @Test
+    void assertYearColumnFromShortTwoThousandValueEncodedAsShortTwoThousand() throws SQLException {
+        MySQLComStmtExecutePacket packet = mock(MySQLComStmtExecutePacket.class);
+        when(packet.getStatementId()).thenReturn(1);
+        QueryHeader yearHeader = mock(QueryHeader.class);
+        when(yearHeader.getColumnTypeName()).thenReturn("YEAR");
+        when(yearHeader.getColumnType()).thenReturn(Types.DATE);
+        when(proxyBackendHandler.execute()).thenReturn(new QueryResponseHeader(Collections.singletonList(yearHeader)));
+        when(proxyBackendHandler.next()).thenReturn(true, false);
+        when(proxyBackendHandler.getRowData()).thenReturn(new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.DATE, Short.valueOf((short) 2000), "YEAR"))));
+        when(ProxyBackendHandlerFactory.newInstance(eq(databaseType), any(QueryContext.class), eq(connectionSession), anyBoolean())).thenReturn(proxyBackendHandler);
+        MySQLComStmtExecuteExecutor executor = new MySQLComStmtExecuteExecutor(packet, connectionSession);
+        executor.execute();
+        assertTrue(executor.next());
+        MySQLPacket rowPacket = executor.getQueryRowPacket();
+        ByteBuf buffer = Unpooled.buffer();
+        rowPacket.write(new MySQLPacketPayload(buffer, StandardCharsets.UTF_8));
+        assertThat(buffer.readUnsignedByte(), is((short) 0x00));
+        assertThat(buffer.readUnsignedByte(), is((short) 0x00));
+        assertThat(buffer.readShortLE(), is((short) 2000));
+    }
+    
+    @Test
     void assertDateColumnNotAdjustedAsYear() throws SQLException {
         MySQLComStmtExecutePacket packet = mock(MySQLComStmtExecutePacket.class);
         when(packet.getStatementId()).thenReturn(1);

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutorTest.java
@@ -182,6 +182,84 @@ class MySQLComStmtPrepareExecutorTest {
     }
     
     @Test
+    void assertPrepareSelectYearAndDateColumnsExposesProtocolTypesFromLocalSchema() {
+        String sql = "SELECT birth_year, birth_date FROM foo_db.user";
+        when(packet.getSQL()).thenReturn(sql);
+        when(packet.getHintValueContext()).thenReturn(new HintValueContext());
+        int connectionId = 5;
+        when(connectionSession.getConnectionId()).thenReturn(connectionId);
+        when(connectionSession.getCurrentDatabaseName()).thenReturn("foo_db");
+        MySQLStatementIdGenerator.getInstance().registerConnection(connectionId);
+        ContextManager contextManager = mockContextManager();
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        Iterator<DatabasePacket> actualIterator = new MySQLComStmtPrepareExecutor(packet, connectionSession).execute().iterator();
+        assertThat(actualIterator.next(), isA(MySQLComStmtPrepareOKPacket.class));
+        DatabasePacket yearPacket = actualIterator.next();
+        assertThat(yearPacket, isA(MySQLColumnDefinition41Packet.class));
+        assertThat(getColumnDefinitionType((MySQLColumnDefinition41Packet) yearPacket), is(MySQLBinaryColumnType.YEAR.getValue()));
+        DatabasePacket datePacket = actualIterator.next();
+        assertThat(datePacket, isA(MySQLColumnDefinition41Packet.class));
+        assertThat(getColumnDefinitionType((MySQLColumnDefinition41Packet) datePacket), is(MySQLBinaryColumnType.DATE.getValue()));
+        assertThat(actualIterator.next(), isA(MySQLEofPacket.class));
+        assertFalse(actualIterator.hasNext());
+        MySQLStatementIdGenerator.getInstance().unregisterConnection(connectionId);
+    }
+    
+    @Test
+    void assertPrepareSelectWithYearAndDateParameterMarkersCarriesProtocolTypes() {
+        String sql = "SELECT name FROM foo_db.user WHERE birth_year = ? AND birth_date = ?";
+        when(packet.getSQL()).thenReturn(sql);
+        when(packet.getHintValueContext()).thenReturn(new HintValueContext());
+        int connectionId = 6;
+        when(connectionSession.getConnectionId()).thenReturn(connectionId);
+        when(connectionSession.getCurrentDatabaseName()).thenReturn("foo_db");
+        MySQLStatementIdGenerator.getInstance().registerConnection(connectionId);
+        ContextManager contextManager = mockContextManager();
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        new MySQLComStmtPrepareExecutor(packet, connectionSession).execute();
+        MySQLServerPreparedStatement actualPreparedStatement = connectionSession.getServerPreparedStatementRegistry().getPreparedStatement(1);
+        assertThat(actualPreparedStatement.getParameterColumnTypes(), is(Arrays.asList(MySQLBinaryColumnType.YEAR, MySQLBinaryColumnType.DATE)));
+        MySQLStatementIdGenerator.getInstance().unregisterConnection(connectionId);
+    }
+    
+    @Test
+    void assertPrepareSelectExpressionStatementByProbeReturnsYearProtocolType() throws Exception {
+        String sql = "SELECT YEAR(birth_date) AS year_value FROM foo_db.user";
+        when(packet.getSQL()).thenReturn(sql);
+        when(packet.getHintValueContext()).thenReturn(new HintValueContext());
+        int connectionId = 7;
+        when(connectionSession.getConnectionId()).thenReturn(connectionId);
+        when(connectionSession.getCurrentDatabaseName()).thenReturn("foo_db");
+        when(connectionSession.getUsedDatabaseName()).thenReturn("foo_db");
+        MySQLStatementIdGenerator.getInstance().registerConnection(connectionId);
+        ContextManager contextManager = mockContextManager();
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        PreparedStatement actualPreparedStatement = mock(PreparedStatement.class);
+        ResultSetMetaData resultSetMetaData = mock(ResultSetMetaData.class);
+        when(actualPreparedStatement.getMetaData()).thenReturn(resultSetMetaData);
+        when(resultSetMetaData.getColumnCount()).thenReturn(1);
+        when(resultSetMetaData.getColumnName(1)).thenReturn("year_value");
+        when(resultSetMetaData.getColumnLabel(1)).thenReturn("year_value");
+        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.DATE);
+        when(resultSetMetaData.getColumnTypeName(1)).thenReturn("YEAR");
+        when(resultSetMetaData.getColumnDisplaySize(1)).thenReturn(4);
+        when(resultSetMetaData.getScale(1)).thenReturn(0);
+        when(resultSetMetaData.isSigned(1)).thenReturn(false);
+        when(resultSetMetaData.isNullable(1)).thenReturn(ResultSetMetaData.columnNoNulls);
+        when(resultSetMetaData.isAutoIncrement(1)).thenReturn(false);
+        when(resultSetMetaData.getTableName(1)).thenReturn("");
+        when(MySQLPreparedStatementMetadataFactory.load(eq(connectionSession), any(MySQLServerPreparedStatement.class))).thenReturn(actualPreparedStatement);
+        Iterator<DatabasePacket> actualIterator = new MySQLComStmtPrepareExecutor(packet, connectionSession).execute().iterator();
+        assertThat(actualIterator.next(), isA(MySQLComStmtPrepareOKPacket.class));
+        DatabasePacket actualProjectionPacket = actualIterator.next();
+        assertThat(actualProjectionPacket, isA(MySQLColumnDefinition41Packet.class));
+        assertThat(getColumnDefinitionType((MySQLColumnDefinition41Packet) actualProjectionPacket), is(MySQLBinaryColumnType.YEAR.getValue()));
+        assertThat(actualIterator.next(), isA(MySQLEofPacket.class));
+        assertFalse(actualIterator.hasNext());
+        MySQLStatementIdGenerator.getInstance().unregisterConnection(connectionId);
+    }
+    
+    @Test
     void assertPrepareInsertStatement() {
         String sql = "INSERT INTO user (id, name, age) VALUES (1, ?, ?), (?, 'bar', ?)";
         when(packet.getSQL()).thenReturn(sql);
@@ -346,7 +424,9 @@ class MySQLComStmtPrepareExecutorTest {
     private ShardingSphereDatabase createDatabase() {
         ShardingSphereTable table = new ShardingSphereTable("user", Arrays.asList(new ShardingSphereColumn("id", Types.BIGINT, true, false, false, false, true, false),
                 new ShardingSphereColumn("name", Types.VARCHAR, false, false, false, false, false, false),
-                new ShardingSphereColumn("age", Types.SMALLINT, false, false, false, false, true, false)), Collections.emptyList(), Collections.emptyList());
+                new ShardingSphereColumn("age", Types.SMALLINT, false, false, false, false, true, false),
+                new ShardingSphereColumn("birth_year", Types.DATE, false, false, false, false, false, false, "YEAR"),
+                new ShardingSphereColumn("birth_date", Types.DATE, false, false, false, false, false, false, "DATE")), Collections.emptyList(), Collections.emptyList());
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_db", databaseType, Collections.singleton(table), Collections.emptyList());
         return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()), Collections.singleton(schema),
                 new ConfigurationProperties(new Properties()));

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/builder/ResponsePacketBuilderTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/builder/ResponsePacketBuilderTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.proxy.frontend.mysql.command.query.builder;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLBinaryColumnType;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCharacterSets;
 import org.apache.shardingsphere.database.protocol.mysql.packet.command.query.MySQLColumnDefinition41Packet;
 import org.apache.shardingsphere.database.protocol.mysql.packet.command.query.MySQLColumnDefinitionFlag;
@@ -56,7 +57,7 @@ class ResponsePacketBuilderTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("queryResponsePacketsProvider")
     void assertBuildQueryResponsePackets(final String name, final QueryHeader queryHeader, final int sessionCharacterSet, final int statusFlags,
-                                         final int expectedCharacterSet, final int expectedFlags, final int expectedDecimals) {
+                                         final int expectedCharacterSet, final int expectedFlags, final int expectedDecimals, final int expectedColumnType) {
         QueryResponseHeader queryResponseHeader = new QueryResponseHeader(Collections.singletonList(queryHeader));
         Collection<DatabasePacket> actual = ResponsePacketBuilder.buildQueryResponsePackets(queryResponseHeader, sessionCharacterSet, statusFlags);
         List<DatabasePacket> actualPackets = new ArrayList<>(actual);
@@ -77,9 +78,10 @@ class ResponsePacketBuilderTest {
         payload.readIntLenenc();
         int actualCharacterSet = payload.readInt2();
         payload.readInt4();
-        payload.readInt1();
+        int actualColumnType = payload.readInt1();
         int actualFlags = payload.readInt2();
         assertThat(actualCharacterSet, is(expectedCharacterSet));
+        assertThat(actualColumnType, is(expectedColumnType));
         assertThat(actualFlags, is(expectedFlags));
         int actualDecimals = payload.readInt1();
         assertThat(actualDecimals, is(expectedDecimals));
@@ -111,7 +113,8 @@ class ResponsePacketBuilderTest {
                         1,
                         SESSION_CHARACTER_SET,
                         MySQLColumnDefinitionFlag.PRIMARY_KEY.getValue() + MySQLColumnDefinitionFlag.UNSIGNED.getValue() + MySQLColumnDefinitionFlag.AUTO_INCREMENT.getValue(),
-                        2),
+                        2,
+                        MySQLBinaryColumnType.LONG.getValue()),
                 Arguments.of(
                         "Binary column type sets BINARY charset, binary collation and blob flag",
                         new QueryHeader("schema2", "table2", "columnLabel2", "columnName2", Types.BINARY, "BLOB", 9, 1, true, false, true, false),
@@ -119,7 +122,8 @@ class ResponsePacketBuilderTest {
                         2,
                         MySQLCharacterSets.BINARY.getId(),
                         MySQLColumnDefinitionFlag.NOT_NULL.getValue() + MySQLColumnDefinitionFlag.BINARY_COLLATION.getValue() + MySQLColumnDefinitionFlag.BLOB.getValue(),
-                        1),
+                        1,
+                        MySQLBinaryColumnType.LONG_BLOB.getValue()),
                 Arguments.of(
                         "Binary type name only keeps session charset and binary collation without blob flag",
                         new QueryHeader("schema3", "table3", "columnLabel3", "columnName3", Types.VARCHAR, "VARBINARY", 12, 0, true, false, false, false),
@@ -127,6 +131,25 @@ class ResponsePacketBuilderTest {
                         4,
                         SESSION_CHARACTER_SET,
                         MySQLColumnDefinitionFlag.BINARY_COLLATION.getValue(),
-                        0));
+                        0,
+                        MySQLBinaryColumnType.VAR_STRING.getValue()),
+                Arguments.of(
+                        "YEAR column encodes as protocol type YEAR",
+                        new QueryHeader("schema4", "table4", "columnLabel4", "columnName4", Types.DATE, "YEAR", 4, 0, true, false, true, false),
+                        SESSION_CHARACTER_SET,
+                        1,
+                        SESSION_CHARACTER_SET,
+                        MySQLColumnDefinitionFlag.NOT_NULL.getValue(),
+                        0,
+                        MySQLBinaryColumnType.YEAR.getValue()),
+                Arguments.of(
+                        "DATE column encodes as protocol type DATE",
+                        new QueryHeader("schema5", "table5", "columnLabel5", "columnName5", Types.DATE, "DATE", 10, 0, true, false, false, false),
+                        SESSION_CHARACTER_SET,
+                        1,
+                        SESSION_CHARACTER_SET,
+                        0,
+                        0,
+                        MySQLBinaryColumnType.DATE.getValue()));
     }
 }

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutorTest.java
@@ -222,6 +222,48 @@ class MySQLComQueryPacketExecutorTest {
     }
     
     @Test
+    void assertYearColumnRowEmitsFourZerosFromShortZero() throws SQLException, NoSuchFieldException, IllegalAccessException {
+        MySQLComQueryPacketExecutor executor = new MySQLComQueryPacketExecutor(packet, connectionSession);
+        Plugins.getMemberAccessor().set(MySQLComQueryPacketExecutor.class.getDeclaredField("proxyBackendHandler"), executor, proxyBackendHandler);
+        when(proxyBackendHandler.getRowData()).thenReturn(new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.DATE, Short.valueOf((short) 0), "YEAR"))));
+        MySQLPacket rowPacket = executor.getQueryRowPacket();
+        ByteBuf buffer = Unpooled.buffer();
+        rowPacket.write(new MySQLPacketPayload(buffer, StandardCharsets.UTF_8));
+        assertThat(buffer.readUnsignedByte(), is((short) 4));
+        byte[] yearBytes = new byte[4];
+        buffer.readBytes(yearBytes);
+        assertThat(new String(yearBytes, StandardCharsets.UTF_8), is("0000"));
+    }
+    
+    @Test
+    void assertYearColumnRowEmitsFourDigitYearFromShortTwoThousand() throws SQLException, NoSuchFieldException, IllegalAccessException {
+        MySQLComQueryPacketExecutor executor = new MySQLComQueryPacketExecutor(packet, connectionSession);
+        Plugins.getMemberAccessor().set(MySQLComQueryPacketExecutor.class.getDeclaredField("proxyBackendHandler"), executor, proxyBackendHandler);
+        when(proxyBackendHandler.getRowData()).thenReturn(new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.DATE, Short.valueOf((short) 2000), "YEAR"))));
+        MySQLPacket rowPacket = executor.getQueryRowPacket();
+        ByteBuf buffer = Unpooled.buffer();
+        rowPacket.write(new MySQLPacketPayload(buffer, StandardCharsets.UTF_8));
+        assertThat(buffer.readUnsignedByte(), is((short) 4));
+        byte[] yearBytes = new byte[4];
+        buffer.readBytes(yearBytes);
+        assertThat(new String(yearBytes, StandardCharsets.UTF_8), is("2000"));
+    }
+    
+    @Test
+    void assertYearColumnRowEmitsFourDigitYearFromShortNineteenTwentyFive() throws SQLException, NoSuchFieldException, IllegalAccessException {
+        MySQLComQueryPacketExecutor executor = new MySQLComQueryPacketExecutor(packet, connectionSession);
+        Plugins.getMemberAccessor().set(MySQLComQueryPacketExecutor.class.getDeclaredField("proxyBackendHandler"), executor, proxyBackendHandler);
+        when(proxyBackendHandler.getRowData()).thenReturn(new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.DATE, Short.valueOf((short) 1925), "YEAR"))));
+        MySQLPacket rowPacket = executor.getQueryRowPacket();
+        ByteBuf buffer = Unpooled.buffer();
+        rowPacket.write(new MySQLPacketPayload(buffer, StandardCharsets.UTF_8));
+        assertThat(buffer.readUnsignedByte(), is((short) 4));
+        byte[] yearBytes = new byte[4];
+        buffer.readBytes(yearBytes);
+        assertThat(new String(yearBytes, StandardCharsets.UTF_8), is("1925"));
+    }
+    
+    @Test
     void assertDateColumnRowEmitsFullDateString() throws SQLException, NoSuchFieldException, IllegalAccessException {
         MySQLComQueryPacketExecutor executor = new MySQLComQueryPacketExecutor(packet, connectionSession);
         Plugins.getMemberAccessor().set(MySQLComQueryPacketExecutor.class.getDeclaredField("proxyBackendHandler"), executor, proxyBackendHandler);

--- a/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutorTest.java
+++ b/proxy/frontend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutorTest.java
@@ -17,13 +17,19 @@
 
 package org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLCharacterSets;
 import org.apache.shardingsphere.database.protocol.mysql.constant.MySQLConstants;
+import org.apache.shardingsphere.database.protocol.mysql.packet.MySQLPacket;
 import org.apache.shardingsphere.database.protocol.mysql.packet.command.query.text.MySQLTextResultSetRowPacket;
 import org.apache.shardingsphere.database.protocol.mysql.packet.command.query.text.query.MySQLComQueryPacket;
 import org.apache.shardingsphere.database.protocol.mysql.packet.generic.MySQLOKPacket;
+import org.apache.shardingsphere.database.protocol.mysql.payload.MySQLPacketPayload;
 import org.apache.shardingsphere.database.protocol.packet.DatabasePacket;
+import org.apache.shardingsphere.proxy.backend.response.data.QueryResponseCell;
+import org.apache.shardingsphere.proxy.backend.response.data.QueryResponseRow;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -61,6 +67,8 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.plugins.MemberAccessor;
 import org.mockito.quality.Strictness;
 
+import java.nio.charset.StandardCharsets;
+import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Arrays;
@@ -197,6 +205,34 @@ class MySQLComQueryPacketExecutorTest {
     @Test
     void assertGetQueryRowPacket() throws SQLException {
         assertThat(new MySQLComQueryPacketExecutor(packet, connectionSession).getQueryRowPacket(), isA(MySQLTextResultSetRowPacket.class));
+    }
+    
+    @Test
+    void assertYearColumnRowEmitsFourDigitYearFromDate() throws SQLException, NoSuchFieldException, IllegalAccessException {
+        MySQLComQueryPacketExecutor executor = new MySQLComQueryPacketExecutor(packet, connectionSession);
+        Plugins.getMemberAccessor().set(MySQLComQueryPacketExecutor.class.getDeclaredField("proxyBackendHandler"), executor, proxyBackendHandler);
+        when(proxyBackendHandler.getRowData()).thenReturn(new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.DATE, Date.valueOf("1925-01-01"), "YEAR"))));
+        MySQLPacket rowPacket = executor.getQueryRowPacket();
+        ByteBuf buffer = Unpooled.buffer();
+        rowPacket.write(new MySQLPacketPayload(buffer, StandardCharsets.UTF_8));
+        assertThat(buffer.readUnsignedByte(), is((short) 4));
+        byte[] yearBytes = new byte[4];
+        buffer.readBytes(yearBytes);
+        assertThat(new String(yearBytes, StandardCharsets.UTF_8), is("1925"));
+    }
+    
+    @Test
+    void assertDateColumnRowEmitsFullDateString() throws SQLException, NoSuchFieldException, IllegalAccessException {
+        MySQLComQueryPacketExecutor executor = new MySQLComQueryPacketExecutor(packet, connectionSession);
+        Plugins.getMemberAccessor().set(MySQLComQueryPacketExecutor.class.getDeclaredField("proxyBackendHandler"), executor, proxyBackendHandler);
+        when(proxyBackendHandler.getRowData()).thenReturn(new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.DATE, Date.valueOf("2025-05-26"), "DATE"))));
+        MySQLPacket rowPacket = executor.getQueryRowPacket();
+        ByteBuf buffer = Unpooled.buffer();
+        rowPacket.write(new MySQLPacketPayload(buffer, StandardCharsets.UTF_8));
+        assertThat(buffer.readUnsignedByte(), is((short) 10));
+        byte[] dateBytes = new byte[10];
+        buffer.readBytes(dateBytes);
+        assertThat(new String(dateBytes, StandardCharsets.UTF_8), is("2025-05-26"));
     }
     
     @Test


### PR DESCRIPTION
Fixes #28858.

Changes proposed in this pull request:
  - Add `MySQLBinaryColumnType.valueOfJDBCType(int, String)` and an `isYear` helper that recognises `(Types.DATE, "YEAR")` and returns the `YEAR` enum, mirroring the existing `PostgreSQLBinaryColumnType` overload pattern.
  - Switch the text-protocol column-definition builder (`ResponsePacketBuilder`) to the new overload, threading `QueryHeader#getColumnTypeName()` so a MySQL `YEAR` column is advertised as protocol type `0x0d` instead of `DATE` (`0x0a`). mysql-connector-j now enters its YEAR branch and the driver-side `yearIsDateType=false` URL property takes effect.
  - `ResponsePacketBuilderTest`: the parametric case now asserts the on-wire column-type byte for every row, with new rows pinning YEAR → `0x0d` and DATE → `0x0a`.

The binary (prepared-statement) protocol path has the same gap but needs a paired writer change (`java.sql.Date` → 2-byte short for `MySQLInt2BinaryProtocolValue`); sending that as a separate follow-up rather than crammed into this one.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally for the affected modules (spotless, checkstyle, unit tests).
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)