### PR TITLE
preserve the case of the rule name when drop encrypt rule

### DIFF
--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/DropEncryptRuleExecutor.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/DropEncryptRuleExecutor.java
@@ -70,8 +70,11 @@ public final class DropEncryptRuleExecutor implements DatabaseRuleDropExecutor<D
         Collection<EncryptTableRuleConfiguration> toBeDroppedTables = new LinkedList<>();
         Map<String, AlgorithmConfiguration> toBeDroppedEncryptors = new HashMap<>(sqlStatement.getTables().size(), 1F);
         for (String each : sqlStatement.getTables()) {
-            toBeDroppedTables.add(new EncryptTableRuleConfiguration(each, Collections.emptyList()));
-            dropRule(each);
+            Optional<EncryptTableRuleConfiguration> tableRuleConfig = rule.getConfiguration().getTables().stream().filter(optional -> optional.getName().equalsIgnoreCase(each)).findFirst();
+            if (tableRuleConfig.isPresent()) {
+                toBeDroppedTables.add(new EncryptTableRuleConfiguration(tableRuleConfig.get().getName(), Collections.emptyList()));
+                dropRule(tableRuleConfig.get().getName());
+            }
         }
         UnusedAlgorithmFinder.findUnusedEncryptor(rule.getConfiguration()).forEach(each -> toBeDroppedEncryptors.put(each, rule.getConfiguration().getEncryptors().get(each)));
         return new EncryptRuleConfiguration(toBeDroppedTables, toBeDroppedEncryptors);

--- a/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/DropEncryptRuleExecutorTest.java
+++ b/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/DropEncryptRuleExecutorTest.java
@@ -74,6 +74,18 @@ class DropEncryptRuleExecutorTest {
         metaDataManagerPersistService.alterRuleConfiguration(any(), ArgumentMatchers.argThat(this::assertRuleConfiguration));
     }
     
+    @Test
+    void assertBuildToBeDroppedRuleConfigurationUsesOriginalCaseTableName() {
+        EncryptRuleConfiguration ruleConfig = createCurrentRuleConfigurationWithCaseSensitiveTableName();
+        EncryptRule rule = mock(EncryptRule.class);
+        when(rule.getConfiguration()).thenReturn(ruleConfig);
+        DropEncryptRuleExecutor executor = new DropEncryptRuleExecutor();
+        executor.setRule(rule);
+        EncryptRuleConfiguration actual = executor.buildToBeDroppedRuleConfiguration(createSQLStatement("T_ENCRYPT"));
+        assertThat(actual.getTables().size(), is(1));
+        assertThat(actual.getTables().iterator().next().getName(), is("t_Encrypt"));
+    }
+    
     private boolean assertRuleConfiguration(final EncryptRuleConfiguration actual) {
         assertThat(actual.getTables().size(), is(1));
         assertThat(actual.getEncryptors().size(), is(3));
@@ -136,6 +148,13 @@ class DropEncryptRuleExecutorTest {
         Map<String, AlgorithmConfiguration> encryptors = Collections.singletonMap("t_encrypt_user_id_MD5", new AlgorithmConfiguration("TEST", new Properties()));
         return new EncryptRuleConfiguration(new LinkedList<>(Arrays.asList(tableRuleConfig,
                 new EncryptTableRuleConfiguration("t_encrypt_another", Collections.singleton(columnRuleConfig)))), encryptors);
+    }
+    
+    private EncryptRuleConfiguration createCurrentRuleConfigurationWithCaseSensitiveTableName() {
+        EncryptColumnRuleConfiguration columnRuleConfig = new EncryptColumnRuleConfiguration("user_id", new EncryptColumnItemRuleConfiguration("user_cipher", "t_encrypt_user_id_MD5"));
+        EncryptTableRuleConfiguration tableRuleConfig = new EncryptTableRuleConfiguration("t_Encrypt", Collections.singleton(columnRuleConfig));
+        Map<String, AlgorithmConfiguration> encryptors = Collections.singletonMap("t_encrypt_user_id_MD5", new AlgorithmConfiguration("TEST", new Properties()));
+        return new EncryptRuleConfiguration(new LinkedList<>(Collections.singleton(tableRuleConfig)), encryptors);
     }
     
     private ContextManager mockContextManager(final EncryptRule rule) {


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - preserve the case of the rule name when drop encrypt rule

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
