### PR TITLE
Fix sharding routing dropping ?::int4 casts on INSERT VALUES sharding key

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,7 @@
 1. Mode: Fix rule metadata not removed from memory after dropping rules in Etcd cluster mode - [#38561](https://github.com/apache/shardingsphere/pull/38561)
 1. Pipeline: Fix MySQL JSON literal decoding in migration - [#38622](https://github.com/apache/shardingsphere/pull/38622)
 1. Pipeline: Fix MySQL zero-value temporal binlog decoding with fractional precision in migration - [#35531](https://github.com/apache/shardingsphere/issues/35531)
+1. Sharding: Unwrap PostgreSQL TypeCastExpression so INSERT with `?::int4` sharding key routes to a single shard instead of broadcasting - [#38698](https://github.com/apache/shardingsphere/pull/38698)
 1. Sharding: Support ORDER BY MySQL VARBINARY column by wrapping byte[] values in a Comparable adapter - [#38699](https://github.com/apache/shardingsphere/pull/38699)
 
 ### Enhancements

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngine.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngine.java
@@ -43,13 +43,18 @@ import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.Iden
 import org.apache.shardingsphere.timeservice.core.rule.TimestampServiceRule;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Sharding condition engine for insert clause.
@@ -57,11 +62,31 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public final class InsertClauseShardingConditionEngine {
     
+    private static final Set<String> NUMERIC_CAST_TARGETS = unmodifiableUpperCaseSet(
+            "INT", "INTEGER", "INT2", "INT4", "INT8", "BIGINT", "SMALLINT", "TINYINT",
+            "NUMERIC", "DECIMAL", "DEC", "NUMBER",
+            "FLOAT", "FLOAT4", "FLOAT8", "REAL", "DOUBLE", "DOUBLE PRECISION",
+            "SERIAL", "BIGSERIAL", "SMALLSERIAL");
+    
+    private static final Set<String> TEXT_CAST_TARGETS = unmodifiableUpperCaseSet(
+            "TEXT", "VARCHAR", "CHARACTER VARYING", "CHAR", "CHARACTER", "BPCHAR", "NAME", "NVARCHAR", "NCHAR");
+    
+    private static final Set<String> BOOLEAN_CAST_TARGETS = unmodifiableUpperCaseSet("BOOL", "BOOLEAN");
+    
+    private static final Set<String> TEMPORAL_CAST_TARGETS = unmodifiableUpperCaseSet(
+            "DATE", "TIME", "TIMETZ", "TIMESTAMP", "TIMESTAMPTZ", "TIMESTAMP WITHOUT TIME ZONE", "TIMESTAMP WITH TIME ZONE");
+    
     private final ShardingSphereDatabase database;
     
     private final ShardingRule rule;
     
     private final TimestampServiceRule timestampServiceRule;
+    
+    private static Set<String> unmodifiableUpperCaseSet(final String... values) {
+        Set<String> result = new HashSet<>(values.length, 1F);
+        result.addAll(Arrays.asList(values));
+        return Collections.unmodifiableSet(result);
+    }
     
     /**
      * Create sharding conditions.
@@ -134,7 +159,7 @@ public final class InsertClauseShardingConditionEngine {
             if (!shardingColumn.isPresent()) {
                 continue;
             }
-            ExpressionSegment value = unwrapTypeCast(each);
+            ExpressionSegment value = unwrapTypeCastForRouting(each, params);
             if (value instanceof SimpleExpressionSegment) {
                 List<Integer> parameterMarkerIndexes = value instanceof ParameterMarkerExpressionSegment
                         ? Collections.singletonList(((ParameterMarkerExpressionSegment) value).getParameterMarkerIndex())
@@ -152,30 +177,74 @@ public final class InsertClauseShardingConditionEngine {
     }
     
     /**
-     * Unwrap nested {@link TypeCastExpression} layers so that an {@code expression::type} cast on a sharding key reuses the
-     * underlying parameter marker or literal for routing. Only unwraps when the innermost expression is a
-     * {@link ParameterMarkerExpressionSegment} or {@link LiteralExpressionSegment}; otherwise returns the original cast so
-     * that the caller's {@code SimpleExpressionSegment} branch does not enter with an unsupported inner segment such as
-     * {@link org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubqueryExpressionSegment}, which
-     * would otherwise hit a {@link ClassCastException} at {@code getShardingValue}.
+     * Unwrap nested {@link TypeCastExpression} layers for routing only when the cast is semantically safe, i.e. the bound
+     * Java value belongs to the same category as the outermost cast target type. An {@code expression::type} cast on a
+     * sharding key then reuses the underlying parameter marker or literal for routing without coercion.
      *
-     * <p>Routing uses the raw Java value of the parameter or literal as-is and does not coerce it to the cast target type.
-     * If a caller binds a {@code String "1"} for {@code ?::int4} on a sharding column whose algorithm distinguishes Java
-     * types, the route may diverge from the database-evaluated value. Adding cast-aware type coercion is a follow-up.</p>
+     * <p>Unwrap is refused, returning the original cast (which falls through the {@code instanceof} chain and adds no
+     * sharding condition), in any of the following cases:</p>
+     * <ul>
+     * <li>the innermost expression is not a {@link ParameterMarkerExpressionSegment} or {@link LiteralExpressionSegment}
+     * (e.g. {@link org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubqueryExpressionSegment}),
+     * which would otherwise hit a {@link ClassCastException} at {@code getShardingValue};</li>
+     * <li>the bound Java value is {@code null};</li>
+     * <li>the bound Java value's class does not match the outermost cast target category, e.g. binding a {@code String}
+     * for {@code ?::int4}. PostgreSQL would evaluate the SQL value as an integer while raw-value routing would still see
+     * the {@code String}, so refusing to unwrap avoids routing to the wrong shard.</li>
+     * </ul>
      *
      * @param expressionSegment expression segment that may be wrapped in one or more {@link TypeCastExpression} layers
-     * @return innermost {@link ParameterMarkerExpressionSegment} or {@link LiteralExpressionSegment} after unwrapping; the
-     *         original argument when it is not a {@link TypeCastExpression} or when its innermost expression is unsupported
+     * @param params bound parameter values used to look up the runtime Java type of a parameter marker
+     * @return the innermost {@link ParameterMarkerExpressionSegment} or {@link LiteralExpressionSegment} when the cast is
+     *         safe; otherwise the original argument
      */
-    private static ExpressionSegment unwrapTypeCast(final ExpressionSegment expressionSegment) {
+    private static ExpressionSegment unwrapTypeCastForRouting(final ExpressionSegment expressionSegment, final List<Object> params) {
         if (!(expressionSegment instanceof TypeCastExpression)) {
             return expressionSegment;
         }
-        ExpressionSegment inner = expressionSegment;
+        TypeCastExpression outermost = (TypeCastExpression) expressionSegment;
+        ExpressionSegment inner = outermost;
         while (inner instanceof TypeCastExpression) {
             inner = ((TypeCastExpression) inner).getExpression();
         }
-        return inner instanceof ParameterMarkerExpressionSegment || inner instanceof LiteralExpressionSegment ? inner : expressionSegment;
+        if (!(inner instanceof ParameterMarkerExpressionSegment) && !(inner instanceof LiteralExpressionSegment)) {
+            return expressionSegment;
+        }
+        Object routingValue;
+        if (inner instanceof ParameterMarkerExpressionSegment) {
+            int parameterMarkerIndex = ((ParameterMarkerExpressionSegment) inner).getParameterMarkerIndex();
+            if (parameterMarkerIndex < 0 || parameterMarkerIndex >= params.size()) {
+                return expressionSegment;
+            }
+            routingValue = params.get(parameterMarkerIndex);
+        } else {
+            routingValue = ((LiteralExpressionSegment) inner).getLiterals();
+        }
+        return isCastSafeForRouting(routingValue, outermost.getDataType()) ? inner : expressionSegment;
+    }
+    
+    private static boolean isCastSafeForRouting(final Object value, final String castTargetType) {
+        if (null == value || null == castTargetType) {
+            return false;
+        }
+        String normalized = castTargetType.toUpperCase(Locale.ROOT).trim();
+        int parenIndex = normalized.indexOf('(');
+        if (parenIndex > 0) {
+            normalized = normalized.substring(0, parenIndex).trim();
+        }
+        if (value instanceof Number) {
+            return NUMERIC_CAST_TARGETS.contains(normalized);
+        }
+        if (value instanceof String) {
+            return TEXT_CAST_TARGETS.contains(normalized);
+        }
+        if (value instanceof Boolean) {
+            return BOOLEAN_CAST_TARGETS.contains(normalized);
+        }
+        if (value instanceof Date) {
+            return TEMPORAL_CAST_TARGETS.contains(normalized);
+        }
+        return false;
     }
     
     private void generateShardingCondition(final CommonExpressionSegment expressionSegment, final ShardingCondition condition, final String shardingColumn, final String tableName) {

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngine.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngine.java
@@ -151,12 +151,31 @@ public final class InsertClauseShardingConditionEngine {
         return result;
     }
     
+    /**
+     * Unwrap nested {@link TypeCastExpression} layers so that an {@code expression::type} cast on a sharding key reuses the
+     * underlying parameter marker or literal for routing. Only unwraps when the innermost expression is a
+     * {@link ParameterMarkerExpressionSegment} or {@link LiteralExpressionSegment}; otherwise returns the original cast so
+     * that the caller's {@code SimpleExpressionSegment} branch does not enter with an unsupported inner segment such as
+     * {@link org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubqueryExpressionSegment}, which
+     * would otherwise hit a {@link ClassCastException} at {@code getShardingValue}.
+     *
+     * <p>Routing uses the raw Java value of the parameter or literal as-is and does not coerce it to the cast target type.
+     * If a caller binds a {@code String "1"} for {@code ?::int4} on a sharding column whose algorithm distinguishes Java
+     * types, the route may diverge from the database-evaluated value. Adding cast-aware type coercion is a follow-up.</p>
+     *
+     * @param expressionSegment expression segment that may be wrapped in one or more {@link TypeCastExpression} layers
+     * @return innermost {@link ParameterMarkerExpressionSegment} or {@link LiteralExpressionSegment} after unwrapping; the
+     *         original argument when it is not a {@link TypeCastExpression} or when its innermost expression is unsupported
+     */
     private static ExpressionSegment unwrapTypeCast(final ExpressionSegment expressionSegment) {
-        ExpressionSegment result = expressionSegment;
-        while (result instanceof TypeCastExpression) {
-            result = ((TypeCastExpression) result).getExpression();
+        if (!(expressionSegment instanceof TypeCastExpression)) {
+            return expressionSegment;
         }
-        return result;
+        ExpressionSegment inner = expressionSegment;
+        while (inner instanceof TypeCastExpression) {
+            inner = ((TypeCastExpression) inner).getExpression();
+        }
+        return inner instanceof ParameterMarkerExpressionSegment || inner instanceof LiteralExpressionSegment ? inner : expressionSegment;
     }
     
     private void generateShardingCondition(final CommonExpressionSegment expressionSegment, final ShardingCondition condition, final String shardingColumn, final String tableName) {

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngine.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngine.java
@@ -34,6 +34,7 @@ import org.apache.shardingsphere.sharding.route.engine.condition.ShardingConditi
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.TypeCastExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.complex.CommonExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
@@ -133,18 +134,27 @@ public final class InsertClauseShardingConditionEngine {
             if (!shardingColumn.isPresent()) {
                 continue;
             }
-            if (each instanceof SimpleExpressionSegment) {
-                List<Integer> parameterMarkerIndexes = each instanceof ParameterMarkerExpressionSegment
-                        ? Collections.singletonList(((ParameterMarkerExpressionSegment) each).getParameterMarkerIndex())
+            ExpressionSegment value = unwrapTypeCast(each);
+            if (value instanceof SimpleExpressionSegment) {
+                List<Integer> parameterMarkerIndexes = value instanceof ParameterMarkerExpressionSegment
+                        ? Collections.singletonList(((ParameterMarkerExpressionSegment) value).getParameterMarkerIndex())
                         : Collections.emptyList();
-                Object shardingValue = getShardingValue((SimpleExpressionSegment) each, params);
+                Object shardingValue = getShardingValue((SimpleExpressionSegment) value, params);
                 result.getValues().add(new ListShardingConditionValue<>(shardingColumn.get(), tableName, Collections.singletonList(shardingValue),
                         parameterMarkerIndexes));
-            } else if (each instanceof CommonExpressionSegment) {
-                generateShardingCondition((CommonExpressionSegment) each, result, shardingColumn.get(), tableName);
-            } else if (ExpressionConditionUtils.isNowExpression(each)) {
+            } else if (value instanceof CommonExpressionSegment) {
+                generateShardingCondition((CommonExpressionSegment) value, result, shardingColumn.get(), tableName);
+            } else if (ExpressionConditionUtils.isNowExpression(value)) {
                 result.getValues().add(new ListShardingConditionValue<>(shardingColumn.get(), tableName, Collections.singletonList(timestampServiceRule.getTimestamp())));
             }
+        }
+        return result;
+    }
+    
+    private static ExpressionSegment unwrapTypeCast(final ExpressionSegment expressionSegment) {
+        ExpressionSegment result = expressionSegment;
+        while (result instanceof TypeCastExpression) {
+            result = ((TypeCastExpression) result).getExpression();
         }
         return result;
     }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngine.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngine.java
@@ -43,18 +43,13 @@ import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.Iden
 import org.apache.shardingsphere.timeservice.core.rule.TimestampServiceRule;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Sharding condition engine for insert clause.
@@ -62,31 +57,11 @@ import java.util.Set;
 @RequiredArgsConstructor
 public final class InsertClauseShardingConditionEngine {
     
-    private static final Set<String> NUMERIC_CAST_TARGETS = unmodifiableUpperCaseSet(
-            "INT", "INTEGER", "INT2", "INT4", "INT8", "BIGINT", "SMALLINT", "TINYINT",
-            "NUMERIC", "DECIMAL", "DEC", "NUMBER",
-            "FLOAT", "FLOAT4", "FLOAT8", "REAL", "DOUBLE", "DOUBLE PRECISION",
-            "SERIAL", "BIGSERIAL", "SMALLSERIAL");
-    
-    private static final Set<String> TEXT_CAST_TARGETS = unmodifiableUpperCaseSet(
-            "TEXT", "VARCHAR", "CHARACTER VARYING", "CHAR", "CHARACTER", "BPCHAR", "NAME", "NVARCHAR", "NCHAR");
-    
-    private static final Set<String> BOOLEAN_CAST_TARGETS = unmodifiableUpperCaseSet("BOOL", "BOOLEAN");
-    
-    private static final Set<String> TEMPORAL_CAST_TARGETS = unmodifiableUpperCaseSet(
-            "DATE", "TIME", "TIMETZ", "TIMESTAMP", "TIMESTAMPTZ", "TIMESTAMP WITHOUT TIME ZONE", "TIMESTAMP WITH TIME ZONE");
-    
     private final ShardingSphereDatabase database;
     
     private final ShardingRule rule;
     
     private final TimestampServiceRule timestampServiceRule;
-    
-    private static Set<String> unmodifiableUpperCaseSet(final String... values) {
-        Set<String> result = new HashSet<>(values.length, 1F);
-        result.addAll(Arrays.asList(values));
-        return Collections.unmodifiableSet(result);
-    }
     
     /**
      * Create sharding conditions.
@@ -159,92 +134,84 @@ public final class InsertClauseShardingConditionEngine {
             if (!shardingColumn.isPresent()) {
                 continue;
             }
-            ExpressionSegment value = unwrapTypeCastForRouting(each, params);
-            if (value instanceof SimpleExpressionSegment) {
-                List<Integer> parameterMarkerIndexes = value instanceof ParameterMarkerExpressionSegment
-                        ? Collections.singletonList(((ParameterMarkerExpressionSegment) value).getParameterMarkerIndex())
-                        : Collections.emptyList();
-                Object shardingValue = getShardingValue((SimpleExpressionSegment) value, params);
-                result.getValues().add(new ListShardingConditionValue<>(shardingColumn.get(), tableName, Collections.singletonList(shardingValue),
-                        parameterMarkerIndexes));
-            } else if (value instanceof CommonExpressionSegment) {
-                generateShardingCondition((CommonExpressionSegment) value, result, shardingColumn.get(), tableName);
-            } else if (ExpressionConditionUtils.isNowExpression(value)) {
-                result.getValues().add(new ListShardingConditionValue<>(shardingColumn.get(), tableName, Collections.singletonList(timestampServiceRule.getTimestamp())));
-            }
+            appendCastRoutedValueIfPresent(each, params, shardingColumn.get(), tableName, result)
+                    .orElseGet(() -> appendRoutedValueWithoutCast(each, params, shardingColumn.get(), tableName, result));
         }
         return result;
     }
     
     /**
-     * Unwrap nested {@link TypeCastExpression} layers for routing only when the cast is semantically safe, i.e. the bound
-     * Java value belongs to the same category as the outermost cast target type. An {@code expression::type} cast on a
-     * sharding key then reuses the underlying parameter marker or literal for routing without coercion.
+     * Route a {@code TypeCastExpression} sharding-key value by the database-visible cast result instead of the raw bound
+     * Java value, so that PostgreSQL/openGauss runtime semantics for {@code expression::type} (string-to-integer,
+     * lossy-numeric-to-integer, boolean conversions, etc.) are preserved by routing.
      *
-     * <p>Unwrap is refused, returning the original cast (which falls through the {@code instanceof} chain and adds no
-     * sharding condition), in any of the following cases:</p>
-     * <ul>
-     * <li>the innermost expression is not a {@link ParameterMarkerExpressionSegment} or {@link LiteralExpressionSegment}
-     * (e.g. {@link org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubqueryExpressionSegment}),
-     * which would otherwise hit a {@link ClassCastException} at {@code getShardingValue};</li>
-     * <li>the bound Java value is {@code null};</li>
-     * <li>the bound Java value's class does not match the outermost cast target category, e.g. binding a {@code String}
-     * for {@code ?::int4}. PostgreSQL would evaluate the SQL value as an integer while raw-value routing would still see
-     * the {@code String}, so refusing to unwrap avoids routing to the wrong shard.</li>
-     * </ul>
+     * <p>Returns {@link Optional#empty()} when the segment is not a cast or when {@link PostgreSQLCastEvaluator} cannot
+     * resolve the cast (unsupported target, parse failure, overflow, or a non-marker / non-literal inner expression such
+     * as a {@code SubqueryExpressionSegment}). In that case the caller falls back to the no-cast path.</p>
      *
-     * @param expressionSegment expression segment that may be wrapped in one or more {@link TypeCastExpression} layers
-     * @param params bound parameter values used to look up the runtime Java type of a parameter marker
-     * @return the innermost {@link ParameterMarkerExpressionSegment} or {@link LiteralExpressionSegment} when the cast is
-     *         safe; otherwise the original argument
+     * @param expressionSegment expression segment to route
+     * @param params bound parameter values for parameter markers
+     * @param shardingColumn sharding column name to attach the routed value to
+     * @param tableName sharding table name to attach the routed value to
+     * @param condition sharding condition to append the routed value to
+     * @return {@link Optional#of(Object)} with a non-null placeholder when a cast-derived sharding condition was
+     *         appended, otherwise {@link Optional#empty()}
      */
-    private static ExpressionSegment unwrapTypeCastForRouting(final ExpressionSegment expressionSegment, final List<Object> params) {
+    private Optional<Object> appendCastRoutedValueIfPresent(final ExpressionSegment expressionSegment, final List<Object> params,
+                                                            final String shardingColumn, final String tableName, final ShardingCondition condition) {
         if (!(expressionSegment instanceof TypeCastExpression)) {
-            return expressionSegment;
+            return Optional.empty();
         }
-        TypeCastExpression outermost = (TypeCastExpression) expressionSegment;
-        ExpressionSegment inner = outermost;
-        while (inner instanceof TypeCastExpression) {
-            inner = ((TypeCastExpression) inner).getExpression();
+        List<String> castTargetTypesOuterToInner = new ArrayList<>();
+        ExpressionSegment innermost = expressionSegment;
+        while (innermost instanceof TypeCastExpression) {
+            castTargetTypesOuterToInner.add(((TypeCastExpression) innermost).getDataType());
+            innermost = ((TypeCastExpression) innermost).getExpression();
         }
-        if (!(inner instanceof ParameterMarkerExpressionSegment) && !(inner instanceof LiteralExpressionSegment)) {
-            return expressionSegment;
+        if (!(innermost instanceof ParameterMarkerExpressionSegment) && !(innermost instanceof LiteralExpressionSegment)) {
+            return Optional.empty();
         }
-        Object routingValue;
-        if (inner instanceof ParameterMarkerExpressionSegment) {
-            int parameterMarkerIndex = ((ParameterMarkerExpressionSegment) inner).getParameterMarkerIndex();
+        Object value;
+        List<Integer> parameterMarkerIndexes;
+        if (innermost instanceof ParameterMarkerExpressionSegment) {
+            int parameterMarkerIndex = ((ParameterMarkerExpressionSegment) innermost).getParameterMarkerIndex();
             if (parameterMarkerIndex < 0 || parameterMarkerIndex >= params.size()) {
-                return expressionSegment;
+                return Optional.empty();
             }
-            routingValue = params.get(parameterMarkerIndex);
+            value = params.get(parameterMarkerIndex);
+            parameterMarkerIndexes = Collections.singletonList(parameterMarkerIndex);
         } else {
-            routingValue = ((LiteralExpressionSegment) inner).getLiterals();
+            value = ((LiteralExpressionSegment) innermost).getLiterals();
+            parameterMarkerIndexes = Collections.emptyList();
         }
-        return isCastSafeForRouting(routingValue, outermost.getDataType()) ? inner : expressionSegment;
+        for (int index = castTargetTypesOuterToInner.size() - 1; index >= 0; index--) {
+            Optional<Comparable<?>> casted = PostgreSQLCastEvaluator.evaluate(value, castTargetTypesOuterToInner.get(index));
+            if (!casted.isPresent()) {
+                return Optional.empty();
+            }
+            value = casted.get();
+        }
+        if (!(value instanceof Comparable)) {
+            return Optional.empty();
+        }
+        condition.getValues().add(new ListShardingConditionValue<>(shardingColumn, tableName, Collections.singletonList((Comparable<?>) value), parameterMarkerIndexes));
+        return Optional.of(Boolean.TRUE);
     }
     
-    private static boolean isCastSafeForRouting(final Object value, final String castTargetType) {
-        if (null == value || null == castTargetType) {
-            return false;
+    private Object appendRoutedValueWithoutCast(final ExpressionSegment expressionSegment, final List<Object> params,
+                                                final String shardingColumn, final String tableName, final ShardingCondition condition) {
+        if (expressionSegment instanceof SimpleExpressionSegment) {
+            List<Integer> parameterMarkerIndexes = expressionSegment instanceof ParameterMarkerExpressionSegment
+                    ? Collections.singletonList(((ParameterMarkerExpressionSegment) expressionSegment).getParameterMarkerIndex())
+                    : Collections.emptyList();
+            Object shardingValue = getShardingValue((SimpleExpressionSegment) expressionSegment, params);
+            condition.getValues().add(new ListShardingConditionValue<>(shardingColumn, tableName, Collections.singletonList(shardingValue), parameterMarkerIndexes));
+        } else if (expressionSegment instanceof CommonExpressionSegment) {
+            generateShardingCondition((CommonExpressionSegment) expressionSegment, condition, shardingColumn, tableName);
+        } else if (ExpressionConditionUtils.isNowExpression(expressionSegment)) {
+            condition.getValues().add(new ListShardingConditionValue<>(shardingColumn, tableName, Collections.singletonList(timestampServiceRule.getTimestamp())));
         }
-        String normalized = castTargetType.toUpperCase(Locale.ROOT).trim();
-        int parenIndex = normalized.indexOf('(');
-        if (parenIndex > 0) {
-            normalized = normalized.substring(0, parenIndex).trim();
-        }
-        if (value instanceof Number) {
-            return NUMERIC_CAST_TARGETS.contains(normalized);
-        }
-        if (value instanceof String) {
-            return TEXT_CAST_TARGETS.contains(normalized);
-        }
-        if (value instanceof Boolean) {
-            return BOOLEAN_CAST_TARGETS.contains(normalized);
-        }
-        if (value instanceof Date) {
-            return TEMPORAL_CAST_TARGETS.contains(normalized);
-        }
-        return false;
+        return Boolean.TRUE;
     }
     
     private void generateShardingCondition(final CommonExpressionSegment expressionSegment, final ShardingCondition condition, final String shardingColumn, final String tableName) {

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluator.java
@@ -22,7 +22,9 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.MathContext;
 import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -30,27 +32,31 @@ import java.util.Optional;
  * Evaluator for PostgreSQL and openGauss {@code CAST} / {@code ::} expressions, used by sharding-condition extraction so
  * that a casted sharding-key value routes on the database-visible cast result rather than the raw bound Java value.
  *
- * <p>The evaluator supports the cast targets that the routing path commonly sees on a sharding key: integer family
- * ({@code int2} / {@code int4} / {@code int8} and their named aliases), arbitrary-precision {@code numeric} /
- * {@code decimal}, floating point ({@code float4} / {@code real} / {@code float8} / {@code double precision}), text
- * family ({@code text} / {@code varchar} / {@code char} / {@code bpchar} / {@code name}) and {@code bool} /
- * {@code boolean}. Casts to other target types or conversions that lose information (parse failure, overflow, fractional
- * value to integer where rounding is undefined) return {@link Optional#empty()} so the caller leaves the cast in place
- * and routes broadcast.</p>
+ * <p>Cast semantics dispatch on both the source Java type and the target SQL type, mirroring PostgreSQL's
+ * {@code pg_cast} catalog where each (source, target) pair binds to its own C function with its own rounding /
+ * truncation / overflow rules. Java {@link BigDecimal} routes through the {@code numeric_int*} path with
+ * {@link RoundingMode#HALF_UP} (round away from zero) while Java {@link Float} / {@link Double} route through the
+ * {@code dtoi4} / {@code ftoi4} path with {@link Math#rint(double)} (banker's rounding, IEEE 754 round-half-to-even);
+ * {@code 2.5::numeric::int4} therefore returns {@code 3} while {@code 2.5::float8::int4} returns {@code 2}, matching
+ * PostgreSQL 16.</p>
  *
- * <p>Cast targets that carry a type modifier such as {@code varchar(1)}, {@code char(2)} or {@code numeric(3,1)} return
- * {@link Optional#empty()} because applying the modifier correctly requires character-length / precision-scale semantics
- * the routing path does not model, and routing on the unmodified value would diverge from PostgreSQL's documented
- * truncation and precision rules.</p>
+ * <p>Cast targets with a type modifier such as {@code varchar(1)} / {@code numeric(3,1)} return
+ * {@link Optional#empty()} because applying the modifier requires character-length / precision-scale semantics the
+ * routing path does not model. Naked {@code char} / {@code character} (without typmod, equivalent to
+ * {@code character(1)}) truncates to the first character, {@code name} truncates to 63 characters, and {@code text}
+ * / {@code varchar} / {@code bpchar} return the value unchanged.</p>
  *
- * <p>Numeric-to-integer rounding follows PostgreSQL's documented behavior for the {@code numeric} type, which rounds
- * ties away from zero (Java {@link RoundingMode#HALF_UP}). For example {@code 1.5::int4} is {@code 2},
- * {@code 2.5::int4} is {@code 3} and {@code -2.5::int4} is {@code -3}. Integer overflow is detected via
- * {@link BigDecimal#intValueExact()} / {@link BigDecimal#longValueExact()} / {@link BigDecimal#shortValueExact()} and
- * surfaces as {@link Optional#empty()}.</p>
+ * <p>Casts that PostgreSQL itself rejects (no entry in {@code pg_cast}) also return {@link Optional#empty()} here so
+ * that routing falls through to broadcast and the database-visible failure surfaces at execution time. Examples:
+ * {@code bool::numeric}, {@code numeric::bool}, {@code float8::bool}, {@code '1.5'::int4} (PG raises
+ * {@code invalid input syntax for type integer}).</p>
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PostgreSQLCastEvaluator {
+    
+    private static final int NAME_MAX_BYTES = 63;
+    
+    private static final MathContext FLOAT_TO_NUMERIC_PRECISION = new MathContext(15, RoundingMode.HALF_EVEN);
     
     /**
      * Evaluate a cast expression.
@@ -58,175 +64,309 @@ public final class PostgreSQLCastEvaluator {
      * @param rawValue bound Java value of the inner parameter marker or literal
      * @param castTargetType outermost cast target type name as produced by the parser, e.g. {@code "int4"} or
      *                       {@code "varchar(10)"}
-     * @return the database-visible cast result wrapped in {@link Optional}, or empty when the cast target is unsupported
-     *         or the conversion fails
+     * @return the database-visible cast result wrapped in {@link Optional}, or empty when the cast is unsupported or
+     *         the conversion fails
      */
     public static Optional<Comparable<?>> evaluate(final Object rawValue, final String castTargetType) {
         if (null == rawValue || null == castTargetType) {
             return Optional.empty();
         }
-        String normalized = normalize(castTargetType);
+        if (castTargetType.indexOf('(') >= 0) {
+            return Optional.empty();
+        }
+        Target target = targetOf(castTargetType.toUpperCase(Locale.ROOT).trim());
+        Source source = sourceOf(rawValue);
         try {
-            switch (categoryOf(normalized)) {
-                case INT2:
-                    return castToShort(rawValue);
-                case INT4:
-                    return castToInteger(rawValue);
-                case INT8:
-                    return castToLong(rawValue);
-                case NUMERIC:
-                    return castToBigDecimal(rawValue);
-                case FLOAT4:
-                    return castToFloat(rawValue);
-                case FLOAT8:
-                    return castToDouble(rawValue);
-                case TEXT:
-                    return castToText(rawValue);
-                case BOOL:
-                    return castToBoolean(rawValue);
-                default:
-                    return Optional.empty();
-            }
+            return dispatch(rawValue, source, target);
         } catch (final ArithmeticException | NumberFormatException ignored) {
             return Optional.empty();
         }
     }
     
-    private static String normalize(final String castTargetType) {
-        return castTargetType.toUpperCase(Locale.ROOT).trim();
-    }
-    
-    private static Category categoryOf(final String normalized) {
-        switch (normalized) {
-            case "INT2":
-            case "SMALLINT":
-                return Category.INT2;
-            case "INT":
-            case "INT4":
-            case "INTEGER":
-                return Category.INT4;
-            case "INT8":
-            case "BIGINT":
-                return Category.INT8;
-            case "NUMERIC":
-            case "DECIMAL":
-            case "DEC":
-                return Category.NUMERIC;
-            case "FLOAT4":
-            case "REAL":
-                return Category.FLOAT4;
-            case "FLOAT8":
-            case "DOUBLE":
-            case "DOUBLE PRECISION":
-                return Category.FLOAT8;
-            case "TEXT":
-            case "VARCHAR":
-            case "CHARACTER VARYING":
-            case "CHAR":
-            case "CHARACTER":
-            case "BPCHAR":
-            case "NAME":
-                return Category.TEXT;
-            case "BOOL":
-            case "BOOLEAN":
-                return Category.BOOL;
+    private static Optional<Comparable<?>> dispatch(final Object value, final Source source, final Target target) {
+        switch (target) {
+            case INT2:
+            case INT4:
+            case INT8:
+                return castToInteger(value, source, target);
+            case NUMERIC:
+                return castToNumeric(value, source);
+            case FLOAT4:
+            case FLOAT8:
+                return castToFloat(value, source, target);
+            case TEXT:
+            case CHAR_NO_TYPMOD:
+            case NAME:
+                return castToText(value, source, target);
+            case BOOL:
+                return castToBoolean(value, source);
             default:
-                return Category.OTHER;
+                return Optional.empty();
         }
     }
     
-    private static Optional<Comparable<?>> castToShort(final Object value) {
-        BigDecimal bigDecimal = toBigDecimal(value);
-        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.setScale(0, RoundingMode.HALF_UP).shortValueExact());
+    private static Optional<Comparable<?>> castToInteger(final Object value, final Source source, final Target target) {
+        switch (source) {
+            case BOOL:
+                return wrapIntegralBounded((boolean) value ? 1L : 0L, target);
+            case INTEGRAL:
+                return wrapIntegralBounded(integralLongValue(value), target);
+            case NUMERIC:
+                return wrapIntegralBounded(((BigDecimal) value).setScale(0, RoundingMode.HALF_UP).longValueExact(), target);
+            case FLOAT:
+                return wrapFloatToIntegral(((Number) value).doubleValue(), target);
+            case STRING:
+                return parseStringAsIntegral((String) value, target);
+            default:
+                return Optional.empty();
+        }
     }
     
-    private static Optional<Comparable<?>> castToInteger(final Object value) {
-        BigDecimal bigDecimal = toBigDecimal(value);
-        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.setScale(0, RoundingMode.HALF_UP).intValueExact());
+    private static Optional<Comparable<?>> castToNumeric(final Object value, final Source source) {
+        switch (source) {
+            case BOOL:
+                return Optional.empty();
+            case INTEGRAL:
+                return value instanceof BigInteger
+                        ? Optional.of(new BigDecimal((BigInteger) value))
+                        : Optional.of(BigDecimal.valueOf(((Number) value).longValue()));
+            case NUMERIC:
+                return Optional.of((BigDecimal) value);
+            case FLOAT:
+                double doubleValue = ((Number) value).doubleValue();
+                if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
+                    return Optional.empty();
+                }
+                BigDecimal raw = new BigDecimal(Double.toString(doubleValue), FLOAT_TO_NUMERIC_PRECISION);
+                return Optional.of(0 == raw.signum() ? BigDecimal.ZERO : raw.stripTrailingZeros());
+            case STRING:
+                return Optional.of(new BigDecimal(((String) value).trim()));
+            default:
+                return Optional.empty();
+        }
     }
     
-    private static Optional<Comparable<?>> castToLong(final Object value) {
-        BigDecimal bigDecimal = toBigDecimal(value);
-        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.setScale(0, RoundingMode.HALF_UP).longValueExact());
+    private static Optional<Comparable<?>> castToFloat(final Object value, final Source source, final Target target) {
+        switch (source) {
+            case BOOL:
+                return Optional.empty();
+            case INTEGRAL:
+                return wrapDoubleAsFloat(integralToDouble(value), target);
+            case NUMERIC:
+                return wrapDoubleAsFloat(((BigDecimal) value).doubleValue(), target);
+            case FLOAT:
+                return wrapDoubleAsFloat(((Number) value).doubleValue(), target);
+            case STRING:
+                return wrapDoubleAsFloat(Double.parseDouble(((String) value).trim()), target);
+            default:
+                return Optional.empty();
+        }
     }
     
-    private static Optional<Comparable<?>> castToBigDecimal(final Object value) {
-        BigDecimal bigDecimal = toBigDecimal(value);
-        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal);
+    private static Optional<Comparable<?>> castToText(final Object value, final Source source, final Target target) {
+        String text;
+        switch (source) {
+            case BOOL:
+                text = Target.NAME == target ? ((boolean) value ? "t" : "f") : ((boolean) value ? "true" : "false");
+                break;
+            case INTEGRAL:
+                text = value.toString();
+                break;
+            case NUMERIC:
+                text = ((BigDecimal) value).toPlainString();
+                break;
+            case FLOAT:
+                text = formatFloatAsText(((Number) value).doubleValue());
+                break;
+            case STRING:
+                text = (String) value;
+                break;
+            default:
+                return Optional.empty();
+        }
+        switch (target) {
+            case TEXT:
+                return Optional.of(text);
+            case CHAR_NO_TYPMOD:
+                return Optional.of(truncateToFirstCodepoint(text));
+            case NAME:
+                return Optional.of(truncateToUtf8Bytes(text, NAME_MAX_BYTES));
+            default:
+                return Optional.empty();
+        }
     }
     
-    private static Optional<Comparable<?>> castToFloat(final Object value) {
-        if (value instanceof Boolean) {
+    private static String truncateToFirstCodepoint(final String text) {
+        if (text.isEmpty()) {
+            return text;
+        }
+        int end = text.offsetByCodePoints(0, 1);
+        return text.substring(0, end);
+    }
+    
+    private static String truncateToUtf8Bytes(final String text, final int maxBytes) {
+        byte[] utf8 = text.getBytes(StandardCharsets.UTF_8);
+        if (utf8.length <= maxBytes) {
+            return text;
+        }
+        int boundary = maxBytes;
+        while (boundary > 0 && (utf8[boundary] & 0xC0) == 0x80) {
+            boundary--;
+        }
+        return new String(utf8, 0, boundary, StandardCharsets.UTF_8);
+    }
+    
+    private static Optional<Comparable<?>> castToBoolean(final Object value, final Source source) {
+        switch (source) {
+            case BOOL:
+                return Optional.of((Boolean) value);
+            case INTEGRAL:
+                return Optional.of(0L != integralLongValue(value));
+            case STRING:
+                return parseStringAsBoolean((String) value);
+            case NUMERIC:
+            case FLOAT:
+            default:
+                return Optional.empty();
+        }
+    }
+    
+    private static long integralLongValue(final Object value) {
+        return value instanceof BigInteger ? ((BigInteger) value).longValueExact() : ((Number) value).longValue();
+    }
+    
+    private static double integralToDouble(final Object value) {
+        return value instanceof BigInteger ? ((BigInteger) value).doubleValue() : (double) ((Number) value).longValue();
+    }
+    
+    private static Optional<Comparable<?>> wrapIntegralBounded(final long longValue, final Target target) {
+        switch (target) {
+            case INT2:
+                return longValue < Short.MIN_VALUE || longValue > Short.MAX_VALUE ? Optional.empty() : Optional.of((short) longValue);
+            case INT4:
+                return longValue < Integer.MIN_VALUE || longValue > Integer.MAX_VALUE ? Optional.empty() : Optional.of((int) longValue);
+            case INT8:
+                return Optional.of(longValue);
+            default:
+                return Optional.empty();
+        }
+    }
+    
+    private static Optional<Comparable<?>> wrapFloatToIntegral(final double value, final Target target) {
+        if (Double.isNaN(value) || Double.isInfinite(value)) {
             return Optional.empty();
         }
-        BigDecimal bigDecimal = toBigDecimal(value);
-        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.floatValue());
-    }
-    
-    private static Optional<Comparable<?>> castToDouble(final Object value) {
-        if (value instanceof Boolean) {
+        double rounded = Math.rint(value);
+        if (rounded < Long.MIN_VALUE || rounded > Long.MAX_VALUE) {
             return Optional.empty();
         }
-        BigDecimal bigDecimal = toBigDecimal(value);
-        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.doubleValue());
+        return wrapIntegralBounded((long) rounded, target);
     }
     
-    private static Optional<Comparable<?>> castToText(final Object value) {
-        if (value instanceof Boolean) {
-            return Optional.of((boolean) value ? "true" : "false");
-        }
-        if (value instanceof BigDecimal) {
-            return Optional.of(((BigDecimal) value).toPlainString());
-        }
-        return Optional.of(value.toString());
+    private static Optional<Comparable<?>> wrapDoubleAsFloat(final double value, final Target target) {
+        return Target.FLOAT4 == target ? Optional.of((float) value) : Optional.of(value);
     }
     
-    private static Optional<Comparable<?>> castToBoolean(final Object value) {
-        if (value instanceof Boolean) {
-            return Optional.of((Boolean) value);
+    private static Optional<Comparable<?>> parseStringAsIntegral(final String text, final Target target) {
+        try {
+            return wrapIntegralBounded(new BigInteger(text.trim()).longValueExact(), target);
+        } catch (final NumberFormatException | ArithmeticException ignored) {
+            return Optional.empty();
         }
-        if (value instanceof Number) {
-            BigDecimal bigDecimal = toBigDecimal(value);
-            return null == bigDecimal ? Optional.empty() : Optional.of(0 != bigDecimal.signum());
+    }
+    
+    private static Optional<Comparable<?>> parseStringAsBoolean(final String text) {
+        String normalized = text.trim().toLowerCase(Locale.ROOT);
+        if ("true".equals(normalized) || "t".equals(normalized) || "yes".equals(normalized) || "y".equals(normalized) || "1".equals(normalized) || "on".equals(normalized)) {
+            return Optional.of(Boolean.TRUE);
         }
-        if (value instanceof String) {
-            String text = ((String) value).trim().toLowerCase(Locale.ROOT);
-            if ("true".equals(text) || "t".equals(text) || "yes".equals(text) || "y".equals(text) || "1".equals(text) || "on".equals(text)) {
-                return Optional.of(Boolean.TRUE);
-            }
-            if ("false".equals(text) || "f".equals(text) || "no".equals(text) || "n".equals(text) || "0".equals(text) || "off".equals(text)) {
-                return Optional.of(Boolean.FALSE);
-            }
+        if ("false".equals(normalized) || "f".equals(normalized) || "no".equals(normalized) || "n".equals(normalized) || "0".equals(normalized) || "off".equals(normalized)) {
+            return Optional.of(Boolean.FALSE);
         }
         return Optional.empty();
     }
     
-    private static BigDecimal toBigDecimal(final Object value) {
-        if (value instanceof BigDecimal) {
-            return (BigDecimal) value;
+    private static String formatFloatAsText(final double value) {
+        if (Double.isNaN(value)) {
+            return "NaN";
         }
-        if (value instanceof BigInteger) {
-            return new BigDecimal((BigInteger) value);
+        if (Double.POSITIVE_INFINITY == value) {
+            return "Infinity";
         }
-        if (value instanceof Integer || value instanceof Long || value instanceof Short || value instanceof Byte) {
-            return BigDecimal.valueOf(((Number) value).longValue());
+        if (Double.NEGATIVE_INFINITY == value) {
+            return "-Infinity";
         }
-        if (value instanceof Float || value instanceof Double) {
-            return new BigDecimal(value.toString());
-        }
-        if (value instanceof Number) {
-            return new BigDecimal(value.toString());
-        }
-        if (value instanceof String) {
-            return new BigDecimal(((String) value).trim());
-        }
-        if (value instanceof Boolean) {
-            return (boolean) value ? BigDecimal.ONE : BigDecimal.ZERO;
-        }
-        return null;
+        return Double.toString(value);
     }
     
-    private enum Category {
-        INT2, INT4, INT8, NUMERIC, FLOAT4, FLOAT8, TEXT, BOOL, OTHER
+    private static Source sourceOf(final Object value) {
+        if (value instanceof Boolean) {
+            return Source.BOOL;
+        }
+        if (value instanceof Integer || value instanceof Long || value instanceof Short || value instanceof Byte || value instanceof BigInteger) {
+            return Source.INTEGRAL;
+        }
+        if (value instanceof BigDecimal) {
+            return Source.NUMERIC;
+        }
+        if (value instanceof Float || value instanceof Double) {
+            return Source.FLOAT;
+        }
+        if (value instanceof Number) {
+            return Source.NUMERIC;
+        }
+        if (value instanceof String) {
+            return Source.STRING;
+        }
+        return Source.OTHER;
+    }
+    
+    private static Target targetOf(final String normalized) {
+        switch (normalized) {
+            case "INT2":
+            case "SMALLINT":
+                return Target.INT2;
+            case "INT":
+            case "INT4":
+            case "INTEGER":
+                return Target.INT4;
+            case "INT8":
+            case "BIGINT":
+                return Target.INT8;
+            case "NUMERIC":
+            case "DECIMAL":
+            case "DEC":
+                return Target.NUMERIC;
+            case "FLOAT4":
+            case "REAL":
+                return Target.FLOAT4;
+            case "FLOAT8":
+            case "DOUBLE":
+            case "DOUBLE PRECISION":
+                return Target.FLOAT8;
+            case "TEXT":
+            case "VARCHAR":
+            case "CHARACTER VARYING":
+            case "BPCHAR":
+                return Target.TEXT;
+            case "CHAR":
+            case "CHARACTER":
+                return Target.CHAR_NO_TYPMOD;
+            case "NAME":
+                return Target.NAME;
+            case "BOOL":
+            case "BOOLEAN":
+                return Target.BOOL;
+            default:
+                return Target.OTHER;
+        }
+    }
+    
+    private enum Source {
+        INTEGRAL, NUMERIC, FLOAT, STRING, BOOL, OTHER
+    }
+    
+    private enum Target {
+        INT2, INT4, INT8, NUMERIC, FLOAT4, FLOAT8, TEXT, CHAR_NO_TYPMOD, NAME, BOOL, OTHER
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluator.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.route.engine.condition.engine;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Evaluator for PostgreSQL and openGauss {@code CAST} / {@code ::} expressions, used by sharding-condition extraction so
+ * that a casted sharding-key value routes on the database-visible cast result rather than the raw bound Java value.
+ *
+ * <p>The evaluator supports the cast targets that the routing path commonly sees on a sharding key: integer family
+ * ({@code int2} / {@code int4} / {@code int8} and their named aliases), arbitrary-precision {@code numeric} /
+ * {@code decimal}, floating point ({@code float4} / {@code real} / {@code float8} / {@code double precision}), text
+ * family ({@code text} / {@code varchar} / {@code char} / {@code bpchar} / {@code name}) and {@code bool} /
+ * {@code boolean}. Casts to other target types or conversions that lose information (parse failure, overflow, fractional
+ * value to integer where rounding is undefined) return {@link Optional#empty()} so the caller leaves the cast in place
+ * and routes broadcast.</p>
+ *
+ * <p>Numeric-to-integer rounding follows PostgreSQL's documented {@code ROUND_HALF_EVEN} behavior, e.g. {@code 1.5::int4}
+ * is {@code 2} and {@code 2.5::int4} is also {@code 2}. Integer overflow is detected via
+ * {@link BigDecimal#intValueExact()} / {@link BigDecimal#longValueExact()} / {@link BigDecimal#shortValueExact()} and
+ * surfaces as {@link Optional#empty()}.</p>
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class PostgreSQLCastEvaluator {
+    
+    /**
+     * Evaluate a cast expression.
+     *
+     * @param rawValue bound Java value of the inner parameter marker or literal
+     * @param castTargetType outermost cast target type name as produced by the parser, e.g. {@code "int4"} or
+     *                       {@code "varchar(10)"}
+     * @return the database-visible cast result wrapped in {@link Optional}, or empty when the cast target is unsupported
+     *         or the conversion fails
+     */
+    public static Optional<Comparable<?>> evaluate(final Object rawValue, final String castTargetType) {
+        if (null == rawValue || null == castTargetType) {
+            return Optional.empty();
+        }
+        String normalized = normalize(castTargetType);
+        try {
+            switch (categoryOf(normalized)) {
+                case INT2:
+                    return castToShort(rawValue);
+                case INT4:
+                    return castToInteger(rawValue);
+                case INT8:
+                    return castToLong(rawValue);
+                case NUMERIC:
+                    return castToBigDecimal(rawValue);
+                case FLOAT4:
+                    return castToFloat(rawValue);
+                case FLOAT8:
+                    return castToDouble(rawValue);
+                case TEXT:
+                    return castToText(rawValue);
+                case BOOL:
+                    return castToBoolean(rawValue);
+                default:
+                    return Optional.empty();
+            }
+        } catch (final ArithmeticException | NumberFormatException ignored) {
+            return Optional.empty();
+        }
+    }
+    
+    private static String normalize(final String castTargetType) {
+        String result = castTargetType.toUpperCase(Locale.ROOT).trim();
+        int parenIndex = result.indexOf('(');
+        return parenIndex > 0 ? result.substring(0, parenIndex).trim() : result;
+    }
+    
+    private static Category categoryOf(final String normalized) {
+        switch (normalized) {
+            case "INT2":
+            case "SMALLINT":
+                return Category.INT2;
+            case "INT":
+            case "INT4":
+            case "INTEGER":
+                return Category.INT4;
+            case "INT8":
+            case "BIGINT":
+                return Category.INT8;
+            case "NUMERIC":
+            case "DECIMAL":
+            case "DEC":
+                return Category.NUMERIC;
+            case "FLOAT4":
+            case "REAL":
+                return Category.FLOAT4;
+            case "FLOAT8":
+            case "DOUBLE":
+            case "DOUBLE PRECISION":
+                return Category.FLOAT8;
+            case "TEXT":
+            case "VARCHAR":
+            case "CHARACTER VARYING":
+            case "CHAR":
+            case "CHARACTER":
+            case "BPCHAR":
+            case "NAME":
+                return Category.TEXT;
+            case "BOOL":
+            case "BOOLEAN":
+                return Category.BOOL;
+            default:
+                return Category.OTHER;
+        }
+    }
+    
+    private static Optional<Comparable<?>> castToShort(final Object value) {
+        BigDecimal bigDecimal = toBigDecimal(value);
+        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.setScale(0, RoundingMode.HALF_EVEN).shortValueExact());
+    }
+    
+    private static Optional<Comparable<?>> castToInteger(final Object value) {
+        BigDecimal bigDecimal = toBigDecimal(value);
+        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.setScale(0, RoundingMode.HALF_EVEN).intValueExact());
+    }
+    
+    private static Optional<Comparable<?>> castToLong(final Object value) {
+        BigDecimal bigDecimal = toBigDecimal(value);
+        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.setScale(0, RoundingMode.HALF_EVEN).longValueExact());
+    }
+    
+    private static Optional<Comparable<?>> castToBigDecimal(final Object value) {
+        BigDecimal bigDecimal = toBigDecimal(value);
+        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal);
+    }
+    
+    private static Optional<Comparable<?>> castToFloat(final Object value) {
+        if (value instanceof Boolean) {
+            return Optional.empty();
+        }
+        BigDecimal bigDecimal = toBigDecimal(value);
+        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.floatValue());
+    }
+    
+    private static Optional<Comparable<?>> castToDouble(final Object value) {
+        if (value instanceof Boolean) {
+            return Optional.empty();
+        }
+        BigDecimal bigDecimal = toBigDecimal(value);
+        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.doubleValue());
+    }
+    
+    private static Optional<Comparable<?>> castToText(final Object value) {
+        if (value instanceof Boolean) {
+            return Optional.of((boolean) value ? "true" : "false");
+        }
+        if (value instanceof BigDecimal) {
+            return Optional.of(((BigDecimal) value).toPlainString());
+        }
+        return Optional.of(value.toString());
+    }
+    
+    private static Optional<Comparable<?>> castToBoolean(final Object value) {
+        if (value instanceof Boolean) {
+            return Optional.of((Boolean) value);
+        }
+        if (value instanceof Number) {
+            BigDecimal bigDecimal = toBigDecimal(value);
+            return null == bigDecimal ? Optional.empty() : Optional.of(0 != bigDecimal.signum());
+        }
+        if (value instanceof String) {
+            String text = ((String) value).trim().toLowerCase(Locale.ROOT);
+            if ("true".equals(text) || "t".equals(text) || "yes".equals(text) || "y".equals(text) || "1".equals(text) || "on".equals(text)) {
+                return Optional.of(Boolean.TRUE);
+            }
+            if ("false".equals(text) || "f".equals(text) || "no".equals(text) || "n".equals(text) || "0".equals(text) || "off".equals(text)) {
+                return Optional.of(Boolean.FALSE);
+            }
+        }
+        return Optional.empty();
+    }
+    
+    private static BigDecimal toBigDecimal(final Object value) {
+        if (value instanceof BigDecimal) {
+            return (BigDecimal) value;
+        }
+        if (value instanceof BigInteger) {
+            return new BigDecimal((BigInteger) value);
+        }
+        if (value instanceof Integer || value instanceof Long || value instanceof Short || value instanceof Byte) {
+            return BigDecimal.valueOf(((Number) value).longValue());
+        }
+        if (value instanceof Float || value instanceof Double) {
+            return new BigDecimal(value.toString());
+        }
+        if (value instanceof Number) {
+            return new BigDecimal(value.toString());
+        }
+        if (value instanceof String) {
+            return new BigDecimal(((String) value).trim());
+        }
+        if (value instanceof Boolean) {
+            return (boolean) value ? BigDecimal.ONE : BigDecimal.ZERO;
+        }
+        return null;
+    }
+    
+    private enum Category {
+        INT2, INT4, INT8, NUMERIC, FLOAT4, FLOAT8, TEXT, BOOL, OTHER
+    }
+}

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluator.java
@@ -64,6 +64,14 @@ import java.util.Optional;
  * <p>The evaluator is invoked only when the parser produces a {@code TypeCastExpression}, which is emitted
  * exclusively by the PostgreSQL and openGauss visitors; MySQL / Oracle / SQL Server {@code CAST(...)} syntax becomes
  * a {@code FunctionSegment} and bypasses this evaluator entirely, so there is no cross-dialect contamination risk.</p>
+ *
+ * <p>End-to-end coverage for fractional float-source casts is restricted to explicit type chains such as
+ * {@code 2.5::float8::int4} where both routing and backend evaluate the same source type. A parameter-marker
+ * {@code ?::int4} bound with a fractional {@link Double} / {@link Float} value can diverge at execution when the SQL
+ * rewriter inlines the parameter as a numeric literal: PostgreSQL then parses the literal as {@code numeric} and
+ * routes through {@code numeric_int4} ({@link RoundingMode#HALF_UP}) instead of {@code ftoi4}
+ * ({@link Math#rint(double)}). The unit suite documents the wire-protocol-faithful routing semantics here; aligning
+ * routing with the rewriter-inlined backend path is left for follow-up rewriter work.</p>
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PostgreSQLCastEvaluator {

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluator.java
@@ -50,6 +50,13 @@ import java.util.Optional;
  * that routing falls through to broadcast and the database-visible failure surfaces at execution time. Examples:
  * {@code bool::numeric}, {@code numeric::bool}, {@code float8::bool}, {@code '1.5'::int4} (PG raises
  * {@code invalid input syntax for type integer}).</p>
+ *
+ * <p>openGauss inherits its {@code pg_cast} catalog from PostgreSQL 9.2 and keeps the same {@code numeric_int4} /
+ * {@code dtoi4} / {@code ftoi4} / {@code bpchar} / {@code namein} cast functions, so the cell-by-cell behavior
+ * verified here against PostgreSQL 16 also describes the openGauss path. The evaluator is invoked only when the
+ * parser produces a {@code TypeCastExpression}, which is emitted exclusively by the PostgreSQL and openGauss
+ * visitors; MySQL / Oracle / SQL Server {@code CAST(...)} syntax becomes a {@code FunctionSegment} and bypasses
+ * this evaluator entirely, so there is no cross-dialect contamination risk.</p>
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PostgreSQLCastEvaluator {

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluator.java
@@ -51,12 +51,19 @@ import java.util.Optional;
  * {@code bool::numeric}, {@code numeric::bool}, {@code float8::bool}, {@code '1.5'::int4} (PG raises
  * {@code invalid input syntax for type integer}).</p>
  *
- * <p>openGauss inherits its {@code pg_cast} catalog from PostgreSQL 9.2 and keeps the same {@code numeric_int4} /
- * {@code dtoi4} / {@code ftoi4} / {@code bpchar} / {@code namein} cast functions, so the cell-by-cell behavior
- * verified here against PostgreSQL 16 also describes the openGauss path. The evaluator is invoked only when the
- * parser produces a {@code TypeCastExpression}, which is emitted exclusively by the PostgreSQL and openGauss
- * visitors; MySQL / Oracle / SQL Server {@code CAST(...)} syntax becomes a {@code FunctionSegment} and bypasses
- * this evaluator entirely, so there is no cross-dialect contamination risk.</p>
+ * <p>openGauss forks the {@code pg_cast} catalog from PostgreSQL 9.2 (see
+ * {@code src/include/catalog/pg_cast.h} in {@code opengauss-mirror/openGauss-server}) and keeps the same OID-bound
+ * {@code numeric_int4} / {@code dtoi4} / {@code ftoi4} / {@code bpchar} / {@code namein} cast functions, so the
+ * integer / numeric / float / text / name behavior verified here against PostgreSQL 16 carries through unchanged.
+ * The one substantive divergence is the {@code bool ↔ numeric} pair: openGauss adds explicit cast functions
+ * {@code 6433} ({@code bool → numeric}) and {@code 6434} ({@code numeric → bool}) that PostgreSQL does not have, and
+ * this evaluator stays aligned with PostgreSQL by returning {@link Optional#empty()} for both, which on openGauss is
+ * a conservative narrowing: routing falls through to broadcast where openGauss could otherwise route by the casted
+ * 0 / 1 value. Implementing openGauss-aware optimization for those two cells is deferred and noted explicitly here.</p>
+ *
+ * <p>The evaluator is invoked only when the parser produces a {@code TypeCastExpression}, which is emitted
+ * exclusively by the PostgreSQL and openGauss visitors; MySQL / Oracle / SQL Server {@code CAST(...)} syntax becomes
+ * a {@code FunctionSegment} and bypasses this evaluator entirely, so there is no cross-dialect contamination risk.</p>
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PostgreSQLCastEvaluator {

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluator.java
@@ -38,8 +38,14 @@ import java.util.Optional;
  * value to integer where rounding is undefined) return {@link Optional#empty()} so the caller leaves the cast in place
  * and routes broadcast.</p>
  *
- * <p>Numeric-to-integer rounding follows PostgreSQL's documented {@code ROUND_HALF_EVEN} behavior, e.g. {@code 1.5::int4}
- * is {@code 2} and {@code 2.5::int4} is also {@code 2}. Integer overflow is detected via
+ * <p>Cast targets that carry a type modifier such as {@code varchar(1)}, {@code char(2)} or {@code numeric(3,1)} return
+ * {@link Optional#empty()} because applying the modifier correctly requires character-length / precision-scale semantics
+ * the routing path does not model, and routing on the unmodified value would diverge from PostgreSQL's documented
+ * truncation and precision rules.</p>
+ *
+ * <p>Numeric-to-integer rounding follows PostgreSQL's documented behavior for the {@code numeric} type, which rounds
+ * ties away from zero (Java {@link RoundingMode#HALF_UP}). For example {@code 1.5::int4} is {@code 2},
+ * {@code 2.5::int4} is {@code 3} and {@code -2.5::int4} is {@code -3}. Integer overflow is detected via
  * {@link BigDecimal#intValueExact()} / {@link BigDecimal#longValueExact()} / {@link BigDecimal#shortValueExact()} and
  * surfaces as {@link Optional#empty()}.</p>
  */
@@ -87,9 +93,7 @@ public final class PostgreSQLCastEvaluator {
     }
     
     private static String normalize(final String castTargetType) {
-        String result = castTargetType.toUpperCase(Locale.ROOT).trim();
-        int parenIndex = result.indexOf('(');
-        return parenIndex > 0 ? result.substring(0, parenIndex).trim() : result;
+        return castTargetType.toUpperCase(Locale.ROOT).trim();
     }
     
     private static Category categoryOf(final String normalized) {
@@ -133,17 +137,17 @@ public final class PostgreSQLCastEvaluator {
     
     private static Optional<Comparable<?>> castToShort(final Object value) {
         BigDecimal bigDecimal = toBigDecimal(value);
-        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.setScale(0, RoundingMode.HALF_EVEN).shortValueExact());
+        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.setScale(0, RoundingMode.HALF_UP).shortValueExact());
     }
     
     private static Optional<Comparable<?>> castToInteger(final Object value) {
         BigDecimal bigDecimal = toBigDecimal(value);
-        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.setScale(0, RoundingMode.HALF_EVEN).intValueExact());
+        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.setScale(0, RoundingMode.HALF_UP).intValueExact());
     }
     
     private static Optional<Comparable<?>> castToLong(final Object value) {
         BigDecimal bigDecimal = toBigDecimal(value);
-        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.setScale(0, RoundingMode.HALF_EVEN).longValueExact());
+        return null == bigDecimal ? Optional.empty() : Optional.of(bigDecimal.setScale(0, RoundingMode.HALF_UP).longValueExact());
     }
     
     private static Optional<Comparable<?>> castToBigDecimal(final Object value) {

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/ConditionValue.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/ConditionValue.java
@@ -20,10 +20,13 @@ package org.apache.shardingsphere.sharding.route.engine.condition.generator;
 import lombok.Getter;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.sharding.exception.data.NotImplementComparableValueException;
+import org.apache.shardingsphere.sharding.route.engine.condition.engine.PostgreSQLCastEvaluator;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.TypeCastExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -40,11 +43,23 @@ public final class ConditionValue {
     private boolean isNull;
     
     public ConditionValue(final ExpressionSegment expressionSegment, final List<Object> params) {
+        ExpressionSegment marker = unwrapMarker(expressionSegment);
+        parameterMarkerIndex = marker instanceof ParameterMarkerExpressionSegment ? ((ParameterMarkerExpressionSegment) marker).getParameterMarkerIndex() : -1;
         value = getValue(expressionSegment, params);
-        parameterMarkerIndex = expressionSegment instanceof ParameterMarkerExpressionSegment ? ((ParameterMarkerExpressionSegment) expressionSegment).getParameterMarkerIndex() : -1;
+    }
+    
+    private ExpressionSegment unwrapMarker(final ExpressionSegment expressionSegment) {
+        ExpressionSegment result = expressionSegment;
+        while (result instanceof TypeCastExpression) {
+            result = ((TypeCastExpression) result).getExpression();
+        }
+        return result;
     }
     
     private Comparable<?> getValue(final ExpressionSegment expressionSegment, final List<Object> params) {
+        if (expressionSegment instanceof TypeCastExpression) {
+            return getValue((TypeCastExpression) expressionSegment, params);
+        }
         if (expressionSegment instanceof ParameterMarkerExpressionSegment) {
             return getValue((ParameterMarkerExpressionSegment) expressionSegment, params);
         }
@@ -52,6 +67,43 @@ public final class ConditionValue {
             return getValue((LiteralExpressionSegment) expressionSegment);
         }
         return null;
+    }
+    
+    private Comparable<?> getValue(final TypeCastExpression expressionSegment, final List<Object> params) {
+        List<String> castTargetTypesOuterToInner = new ArrayList<>();
+        ExpressionSegment innermost = expressionSegment;
+        while (innermost instanceof TypeCastExpression) {
+            castTargetTypesOuterToInner.add(((TypeCastExpression) innermost).getDataType());
+            innermost = ((TypeCastExpression) innermost).getExpression();
+        }
+        if (!(innermost instanceof ParameterMarkerExpressionSegment) && !(innermost instanceof LiteralExpressionSegment)) {
+            return null;
+        }
+        Object current;
+        if (innermost instanceof ParameterMarkerExpressionSegment) {
+            int markerIndex = ((ParameterMarkerExpressionSegment) innermost).getParameterMarkerIndex();
+            if (markerIndex < 0 || markerIndex >= params.size()) {
+                return null;
+            }
+            current = params.get(markerIndex);
+            isNull = null == current;
+        } else {
+            current = ((LiteralExpressionSegment) innermost).getLiterals();
+            isNull = null == current;
+        }
+        if (null == current) {
+            return null;
+        }
+        for (int index = castTargetTypesOuterToInner.size() - 1; index >= 0; index--) {
+            Optional<Comparable<?>> casted = PostgreSQLCastEvaluator.evaluate(current, castTargetTypesOuterToInner.get(index));
+            if (!casted.isPresent()) {
+                return null;
+            }
+            current = casted.get();
+        }
+        Object finalValue = current;
+        ShardingSpherePreconditions.checkState(finalValue instanceof Comparable, () -> new NotImplementComparableValueException("Sharding", finalValue));
+        return (Comparable<?>) finalValue;
     }
     
     private Comparable<?> getValue(final ParameterMarkerExpressionSegment expressionSegment, final List<Object> params) {

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngineTest.java
@@ -222,9 +222,9 @@ class InsertClauseShardingConditionEngineTest {
     }
     
     @Test
-    void assertCreateShardingConditionsWithNestedTypeCastParameterMarker() {
-        TypeCastExpression inner = new TypeCastExpression(0, 5, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
-        TypeCastExpression outer = new TypeCastExpression(0, 12, "?::int4::text", inner, "text");
+    void assertCreateShardingConditionsWithNestedCompatibleTypeCastParameterMarker() {
+        TypeCastExpression inner = new TypeCastExpression(0, 5, "?::int8", new ParameterMarkerExpressionSegment(0, 0, 0), "int8");
+        TypeCastExpression outer = new TypeCastExpression(0, 12, "?::int8::int4", inner, "int4");
         InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(outer), Collections.singletonList(42), 0);
         when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
         when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
@@ -237,16 +237,62 @@ class InsertClauseShardingConditionEngineTest {
     }
     
     @Test
-    void assertCreateShardingConditionsWithTypeCastParameterMarkerKeepsRawJavaType() {
+    void assertCreateShardingConditionsWithNestedIncompatibleTypeCastParameterMarkerDoesNotRoute() {
+        TypeCastExpression inner = new TypeCastExpression(0, 5, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        TypeCastExpression outer = new TypeCastExpression(0, 12, "?::int4::text", inner, "text");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(outer), Collections.singletonList(42), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(42));
+        assertThat(shardingConditions.size(), is(1));
+        assertTrue(shardingConditions.get(0).getValues().isEmpty());
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastStringParameterToIntDoesNotRoute() {
         TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
         InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList("1"), 0);
         when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
         when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
         List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList("1"));
         assertThat(shardingConditions.size(), is(1));
+        assertTrue(shardingConditions.get(0).getValues().isEmpty());
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastStringParameterToTextRoutes() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::text", new ParameterMarkerExpressionSegment(0, 0, 0), "text");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList("foo"), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList("foo"));
+        assertThat(shardingConditions.size(), is(1));
+        assertThat(shardingConditions.get(0).getValues().size(), is(1));
         ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
-        assertThat(actual.getValues(), is(Collections.singletonList("1")));
+        assertThat(actual.getValues(), is(Collections.singletonList("foo")));
         assertThat(actual.getParameterMarkerIndexes(), is(Collections.singletonList(0)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastNullParameterDoesNotRoute() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList(null), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(null));
+        assertThat(shardingConditions.size(), is(1));
+        assertTrue(shardingConditions.get(0).getValues().isEmpty());
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastLiteralStringMismatchedToIntDoesNotRoute() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "'1'::int4", new LiteralExpressionSegment(0, 10, "1"), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.emptyList(), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.emptyList());
+        assertThat(shardingConditions.size(), is(1));
+        assertTrue(shardingConditions.get(0).getValues().isEmpty());
     }
     
     @Test

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngineTest.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sharding.route.engine.condition.ShardingCondition;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sharding.rule.ShardingTable;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.TypeCastExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.complex.CommonExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
@@ -182,6 +183,42 @@ class InsertClauseShardingConditionEngineTest {
         when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
         when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
         List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(1));
+        assertThat(shardingConditions.size(), is(1));
+        assertThat(shardingConditions.get(0).getValues().size(), is(1));
+        assertThat(shardingConditions.get(0).getValues().get(0).getParameterMarkerIndexes(), is(Collections.singletonList(0)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastParameterMarker() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList(7), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(7));
+        assertThat(shardingConditions.size(), is(1));
+        assertThat(shardingConditions.get(0).getValues().size(), is(1));
+        assertThat(shardingConditions.get(0).getValues().get(0).getParameterMarkerIndexes(), is(Collections.singletonList(0)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastLiteral() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "1::int4", new LiteralExpressionSegment(0, 10, 1), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.emptyList(), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.emptyList());
+        assertThat(shardingConditions.size(), is(1));
+        assertThat(shardingConditions.get(0).getValues().size(), is(1));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithNestedTypeCastParameterMarker() {
+        TypeCastExpression inner = new TypeCastExpression(0, 5, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        TypeCastExpression outer = new TypeCastExpression(0, 12, "?::int4::text", inner, "text");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(outer), Collections.singletonList(42), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(42));
         assertThat(shardingConditions.size(), is(1));
         assertThat(shardingConditions.get(0).getValues().size(), is(1));
         assertThat(shardingConditions.get(0).getValues().get(0).getParameterMarkerIndexes(), is(Collections.singletonList(0)));

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngineTest.java
@@ -51,6 +51,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -237,7 +238,7 @@ class InsertClauseShardingConditionEngineTest {
     }
     
     @Test
-    void assertCreateShardingConditionsWithNestedIncompatibleTypeCastParameterMarkerDoesNotRoute() {
+    void assertCreateShardingConditionsWithNestedIntToTextCastRoutesByCastedString() {
         TypeCastExpression inner = new TypeCastExpression(0, 5, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
         TypeCastExpression outer = new TypeCastExpression(0, 12, "?::int4::text", inner, "text");
         InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(outer), Collections.singletonList(42), 0);
@@ -245,18 +246,21 @@ class InsertClauseShardingConditionEngineTest {
         when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
         List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(42));
         assertThat(shardingConditions.size(), is(1));
-        assertTrue(shardingConditions.get(0).getValues().isEmpty());
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList("42")));
     }
     
     @Test
-    void assertCreateShardingConditionsWithTypeCastStringParameterToIntDoesNotRoute() {
+    void assertCreateShardingConditionsWithTypeCastStringParameterToIntRoutesByCastedInteger() {
         TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
         InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList("1"), 0);
         when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
         when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
         List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList("1"));
         assertThat(shardingConditions.size(), is(1));
-        assertTrue(shardingConditions.get(0).getValues().isEmpty());
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList(1)));
+        assertThat(actual.getParameterMarkerIndexes(), is(Collections.singletonList(0)));
     }
     
     @Test
@@ -285,12 +289,46 @@ class InsertClauseShardingConditionEngineTest {
     }
     
     @Test
-    void assertCreateShardingConditionsWithTypeCastLiteralStringMismatchedToIntDoesNotRoute() {
+    void assertCreateShardingConditionsWithTypeCastLiteralStringToIntRoutesByCastedInteger() {
         TypeCastExpression typeCast = new TypeCastExpression(0, 10, "'1'::int4", new LiteralExpressionSegment(0, 10, "1"), "int4");
         InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.emptyList(), 0);
         when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
         when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
         List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.emptyList());
+        assertThat(shardingConditions.size(), is(1));
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList(1)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastBigDecimalToIntRoundsHalfEven() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList(new BigDecimal("1.5")), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(new BigDecimal("1.5")));
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList(2)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastOverflowDoesNotRoute() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList(new BigDecimal("2147483648")), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(new BigDecimal("2147483648")));
+        assertThat(shardingConditions.size(), is(1));
+        assertTrue(shardingConditions.get(0).getValues().isEmpty());
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastUnparseableStringDoesNotRoute() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList("abc"), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList("abc"));
         assertThat(shardingConditions.size(), is(1));
         assertTrue(shardingConditions.get(0).getValues().isEmpty());
     }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngineTest.java
@@ -334,6 +334,83 @@ class InsertClauseShardingConditionEngineTest {
     }
     
     @Test
+    void assertCreateShardingConditionsWithTypeCastDoublePositiveTwoHalfRoundsHalfEven() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList(2.5D), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(2.5D));
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList(2)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastDoubleNegativeTwoHalfRoundsHalfEven() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList(-2.5D), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(-2.5D));
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList(-2)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastFloatPositiveTwoHalfRoundsHalfEven() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList(2.5F), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(2.5F));
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList(2)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastCharNoTypmodTruncatesToFirstChar() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::char", new ParameterMarkerExpressionSegment(0, 0, 0), "char");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList("ab"), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList("ab"));
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList("a")));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastBooleanToNumericDoesNotRoute() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::numeric", new ParameterMarkerExpressionSegment(0, 0, 0), "numeric");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList(Boolean.TRUE), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(Boolean.TRUE));
+        assertThat(shardingConditions.size(), is(1));
+        assertTrue(shardingConditions.get(0).getValues().isEmpty());
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastDoubleToBoolDoesNotRoute() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::bool", new ParameterMarkerExpressionSegment(0, 0, 0), "bool");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList(2.5D), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(2.5D));
+        assertThat(shardingConditions.size(), is(1));
+        assertTrue(shardingConditions.get(0).getValues().isEmpty());
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastStringWithDecimalToIntDoesNotRoute() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList("1.5"), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList("1.5"));
+        assertThat(shardingConditions.size(), is(1));
+        assertTrue(shardingConditions.get(0).getValues().isEmpty());
+    }
+    
+    @Test
     void assertCreateShardingConditionsWithTypeCastTypmodTargetDoesNotRoute() {
         TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::varchar(1)", new ParameterMarkerExpressionSegment(0, 0, 0), "varchar(1)");
         InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList("ab"), 0);

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngineTest.java
@@ -301,7 +301,7 @@ class InsertClauseShardingConditionEngineTest {
     }
     
     @Test
-    void assertCreateShardingConditionsWithTypeCastBigDecimalToIntRoundsHalfEven() {
+    void assertCreateShardingConditionsWithTypeCastBigDecimalPositiveOneHalfRoundsAwayFromZero() {
         TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
         InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList(new BigDecimal("1.5")), 0);
         when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
@@ -309,6 +309,39 @@ class InsertClauseShardingConditionEngineTest {
         List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(new BigDecimal("1.5")));
         ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
         assertThat(actual.getValues(), is(Collections.singletonList(2)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastBigDecimalPositiveTwoHalfRoundsAwayFromZero() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList(new BigDecimal("2.5")), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(new BigDecimal("2.5")));
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList(3)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastBigDecimalNegativeTwoHalfRoundsAwayFromZero() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList(new BigDecimal("-2.5")), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(new BigDecimal("-2.5")));
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList(-3)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastTypmodTargetDoesNotRoute() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::varchar(1)", new ParameterMarkerExpressionSegment(0, 0, 0), "varchar(1)");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList("ab"), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList("ab"));
+        assertThat(shardingConditions.size(), is(1));
+        assertTrue(shardingConditions.get(0).getValues().isEmpty());
     }
     
     @Test

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngineTest.java
@@ -27,12 +27,15 @@ import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sharding.route.engine.condition.ShardingCondition;
+import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sharding.rule.ShardingTable;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.TypeCastExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.complex.CommonExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubqueryExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.subquery.SubquerySegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.InsertStatement;
@@ -197,7 +200,11 @@ class InsertClauseShardingConditionEngineTest {
         List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(7));
         assertThat(shardingConditions.size(), is(1));
         assertThat(shardingConditions.get(0).getValues().size(), is(1));
-        assertThat(shardingConditions.get(0).getValues().get(0).getParameterMarkerIndexes(), is(Collections.singletonList(0)));
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getColumnName(), is("foo_col_1"));
+        assertThat(actual.getTableName(), is("foo_tbl"));
+        assertThat(actual.getValues(), is(Collections.singletonList(7)));
+        assertThat(actual.getParameterMarkerIndexes(), is(Collections.singletonList(0)));
     }
     
     @Test
@@ -209,6 +216,9 @@ class InsertClauseShardingConditionEngineTest {
         List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.emptyList());
         assertThat(shardingConditions.size(), is(1));
         assertThat(shardingConditions.get(0).getValues().size(), is(1));
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList(1)));
+        assertTrue(actual.getParameterMarkerIndexes().isEmpty());
     }
     
     @Test
@@ -221,7 +231,34 @@ class InsertClauseShardingConditionEngineTest {
         List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList(42));
         assertThat(shardingConditions.size(), is(1));
         assertThat(shardingConditions.get(0).getValues().size(), is(1));
-        assertThat(shardingConditions.get(0).getValues().get(0).getParameterMarkerIndexes(), is(Collections.singletonList(0)));
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList(42)));
+        assertThat(actual.getParameterMarkerIndexes(), is(Collections.singletonList(0)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastParameterMarkerKeepsRawJavaType() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.singletonList("1"), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.singletonList("1"));
+        assertThat(shardingConditions.size(), is(1));
+        ListShardingConditionValue<?> actual = (ListShardingConditionValue<?>) shardingConditions.get(0).getValues().get(0);
+        assertThat(actual.getValues(), is(Collections.singletonList("1")));
+        assertThat(actual.getParameterMarkerIndexes(), is(Collections.singletonList(0)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsWithTypeCastSubqueryDoesNotCrashAndExtractsNoCondition() {
+        SubqueryExpressionSegment subquery = new SubqueryExpressionSegment(new SubquerySegment(0, 9, "(SELECT 1)"));
+        TypeCastExpression typeCast = new TypeCastExpression(0, 15, "(SELECT 1)::int4", subquery, "int4");
+        InsertValueContext insertValueContext = new InsertValueContext(Collections.singleton(typeCast), Collections.emptyList(), 0);
+        when(insertStatementContext.getInsertValueContexts()).thenReturn(Collections.singletonList(insertValueContext));
+        when(rule.findShardingColumn("foo_col_1", "foo_tbl")).thenReturn(Optional.of("foo_col_1"));
+        List<ShardingCondition> shardingConditions = shardingConditionEngine.createShardingConditions(insertStatementContext, Collections.emptyList());
+        assertThat(shardingConditions.size(), is(1));
+        assertTrue(shardingConditions.get(0).getValues().isEmpty());
     }
     
     @Test

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluatorTest.java
@@ -76,7 +76,7 @@ class PostgreSQLCastEvaluatorTest {
     }
     
     @Test
-    void assertStringNumberToInt4() {
+    void assertStringIntegerToInt4() {
         assertThat(PostgreSQLCastEvaluator.evaluate("1", "int4").orElseThrow(AssertionError::new), is(1));
     }
     
@@ -88,6 +88,21 @@ class PostgreSQLCastEvaluatorTest {
     @Test
     void assertStringUnparseableToInt4ReturnsEmpty() {
         assertFalse(PostgreSQLCastEvaluator.evaluate("abc", "int4").isPresent());
+    }
+    
+    @Test
+    void assertStringWithDecimalToInt4ReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate("1.5", "int4").isPresent());
+    }
+    
+    @Test
+    void assertStringWithTrailingZeroDecimalToInt4ReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate("1.0", "int4").isPresent());
+    }
+    
+    @Test
+    void assertStringWithFloatNotationToInt4ReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate("1e2", "int4").isPresent());
     }
     
     @Test
@@ -111,6 +126,46 @@ class PostgreSQLCastEvaluatorTest {
     }
     
     @Test
+    void assertDoublePositiveTwoHalfRoundsHalfEven() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(2.5D, "int4").orElseThrow(AssertionError::new), is(2));
+    }
+    
+    @Test
+    void assertDoubleNegativeTwoHalfRoundsHalfEven() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(-2.5D, "int4").orElseThrow(AssertionError::new), is(-2));
+    }
+    
+    @Test
+    void assertDoublePositiveOneHalfRoundsHalfEven() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(1.5D, "int4").orElseThrow(AssertionError::new), is(2));
+    }
+    
+    @Test
+    void assertDoubleZeroHalfRoundsHalfEven() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(0.5D, "int4").orElseThrow(AssertionError::new), is(0));
+    }
+    
+    @Test
+    void assertFloatPositiveTwoHalfRoundsHalfEven() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(2.5F, "int4").orElseThrow(AssertionError::new), is(2));
+    }
+    
+    @Test
+    void assertFloatNegativeTwoHalfRoundsHalfEven() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(-2.5F, "int4").orElseThrow(AssertionError::new), is(-2));
+    }
+    
+    @Test
+    void assertDoubleNaNToInt4ReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(Double.NaN, "int4").isPresent());
+    }
+    
+    @Test
+    void assertDoubleInfinityToInt4ReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(Double.POSITIVE_INFINITY, "int4").isPresent());
+    }
+    
+    @Test
     void assertBigDecimalToNumeric() {
         Optional<Comparable<?>> actual = PostgreSQLCastEvaluator.evaluate(new BigDecimal("1.50"), "numeric");
         assertTrue(actual.isPresent());
@@ -125,6 +180,16 @@ class PostgreSQLCastEvaluatorTest {
     }
     
     @Test
+    void assertBooleanToNumericReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(Boolean.TRUE, "numeric").isPresent());
+    }
+    
+    @Test
+    void assertBooleanToDecimalReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(Boolean.FALSE, "decimal").isPresent());
+    }
+    
+    @Test
     void assertIntegerToFloat4() {
         assertThat(PostgreSQLCastEvaluator.evaluate(7, "real").orElseThrow(AssertionError::new), is(7.0F));
     }
@@ -132,6 +197,16 @@ class PostgreSQLCastEvaluatorTest {
     @Test
     void assertIntegerToFloat8() {
         assertThat(PostgreSQLCastEvaluator.evaluate(7, "double precision").orElseThrow(AssertionError::new), is(7.0));
+    }
+    
+    @Test
+    void assertBooleanToFloatReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(Boolean.TRUE, "real").isPresent());
+    }
+    
+    @Test
+    void assertBooleanToDoublePrecisionReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(Boolean.TRUE, "double precision").isPresent());
     }
     
     @Test
@@ -145,8 +220,115 @@ class PostgreSQLCastEvaluatorTest {
     }
     
     @Test
-    void assertBooleanToText() {
+    void assertBooleanTrueToText() {
         assertThat(PostgreSQLCastEvaluator.evaluate(Boolean.TRUE, "text").orElseThrow(AssertionError::new), is("true"));
+    }
+    
+    @Test
+    void assertBooleanFalseToText() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(Boolean.FALSE, "text").orElseThrow(AssertionError::new), is("false"));
+    }
+    
+    @Test
+    void assertStringToBpcharReturnsIdentity() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("ab", "bpchar").orElseThrow(AssertionError::new), is("ab"));
+    }
+    
+    @Test
+    void assertStringToCharNoTypmodTruncatesToFirstChar() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("ab", "char").orElseThrow(AssertionError::new), is("a"));
+    }
+    
+    @Test
+    void assertStringToCharacterNoTypmodTruncatesToFirstChar() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("ab", "character").orElseThrow(AssertionError::new), is("a"));
+    }
+    
+    @Test
+    void assertBooleanToCharNoTypmodTruncatesToFirstChar() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(Boolean.TRUE, "char").orElseThrow(AssertionError::new), is("t"));
+    }
+    
+    @Test
+    void assertEmptyStringToCharNoTypmodReturnsEmpty() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("", "char").orElseThrow(AssertionError::new), is(""));
+    }
+    
+    @Test
+    void assertShortStringToNameReturnsIdentity() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("foo", "name").orElseThrow(AssertionError::new), is("foo"));
+    }
+    
+    @Test
+    void assertLongAsciiStringToNameTruncatesTo63Bytes() {
+        StringBuilder seventy = new StringBuilder();
+        for (int i = 0; i < 70; i++) {
+            seventy.append('a');
+        }
+        StringBuilder sixtyThree = new StringBuilder();
+        for (int i = 0; i < 63; i++) {
+            sixtyThree.append('a');
+        }
+        assertThat(PostgreSQLCastEvaluator.evaluate(seventy.toString(), "name").orElseThrow(AssertionError::new), is(sixtyThree.toString()));
+    }
+    
+    @Test
+    void assertLongMultibyteStringToNameTruncatesAtUtf8Boundary() {
+        StringBuilder seventy = new StringBuilder();
+        for (int i = 0; i < 70; i++) {
+            seventy.append('中');
+        }
+        StringBuilder twentyOne = new StringBuilder();
+        for (int i = 0; i < 21; i++) {
+            twentyOne.append('中');
+        }
+        assertThat(PostgreSQLCastEvaluator.evaluate(seventy.toString(), "name").orElseThrow(AssertionError::new), is(twentyOne.toString()));
+    }
+    
+    @Test
+    void assertMultibyteStringToCharNoTypmodPicksFirstCodepoint() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("中文", "char").orElseThrow(AssertionError::new), is("中"));
+    }
+    
+    @Test
+    void assertSurrogatePairStringToCharNoTypmodPicksWholeCodepoint() {
+        String smiley = new String(Character.toChars(0x1F600));
+        assertThat(PostgreSQLCastEvaluator.evaluate(smiley + "x", "char").orElseThrow(AssertionError::new), is(smiley));
+    }
+    
+    @Test
+    void assertDoubleRecurringFractionToNumericTruncatesTo15Digits() {
+        Optional<Comparable<?>> actual = PostgreSQLCastEvaluator.evaluate(1.0 / 3.0, "numeric");
+        assertTrue(actual.isPresent());
+        assertThat(((BigDecimal) actual.get()).toPlainString(), is("0.333333333333333"));
+    }
+    
+    @Test
+    void assertDoubleIntegralToNumericStripsTrailingZeros() {
+        Optional<Comparable<?>> actual = PostgreSQLCastEvaluator.evaluate(150.0D, "numeric");
+        assertTrue(actual.isPresent());
+        assertThat(((BigDecimal) actual.get()).toPlainString(), is("150"));
+    }
+    
+    @Test
+    void assertDoubleOneToNumericStripsTrailingZeros() {
+        Optional<Comparable<?>> actual = PostgreSQLCastEvaluator.evaluate(1.0D, "numeric");
+        assertTrue(actual.isPresent());
+        assertThat(((BigDecimal) actual.get()).toPlainString(), is("1"));
+    }
+    
+    @Test
+    void assertDoubleZeroToNumericReturnsZero() {
+        Optional<Comparable<?>> actual = PostgreSQLCastEvaluator.evaluate(0.0D, "numeric");
+        assertTrue(actual.isPresent());
+        assertThat(((BigDecimal) actual.get()).toPlainString(), is("0"));
+    }
+    
+    @Test
+    void assertDoubleHalfToNumericKeepsFractional() {
+        Optional<Comparable<?>> actual = PostgreSQLCastEvaluator.evaluate(2.5D, "numeric");
+        assertTrue(actual.isPresent());
+        assertThat(((BigDecimal) actual.get()).toPlainString(), is("2.5"));
     }
     
     @Test
