### PR TITLE
Add pre get to avoid ConcurrentHashMap#computeIfAbsent performance problem in JDK 8

### DIFF
--- a/.codex/skills/review-pr/SKILL.md
+++ b/.codex/skills/review-pr/SKILL.md
@@ -67,6 +67,9 @@ description: >-
     - If official documentation support is missing, ambiguous, or contradicts the PR behavior, bias to `Merge Verdict: Not Mergeable`.
     - If any related dialect remains unresolved, or the review skips the family scan, bias to `Merge Verdict: Not Mergeable`.
     - Do not recommend unsupported or undocumented SQL syntax in review feedback.
+16. If a method reachable from the Proxy or JDBC DML/DQL high-frequency SQL execution path uses `ConcurrentHashMap#computeIfAbsent`,
+    require a preceding `get` lookup and call `computeIfAbsent` only when the value is missing, to avoid the JDK 8 implementation bottleneck.
+    If this pattern is absent and the path is high-frequency, bias to `Merge Verdict: Not Mergeable`.
 
 ## Execution Boundary
 
@@ -142,6 +145,7 @@ When information gaps block mergeability, request at least:
 4. Risk scan:
    - Design: abstraction level, responsibility boundaries, temporary compatibility branches
    - Performance: new loops/remote calls/object allocations on hot paths
+   - Performance: in Proxy/JDBC DML/DQL high-frequency SQL paths, flag direct `ConcurrentHashMap#computeIfAbsent` use without a preceding `get` miss check
    - Compatibility: behavior/config/API-SPI/SQL dialect versions
    - Regression: similar statements, adjacent features, exception branches
    - For parser, binder, routing, and default-schema changes, explicitly compare the new behavior against official dialect semantics and check whether precedence or shadowing rules changed
@@ -189,7 +193,7 @@ If the root-cause chain cannot be fully proven fixed, set `Merge Verdict: Not Me
 ## Risk Checklist (Must Cover)
 
 - Design risk: broken layering, duplicated logic, bypassed SPI/metadata cache, implicit state.
-- Performance risk: complexity increase, extra hot-path allocations, unbounded retries, blocking I/O.
+- Performance risk: complexity increase, extra hot-path allocations, unbounded retries, blocking I/O, or direct `ConcurrentHashMap#computeIfAbsent` in Proxy/JDBC DML/DQL high-frequency SQL paths without a preceding `get` miss check.
 - Compatibility risk:
   - Behavior compatibility
   - Config compatibility
@@ -286,3 +290,4 @@ Use committer tone, gentle wording, no emojis; structure:
 - Do not include emojis in change request text.
 - Do not output `Mergeable` for a shared-code change unless you have checked at least one non-target dialect or feature that also uses the changed path.
 - Do not output `Mergeable` when local verification omitted `-am` on a module-scoped Maven run and dependency freshness matters.
+- Do not output `Mergeable` when Proxy/JDBC DML/DQL high-frequency SQL paths directly call `ConcurrentHashMap#computeIfAbsent` without a preceding `get` miss check.

--- a/kernel/transaction/core/src/main/java/org/apache/shardingsphere/transaction/savepoint/ConnectionSavepointManager.java
+++ b/kernel/transaction/core/src/main/java/org/apache/shardingsphere/transaction/savepoint/ConnectionSavepointManager.java
@@ -60,7 +60,15 @@ public final class ConnectionSavepointManager {
      */
     public void setSavepoint(final Connection connection, final String savepointName) throws SQLException {
         Savepoint result = connection.setSavepoint(savepointName);
-        CONNECTION_SAVEPOINT_MAP.computeIfAbsent(connection, unused -> new LinkedHashMap<>()).put(savepointName, result);
+        getConnectionSavepoints(connection).put(savepointName, result);
+    }
+    
+    private Map<String, Savepoint> getConnectionSavepoints(final Connection connection) {
+        Map<String, Savepoint> result = CONNECTION_SAVEPOINT_MAP.get(connection);
+        if (null == result) {
+            result = CONNECTION_SAVEPOINT_MAP.computeIfAbsent(connection, unused -> new LinkedHashMap<>());
+        }
+        return result;
     }
     
     /**

--- a/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/PostgreSQLPortalContextRegistry.java
+++ b/proxy/frontend/dialect/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/PostgreSQLPortalContextRegistry.java
@@ -49,7 +49,11 @@ public final class PostgreSQLPortalContextRegistry {
      * @return PostgreSQL portal context
      */
     public PortalContext get(final int connectionId) {
-        return portalContexts.computeIfAbsent(connectionId, unused -> new PortalContext());
+        PortalContext result = portalContexts.get(connectionId);
+        if (null == result) {
+            result = portalContexts.computeIfAbsent(connectionId, unused -> new PortalContext());
+        }
+        return result;
     }
     
     /**


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Add pre get to avoid ConcurrentHashMap#computeIfAbsent performance problem in JDK 8

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
