### PR TITLE
Make ProxyConfigurationLoader compatible with classless runtime environments

### DIFF
--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
@@ -100,6 +100,9 @@ public final class ProxyConfigurationLoader {
         if (result.exists()) {
             return result;
         }
+        if (result.isAbsolute() && null != result.getParentFile() && result.getParentFile().exists()) {
+            return result;
+        }
         URL url = ProxyConfigurationLoader.class.getResource(path);
         return null == url ? result : new File(url.toURI());
     }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
@@ -90,17 +90,21 @@ public final class ProxyConfigurationLoader {
     }
     
     private static File getGlobalConfigFile(final String path) {
-        File result = getResourceFile(String.join("/", path, GLOBAL_CONFIG_FILE));
-        return result.exists() ? result : getResourceFile(String.join("/", path, COMPATIBLE_GLOBAL_CONFIG_FILE));
+        File globalFile = new File(path, GLOBAL_CONFIG_FILE);
+        if (globalFile.exists()) {
+            return globalFile;
+        }
+        File compatibleFile = new File(path, COMPATIBLE_GLOBAL_CONFIG_FILE);
+        if (compatibleFile.exists()) {
+            return compatibleFile;
+        }
+        return getResourceFile(String.join("/", path, GLOBAL_CONFIG_FILE));
     }
     
     @SneakyThrows(URISyntaxException.class)
     private static File getResourceFile(final String path) {
         File result = new File(path);
         if (result.exists()) {
-            return result;
-        }
-        if (result.isAbsolute() && null != result.getParentFile() && result.getParentFile().exists()) {
             return result;
         }
         URL url = ProxyConfigurationLoader.class.getResource(path);

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
@@ -98,7 +98,11 @@ public final class ProxyConfigurationLoader {
         if (compatibleFile.exists()) {
             return compatibleFile;
         }
-        return getResourceFile(String.join("/", path, GLOBAL_CONFIG_FILE));
+        File classpathGlobal = getResourceFile(String.join("/", path, GLOBAL_CONFIG_FILE));
+        if (classpathGlobal.exists()) {
+            return classpathGlobal;
+        }
+        return getResourceFile(String.join("/", path, COMPATIBLE_GLOBAL_CONFIG_FILE));
     }
     
     @SneakyThrows(URISyntaxException.class)

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
@@ -96,8 +96,12 @@ public final class ProxyConfigurationLoader {
     
     @SneakyThrows(URISyntaxException.class)
     private static File getResourceFile(final String path) {
+        File result = new File(path);
+        if (result.exists()) {
+            return result;
+        }
         URL url = ProxyConfigurationLoader.class.getResource(path);
-        return null == url ? new File(path) : new File(url.toURI().getPath());
+        return null == url ? result : new File(url.toURI());
     }
     
     private static YamlProxyServerConfiguration loadServerConfiguration(final File yamlFile) throws IOException {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoaderTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoaderTest.java
@@ -173,6 +173,15 @@ class ProxyConfigurationLoaderTest {
         assertTrue(actual.getDatabaseConfigurations().isEmpty());
     }
     
+    @Test
+    void assertLoadFromClasspathWhenFilesystemParentExistsButTargetDoesNot(@TempDir final Path tempDir) throws IOException {
+        Path parentDir = tempDir.resolve("conf");
+        Files.createDirectories(parentDir);
+        YamlProxyConfiguration actual = ProxyConfigurationLoader.load("/conf/config_loader/");
+        assertNotNull(actual.getServerConfiguration());
+        assertThat(actual.getDatabaseConfigurations().size(), is(3));
+    }
+    
     private void assertShardingRuleConfiguration(final YamlProxyDatabaseConfiguration actual) {
         assertThat(actual.getDatabaseName(), is("sharding_db"));
         assertThat(actual.getDataSources().size(), is(2));

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoaderTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoaderTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -61,8 +60,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mockStatic;
-
-import org.mockito.internal.configuration.plugins.Plugins;
 
 class ProxyConfigurationLoaderTest {
     
@@ -156,25 +153,24 @@ class ProxyConfigurationLoaderTest {
     }
     
     @Test
-    void assertGetResourceFileWithFilesystemPath(@TempDir final Path tempDir) throws Exception {
-        Files.write(tempDir.resolve("global.yaml"), Collections.singletonList(""));
-        File actual = (File) Plugins.getMemberAccessor().invoke(ProxyConfigurationLoader.class.getDeclaredMethod("getResourceFile", String.class), null, tempDir.toString());
-        assertTrue(actual.exists());
-        assertThat(actual.getPath(), is(tempDir.toString()));
+    void assertLoadWithFilesystemPath(@TempDir final Path tempDir) throws IOException {
+        writeConfigurationFile(tempDir, "global.yaml", "");
+        YamlProxyConfiguration actual = ProxyConfigurationLoader.load(tempDir.toString());
+        assertNotNull(actual.getServerConfiguration());
+        assertTrue(actual.getServerConfiguration().getRules().isEmpty());
+        assertTrue(actual.getDatabaseConfigurations().isEmpty());
     }
     
     @Test
-    void assertGetResourceFileWithClasspathResource() throws Exception {
-        File actual = (File) Plugins.getMemberAccessor().invoke(ProxyConfigurationLoader.class.getDeclaredMethod("getResourceFile", String.class), null, "/conf/empty/");
-        assertTrue(actual.exists());
-        assertTrue(actual.isDirectory());
-    }
-    
-    @Test
-    void assertGetResourceFileWithNonExistentPath() throws Exception {
-        File actual = (File) Plugins.getMemberAccessor().invoke(ProxyConfigurationLoader.class.getDeclaredMethod("getResourceFile", String.class), null, "/non/existent/path/");
-        assertFalse(actual.exists());
-        assertThat(actual.getPath(), is("/non/existent/path"));
+    void assertLoadWithCompatibleServerYamlOnly(@TempDir final Path tempDir) throws IOException {
+        writeConfigurationFile(tempDir, "server.yaml", "authority:\n"
+                + "  users:\n"
+                + "    - user: root\n"
+                + "      password: root\n");
+        YamlProxyConfiguration actual = ProxyConfigurationLoader.load(tempDir.toString());
+        assertNotNull(actual.getServerConfiguration());
+        assertFalse(actual.getServerConfiguration().getRules().isEmpty());
+        assertTrue(actual.getDatabaseConfigurations().isEmpty());
     }
     
     private void assertShardingRuleConfiguration(final YamlProxyDatabaseConfiguration actual) {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoaderTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoaderTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -60,6 +61,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mockStatic;
+
+import org.mockito.internal.configuration.plugins.Plugins;
 
 class ProxyConfigurationLoaderTest {
     
@@ -150,6 +153,28 @@ class ProxyConfigurationLoaderTest {
             IllegalStateException actual = assertThrows(IllegalStateException.class, () -> ProxyConfigurationLoader.load(tempDir.toString()));
             assertThat(actual.getMessage(), is("Not find rule tag name of class class " + MockedRuleConfiguration.class.getName()));
         }
+    }
+    
+    @Test
+    void assertGetResourceFileWithFilesystemPath(@TempDir final Path tempDir) throws Exception {
+        Files.write(tempDir.resolve("global.yaml"), Collections.singletonList(""));
+        File actual = (File) Plugins.getMemberAccessor().invoke(ProxyConfigurationLoader.class.getDeclaredMethod("getResourceFile", String.class), null, tempDir.toString());
+        assertTrue(actual.exists());
+        assertThat(actual.getPath(), is(tempDir.toString()));
+    }
+    
+    @Test
+    void assertGetResourceFileWithClasspathResource() throws Exception {
+        File actual = (File) Plugins.getMemberAccessor().invoke(ProxyConfigurationLoader.class.getDeclaredMethod("getResourceFile", String.class), null, "/conf/empty/");
+        assertTrue(actual.exists());
+        assertTrue(actual.isDirectory());
+    }
+    
+    @Test
+    void assertGetResourceFileWithNonExistentPath() throws Exception {
+        File actual = (File) Plugins.getMemberAccessor().invoke(ProxyConfigurationLoader.class.getDeclaredMethod("getResourceFile", String.class), null, "/non/existent/path/");
+        assertFalse(actual.exists());
+        assertThat(actual.getPath(), is("/non/existent/path"));
     }
     
     private void assertShardingRuleConfiguration(final YamlProxyDatabaseConfiguration actual) {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoaderTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoaderTest.java
@@ -174,12 +174,18 @@ class ProxyConfigurationLoaderTest {
     }
     
     @Test
-    void assertLoadFromClasspathWhenFilesystemParentExistsButTargetDoesNot(@TempDir final Path tempDir) throws IOException {
-        Path parentDir = tempDir.resolve("conf");
-        Files.createDirectories(parentDir);
+    void assertLoadFromClasspathWhenPathDoesNotExistOnFilesystem() throws IOException {
         YamlProxyConfiguration actual = ProxyConfigurationLoader.load("/conf/config_loader/");
         assertNotNull(actual.getServerConfiguration());
         assertThat(actual.getDatabaseConfigurations().size(), is(3));
+    }
+    
+    @Test
+    void assertLoadFromClasspathWithCompatibleServerYaml() throws IOException {
+        YamlProxyConfiguration actual = ProxyConfigurationLoader.load("/conf/compatible_server_yaml/");
+        assertNotNull(actual.getServerConfiguration());
+        assertFalse(actual.getServerConfiguration().getRules().isEmpty());
+        assertTrue(actual.getDatabaseConfigurations().isEmpty());
     }
     
     private void assertShardingRuleConfiguration(final YamlProxyDatabaseConfiguration actual) {

--- a/proxy/backend/core/src/test/resources/conf/compatible_server_yaml/server.yaml
+++ b/proxy/backend/core/src/test/resources/conf/compatible_server_yaml/server.yaml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+authority:
+  users:
+    - user: root
+      password: root
+      admin: true
+  privilege:
+    type: ALL_PERMITTED
+
+props:
+  max-connections-size-per-query: 1
+  sql-show: false


### PR DESCRIPTION
For #38682 .

Changes proposed in this pull request:
  - Make ProxyConfigurationLoader compatible with classless runtime environments. Split from https://github.com/apache/shardingsphere/pull/38682 .
  - Previously, the test class `org.apache.shardingsphere.test.natived.proxy.databases.**` passed the absolute file system path to `org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader`. `org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader` first resolved the path using the classpath, causing the GraalVM native image to encounter abnormal paths during resource matching. Now, `org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader` first checks the file system path and then falls back to the classpath, avoiding passing absolute path errors to `java.lang.Class#getResource(java.lang.String)`. This is the root cause change that fixed the CompressedGlobTrie in the GraalVM native image. 
    - As for why GraalVM CE for JDK 24.0.2 did not trigger this problem, but GraalVM CE for JDK 25.0.2 did, see https://github.com/oracle/graal/commit/3bdd5776363d43d5bc951a502006df257ef5ccae , https://github.com/oracle/graal/commit/c98c972629ae1250d3763628e56d30ad1550b347 , https://github.com/oracle/graal/pull/11553 , https://github.com/oracle/graal/pull/11822 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