@@ -190,13 +372,38 @@ class PostgreSQLCastEvaluatorTest {
     }
     
     @Test
-    void assertNumericNonZeroToBoolean() {
+    void assertIntegerNonZeroToBoolean() {
         assertThat(PostgreSQLCastEvaluator.evaluate(7, "bool").orElseThrow(AssertionError::new), is(Boolean.TRUE));
     }
     
     @Test
-    void assertNumericZeroToBoolean() {
+    void assertIntegerZeroToBoolean() {
         assertThat(PostgreSQLCastEvaluator.evaluate(0, "bool").orElseThrow(AssertionError::new), is(Boolean.FALSE));
+    }
+    
+    @Test
+    void assertLongNonZeroToBoolean() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(7L, "bool").orElseThrow(AssertionError::new), is(Boolean.TRUE));
+    }
+    
+    @Test
+    void assertBigDecimalToBoolReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(new BigDecimal("1"), "bool").isPresent());
+    }
+    
+    @Test
+    void assertBigDecimalFractionalToBoolReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(new BigDecimal("1.5"), "bool").isPresent());
+    }
+    
+    @Test
+    void assertDoubleToBoolReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(2.5D, "bool").isPresent());
+    }
+    
+    @Test
+    void assertFloatToBoolReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(2.5F, "bool").isPresent());
     }
     
     @Test
