### PR TITLE
Refactor schema match rule to insensitive for mysql

### DIFF
--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProvider.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProvider.java
@@ -66,7 +66,7 @@ public final class MySQLIdentifierCaseRuleProvider implements IdentifierCaseRule
         }
         if (0 == lowerCaseTableNames) {
             Map<IdentifierScope, IdentifierCaseRule> scopedRules = new EnumMap<>(IdentifierScope.class);
-            scopedRules.put(IdentifierScope.SCHEMA, IdentifierCaseRuleSets.newSensitiveRuleSet().getRule(IdentifierScope.SCHEMA));
+            scopedRules.put(IdentifierScope.SCHEMA, IdentifierCaseRuleSets.newMySQLInsensitiveRuleSet().getRule(IdentifierScope.SCHEMA));
             scopedRules.put(IdentifierScope.TABLE, IdentifierCaseRuleSets.newSensitiveRuleSet().getRule(IdentifierScope.TABLE));
             scopedRules.put(IdentifierScope.VIEW, IdentifierCaseRuleSets.newSensitiveRuleSet().getRule(IdentifierScope.VIEW));
             return Optional.of(new IdentifierCaseRuleSet(IdentifierCaseRuleSets.newInsensitiveRuleSet().getRule(IdentifierScope.TABLE), scopedRules));

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProviderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCaseRuleProviderTest.java
@@ -111,7 +111,7 @@ class MySQLIdentifierCaseRuleProviderTest {
     void assertProvideWithLowerCaseTableNamesZeroUsesScopedRules() throws SQLException {
         IdentifierCaseRuleProviderContext context = new IdentifierCaseRuleProviderContext(DATABASE_TYPE, mockDataSource(true, 0));
         IdentifierCaseRuleSet actual = provider.provide(context).orElseThrow(AssertionError::new);
-        assertThat(actual.getRule(IdentifierScope.SCHEMA).matches("foo_schema", "FOO_SCHEMA", QuoteCharacter.NONE), is(Boolean.FALSE));
+        assertThat(actual.getRule(IdentifierScope.SCHEMA).matches("foo_schema", "FOO_SCHEMA", QuoteCharacter.NONE), is(Boolean.TRUE));
         assertThat(actual.getRule(IdentifierScope.TABLE).matches("foo_tbl", "FOO_TBL", QuoteCharacter.NONE), is(Boolean.FALSE));
         assertThat(actual.getRule(IdentifierScope.VIEW).matches("foo_view", "FOO_VIEW", QuoteCharacter.NONE), is(Boolean.FALSE));
         assertThat(actual.getRule(IdentifierScope.COLUMN).matches("foo_col", "FOO_COL", QuoteCharacter.NONE), is(Boolean.TRUE));


### PR DESCRIPTION

Changes proposed in this pull request:
  - Refactor schema match rule to insensitive for mysql

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
