### PR TITLE
Support SqlServer update statement for Specifying a table alias as the target object when use encrypt feature

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,6 +39,7 @@
 1. SQL Binder: Support SQL bind when with temp table name is same with physical table - [#38411](https://github.com/apache/shardingsphere/pull/38411)
 1. JDBC: Support setMaxRows and getMaxRows method in jdbc when not execute SQL - [#38337](https://github.com/apache/shardingsphere/pull/38337)
 1. JDBC: Support safe close statement manager - [#38473](https://github.com/apache/shardingsphere/pull/38473)
+1. Encrypt: Support SqlServer update statement for Specifying a table alias as the target object when use encrypt feature - [#38733](https://github.com/apache/shardingsphere/pull/38733)
 1. Sharding: Fix HASH_MOD routing mismatch for same negative numeric values across numeric Java types with compatibility switch `normalize-numeric-int-range` - [#38327](https://github.com/apache/shardingsphere/pull/38327)
 1. Proxy: Support non column projection for MySQL prepared statement in Proxy - [#38507](https://github.com/apache/shardingsphere/pull/38507)
 1. Proxy: Support driverClassName config in proxy storage unit to solve mysql and mariadb jdbc url conflict - [#38582](https://github.com/apache/shardingsphere/pull/38582)

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/context/TableSegmentBinderContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/context/TableSegmentBinderContext.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context;
 
 import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.OwnerSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
 import java.util.Collection;
@@ -57,6 +58,15 @@ public interface TableSegmentBinderContext {
      * @return original table name
      */
     default Optional<IdentifierValue> getOriginalTableName() {
+        return Optional.empty();
+    }
+    
+    /**
+     * Get original owner.
+     *
+     * @return original owner segment
+     */
+    default Optional<OwnerSegment> getOriginalOwner() {
         return Optional.empty();
     }
 }

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/context/TableSegmentBinderContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/context/TableSegmentBinderContext.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context;
 
 import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -49,4 +50,13 @@ public interface TableSegmentBinderContext {
      * @return table source type
      */
     TableSourceType getTableSourceType();
+    
+    /**
+     * Get original table name.
+     *
+     * @return original table name
+     */
+    default Optional<IdentifierValue> getOriginalTableName() {
+        return Optional.empty();
+    }
 }

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/context/type/SimpleTableSegmentBinderContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/context/type/SimpleTableSegmentBinderContext.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context.Ta
 import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ShorthandProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
 import java.util.Collection;
 import java.util.Map;
@@ -44,6 +45,8 @@ public final class SimpleTableSegmentBinderContext implements TableSegmentBinder
     
     private final TableSourceType tableSourceType;
     
+    private IdentifierValue originalTableName;
+    
     private boolean fromWithSegment;
     
     private boolean containsDBLink;
@@ -52,6 +55,11 @@ public final class SimpleTableSegmentBinderContext implements TableSegmentBinder
         columnLabelProjectionSegments = new CaseInsensitiveMap<>(projectionSegments.size(), 1F);
         projectionSegments.forEach(each -> putColumnLabelProjectionSegments(each, columnLabelProjectionSegments));
         this.tableSourceType = tableSourceType;
+    }
+    
+    public SimpleTableSegmentBinderContext(final Collection<ProjectionSegment> projectionSegments, final TableSourceType tableSourceType, final IdentifierValue originalTableName) {
+        this(projectionSegments, tableSourceType);
+        this.originalTableName = originalTableName;
     }
     
     private void putColumnLabelProjectionSegments(final ProjectionSegment projectionSegment, final Map<String, ProjectionSegment> columnLabelProjectionSegments) {
@@ -70,5 +78,10 @@ public final class SimpleTableSegmentBinderContext implements TableSegmentBinder
     @Override
     public Collection<ProjectionSegment> getProjectionSegments() {
         return columnLabelProjectionSegments.values();
+    }
+    
+    @Override
+    public Optional<IdentifierValue> getOriginalTableName() {
+        return Optional.ofNullable(originalTableName);
     }
 }

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/context/type/SimpleTableSegmentBinderContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/context/type/SimpleTableSegmentBinderContext.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.infra.binder.engine.segment.dml.from.context.Ta
 import org.apache.shardingsphere.sql.parser.statement.core.enums.TableSourceType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ShorthandProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.OwnerSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
 import java.util.Collection;
@@ -46,6 +47,8 @@ public final class SimpleTableSegmentBinderContext implements TableSegmentBinder
     private final TableSourceType tableSourceType;
     
     private IdentifierValue originalTableName;
+    
+    private OwnerSegment originalOwner;
     
     private boolean fromWithSegment;
     
@@ -83,5 +86,10 @@ public final class SimpleTableSegmentBinderContext implements TableSegmentBinder
     @Override
     public Optional<IdentifierValue> getOriginalTableName() {
         return Optional.ofNullable(originalTableName);
+    }
+    
+    @Override
+    public Optional<OwnerSegment> getOriginalOwner() {
+        return Optional.ofNullable(originalOwner);
     }
 }

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/type/SimpleTableSegmentBinder.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/type/SimpleTableSegmentBinder.java
@@ -50,6 +50,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.table.Ren
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ColumnProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.AliasSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.OwnerSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.PivotSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.ColumnSegmentBoundInfo;
@@ -158,7 +159,7 @@ public final class SimpleTableSegmentBinder {
         if (!updateStatement.getFrom().isPresent()) {
             return false;
         }
-        if (!isSupportUpdateTargetTableAlias(binderContext)) {
+        if (!updateStatement.isTargetTableIsFromAlias()) {
             return false;
         }
         if (!(updateStatement.getTable() instanceof SimpleTableSegment)) {
@@ -173,18 +174,16 @@ public final class SimpleTableSegmentBinder {
         return tableBinderContexts.containsKey(CaseInsensitiveString.of(tableNameValue));
     }
     
-    private static boolean isSupportUpdateTargetTableAlias(final SQLStatementBinderContext binderContext) {
-        return "SQLServer".equalsIgnoreCase(binderContext.getSqlStatement().getDatabaseType().getType());
-    }
-    
     private static SimpleTableSegment bindUpdateTargetTableAlias(final SimpleTableSegment segment, final SQLStatementBinderContext binderContext,
                                                                  final Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts, final IdentifierValue databaseName,
                                                                  final Optional<IdentifierValue> schemaName, final IdentifierValue tableName) {
-        TableNameSegment tableNameSegment = new TableNameSegment(segment.getTableName().getStartIndex(), segment.getTableName().getStopIndex(), tableName);
+        IdentifierValue originalTableName = tableBinderContexts.get(CaseInsensitiveString.of(tableName.getValue())).stream()
+                .map(TableSegmentBinderContext::getOriginalTableName).filter(Optional::isPresent).map(Optional::get).findFirst().orElse(tableName);
+        TableNameSegment tableNameSegment = new TableNameSegment(segment.getTableName().getStartIndex(), segment.getTableName().getStopIndex(), originalTableName);
         tableNameSegment.setTableBoundInfo(new TableSegmentBoundInfo(databaseName, schemaName.orElse(null)));
         SimpleTableSegment result = new SimpleTableSegment(tableNameSegment);
         segment.getOwner().ifPresent(result::setOwner);
-        segment.getAliasSegment().ifPresent(result::setAlias);
+        result.setAlias(segment.getAliasSegment().orElseGet(() -> new AliasSegment(segment.getTableName().getStartIndex(), segment.getTableName().getStopIndex(), tableName)));
         return result;
     }
     
@@ -358,7 +357,7 @@ public final class SimpleTableSegmentBinder {
             columnProjectionSegment.setVisible(each.isVisible());
             projectionSegments.add(columnProjectionSegment);
         }
-        return Optional.of(new SimpleTableSegmentBinderContext(projectionSegments, TableSourceType.PHYSICAL_TABLE));
+        return Optional.of(new SimpleTableSegmentBinderContext(projectionSegments, TableSourceType.PHYSICAL_TABLE, tableName));
     }
     
     private static ColumnSegment createColumnSegment(final SimpleTableSegment segment, final IdentifierValue databaseName, final IdentifierValue schemaName,

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/type/SimpleTableSegmentBinder.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/type/SimpleTableSegmentBinder.java
@@ -177,12 +177,16 @@ public final class SimpleTableSegmentBinder {
     private static SimpleTableSegment bindUpdateTargetTableAlias(final SimpleTableSegment segment, final SQLStatementBinderContext binderContext,
                                                                  final Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts, final IdentifierValue databaseName,
                                                                  final Optional<IdentifierValue> schemaName, final IdentifierValue tableName) {
-        IdentifierValue originalTableName = tableBinderContexts.get(CaseInsensitiveString.of(tableName.getValue())).stream()
+        Collection<TableSegmentBinderContext> fromTableContexts = tableBinderContexts.get(CaseInsensitiveString.of(tableName.getValue()));
+        IdentifierValue originalTableName = fromTableContexts.stream()
                 .map(TableSegmentBinderContext::getOriginalTableName).filter(Optional::isPresent).map(Optional::get).findFirst().orElse(tableName);
+        Optional<OwnerSegment> fromTableOwner = fromTableContexts.stream()
+                .map(TableSegmentBinderContext::getOriginalOwner).filter(Optional::isPresent).map(Optional::get).findFirst();
+        IdentifierValue resolvedSchemaName = fromTableOwner.map(OwnerSegment::getIdentifier).orElseGet(() -> schemaName.orElse(null));
         TableNameSegment tableNameSegment = new TableNameSegment(segment.getTableName().getStartIndex(), segment.getTableName().getStopIndex(), originalTableName);
-        tableNameSegment.setTableBoundInfo(new TableSegmentBoundInfo(databaseName, schemaName.orElse(null)));
+        tableNameSegment.setTableBoundInfo(new TableSegmentBoundInfo(databaseName, resolvedSchemaName));
         SimpleTableSegment result = new SimpleTableSegment(tableNameSegment);
-        segment.getOwner().ifPresent(result::setOwner);
+        fromTableOwner.ifPresent(result::setOwner);
         result.setAlias(segment.getAliasSegment().orElseGet(() -> new AliasSegment(segment.getTableName().getStartIndex(), segment.getTableName().getStopIndex(), tableName)));
         return result;
     }
@@ -357,7 +361,9 @@ public final class SimpleTableSegmentBinder {
             columnProjectionSegment.setVisible(each.isVisible());
             projectionSegments.add(columnProjectionSegment);
         }
-        return Optional.of(new SimpleTableSegmentBinderContext(projectionSegments, TableSourceType.PHYSICAL_TABLE, tableName));
+        SimpleTableSegmentBinderContext result = new SimpleTableSegmentBinderContext(projectionSegments, TableSourceType.PHYSICAL_TABLE, tableName);
+        segment.getOwner().ifPresent(result::setOriginalOwner);
+        return Optional.of(result);
     }
     
     private static ColumnSegment createColumnSegment(final SimpleTableSegment segment, final IdentifierValue databaseName, final IdentifierValue schemaName,

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/type/SimpleTableSegmentBinder.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/type/SimpleTableSegmentBinder.java
@@ -158,6 +158,9 @@ public final class SimpleTableSegmentBinder {
         if (!updateStatement.getFrom().isPresent()) {
             return false;
         }
+        if (!isSupportUpdateTargetTableAlias(binderContext)) {
+            return false;
+        }
         if (!(updateStatement.getTable() instanceof SimpleTableSegment)) {
             return false;
         }
@@ -168,6 +171,10 @@ public final class SimpleTableSegmentBinder {
             return false;
         }
         return tableBinderContexts.containsKey(CaseInsensitiveString.of(tableNameValue));
+    }
+    
+    private static boolean isSupportUpdateTargetTableAlias(final SQLStatementBinderContext binderContext) {
+        return "SQLServer".equalsIgnoreCase(binderContext.getSqlStatement().getDatabaseType().getType());
     }
     
     private static SimpleTableSegment bindUpdateTargetTableAlias(final SimpleTableSegment segment, final SQLStatementBinderContext binderContext,

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/type/SimpleTableSegmentBinder.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/segment/dml/from/type/SimpleTableSegmentBinder.java
@@ -65,6 +65,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.ta
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.view.AlterViewStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.view.CreateViewStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.view.DropViewStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.UpdateStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
 import java.util.Collection;
@@ -93,7 +94,10 @@ public final class SimpleTableSegmentBinder {
         Optional<IdentifierValue> schemaName = getSchemaName(segment, binderContext, databaseName);
         IdentifierValue tableName = segment.getTableName().getIdentifier();
         Optional<ShardingSphereSchema> schema = schemaName.map(identifierValue -> binderContext.getMetaData().getDatabase(databaseName).getSchema(identifierValue));
-        checkTableExists(binderContext, schema.orElse(null), tableName, segment);
+        if (isUpdateTargetTableAlias(binderContext, tableBinderContexts, tableName.getValue(), segment)) {
+            return bindUpdateTargetTableAlias(segment, binderContext, tableBinderContexts, databaseName, schemaName, tableName);
+        }
+        checkTableExists(binderContext, schema.orElse(null), tableName, segment, tableBinderContexts);
         checkTableMetadata(binderContext, schema.orElse(null), schemaName.map(IdentifierValue::getValue).orElse(null), tableName);
         String tableAliasOrName = segment.getAliasName().orElseGet(tableName::getValue);
         Optional<SimpleTableSegmentBinderContext> tableBinderContext = createSimpleTableBinderContext(segment, schema.orElse(null), databaseName, schemaName.orElse(null), binderContext);
@@ -145,8 +149,44 @@ public final class SimpleTableSegmentBinder {
         return Optional.ofNullable(database.getDefaultSchemaName()).map(IdentifierValue::new);
     }
     
-    private static void checkTableExists(final SQLStatementBinderContext binderContext, final ShardingSphereSchema schema, final IdentifierValue tableName, final SimpleTableSegment segment) {
+    private static boolean isUpdateTargetTableAlias(final SQLStatementBinderContext binderContext, final Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts,
+                                                    final String tableNameValue, final SimpleTableSegment segment) {
+        if (!(binderContext.getSqlStatement() instanceof UpdateStatement)) {
+            return false;
+        }
+        UpdateStatement updateStatement = (UpdateStatement) binderContext.getSqlStatement();
+        if (!updateStatement.getFrom().isPresent()) {
+            return false;
+        }
+        if (!(updateStatement.getTable() instanceof SimpleTableSegment)) {
+            return false;
+        }
+        if (!((SimpleTableSegment) updateStatement.getTable()).getTableName().getIdentifier().getValue().equalsIgnoreCase(tableNameValue)) {
+            return false;
+        }
+        if (segment.getAliasName().isPresent()) {
+            return false;
+        }
+        return tableBinderContexts.containsKey(CaseInsensitiveString.of(tableNameValue));
+    }
+    
+    private static SimpleTableSegment bindUpdateTargetTableAlias(final SimpleTableSegment segment, final SQLStatementBinderContext binderContext,
+                                                                 final Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts, final IdentifierValue databaseName,
+                                                                 final Optional<IdentifierValue> schemaName, final IdentifierValue tableName) {
+        TableNameSegment tableNameSegment = new TableNameSegment(segment.getTableName().getStartIndex(), segment.getTableName().getStopIndex(), tableName);
+        tableNameSegment.setTableBoundInfo(new TableSegmentBoundInfo(databaseName, schemaName.orElse(null)));
+        SimpleTableSegment result = new SimpleTableSegment(tableNameSegment);
+        segment.getOwner().ifPresent(result::setOwner);
+        segment.getAliasSegment().ifPresent(result::setAlias);
+        return result;
+    }
+    
+    private static void checkTableExists(final SQLStatementBinderContext binderContext, final ShardingSphereSchema schema, final IdentifierValue tableName, final SimpleTableSegment segment,
+                                         final Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts) {
         String tableNameValue = tableName.getValue();
+        if (isUpdateTargetTableAlias(binderContext, tableBinderContexts, tableNameValue, segment)) {
+            return;
+        }
         // TODO refactor table exists check with spi @duanzhengqiang
         if (binderContext.getSqlStatement() instanceof CreateTableStatement && isCreateTable(((CreateTableStatement) binderContext.getSqlStatement()).getTable(), tableNameValue)) {
             ShardingSpherePreconditions.checkState(binderContext.getHintValueContext().isSkipMetadataValidate()

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/UpdateStatementBinder.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/UpdateStatementBinder.java
@@ -46,8 +46,8 @@ public final class UpdateStatementBinder implements SQLStatementBinder<UpdateSta
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> outerTableBinderContexts = LinkedHashMultimap.create();
         WithSegment boundWith = sqlStatement.getWith().map(optional -> WithSegmentBinder.bind(optional, binderContext, outerTableBinderContexts)).orElse(null);
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts = LinkedHashMultimap.create();
-        TableSegment boundTable = TableSegmentBinder.bind(sqlStatement.getTable(), binderContext, tableBinderContexts, outerTableBinderContexts);
         TableSegment boundFrom = sqlStatement.getFrom().map(optional -> TableSegmentBinder.bind(optional, binderContext, tableBinderContexts, outerTableBinderContexts)).orElse(null);
+        TableSegment boundTable = TableSegmentBinder.bind(sqlStatement.getTable(), binderContext, tableBinderContexts, outerTableBinderContexts);
         SetAssignmentSegment boundSetAssignment = sqlStatement.getAssignment()
                 .map(optional -> AssignmentSegmentBinder.bind(optional, binderContext, tableBinderContexts, outerTableBinderContexts)).orElse(null);
         WhereSegment boundWhere = sqlStatement.getWhere().map(optional -> WhereSegmentBinder.bind(optional, binderContext, tableBinderContexts, outerTableBinderContexts)).orElse(null);

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/UpdateStatementBinder.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/UpdateStatementBinder.java
@@ -48,7 +48,7 @@ public final class UpdateStatementBinder implements SQLStatementBinder<UpdateSta
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts = LinkedHashMultimap.create();
         TableSegment boundFrom;
         TableSegment boundTable;
-        if (isSQLServerUpdateFromAlias(sqlStatement)) {
+        if (sqlStatement.isTargetTableIsFromAlias()) {
             boundFrom = sqlStatement.getFrom().map(optional -> TableSegmentBinder.bind(optional, binderContext, tableBinderContexts, outerTableBinderContexts)).orElse(null);
             boundTable = TableSegmentBinder.bind(sqlStatement.getTable(), binderContext, tableBinderContexts, outerTableBinderContexts);
         } else {
@@ -63,14 +63,11 @@ public final class UpdateStatementBinder implements SQLStatementBinder<UpdateSta
         return copy(sqlStatement, boundWith, boundTable, boundFrom, boundSetAssignment, boundWhere, boundOrderBy);
     }
     
-    private boolean isSQLServerUpdateFromAlias(final UpdateStatement sqlStatement) {
-        return sqlStatement.getFrom().isPresent() && "SQLServer".equalsIgnoreCase(sqlStatement.getDatabaseType().getType());
-    }
-    
     private UpdateStatement copy(final UpdateStatement sqlStatement, final WithSegment boundWith, final TableSegment boundTable, final TableSegment boundFrom,
                                  final SetAssignmentSegment boundSetAssignment, final WhereSegment boundWhere, final OrderBySegment boundOrderBy) {
         UpdateStatement result = UpdateStatement.builder().databaseType(sqlStatement.getDatabaseType()).with(boundWith).table(boundTable)
-                .from(boundFrom).setAssignment(boundSetAssignment).where(boundWhere).orderBy(boundOrderBy).limit(sqlStatement.getLimit().orElse(null)).build();
+                .from(boundFrom).setAssignment(boundSetAssignment).where(boundWhere).orderBy(boundOrderBy).limit(sqlStatement.getLimit().orElse(null))
+                .targetTableIsFromAlias(sqlStatement.isTargetTableIsFromAlias()).build();
         SQLStatementCopyUtils.copyAttributes(sqlStatement, result);
         return result;
     }

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/UpdateStatementBinder.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/UpdateStatementBinder.java
@@ -46,14 +46,25 @@ public final class UpdateStatementBinder implements SQLStatementBinder<UpdateSta
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> outerTableBinderContexts = LinkedHashMultimap.create();
         WithSegment boundWith = sqlStatement.getWith().map(optional -> WithSegmentBinder.bind(optional, binderContext, outerTableBinderContexts)).orElse(null);
         Multimap<CaseInsensitiveString, TableSegmentBinderContext> tableBinderContexts = LinkedHashMultimap.create();
-        TableSegment boundFrom = sqlStatement.getFrom().map(optional -> TableSegmentBinder.bind(optional, binderContext, tableBinderContexts, outerTableBinderContexts)).orElse(null);
-        TableSegment boundTable = TableSegmentBinder.bind(sqlStatement.getTable(), binderContext, tableBinderContexts, outerTableBinderContexts);
+        TableSegment boundFrom;
+        TableSegment boundTable;
+        if (isSQLServerUpdateFromAlias(sqlStatement)) {
+            boundFrom = sqlStatement.getFrom().map(optional -> TableSegmentBinder.bind(optional, binderContext, tableBinderContexts, outerTableBinderContexts)).orElse(null);
+            boundTable = TableSegmentBinder.bind(sqlStatement.getTable(), binderContext, tableBinderContexts, outerTableBinderContexts);
+        } else {
+            boundTable = TableSegmentBinder.bind(sqlStatement.getTable(), binderContext, tableBinderContexts, outerTableBinderContexts);
+            boundFrom = sqlStatement.getFrom().map(optional -> TableSegmentBinder.bind(optional, binderContext, tableBinderContexts, outerTableBinderContexts)).orElse(null);
+        }
         SetAssignmentSegment boundSetAssignment = sqlStatement.getAssignment()
                 .map(optional -> AssignmentSegmentBinder.bind(optional, binderContext, tableBinderContexts, outerTableBinderContexts)).orElse(null);
         WhereSegment boundWhere = sqlStatement.getWhere().map(optional -> WhereSegmentBinder.bind(optional, binderContext, tableBinderContexts, outerTableBinderContexts)).orElse(null);
         OrderBySegment boundOrderBy = sqlStatement.getOrderBy()
                 .map(optional -> OrderBySegmentBinder.bind(optional, binderContext, tableBinderContexts, tableBinderContexts, outerTableBinderContexts)).orElse(null);
         return copy(sqlStatement, boundWith, boundTable, boundFrom, boundSetAssignment, boundWhere, boundOrderBy);
+    }
+    
+    private boolean isSQLServerUpdateFromAlias(final UpdateStatement sqlStatement) {
+        return sqlStatement.getFrom().isPresent() && "SQLServer".equalsIgnoreCase(sqlStatement.getDatabaseType().getType());
     }
     
     private UpdateStatement copy(final UpdateStatement sqlStatement, final WithSegment boundWith, final TableSegment boundTable, final TableSegment boundFrom,

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/UpdateStatementContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/UpdateStatementContextTest.java
@@ -45,7 +45,6 @@ import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -80,8 +79,6 @@ class UpdateStatementContextTest {
     
     @Test
     void assertGetTableNamesWithSQLServerUpdateAliasTargetExcludesAlias() {
-        DatabaseType sqlServerType = mock(DatabaseType.class);
-        when(sqlServerType.getType()).thenReturn("SQLServer");
         SimpleTableSegment scrapReason = new SimpleTableSegment(new TableNameSegment(50, 65, new IdentifierValue("ScrapReason")));
         scrapReason.setAlias(new AliasSegment(67, 68, new IdentifierValue("sr")));
         SimpleTableSegment workOrder = new SimpleTableSegment(new TableNameSegment(75, 83, new IdentifierValue("WorkOrder")));
@@ -91,7 +88,8 @@ class UpdateStatementContextTest {
         joinTable.setRight(workOrder);
         SimpleTableSegment aliasTarget = new SimpleTableSegment(new TableNameSegment(7, 8, new IdentifierValue("sr")));
         UpdateStatement updateStatement = UpdateStatement.builder()
-                .databaseType(sqlServerType).table(aliasTarget).from(joinTable).setAssignment(new SetAssignmentSegment(0, 0, Collections.emptyList())).build();
+                .databaseType(databaseType).table(aliasTarget).from(joinTable).setAssignment(new SetAssignmentSegment(0, 0, Collections.emptyList()))
+                .targetTableIsFromAlias(true).build();
         UpdateStatementContext actual = new UpdateStatementContext(updateStatement);
         assertThat(actual.getTablesContext().getTableNames(), is(new HashSet<>(Arrays.asList("ScrapReason", "WorkOrder"))));
         assertFalse(actual.getTablesContext().getTableNames().contains("sr"));
@@ -99,14 +97,13 @@ class UpdateStatementContextTest {
     
     @Test
     void assertGetTableNamesWithPostgreSQLUpdateFromClauseIncludesTargetTable() {
-        DatabaseType postgresType = mock(DatabaseType.class);
-        when(postgresType.getType()).thenReturn("PostgreSQL");
         SimpleTableSegment targetTable = new SimpleTableSegment(new TableNameSegment(7, 18, new IdentifierValue("ScrapReason")));
         targetTable.setAlias(new AliasSegment(20, 21, new IdentifierValue("sr")));
         SimpleTableSegment fromTable = new SimpleTableSegment(new TableNameSegment(50, 58, new IdentifierValue("WorkOrder")));
         fromTable.setAlias(new AliasSegment(60, 61, new IdentifierValue("wo")));
         UpdateStatement updateStatement = UpdateStatement.builder()
-                .databaseType(postgresType).table(targetTable).from(fromTable).setAssignment(new SetAssignmentSegment(0, 0, Collections.emptyList())).build();
+                .databaseType(databaseType).table(targetTable).from(fromTable).setAssignment(new SetAssignmentSegment(0, 0, Collections.emptyList()))
+                .build();
         UpdateStatementContext actual = new UpdateStatementContext(updateStatement);
         assertThat(actual.getTablesContext().getTableNames(), is(new HashSet<>(Arrays.asList("ScrapReason", "WorkOrder"))));
         assertFalse(actual.getTablesContext().getTableNames().contains("sr"));

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/UpdateStatementContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/type/dml/UpdateStatementContextTest.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignmen
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.AliasSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.OwnerSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.bound.TableSegmentBoundInfo;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.JoinTableSegment;
@@ -43,6 +44,8 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -73,6 +76,40 @@ class UpdateStatementContextTest {
         assertThat(actual.getWhereSegments(), is(Collections.singletonList(whereSegment)));
         assertThat(actual.getTablesContext().getSimpleTables().stream().map(each -> each.getTableName().getIdentifier().getValue()).collect(Collectors.toList()),
                 is(Arrays.asList("tbl_1", "tbl_2", "tbl_2")));
+    }
+    
+    @Test
+    void assertGetTableNamesWithSQLServerUpdateAliasTargetExcludesAlias() {
+        DatabaseType sqlServerType = mock(DatabaseType.class);
+        when(sqlServerType.getType()).thenReturn("SQLServer");
+        SimpleTableSegment scrapReason = new SimpleTableSegment(new TableNameSegment(50, 65, new IdentifierValue("ScrapReason")));
+        scrapReason.setAlias(new AliasSegment(67, 68, new IdentifierValue("sr")));
+        SimpleTableSegment workOrder = new SimpleTableSegment(new TableNameSegment(75, 83, new IdentifierValue("WorkOrder")));
+        workOrder.setAlias(new AliasSegment(85, 86, new IdentifierValue("wo")));
+        JoinTableSegment joinTable = new JoinTableSegment();
+        joinTable.setLeft(scrapReason);
+        joinTable.setRight(workOrder);
+        SimpleTableSegment aliasTarget = new SimpleTableSegment(new TableNameSegment(7, 8, new IdentifierValue("sr")));
+        UpdateStatement updateStatement = UpdateStatement.builder()
+                .databaseType(sqlServerType).table(aliasTarget).from(joinTable).setAssignment(new SetAssignmentSegment(0, 0, Collections.emptyList())).build();
+        UpdateStatementContext actual = new UpdateStatementContext(updateStatement);
+        assertThat(actual.getTablesContext().getTableNames(), is(new HashSet<>(Arrays.asList("ScrapReason", "WorkOrder"))));
+        assertFalse(actual.getTablesContext().getTableNames().contains("sr"));
+    }
+    
+    @Test
+    void assertGetTableNamesWithPostgreSQLUpdateFromClauseIncludesTargetTable() {
+        DatabaseType postgresType = mock(DatabaseType.class);
+        when(postgresType.getType()).thenReturn("PostgreSQL");
+        SimpleTableSegment targetTable = new SimpleTableSegment(new TableNameSegment(7, 18, new IdentifierValue("ScrapReason")));
+        targetTable.setAlias(new AliasSegment(20, 21, new IdentifierValue("sr")));
+        SimpleTableSegment fromTable = new SimpleTableSegment(new TableNameSegment(50, 58, new IdentifierValue("WorkOrder")));
+        fromTable.setAlias(new AliasSegment(60, 61, new IdentifierValue("wo")));
+        UpdateStatement updateStatement = UpdateStatement.builder()
+                .databaseType(postgresType).table(targetTable).from(fromTable).setAssignment(new SetAssignmentSegment(0, 0, Collections.emptyList())).build();
+        UpdateStatementContext actual = new UpdateStatementContext(updateStatement);
+        assertThat(actual.getTablesContext().getTableNames(), is(new HashSet<>(Arrays.asList("ScrapReason", "WorkOrder"))));
+        assertFalse(actual.getTablesContext().getTableNames().contains("sr"));
     }
     
     private UpdateStatement createUpdateStatement(final TableNameSegment tableNameSegment1, final TableNameSegment tableNameSegment2) {

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/UpdateStatementBinderTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/UpdateStatementBinderTest.java
@@ -38,6 +38,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.Ord
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.order.item.ColumnOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.AliasSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.OwnerSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WithSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
@@ -125,6 +126,29 @@ class UpdateStatementBinderTest {
         assertThat(((SimpleTableSegment) actual.getTable()).getTableName().getIdentifier().getValue(), is("t_order"));
         assertThat(((SimpleTableSegment) actual.getTable()).getAliasName().get(), is("o"));
         assertThat(actualColumn.getColumnBoundInfo().getOriginalTable().getValue(), is("t_order"));
+        assertTrue(actual.isTargetTableIsFromAlias());
+    }
+    
+    @Test
+    void assertBindSchemaQualifiedUpdateTargetTableAlias() {
+        SimpleTableSegment targetTable = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("o")));
+        SimpleTableSegment fromTable = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")));
+        fromTable.setOwner(new OwnerSegment(0, 0, new IdentifierValue("foo_db")));
+        fromTable.setAlias(new AliasSegment(0, 0, new IdentifierValue("o")));
+        UpdateStatement updateStatement = UpdateStatement.builder()
+                .databaseType(databaseType)
+                .table(targetTable)
+                .from(fromTable)
+                .setAssignment(new SetAssignmentSegment(0, 0, Collections.singletonList(
+                        new ColumnAssignmentSegment(0, 0, Collections.singletonList(new ColumnSegment(0, 0, new IdentifierValue("status"))), new LiteralExpressionSegment(0, 0, 1)))))
+                .targetTableIsFromAlias(true)
+                .build();
+        UpdateStatement actual = new UpdateStatementBinder().bind(updateStatement,
+                new SQLStatementBinderContext(createMetaData(), "foo_db", new HintValueContext(), updateStatement));
+        assertThat(((SimpleTableSegment) actual.getTable()).getTableName().getIdentifier().getValue(), is("t_order"));
+        assertThat(((SimpleTableSegment) actual.getTable()).getAliasName().get(), is("o"));
+        assertTrue(((SimpleTableSegment) actual.getTable()).getOwner().isPresent());
+        assertThat(((SimpleTableSegment) actual.getTable()).getOwner().get().getIdentifier().getValue(), is("foo_db"));
         assertTrue(actual.isTargetTableIsFromAlias());
     }
     

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/UpdateStatementBinderTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/UpdateStatementBinderTest.java
@@ -104,6 +104,30 @@ class UpdateStatementBinderTest {
         assertThat(actualOrderByItem.getColumn().getColumnBoundInfo().getOriginalTable().getValue(), is("t_order"));
     }
     
+    @Test
+    void assertBindUpdateTargetTableAlias() {
+        SimpleTableSegment targetTable = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("o")));
+        SimpleTableSegment fromTable = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")));
+        fromTable.setAlias(new AliasSegment(0, 0, new IdentifierValue("o")));
+        ColumnSegment columnSegment = new ColumnSegment(0, 0, new IdentifierValue("status"));
+        UpdateStatement updateStatement = UpdateStatement.builder()
+                .databaseType(databaseType)
+                .table(targetTable)
+                .from(fromTable)
+                .setAssignment(new SetAssignmentSegment(0, 0, Collections.singletonList(
+                        new ColumnAssignmentSegment(0, 0, Collections.singletonList(columnSegment), new LiteralExpressionSegment(0, 0, 1)))))
+                .targetTableIsFromAlias(true)
+                .build();
+        UpdateStatement actual = new UpdateStatementBinder().bind(updateStatement,
+                new SQLStatementBinderContext(createMetaData(), "foo_db", new HintValueContext(), updateStatement));
+        ColumnSegment actualColumn = actual.getAssignment().get().getAssignments().iterator().next()
+                .getColumns().iterator().next();
+        assertThat(((SimpleTableSegment) actual.getTable()).getTableName().getIdentifier().getValue(), is("t_order"));
+        assertThat(((SimpleTableSegment) actual.getTable()).getAliasName().get(), is("o"));
+        assertThat(actualColumn.getColumnBoundInfo().getOriginalTable().getValue(), is("t_order"));
+        assertTrue(actual.isTargetTableIsFromAlias());
+    }
+    
     private WithSegment createWithSegment() {
         return new WithSegment(0, 0, new LinkedList<>(Collections.singletonList(
                 new CommonTableExpressionSegment(0, 0, new AliasSegment(0, 0, new IdentifierValue("combined_users")),

--- a/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/statement/type/UpdateStatementConverter.java
+++ b/kernel/sql-federation/compiler/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/statement/type/UpdateStatementConverter.java
@@ -58,6 +58,7 @@ public final class UpdateStatementConverter implements SQLStatementConverter<Upd
     }
     
     private SqlUpdate convertUpdate(final UpdateStatement updateStatement) {
+        checkResolvedTargetTable(updateStatement);
         SqlNode table = TableConverter.convert(updateStatement.getTable()).orElseThrow(IllegalStateException::new);
         SqlIdentifier alias = convertTableAlias(updateStatement);
         SqlNode condition = updateStatement.getWhere().flatMap(WhereConverter::convert).orElse(null);
@@ -68,6 +69,12 @@ public final class UpdateStatementConverter implements SQLStatementConverter<Upd
             expressions.add(ExpressionConverter.convert(each.getValue()).orElseThrow(IllegalStateException::new));
         }
         return new SqlUpdate(SqlParserPos.ZERO, getTargetTableName(table), columns, expressions, condition, null, alias);
+    }
+    
+    private void checkResolvedTargetTable(final UpdateStatement updateStatement) {
+        if (updateStatement.isTargetTableIsFromAlias() && !updateStatement.getTable().getAlias().isPresent()) {
+            throw new IllegalStateException("Update target table alias must be resolved before SQL Federation conversion.");
+        }
     }
     
     private SqlIdentifier convertTableAlias(final UpdateStatement updateStatement) {

--- a/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/statement/type/UpdateStatementConverterTest.java
+++ b/kernel/sql-federation/compiler/src/test/java/org/apache/shardingsphere/sqlfederation/compiler/sql/ast/converter/statement/type/UpdateStatementConverterTest.java
@@ -46,8 +46,10 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UpdateStatementConverterTest {
     
@@ -80,6 +82,35 @@ class UpdateStatementConverterTest {
         SqlOrderBy actual = (SqlOrderBy) new UpdateStatementConverter().convert(updateStatement);
         assertNull(actual.offset);
         assertNull(actual.fetch);
+    }
+    
+    @Test
+    void assertConvertWithResolvedTargetTableAlias() {
+        SimpleTableSegment tableSegment = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("ScrapReason")));
+        tableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("sr")));
+        UpdateStatement updateStatement = UpdateStatement.builder()
+                .databaseType(databaseType)
+                .table(tableSegment)
+                .setAssignment(createSetAssignmentSegment())
+                .where(new WhereSegment(0, 0, new ParameterMarkerExpressionSegment(0, 0, 0)))
+                .targetTableIsFromAlias(true)
+                .build();
+        SqlUpdate actual = (SqlUpdate) new UpdateStatementConverter().convert(updateStatement);
+        assertThat(((SqlIdentifier) actual.getTargetTable()).getSimple(), is("ScrapReason"));
+        assertThat(actual.getAlias().getSimple(), is("sr"));
+    }
+    
+    @Test
+    void assertConvertWithUnresolvedTargetTableAlias() {
+        SimpleTableSegment tableSegment = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("sr")));
+        UpdateStatement updateStatement = UpdateStatement.builder()
+                .databaseType(databaseType)
+                .table(tableSegment)
+                .setAssignment(createSetAssignmentSegment())
+                .where(new WhereSegment(0, 0, new ParameterMarkerExpressionSegment(0, 0, 0)))
+                .targetTableIsFromAlias(true)
+                .build();
+        assertThrows(IllegalStateException.class, () -> new UpdateStatementConverter().convert(updateStatement));
     }
     
     private UpdateStatement createUpdateStatement(final boolean withAlias, final OrderBySegment orderBy, final LimitSegment limit) {

--- a/parser/sql/engine/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/engine/sqlserver/visitor/statement/SQLServerStatementVisitor.java
+++ b/parser/sql/engine/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/engine/sqlserver/visitor/statement/SQLServerStatementVisitor.java
@@ -1702,10 +1702,13 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
         if (null != ctx.withClause()) {
             result.with((WithSegment) visit(ctx.withClause()));
         }
-        result.table((TableSegment) visit(ctx.tableReferences()));
+        TableSegment targetTable = (TableSegment) visit(ctx.tableReferences());
+        result.table(targetTable);
         result.setAssignment((SetAssignmentSegment) visit(ctx.setAssignmentsClause()));
+        TableSegment fromTable = null;
         if (null != ctx.fromClause()) {
-            result.from((TableSegment) visit(ctx.fromClause()));
+            fromTable = (TableSegment) visit(ctx.fromClause());
+            result.from(fromTable);
         }
         if (null != ctx.withTableHint()) {
             result.withTableHint((WithTableHintSegment) visit(ctx.withTableHint()));
@@ -1719,9 +1722,28 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
         if (null != ctx.outputClause()) {
             result.output((OutputSegment) visit(ctx.outputClause()));
         }
+        result.targetTableIsFromAlias(isTargetTableAliasInFromClause(targetTable, fromTable));
         UpdateStatement updateStatement = result.build();
         updateStatement.addParameterMarkers(getParameterMarkerSegments());
         return updateStatement;
+    }
+    
+    private boolean isTargetTableAliasInFromClause(final TableSegment targetTable, final TableSegment fromTable) {
+        if (null == fromTable || !(targetTable instanceof SimpleTableSegment)) {
+            return false;
+        }
+        String targetName = ((SimpleTableSegment) targetTable).getTableName().getIdentifier().getValue();
+        return isAliasInFromClause(targetName, fromTable);
+    }
+    
+    private boolean isAliasInFromClause(final String targetName, final TableSegment fromSegment) {
+        if (fromSegment instanceof SimpleTableSegment) {
+            return targetName.equalsIgnoreCase(((SimpleTableSegment) fromSegment).getAliasName().orElse(null));
+        }
+        if (fromSegment instanceof JoinTableSegment) {
+            return isAliasInFromClause(targetName, ((JoinTableSegment) fromSegment).getLeft()) || isAliasInFromClause(targetName, ((JoinTableSegment) fromSegment).getRight());
+        }
+        return false;
     }
     
     @Override

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/extractor/TableExtractor.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/extractor/TableExtractor.java
@@ -313,7 +313,7 @@ public final class TableExtractor {
      * @param updateStatement update statement.
      */
     public void extractTablesFromUpdate(final UpdateStatement updateStatement) {
-        if (!isUpdateTargetTableAlias(updateStatement)) {
+        if (!updateStatement.isTargetTableIsFromAlias()) {
             extractTablesFromTableSegment(updateStatement.getTable());
         }
         updateStatement.getFrom().ifPresent(this::extractTablesFromTableSegment);
@@ -321,27 +321,6 @@ public final class TableExtractor {
         if (updateStatement.getWhere().isPresent()) {
             extractTablesFromExpression(updateStatement.getWhere().get().getExpr());
         }
-    }
-    
-    private boolean isUpdateTargetTableAlias(final UpdateStatement updateStatement) {
-        if (!updateStatement.getFrom().isPresent() || !"SQLServer".equalsIgnoreCase(updateStatement.getDatabaseType().getType())) {
-            return false;
-        }
-        if (!(updateStatement.getTable() instanceof SimpleTableSegment)) {
-            return false;
-        }
-        String targetName = ((SimpleTableSegment) updateStatement.getTable()).getTableName().getIdentifier().getValue();
-        return isAliasInFromClause(targetName, updateStatement.getFrom().get());
-    }
-    
-    private boolean isAliasInFromClause(final String targetName, final TableSegment fromSegment) {
-        if (fromSegment instanceof SimpleTableSegment) {
-            return targetName.equalsIgnoreCase(((SimpleTableSegment) fromSegment).getAliasName().orElse(null));
-        }
-        if (fromSegment instanceof JoinTableSegment) {
-            return isAliasInFromClause(targetName, ((JoinTableSegment) fromSegment).getLeft()) || isAliasInFromClause(targetName, ((JoinTableSegment) fromSegment).getRight());
-        }
-        return false;
     }
     
     /**

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/extractor/TableExtractor.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/extractor/TableExtractor.java
@@ -313,12 +313,35 @@ public final class TableExtractor {
      * @param updateStatement update statement.
      */
     public void extractTablesFromUpdate(final UpdateStatement updateStatement) {
-        extractTablesFromTableSegment(updateStatement.getTable());
+        if (!isUpdateTargetTableAlias(updateStatement)) {
+            extractTablesFromTableSegment(updateStatement.getTable());
+        }
         updateStatement.getFrom().ifPresent(this::extractTablesFromTableSegment);
         updateStatement.getSetAssignment().getAssignments().forEach(each -> extractTablesFromExpression(each.getColumns().get(0)));
         if (updateStatement.getWhere().isPresent()) {
             extractTablesFromExpression(updateStatement.getWhere().get().getExpr());
         }
+    }
+    
+    private boolean isUpdateTargetTableAlias(final UpdateStatement updateStatement) {
+        if (!updateStatement.getFrom().isPresent() || !"SQLServer".equalsIgnoreCase(updateStatement.getDatabaseType().getType())) {
+            return false;
+        }
+        if (!(updateStatement.getTable() instanceof SimpleTableSegment)) {
+            return false;
+        }
+        String targetName = ((SimpleTableSegment) updateStatement.getTable()).getTableName().getIdentifier().getValue();
+        return isAliasInFromClause(targetName, updateStatement.getFrom().get());
+    }
+    
+    private boolean isAliasInFromClause(final String targetName, final TableSegment fromSegment) {
+        if (fromSegment instanceof SimpleTableSegment) {
+            return targetName.equalsIgnoreCase(((SimpleTableSegment) fromSegment).getAliasName().orElse(null));
+        }
+        if (fromSegment instanceof JoinTableSegment) {
+            return isAliasInFromClause(targetName, ((JoinTableSegment) fromSegment).getLeft()) || isAliasInFromClause(targetName, ((JoinTableSegment) fromSegment).getRight());
+        }
+        return false;
     }
     
     /**

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/extractor/TableExtractor.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/extractor/TableExtractor.java
@@ -314,6 +314,7 @@ public final class TableExtractor {
      */
     public void extractTablesFromUpdate(final UpdateStatement updateStatement) {
         extractTablesFromTableSegment(updateStatement.getTable());
+        updateStatement.getFrom().ifPresent(this::extractTablesFromTableSegment);
         updateStatement.getSetAssignment().getAssignments().forEach(each -> extractTablesFromExpression(each.getColumns().get(0)));
         if (updateStatement.getWhere().isPresent()) {
             extractTablesFromExpression(updateStatement.getWhere().get().getExpr());

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/type/dml/UpdateStatement.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/type/dml/UpdateStatement.java
@@ -65,12 +65,15 @@ public final class UpdateStatement extends DMLStatement {
     
     private final OutputSegment output;
     
+    private final boolean targetTableIsFromAlias;
+    
     private final SQLStatementAttributes attributes;
     
     @Builder
     private UpdateStatement(final DatabaseType databaseType, final TableSegment table, final SetAssignmentSegment setAssignment, final WhereSegment where,
                             final OrderBySegment orderBy, final LimitSegment limit, final TableSegment from, final WhereSegment deleteWhere, final WithSegment with,
-                            final ReturningSegment returning, final WithTableHintSegment withTableHint, final OptionHintSegment optionHint, final OutputSegment output) {
+                            final ReturningSegment returning, final WithTableHintSegment withTableHint, final OptionHintSegment optionHint, final OutputSegment output,
+                            final boolean targetTableIsFromAlias) {
         super(databaseType);
         this.table = table;
         this.setAssignment = setAssignment;
@@ -84,6 +87,7 @@ public final class UpdateStatement extends DMLStatement {
         this.withTableHint = withTableHint;
         this.optionHint = optionHint;
         this.output = output;
+        this.targetTableIsFromAlias = targetTableIsFromAlias;
         attributes = new SQLStatementAttributes(new WithSQLStatementAttribute(with));
     }
     

--- a/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewriter/engine/scenario/EncryptSQLRewriterIT.java
+++ b/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewriter/engine/scenario/EncryptSQLRewriterIT.java
@@ -73,6 +73,15 @@ class EncryptSQLRewriterIT extends SQLRewriterIT {
                 new ShardingSphereColumn("email", Types.VARCHAR, false, false, false, true, false, false),
                 new ShardingSphereColumn("telephone", Types.VARCHAR, false, false, false, true, false, false),
                 new ShardingSphereColumn("creation_date", Types.DATE, false, false, false, true, false, false)), Collections.emptyList(), Collections.emptyList()));
+        tables.add(new ShardingSphereTable("ScrapReason", Arrays.asList(
+                new ShardingSphereColumn("ScrapReasonID", Types.INTEGER, false, false, false, true, false, false),
+                new ShardingSphereColumn("Name", Types.VARCHAR, false, false, false, true, false, false),
+                new ShardingSphereColumn("Remark", Types.VARCHAR, false, false, false, true, false, false),
+                new ShardingSphereColumn("ModifiedDate", Types.TIMESTAMP, false, false, false, true, false, false)), Collections.emptyList(), Collections.emptyList()));
+        tables.add(new ShardingSphereTable("WorkOrder", Arrays.asList(
+                new ShardingSphereColumn("WorkOrderID", Types.INTEGER, false, false, false, true, false, false),
+                new ShardingSphereColumn("ScrapReasonID", Types.INTEGER, false, false, false, true, false, false),
+                new ShardingSphereColumn("ScrappedQty", Types.INTEGER, false, false, false, true, false, false)), Collections.emptyList(), Collections.emptyList()));
         return Collections.singleton(new ShardingSphereSchema(schemaName, mock(DatabaseType.class), tables, Collections.emptyList()));
     }
     
@@ -85,6 +94,8 @@ class EncryptSQLRewriterIT extends SQLRewriterIT {
             singleRule.get().getAttributes().getAttribute(MutableDataNodeRuleAttribute.class).put("encrypt_ds", schemaName, "t_account_detail");
             singleRule.get().getAttributes().getAttribute(MutableDataNodeRuleAttribute.class).put("encrypt_ds", schemaName, "t_order");
             singleRule.get().getAttributes().getAttribute(MutableDataNodeRuleAttribute.class).put("encrypt_ds", schemaName, "t_user");
+            singleRule.get().getAttributes().getAttribute(MutableDataNodeRuleAttribute.class).put("encrypt_ds", schemaName, "ScrapReason");
+            singleRule.get().getAttributes().getAttribute(MutableDataNodeRuleAttribute.class).put("encrypt_ds", schemaName, "WorkOrder");
         }
     }
 }

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/update/update.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/update/update.xml
@@ -95,8 +95,13 @@
         <output sql="UPDATE `t_account_bak` SET `account_id` = ?, `cipher_certificate_number` = ?, `assisted_query_certificate_number` = ?, `like_query_certificate_number` = ?, `cipher_password` = ?, `assisted_query_password` = ?, `like_query_password` = ?, `cipher_amount` = ?, `status` = ? WHERE `account_id` = ? AND `assisted_query_certificate_number` = ? AND `assisted_query_password` = ? AND `cipher_amount` = ? AND `status` = ?" parameters="1, encrypt_cert, assisted_query_cert, like_query_cert, encrypt_pwd, assisted_query_pwd, like_query_pwd, encrypt_amt, OK, 2, assisted_query_cert1, assisted_query_pwd1, encrypt_amt1, OK1" />
     </rewrite-assertion>
 
-    <rewrite-assertion id="update_scrap_reason_name_from_join_for_literals" db-types="SQLServer">
+    <rewrite-assertion id="om_jupdate_scrap_reason_name_froin_for_literals" db-types="SQLServer">
         <input sql="UPDATE sr SET sr.Name += ' - tool malfunction', sr.Remark = 'tool malfunction' FROM dbo.ScrapReason AS sr JOIN dbo.WorkOrder AS wo ON sr.ScrapReasonID = wo.ScrapReasonID AND wo.ScrappedQty &gt; 300" />
         <output sql="UPDATE sr SET sr.Name += ' - tool malfunction', [remark_cipher] = 'encrypt_tool malfunction' FROM dbo.ScrapReason AS sr JOIN dbo.WorkOrder AS wo ON sr.ScrapReasonID = wo.ScrapReasonID AND wo.ScrappedQty &gt; 300" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="update_scrap_reason_name_from_join_for_literals" db-types="PostgreSQL,openGauss">
+        <input sql="UPDATE ScrapReason AS sr SET Name = Name || ' - tool malfunction', Remark = 'tool malfunction' FROM WorkOrder AS wo WHERE sr.ScrapReasonID = wo.ScrapReasonID AND wo.ScrappedQty &gt; 300" />
+        <output sql="UPDATE ScrapReason AS sr SET Name = Name || ' - tool malfunction', &quot;remark_cipher&quot; = 'encrypt_tool malfunction' FROM WorkOrder AS wo WHERE sr.ScrapReasonID = wo.ScrapReasonID AND wo.ScrappedQty &gt; 300" />
     </rewrite-assertion>
 </rewrite-assertions>

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/update/update.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/update/update.xml
@@ -94,4 +94,9 @@
         <input sql="UPDATE `t_account_bak` SET `account_id` = ?, `certificate_number` = ?, `password` = ?, `amount` = ?, `status` = ? WHERE `account_id` = ? AND `certificate_number` = ? AND `password` = ? AND `amount` = ? AND `status` = ?" parameters="1, cert, pwd, amt, OK, 2, cert1, pwd1, amt1, OK1" />
         <output sql="UPDATE `t_account_bak` SET `account_id` = ?, `cipher_certificate_number` = ?, `assisted_query_certificate_number` = ?, `like_query_certificate_number` = ?, `cipher_password` = ?, `assisted_query_password` = ?, `like_query_password` = ?, `cipher_amount` = ?, `status` = ? WHERE `account_id` = ? AND `assisted_query_certificate_number` = ? AND `assisted_query_password` = ? AND `cipher_amount` = ? AND `status` = ?" parameters="1, encrypt_cert, assisted_query_cert, like_query_cert, encrypt_pwd, assisted_query_pwd, like_query_pwd, encrypt_amt, OK, 2, assisted_query_cert1, assisted_query_pwd1, encrypt_amt1, OK1" />
     </rewrite-assertion>
+
+    <rewrite-assertion id="update_scrap_reason_name_from_join_for_literals" db-types="SQLServer">
+        <input sql="UPDATE sr SET sr.Name += ' - tool malfunction', sr.Remark = 'tool malfunction' FROM dbo.ScrapReason AS sr JOIN dbo.WorkOrder AS wo ON sr.ScrapReasonID = wo.ScrapReasonID AND wo.ScrappedQty &gt; 300" />
+        <output sql="UPDATE sr SET sr.Name += ' - tool malfunction', [remark_cipher] = 'encrypt_tool malfunction' FROM dbo.ScrapReason AS sr JOIN dbo.WorkOrder AS wo ON sr.ScrapReasonID = wo.ScrapReasonID AND wo.ScrappedQty &gt; 300" />
+    </rewrite-assertion>
 </rewrite-assertions>

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/config/query-with-cipher.yaml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/config/query-with-cipher.yaml
@@ -152,6 +152,12 @@ rules:
           likeQuery:
             name: user_telephone_like
             encryptorName: rewrite_it_like_encryptor_fixture
+    ScrapReason:
+      columns:
+        Remark:
+          cipher:
+            name: remark_cipher
+            encryptorName: rewrite_normal_fixture
   encryptors:
     rewrite_normal_fixture:
       type: REWRITE.NORMAL.FIXTURE


### PR DESCRIPTION
for https://github.com/apache/shardingsphere/issues/30227
official document:https://learn.microsoft.com/en-us/sql/t-sql/queries/update-transact-sql?view=sql-server-ver17#l-specifying-a-table-alias-as-the-target-object

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