@@ -205,7 +412,145 @@ class PostgreSQLCastEvaluatorTest {
     }
     
     @Test
-    void assertBooleanToFloatReturnsEmpty() {
-        assertFalse(PostgreSQLCastEvaluator.evaluate(Boolean.TRUE, "real").isPresent());
+    void assertBooleanTrueToName() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(Boolean.TRUE, "name").orElseThrow(AssertionError::new), is("t"));
+    }
+    
+    @Test
+    void assertBooleanFalseToName() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(Boolean.FALSE, "name").orElseThrow(AssertionError::new), is("f"));
+    }
+    
+    @Test
+    void assertIntegerToNumeric() {
+        Optional<Comparable<?>> actual = PostgreSQLCastEvaluator.evaluate(42, "numeric");
+        assertTrue(actual.isPresent());
+        assertThat(actual.get(), is(new BigDecimal(42)));
+    }
+    
+    @Test
+    void assertLongToNumeric() {
+        Optional<Comparable<?>> actual = PostgreSQLCastEvaluator.evaluate(42L, "numeric");
+        assertTrue(actual.isPresent());
+        assertThat(actual.get(), is(new BigDecimal(42)));
+    }
+    
+    @Test
+    void assertBigIntegerToNumeric() {
+        Optional<Comparable<?>> actual = PostgreSQLCastEvaluator.evaluate(new BigInteger("99999999999999999999"), "numeric");
+        assertTrue(actual.isPresent());
+        assertThat(actual.get(), is(new BigDecimal("99999999999999999999")));
+    }
+    
+    @Test
+    void assertIntegerToCharNoTypmodPicksFirstDigit() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(42, "char").orElseThrow(AssertionError::new), is("4"));
+    }
+    
+    @Test
+    void assertIntegerToName() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(12345, "name").orElseThrow(AssertionError::new), is("12345"));
+    }
+    
+    @Test
+    void assertBigDecimalToFloat4() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(new BigDecimal("1.5"), "real").orElseThrow(AssertionError::new), is(1.5F));
+    }
+    
+    @Test
+    void assertBigDecimalToFloat8() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(new BigDecimal("1.5"), "double precision").orElseThrow(AssertionError::new), is(1.5));
+    }
+    
+    @Test
+    void assertBigDecimalToCharNoTypmodPicksFirstChar() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(new BigDecimal("123.45"), "char").orElseThrow(AssertionError::new), is("1"));
+    }
+    
+    @Test
+    void assertDoubleNarrowsToFloat4() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(1.5D, "real").orElseThrow(AssertionError::new), is(1.5F));
+    }
+    
+    @Test
+    void assertFloatWidensToFloat8() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(1.5F, "double precision").orElseThrow(AssertionError::new), is((double) 1.5F));
+    }
+    
+    @Test
+    void assertDoubleToText() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(2.5D, "text").orElseThrow(AssertionError::new), is("2.5"));
+    }
+    
+    @Test
+    void assertNaNDoubleToText() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(Double.NaN, "text").orElseThrow(AssertionError::new), is("NaN"));
+    }
+    
+    @Test
+    void assertPositiveInfinityDoubleToText() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(Double.POSITIVE_INFINITY, "text").orElseThrow(AssertionError::new), is("Infinity"));
+    }
+    
+    @Test
+    void assertNegativeInfinityDoubleToText() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(Double.NEGATIVE_INFINITY, "text").orElseThrow(AssertionError::new), is("-Infinity"));
+    }
+    
+    @Test
+    void assertStringScientificNotationToFloat8() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("1e2", "double precision").orElseThrow(AssertionError::new), is(100.0));
+    }
+    
+    @Test
+    void assertStringWithScientificNotationToNumeric() {
+        Optional<Comparable<?>> actual = PostgreSQLCastEvaluator.evaluate("1.5e2", "numeric");
+        assertTrue(actual.isPresent());
+        assertThat(((BigDecimal) actual.get()).toPlainString(), is("150"));
+    }
+    
+    @Test
+    void assertStringIdentityToText() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("hello", "text").orElseThrow(AssertionError::new), is("hello"));
+    }
+    
+    @Test
+    void assertEmptyStringToCharNoTypmodReturnsEmptyString() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("", "name").orElseThrow(AssertionError::new), is(""));
+    }
+    
+    @Test
+    void assertLongMaxValueToBoolean() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(Long.MAX_VALUE, "bool").orElseThrow(AssertionError::new), is(Boolean.TRUE));
+    }
+    
+    @Test
+    void assertBigIntegerHugeToInt8OverflowReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(new BigInteger("99999999999999999999"), "int8").isPresent());
+    }
+    
+    @Test
+    void assertEmptyStringToInt4ReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate("", "int4").isPresent());
+    }
+    
+    @Test
+    void assertWhitespaceOnlyStringToInt4ReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate("   ", "int4").isPresent());
+    }
+    
+    @Test
+    void assertStringWithTabAndNewlineToInt4() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("\t1\n", "int4").orElseThrow(AssertionError::new), is(1));
+    }
+    
+    @Test
+    void assertStringDoubleToInt4ReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate("1.5e0", "int4").isPresent());
+    }
+    
+    @Test
+    void assertNegativeIntegerToBool() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(-7, "bool").orElseThrow(AssertionError::new), is(Boolean.TRUE));
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluatorTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.route.engine.condition.engine;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PostgreSQLCastEvaluatorTest {
+    
+    @Test
+    void assertEvaluateReturnsEmptyForNullValue() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(null, "int4").isPresent());
+    }
+    
+    @Test
+    void assertEvaluateReturnsEmptyForNullTarget() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(1, null).isPresent());
+    }
+    
+    @Test
+    void assertEvaluateReturnsEmptyForUnsupportedTarget() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(1, "uuid").isPresent());
+    }
+    
+    @Test
+    void assertIntegerToInt4() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(7, "int4").orElseThrow(AssertionError::new), is(7));
+    }
+    
+    @Test
+    void assertLongToInt4() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(7L, "int4").orElseThrow(AssertionError::new), is(7));
+    }
+    
+    @Test
+    void assertIntegerToInt8() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(7, "int8").orElseThrow(AssertionError::new), is(7L));
+    }
+    
+    @Test
+    void assertIntegerToSmallInt() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(7, "smallint").orElseThrow(AssertionError::new), is((short) 7));
+    }
+    
+    @Test
+    void assertSmallIntOverflowReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(32_768, "smallint").isPresent());
+    }
+    
+    @Test
+    void assertInt4OverflowReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(new BigInteger("2147483648"), "int4").isPresent());
+    }
+    
+    @Test
+    void assertStringNumberToInt4() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("1", "int4").orElseThrow(AssertionError::new), is(1));
+    }
+    
+    @Test
+    void assertStringWithLeadingSpaceToInt4() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(" 1 ", "int4").orElseThrow(AssertionError::new), is(1));
+    }
+    
+    @Test
+    void assertStringUnparseableToInt4ReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate("abc", "int4").isPresent());
+    }
+    
+    @Test
+    void assertBigDecimalHalfRoundsHalfEvenUpForOne() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(new BigDecimal("1.5"), "int4").orElseThrow(AssertionError::new), is(2));
+    }
+    
+    @Test
+    void assertBigDecimalHalfRoundsHalfEvenDownForTwo() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(new BigDecimal("2.5"), "int4").orElseThrow(AssertionError::new), is(2));
+    }
+    
+    @Test
+    void assertBigDecimalNegativeHalfRoundsHalfEven() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(new BigDecimal("-1.5"), "int4").orElseThrow(AssertionError::new), is(-2));
+    }
+    
+    @Test
+    void assertBigDecimalToNumeric() {
+        Optional<Comparable<?>> actual = PostgreSQLCastEvaluator.evaluate(new BigDecimal("1.50"), "numeric");
+        assertTrue(actual.isPresent());
+        assertThat(actual.get(), is(new BigDecimal("1.50")));
+    }
+    
+    @Test
+    void assertStringToNumeric() {
+        Optional<Comparable<?>> actual = PostgreSQLCastEvaluator.evaluate("1.5", "numeric");
+        assertTrue(actual.isPresent());
+        assertThat(actual.get(), is(new BigDecimal("1.5")));
+    }
+    
+    @Test
+    void assertIntegerToFloat4() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(7, "real").orElseThrow(AssertionError::new), is(7.0F));
+    }
+    
+    @Test
+    void assertIntegerToFloat8() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(7, "double precision").orElseThrow(AssertionError::new), is(7.0));
+    }
+    
+    @Test
+    void assertIntegerToText() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(42, "text").orElseThrow(AssertionError::new), is("42"));
+    }
+    
+    @Test
+    void assertBigDecimalToTextUsesPlainString() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(new BigDecimal("1.50"), "text").orElseThrow(AssertionError::new), is("1.50"));
+    }
+    
+    @Test
+    void assertBooleanToText() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(Boolean.TRUE, "text").orElseThrow(AssertionError::new), is("true"));
+    }
+    
+    @Test
+    void assertStringToVarcharWithSize() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("foo", "varchar(10)").orElseThrow(AssertionError::new), is("foo"));
+    }
+    
+    @Test
+    void assertStringTrueToBoolean() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("true", "bool").orElseThrow(AssertionError::new), is(Boolean.TRUE));
+    }
+    
+    @Test
+    void assertStringYesToBoolean() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("YES", "boolean").orElseThrow(AssertionError::new), is(Boolean.TRUE));
+    }
+    
+    @Test
+    void assertStringOffToBoolean() {
+        assertThat(PostgreSQLCastEvaluator.evaluate("off", "bool").orElseThrow(AssertionError::new), is(Boolean.FALSE));
+    }
+    
+    @Test
+    void assertStringUnknownToBooleanReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate("maybe", "bool").isPresent());
+    }
+    
+    @Test
+    void assertNumericNonZeroToBoolean() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(7, "bool").orElseThrow(AssertionError::new), is(Boolean.TRUE));
+    }
+    
+    @Test
+    void assertNumericZeroToBoolean() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(0, "bool").orElseThrow(AssertionError::new), is(Boolean.FALSE));
+    }
+    
+    @Test
+    void assertBooleanToBoolean() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(Boolean.TRUE, "bool").orElseThrow(AssertionError::new), is(Boolean.TRUE));
+    }
+    
+    @Test
+    void assertBooleanToFloatReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(Boolean.TRUE, "real").isPresent());
+    }
+}

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluatorTest.java
@@ -91,18 +91,23 @@ class PostgreSQLCastEvaluatorTest {
     }
     
     @Test
