### PR TITLE
Update the outdated HiveServer2 doc regarding third-party dependencies

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/hiveserver2/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/hiveserver2/_index.cn.md
@@ -55,10 +55,6 @@ ShardingSphere 对 HiveServer2 JDBC Driver 的支持位于可选模块中。
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>
             </exclusion>
-            <exclusion>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-text</artifactId>
-            </exclusion>
         </exclusions>
     </dependency>
 </dependencies>

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/hiveserver2/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/hiveserver2/_index.en.md
@@ -57,10 +57,6 @@ The following is an example of a possible configuration,
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>
             </exclusion>
-            <exclusion>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-text</artifactId>
-            </exclusion>
         </exclusions>
     </dependency>
 </dependencies>

--- a/test/native/pom.xml
+++ b/test/native/pom.xml
@@ -119,10 +119,6 @@
                     <groupId>com.fasterxml.woodstox</groupId>
                     <artifactId>woodstox-core</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-text</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         


### PR DESCRIPTION
For #38682 .

Changes proposed in this pull request:
  - Update the outdated HiveServer2 doc regarding third-party dependencies. Split from https://github.com/apache/shardingsphere/pull/38682 .
  - My review in IntelliJ IDEA shows that the dependency conflict for `org.apache.commons:commons-text` no longer exists, so there is no need to explicitly exclude `org.apache.commons:commons-text` in pom.xml and documentation.
  - <img width="2880" height="1708" alt="image" src="https://github.com/user-attachments/assets/89fdfaad-d6a3-4748-9687-fc6d010e0112" />


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