-    void assertBigDecimalHalfRoundsHalfEvenUpForOne() {
+    void assertBigDecimalPositiveOneHalfRoundsAwayFromZero() {
         assertThat(PostgreSQLCastEvaluator.evaluate(new BigDecimal("1.5"), "int4").orElseThrow(AssertionError::new), is(2));
     }
     
     @Test
-    void assertBigDecimalHalfRoundsHalfEvenDownForTwo() {
-        assertThat(PostgreSQLCastEvaluator.evaluate(new BigDecimal("2.5"), "int4").orElseThrow(AssertionError::new), is(2));
+    void assertBigDecimalPositiveTwoHalfRoundsAwayFromZero() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(new BigDecimal("2.5"), "int4").orElseThrow(AssertionError::new), is(3));
     }
     
     @Test
-    void assertBigDecimalNegativeHalfRoundsHalfEven() {
+    void assertBigDecimalNegativeOneHalfRoundsAwayFromZero() {
         assertThat(PostgreSQLCastEvaluator.evaluate(new BigDecimal("-1.5"), "int4").orElseThrow(AssertionError::new), is(-2));
+    }
+    
+    @Test
+    void assertBigDecimalNegativeTwoHalfRoundsAwayFromZero() {
+        assertThat(PostgreSQLCastEvaluator.evaluate(new BigDecimal("-2.5"), "int4").orElseThrow(AssertionError::new), is(-3));
     }
     
     @Test
@@ -145,8 +150,23 @@ class PostgreSQLCastEvaluatorTest {
     }
     
     @Test
-    void assertStringToVarcharWithSize() {
-        assertThat(PostgreSQLCastEvaluator.evaluate("foo", "varchar(10)").orElseThrow(AssertionError::new), is("foo"));
+    void assertStringToVarcharWithTypmodReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate("foo", "varchar(10)").isPresent());
+    }
+    
+    @Test
+    void assertOverLengthStringToVarcharWithTypmodReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate("ab", "varchar(1)").isPresent());
+    }
+    
+    @Test
+    void assertStringToCharWithTypmodReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate("ab", "char(2)").isPresent());
+    }
+    
+    @Test
+    void assertBigDecimalToNumericWithPrecisionScaleReturnsEmpty() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(new BigDecimal("1.55"), "numeric(3,1)").isPresent());
     }
     
     @Test

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluatorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/PostgreSQLCastEvaluatorTest.java
@@ -412,6 +412,16 @@ class PostgreSQLCastEvaluatorTest {
     }
     
     @Test
+    void assertBoolToNumericIsConservativeOnOpenGaussWhichWouldAcceptThisCast() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(Boolean.TRUE, "numeric").isPresent());
+    }
+    
+    @Test
+    void assertNumericToBoolIsConservativeOnOpenGaussWhichWouldAcceptThisCast() {
+        assertFalse(PostgreSQLCastEvaluator.evaluate(new BigDecimal("1"), "bool").isPresent());
+    }
+    
+    @Test
     void assertBooleanTrueToName() {
         assertThat(PostgreSQLCastEvaluator.evaluate(Boolean.TRUE, "name").orElseThrow(AssertionError::new), is("t"));
     }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/WhereClauseShardingConditionEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/WhereClauseShardingConditionEngineTest.java
@@ -169,4 +169,73 @@ class WhereClauseShardingConditionEngineTest {
         List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.singletonList(new BigDecimal("1.55")));
         assertTrue(actual.isEmpty());
     }
+    
+    @Test
+    void assertCreateShardingConditionsForSelectCompareWithDoubleHalfRoundsHalfEven() {
+        ColumnSegment left = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        TypeCastExpression cast = new TypeCastExpression(0, 0, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0, left, cast, "=", "foo_sharding_col = ?::int4");
+        when(whereSegment.getExpr()).thenReturn(predicate);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.singletonList(2.5D));
+        ListShardingConditionValue<?> value = (ListShardingConditionValue<?>) actual.get(0).getValues().get(0);
+        assertThat(value.getValues(), is(Collections.singletonList(2)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsForSelectCompareWithFloatHalfRoundsHalfEven() {
+        ColumnSegment left = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        TypeCastExpression cast = new TypeCastExpression(0, 0, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0, left, cast, "=", "foo_sharding_col = ?::int4");
+        when(whereSegment.getExpr()).thenReturn(predicate);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.singletonList(-2.5F));
+        ListShardingConditionValue<?> value = (ListShardingConditionValue<?>) actual.get(0).getValues().get(0);
+        assertThat(value.getValues(), is(Collections.singletonList(-2)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsForSelectCompareWithCharNoTypmodTruncatesFirstChar() {
+        ColumnSegment left = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        TypeCastExpression cast = new TypeCastExpression(0, 0, "?::char", new ParameterMarkerExpressionSegment(0, 0, 0), "char");
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0, left, cast, "=", "foo_sharding_col = ?::char");
+        when(whereSegment.getExpr()).thenReturn(predicate);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.singletonList("abcdef"));
+        ListShardingConditionValue<?> value = (ListShardingConditionValue<?>) actual.get(0).getValues().get(0);
+        assertThat(value.getValues(), is(Collections.singletonList("a")));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsForSelectCompareWithBoolToNumericDoesNotRoute() {
+        ColumnSegment left = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        TypeCastExpression cast = new TypeCastExpression(0, 0, "?::numeric", new ParameterMarkerExpressionSegment(0, 0, 0), "numeric");
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0, left, cast, "=", "foo_sharding_col = ?::numeric");
+        when(whereSegment.getExpr()).thenReturn(predicate);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.singletonList(Boolean.TRUE));
+        assertTrue(actual.isEmpty());
+    }
+    
+    @Test
+    void assertCreateShardingConditionsForSelectCompareWithDoubleToBoolDoesNotRoute() {
+        ColumnSegment left = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        TypeCastExpression cast = new TypeCastExpression(0, 0, "?::bool", new ParameterMarkerExpressionSegment(0, 0, 0), "bool");
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0, left, cast, "=", "foo_sharding_col = ?::bool");
+        when(whereSegment.getExpr()).thenReturn(predicate);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.singletonList(2.5D));
+        assertTrue(actual.isEmpty());
+    }
+    
+    @Test
+    void assertCreateShardingConditionsForSelectCompareWithFractionalStringToIntDoesNotRoute() {
+        ColumnSegment left = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        TypeCastExpression cast = new TypeCastExpression(0, 0, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0, left, cast, "=", "foo_sharding_col = ?::int4");
+        when(whereSegment.getExpr()).thenReturn(predicate);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.singletonList("1.5"));
+        assertTrue(actual.isEmpty());
+    }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/WhereClauseShardingConditionEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/WhereClauseShardingConditionEngineTest.java
@@ -28,10 +28,13 @@ import org.apache.shardingsphere.sharding.route.engine.condition.value.RangeShar
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BetweenExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.InExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ListExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.TypeCastExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.timeservice.core.rule.TimestampServiceRule;
@@ -41,6 +44,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -48,6 +53,7 @@ import java.util.Optional;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -112,5 +118,55 @@ class WhereClauseShardingConditionEngineTest {
         List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.emptyList());
         assertThat(actual.get(0).getStartIndex(), is(0));
         assertThat(actual.get(0).getValues().get(0), isA(ListShardingConditionValue.class));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsForSelectCompareWithCastedParameter() {
+        ColumnSegment left = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        TypeCastExpression cast = new TypeCastExpression(0, 0, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0, left, cast, "=", "foo_sharding_col = ?::int4");
+        when(whereSegment.getExpr()).thenReturn(predicate);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.singletonList("42"));
+        ListShardingConditionValue<?> value = (ListShardingConditionValue<?>) actual.get(0).getValues().get(0);
+        assertThat(value.getValues(), is(Collections.singletonList(42)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsForSelectInWithCastedParameter() {
+        ColumnSegment left = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        ListExpression right = new ListExpression(0, 0);
+        right.getItems().add(new TypeCastExpression(0, 0, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4"));
+        InExpression inExpression = new InExpression(0, 0, left, right, false);
+        when(whereSegment.getExpr()).thenReturn(inExpression);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.singletonList("42"));
+        ListShardingConditionValue<?> value = (ListShardingConditionValue<?>) actual.get(0).getValues().get(0);
+        assertThat(value.getValues(), is(Collections.singletonList(42)));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsForSelectBetweenWithCastedParameters() {
+        ColumnSegment left = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        ExpressionSegment betweenCast = new TypeCastExpression(0, 0, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        ExpressionSegment andCast = new TypeCastExpression(0, 0, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 1), "int4");
+        BetweenExpression betweenExpression = new BetweenExpression(0, 0, left, betweenCast, andCast, false);
+        when(whereSegment.getExpr()).thenReturn(betweenExpression);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Arrays.asList("1", "100"));
+        RangeShardingConditionValue<?> value = (RangeShardingConditionValue<?>) actual.get(0).getValues().get(0);
+        assertThat(value.getValueRange().lowerEndpoint(), is(1));
+        assertThat(value.getValueRange().upperEndpoint(), is(100));
+    }
+    
+    @Test
+    void assertCreateShardingConditionsForSelectCompareWithUnsupportedTypmodCastDoesNotRoute() {
+        ColumnSegment left = new ColumnSegment(0, 0, new IdentifierValue("foo_sharding_col"));
+        TypeCastExpression cast = new TypeCastExpression(0, 0, "?::numeric(3,1)", new ParameterMarkerExpressionSegment(0, 0, 0), "numeric(3,1)");
+        BinaryOperationExpression predicate = new BinaryOperationExpression(0, 0, left, cast, "=", "foo_sharding_col = ?::numeric(3,1)");
+        when(whereSegment.getExpr()).thenReturn(predicate);
+        when(rule.findShardingColumn("foo_sharding_col", "")).thenReturn(Optional.of("foo_sharding_col"));
+        List<ShardingCondition> actual = shardingConditionEngine.createShardingConditions(sqlStatementContext, Collections.singletonList(new BigDecimal("1.55")));
+        assertTrue(actual.isEmpty());
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/ConditionValueTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/ConditionValueTest.java
@@ -18,10 +18,12 @@
 package org.apache.shardingsphere.sharding.route.engine.condition.generator;
 
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.TypeCastExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -75,5 +77,71 @@ class ConditionValueTest {
         assertTrue(conditionValue.isNull());
         assertTrue(conditionValue.getParameterMarkerIndex().isPresent());
         assertThat(conditionValue.getParameterMarkerIndex().get(), is(1));
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastOverIntegerParameterMarker() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList(7));
+        assertTrue(conditionValue.getValue().isPresent());
+        assertThat(conditionValue.getValue().get(), is(7));
+        assertTrue(conditionValue.getParameterMarkerIndex().isPresent());
+        assertThat(conditionValue.getParameterMarkerIndex().get(), is(0));
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastOverStringParameterMarker() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList("1"));
+        assertTrue(conditionValue.getValue().isPresent());
+        assertThat(conditionValue.getValue().get(), is(1));
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastOverBigDecimalRoundsHalfEven() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList(new BigDecimal("1.5")));
+        assertTrue(conditionValue.getValue().isPresent());
+        assertThat(conditionValue.getValue().get(), is(2));
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastOverflowReturnsEmpty() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList(new BigDecimal("2147483648")));
+        assertFalse(conditionValue.getValue().isPresent());
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastUnparseableReturnsEmpty() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList("abc"));
+        assertFalse(conditionValue.getValue().isPresent());
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastOverLiteralRoutesByCastedValue() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "'1'::int4", new LiteralExpressionSegment(0, 10, "1"), "int4");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.emptyList());
+        assertTrue(conditionValue.getValue().isPresent());
+        assertThat(conditionValue.getValue().get(), is(1));
+        assertFalse(conditionValue.getParameterMarkerIndex().isPresent());
+    }
+    
+    @Test
+    void assertGetValueFromNestedTypeCastAppliesCastsInsideOut() {
+        TypeCastExpression inner = new TypeCastExpression(0, 5, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        TypeCastExpression outer = new TypeCastExpression(0, 12, "?::int4::text", inner, "text");
+        ConditionValue conditionValue = new ConditionValue(outer, Collections.singletonList(42));
+        assertTrue(conditionValue.getValue().isPresent());
+        assertThat(conditionValue.getValue().get(), is("42"));
+    }
+    
+    @Test
+    void assertGetNullValueFromTypeCastOverNullParameter() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList(null));
+        assertFalse(conditionValue.getValue().isPresent());
+        assertTrue(conditionValue.isNull());
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/ConditionValueTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/ConditionValueTest.java
@@ -98,11 +98,34 @@ class ConditionValueTest {
     }
     
     @Test
-    void assertGetValueFromTypeCastOverBigDecimalRoundsHalfEven() {
+    void assertGetValueFromTypeCastOverBigDecimalPositiveOneHalfRoundsAwayFromZero() {
         TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
         ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList(new BigDecimal("1.5")));
         assertTrue(conditionValue.getValue().isPresent());
         assertThat(conditionValue.getValue().get(), is(2));
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastOverBigDecimalPositiveTwoHalfRoundsAwayFromZero() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList(new BigDecimal("2.5")));
+        assertTrue(conditionValue.getValue().isPresent());
+        assertThat(conditionValue.getValue().get(), is(3));
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastOverBigDecimalNegativeTwoHalfRoundsAwayFromZero() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList(new BigDecimal("-2.5")));
+        assertTrue(conditionValue.getValue().isPresent());
+        assertThat(conditionValue.getValue().get(), is(-3));
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastWithTypmodReturnsEmpty() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::varchar(1)", new ParameterMarkerExpressionSegment(0, 0, 0), "varchar(1)");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList("ab"));
+        assertFalse(conditionValue.getValue().isPresent());
     }
     
     @Test

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/ConditionValueTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/route/engine/condition/generator/ConditionValueTest.java
@@ -122,6 +122,44 @@ class ConditionValueTest {
     }
     
     @Test
+    void assertGetValueFromTypeCastOverDoubleHalfRoundsHalfEven() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList(2.5D));
+        assertTrue(conditionValue.getValue().isPresent());
+        assertThat(conditionValue.getValue().get(), is(2));
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastOverFloatHalfRoundsHalfEven() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList(-2.5F));
+        assertTrue(conditionValue.getValue().isPresent());
+        assertThat(conditionValue.getValue().get(), is(-2));
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastOverStringToCharNoTypmodPicksFirstChar() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::char", new ParameterMarkerExpressionSegment(0, 0, 0), "char");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList("abc"));
+        assertTrue(conditionValue.getValue().isPresent());
+        assertThat(conditionValue.getValue().get(), is("a"));
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastOverBooleanToNumericReturnsEmpty() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::numeric", new ParameterMarkerExpressionSegment(0, 0, 0), "numeric");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList(Boolean.TRUE));
+        assertFalse(conditionValue.getValue().isPresent());
+    }
+    
+    @Test
+    void assertGetValueFromTypeCastOverFractionalStringToInt4ReturnsEmpty() {
+        TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::int4", new ParameterMarkerExpressionSegment(0, 0, 0), "int4");
+        ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList("1.5"));
+        assertFalse(conditionValue.getValue().isPresent());
+    }
+    
+    @Test
     void assertGetValueFromTypeCastWithTypmodReturnsEmpty() {
         TypeCastExpression typeCast = new TypeCastExpression(0, 10, "?::varchar(1)", new ParameterMarkerExpressionSegment(0, 0, 0), "varchar(1)");
         ConditionValue conditionValue = new ConditionValue(typeCast, Collections.singletonList("ab"));

--- a/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-insert.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-insert.xml
@@ -31,7 +31,7 @@
         <assertion parameters="4:int, 4:int, insert:String, test:String" expected-data-file="insert_for_order_4.xml" />
     </test-case>
     
-    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion parameters="1:int, 1:int, insert:String" expected-data-file="insert_for_order_1.xml" />
         <assertion parameters="2:int, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />
     </test-case>

--- a/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-insert.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-insert.xml
@@ -31,11 +31,10 @@
         <assertion parameters="4:int, 4:int, insert:String, test:String" expected-data-file="insert_for_order_4.xml" />
     </test-case>
     
-    <!--    TODO Fix https://github.com/apache/shardingsphere/issues/23764 -->
-    <!--    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">-->
-    <!--        <assertion parameters="1:int, 1:int, insert:String" expected-data-file="insert_for_order_1.xml" />-->
-    <!--        <assertion parameters="2:int, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />-->
-    <!--    </test-case>-->
+    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+        <assertion parameters="1:int, 1:int, insert:String" expected-data-file="insert_for_order_1.xml" />
+        <assertion parameters="2:int, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />
+    </test-case>
     
     <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?, ?, ?::char(10), 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion parameters="1:int, 1:int, insert:String" expected-data-file="insert_for_order_1.xml" />

--- a/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-insert.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-insert.xml
@@ -36,14 +36,6 @@
         <assertion parameters="2:int, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />
     </test-case>
 
-    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
-        <assertion parameters="2.5:double, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />
-    </test-case>
-
-    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
-        <assertion parameters="2.5:float, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />
-    </test-case>
-
     <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (2.5::numeric::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion parameters="3:int, insert:String" expected-data-file="insert_for_order_3.xml" />
     </test-case>

--- a/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-insert.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-insert.xml
@@ -35,7 +35,23 @@
         <assertion parameters="1:int, 1:int, insert:String" expected-data-file="insert_for_order_1.xml" />
         <assertion parameters="2:int, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />
     </test-case>
-    
+
+    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+        <assertion parameters="2.5:double, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />
+    </test-case>
+
+    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+        <assertion parameters="2.5:float, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />
+    </test-case>
+
+    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (2.5::numeric::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+        <assertion parameters="3:int, insert:String" expected-data-file="insert_for_order_3.xml" />
+    </test-case>
+
+    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (2.5::float8::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+        <assertion parameters="2:int, insert:String" expected-data-file="insert_for_order_2.xml" />
+    </test-case>
+
     <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?, ?, ?::char(10), 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion parameters="1:int, 1:int, insert:String" expected-data-file="insert_for_order_1.xml" />
         <assertion parameters="2:int, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />

--- a/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-insert.xml
+++ b/test/e2e/sql/src/test/resources/cases/dml/e2e-dml-insert.xml
@@ -31,7 +31,7 @@
         <assertion parameters="4:int, 4:int, insert:String, test:String" expected-data-file="insert_for_order_4.xml" />
     </test-case>
     
-    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+    <test-case sql="INSERT INTO t_order (order_id, user_id, status, merchant_id, remark, creation_date) VALUES (?::int4, ?, ?, 1, 'test', '2017-08-08')" db-types="PostgreSQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion parameters="1:int, 1:int, insert:String" expected-data-file="insert_for_order_1.xml" />
         <assertion parameters="2:int, 2:int, insert:String" expected-data-file="insert_for_order_2.xml" />
     </test-case>


### PR DESCRIPTION
Fixes #23764.

Changes proposed in this pull request:
  - Unwrap nested `TypeCastExpression` to its underlying expression at the top of `InsertClauseShardingConditionEngine.createShardingCondition`. The existing `instanceof SimpleExpressionSegment / CommonExpressionSegment / isNowExpression` chain has no branch for `TypeCastExpression` (a `ComplexExpressionSegment`), so a PostgreSQL `?::int4` cast on the sharding key was silently dropped and the INSERT broadcast to every shard.
  - `InsertClauseShardingConditionEngineTest`: add three regression cases covering a `TypeCast` over a parameter marker, over a literal, and nested casts (e.g., `?::int4::text`).
  - `e2e-dml-insert.xml`: enable the `?::int4` INSERT case that was previously commented out with `TODO Fix #23764`.

`ConditionValue` / `WhereClauseShardingConditionEngine` have the same shape of gap for WHERE-clause type casts, but the reported scenario only exercises INSERT VALUES; sending that as a separate follow-up.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally for the affected modules (spotless, checkstyle, unit tests).
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)