### PR TITLE
Add session attribution context propagation

### DIFF
--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/MCPHandlerContext.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/MCPHandlerContext.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * Marker interface for MCP handler execution context.
  */
 public interface MCPHandlerContext {
-
+    
     /**
      * Find session attribution.
      *

--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/session/MCPSessionAttribution.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/session/MCPSessionAttribution.java
@@ -15,23 +15,30 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.mcp.api;
+package org.apache.shardingsphere.mcp.api.session;
 
-import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
-import java.util.Optional;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
- * Marker interface for MCP handler execution context.
+ * MCP session attribution.
  */
-public interface MCPHandlerContext {
+@Getter
+@EqualsAndHashCode
+public final class MCPSessionAttribution {
 
-    /**
-     * Find session attribution.
-     *
-     * @return session attribution
-     */
-    default Optional<MCPSessionAttribution> findSessionAttribution() {
-        return Optional.empty();
+    private final String subject;
+
+    private final String source;
+
+    private final Map<String, String> attributes;
+
+    public MCPSessionAttribution(final String subject, final String source, final Map<String, String> attributes) {
+        this.subject = subject;
+        this.source = source;
+        this.attributes = new LinkedHashMap<>(attributes);
     }
 }

--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/session/MCPSessionAttribution.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/session/MCPSessionAttribution.java
@@ -19,13 +19,14 @@ package org.apache.shardingsphere.mcp.api.session;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
  * MCP session attribution.
  */
+@RequiredArgsConstructor
 @Getter
 @EqualsAndHashCode
 public final class MCPSessionAttribution {
@@ -35,10 +36,4 @@ public final class MCPSessionAttribution {
     private final String source;
     
     private final Map<String, String> attributes;
-    
-    public MCPSessionAttribution(final String subject, final String source, final Map<String, String> attributes) {
-        this.subject = subject;
-        this.source = source;
-        this.attributes = new LinkedHashMap<>(attributes);
-    }
 }

--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/session/MCPSessionAttribution.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/session/MCPSessionAttribution.java
@@ -29,13 +29,13 @@ import java.util.Map;
 @Getter
 @EqualsAndHashCode
 public final class MCPSessionAttribution {
-
+    
     private final String subject;
-
+    
     private final String source;
-
+    
     private final Map<String, String> attributes;
-
+    
     public MCPSessionAttribution(final String subject, final String source, final Map<String, String> attributes) {
         this.subject = subject;
         this.source = source;

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/MCPRuntimeLauncher.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/MCPRuntimeLauncher.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.mcp.bootstrap.config.MCPTransportType;
 import org.apache.shardingsphere.mcp.bootstrap.transport.server.MCPRuntimeServer;
 import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.StreamableHttpMCPServer;
 import org.apache.shardingsphere.mcp.bootstrap.transport.server.stdio.StdioMCPServer;
+import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.SessionAttributionResolver;
 import org.apache.shardingsphere.mcp.core.context.MCPRuntimeContext;
 import org.apache.shardingsphere.mcp.core.session.MCPSessionManager;
 import org.apache.shardingsphere.mcp.support.database.capability.MCPDatabaseCapabilityProvider;
@@ -72,8 +73,9 @@ public final class MCPRuntimeLauncher {
     private List<String> createHttpStartupLogMessages(final MCPLaunchConfiguration config, final MCPRuntimeServer server) {
         int port = server instanceof StreamableHttpMCPServer ? ((StreamableHttpMCPServer) server).getLocalPort() : config.getHttpTransport().getPort();
         String endpoint = String.format("http://%s:%d%s", config.getHttpTransport().getBindHost(), port, config.getHttpTransport().getEndpointPath());
-        return List.of(String.format("ShardingSphere MCP runtime started, transport=http, config=%s, databases=%d, endpoint=%s, authorization=none, logs=%s.",
-                configPath, config.getDatabases().size(), endpoint, LOG_PATH));
+        SessionAttributionResolver sessionAttributionResolver = new SessionAttributionResolver(config.getHttpTransport().getSessionAttributionSource());
+        return List.of(String.format("ShardingSphere MCP runtime started, transport=http, config=%s, databases=%d, endpoint=%s, session_attribution=%s, logs=%s.",
+                configPath, config.getDatabases().size(), endpoint, sessionAttributionResolver.getSummary(), LOG_PATH));
     }
     
     private List<String> createStdioStartupLogMessages(final MCPLaunchConfiguration config) {

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/HttpTransportConfiguration.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/HttpTransportConfiguration.java
@@ -24,19 +24,19 @@ import lombok.Getter;
  */
 @Getter
 public final class HttpTransportConfiguration {
-
+    
     private final String bindHost;
-
+    
     private final int port;
-
+    
     private final String endpointPath;
-
+    
     private final SessionAttributionSourceConfiguration sessionAttributionSource;
-
+    
     public HttpTransportConfiguration(final String bindHost, final int port, final String endpointPath) {
         this(bindHost, port, endpointPath, null);
     }
-
+    
     public HttpTransportConfiguration(final String bindHost, final int port, final String endpointPath, final SessionAttributionSourceConfiguration sessionAttributionSource) {
         this.bindHost = bindHost;
         this.port = port;

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/HttpTransportConfiguration.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/HttpTransportConfiguration.java
@@ -18,18 +18,29 @@
 package org.apache.shardingsphere.mcp.bootstrap.config;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * HTTP transport configuration.
  */
-@RequiredArgsConstructor
 @Getter
 public final class HttpTransportConfiguration {
-    
+
     private final String bindHost;
-    
+
     private final int port;
-    
+
     private final String endpointPath;
+
+    private final SessionAttributionSourceConfiguration sessionAttributionSource;
+
+    public HttpTransportConfiguration(final String bindHost, final int port, final String endpointPath) {
+        this(bindHost, port, endpointPath, null);
+    }
+
+    public HttpTransportConfiguration(final String bindHost, final int port, final String endpointPath, final SessionAttributionSourceConfiguration sessionAttributionSource) {
+        this.bindHost = bindHost;
+        this.port = port;
+        this.endpointPath = endpointPath;
+        this.sessionAttributionSource = sessionAttributionSource;
+    }
 }

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/SessionAttributionSourceConfiguration.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/SessionAttributionSourceConfiguration.java
@@ -26,10 +26,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public final class SessionAttributionSourceConfiguration {
-
+    
     private final String subjectHeader;
-
+    
     private final String sourceHeader;
-
+    
     private final String attributeHeaderPrefix;
 }

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/SessionAttributionSourceConfiguration.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/SessionAttributionSourceConfiguration.java
@@ -15,23 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.mcp.api;
+package org.apache.shardingsphere.mcp.bootstrap.config;
 
-import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
-
-import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Marker interface for MCP handler execution context.
+ * Session attribution source configuration.
  */
-public interface MCPHandlerContext {
+@RequiredArgsConstructor
+@Getter
+public final class SessionAttributionSourceConfiguration {
 
-    /**
-     * Find session attribution.
-     *
-     * @return session attribution
-     */
-    default Optional<MCPSessionAttribution> findSessionAttribution() {
-        return Optional.empty();
-    }
+    private final String subjectHeader;
+
+    private final String sourceHeader;
+
+    private final String attributeHeaderPrefix;
 }

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/config/YamlHttpTransportConfiguration.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/config/YamlHttpTransportConfiguration.java
@@ -29,10 +29,12 @@ import org.apache.shardingsphere.mcp.bootstrap.config.yaml.validator.ValidHttpTr
 @Setter
 @ValidHttpTransportConfiguration
 public final class YamlHttpTransportConfiguration implements YamlConfiguration {
-    
+
     private String bindHost;
-    
+
     private Integer port;
-    
+
     private String endpointPath;
+
+    private YamlSessionAttributionSourceConfiguration sessionAttributionSource;
 }

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/config/YamlHttpTransportConfiguration.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/config/YamlHttpTransportConfiguration.java
@@ -29,12 +29,12 @@ import org.apache.shardingsphere.mcp.bootstrap.config.yaml.validator.ValidHttpTr
 @Setter
 @ValidHttpTransportConfiguration
 public final class YamlHttpTransportConfiguration implements YamlConfiguration {
-
+    
     private String bindHost;
-
+    
     private Integer port;
-
+    
     private String endpointPath;
-
+    
     private YamlSessionAttributionSourceConfiguration sessionAttributionSource;
 }

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/config/YamlSessionAttributionSourceConfiguration.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/config/YamlSessionAttributionSourceConfiguration.java
@@ -15,23 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.mcp.api;
+package org.apache.shardingsphere.mcp.bootstrap.config.yaml.config;
 
-import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
-
-import java.util.Optional;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- * Marker interface for MCP handler execution context.
+ * YAML session attribution source configuration.
  */
-public interface MCPHandlerContext {
-
-    /**
-     * Find session attribution.
-     *
-     * @return session attribution
-     */
-    default Optional<MCPSessionAttribution> findSessionAttribution() {
-        return Optional.empty();
-    }
+@Getter
+@Setter
+public final class YamlSessionAttributionSourceConfiguration {
+    
+    private String subjectHeader;
+    
+    private String sourceHeader;
+    
+    private String attributeHeaderPrefix;
 }

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/swapper/YamlHttpTransportConfigurationSwapper.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/swapper/YamlHttpTransportConfigurationSwapper.java
@@ -29,19 +29,19 @@ import java.util.Objects;
  * YAML HTTP transport configuration swapper.
  */
 public final class YamlHttpTransportConfigurationSwapper implements YamlConfigurationSwapper<YamlHttpTransportConfiguration, HttpTransportConfiguration> {
-
+    
     private static final String DEFAULT_BIND_HOST = "127.0.0.1";
-
+    
     private static final int DEFAULT_PORT = 18088;
-
+    
     private static final String DEFAULT_ENDPOINT_PATH = "/mcp";
-
+    
     private static final String DEFAULT_SUBJECT_HEADER = "X-ShardingSphere-MCP-Subject";
-
+    
     private static final String DEFAULT_SOURCE_HEADER = "X-ShardingSphere-MCP-Source";
-
+    
     private static final String DEFAULT_ATTRIBUTE_HEADER_PREFIX = "X-ShardingSphere-MCP-Attribute-";
-
+    
     @Override
     public YamlHttpTransportConfiguration swapToYamlConfiguration(final HttpTransportConfiguration data) {
         YamlHttpTransportConfiguration result = new YamlHttpTransportConfiguration();
@@ -51,7 +51,7 @@ public final class YamlHttpTransportConfigurationSwapper implements YamlConfigur
         result.setSessionAttributionSource(swapToYamlConfiguration(data.getSessionAttributionSource()));
         return result;
     }
-
+    
     private YamlSessionAttributionSourceConfiguration swapToYamlConfiguration(final SessionAttributionSourceConfiguration data) {
         if (null == data) {
             return null;
@@ -62,7 +62,7 @@ public final class YamlHttpTransportConfigurationSwapper implements YamlConfigur
         result.setAttributeHeaderPrefix(data.getAttributeHeaderPrefix());
         return result;
     }
-
+    
     @Override
     public HttpTransportConfiguration swapToObject(final YamlHttpTransportConfiguration yamlConfig) {
         if (null == yamlConfig) {
@@ -72,7 +72,7 @@ public final class YamlHttpTransportConfigurationSwapper implements YamlConfigur
         return new HttpTransportConfiguration(getValueOrDefault(yamlConfig.getBindHost(), DEFAULT_BIND_HOST), null == yamlConfig.getPort() ? DEFAULT_PORT : yamlConfig.getPort(),
                 getValueOrDefault(yamlConfig.getEndpointPath(), DEFAULT_ENDPOINT_PATH), swapToObject(yamlConfig.getSessionAttributionSource()));
     }
-
+    
     private SessionAttributionSourceConfiguration swapToObject(final YamlSessionAttributionSourceConfiguration yamlConfig) {
         if (null == yamlConfig) {
             return null;
@@ -80,7 +80,7 @@ public final class YamlHttpTransportConfigurationSwapper implements YamlConfigur
         return new SessionAttributionSourceConfiguration(getValueOrDefault(yamlConfig.getSubjectHeader(), DEFAULT_SUBJECT_HEADER),
                 getValueOrDefault(yamlConfig.getSourceHeader(), DEFAULT_SOURCE_HEADER), getValueOrDefault(yamlConfig.getAttributeHeaderPrefix(), DEFAULT_ATTRIBUTE_HEADER_PREFIX));
     }
-
+    
     private String getValueOrDefault(final String value, final String defaultValue) {
         String result = Objects.toString(value, "").trim();
         return result.isEmpty() ? defaultValue : result;

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/swapper/YamlHttpTransportConfigurationSwapper.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/swapper/YamlHttpTransportConfigurationSwapper.java
@@ -17,9 +17,11 @@
 
 package org.apache.shardingsphere.mcp.bootstrap.config.yaml.swapper;
 
+import org.apache.shardingsphere.mcp.bootstrap.config.SessionAttributionSourceConfiguration;
 import org.apache.shardingsphere.infra.util.yaml.swapper.YamlConfigurationSwapper;
 import org.apache.shardingsphere.mcp.bootstrap.config.HttpTransportConfiguration;
 import org.apache.shardingsphere.mcp.bootstrap.config.yaml.config.YamlHttpTransportConfiguration;
+import org.apache.shardingsphere.mcp.bootstrap.config.yaml.config.YamlSessionAttributionSourceConfiguration;
 import org.apache.shardingsphere.mcp.support.yaml.MCPYamlConfigurationValidator;
 import java.util.Objects;
 
@@ -27,22 +29,40 @@ import java.util.Objects;
  * YAML HTTP transport configuration swapper.
  */
 public final class YamlHttpTransportConfigurationSwapper implements YamlConfigurationSwapper<YamlHttpTransportConfiguration, HttpTransportConfiguration> {
-    
+
     private static final String DEFAULT_BIND_HOST = "127.0.0.1";
-    
+
     private static final int DEFAULT_PORT = 18088;
-    
+
     private static final String DEFAULT_ENDPOINT_PATH = "/mcp";
-    
+
+    private static final String DEFAULT_SUBJECT_HEADER = "X-ShardingSphere-MCP-Subject";
+
+    private static final String DEFAULT_SOURCE_HEADER = "X-ShardingSphere-MCP-Source";
+
+    private static final String DEFAULT_ATTRIBUTE_HEADER_PREFIX = "X-ShardingSphere-MCP-Attribute-";
+
     @Override
     public YamlHttpTransportConfiguration swapToYamlConfiguration(final HttpTransportConfiguration data) {
         YamlHttpTransportConfiguration result = new YamlHttpTransportConfiguration();
         result.setBindHost(data.getBindHost());
         result.setPort(data.getPort());
         result.setEndpointPath(data.getEndpointPath());
+        result.setSessionAttributionSource(swapToYamlConfiguration(data.getSessionAttributionSource()));
         return result;
     }
-    
+
+    private YamlSessionAttributionSourceConfiguration swapToYamlConfiguration(final SessionAttributionSourceConfiguration data) {
+        if (null == data) {
+            return null;
+        }
+        YamlSessionAttributionSourceConfiguration result = new YamlSessionAttributionSourceConfiguration();
+        result.setSubjectHeader(data.getSubjectHeader());
+        result.setSourceHeader(data.getSourceHeader());
+        result.setAttributeHeaderPrefix(data.getAttributeHeaderPrefix());
+        return result;
+    }
+
     @Override
     public HttpTransportConfiguration swapToObject(final YamlHttpTransportConfiguration yamlConfig) {
         if (null == yamlConfig) {
@@ -50,9 +70,17 @@ public final class YamlHttpTransportConfigurationSwapper implements YamlConfigur
         }
         MCPYamlConfigurationValidator.validate(yamlConfig, "MCP HTTP transport configuration");
         return new HttpTransportConfiguration(getValueOrDefault(yamlConfig.getBindHost(), DEFAULT_BIND_HOST), null == yamlConfig.getPort() ? DEFAULT_PORT : yamlConfig.getPort(),
-                getValueOrDefault(yamlConfig.getEndpointPath(), DEFAULT_ENDPOINT_PATH));
+                getValueOrDefault(yamlConfig.getEndpointPath(), DEFAULT_ENDPOINT_PATH), swapToObject(yamlConfig.getSessionAttributionSource()));
     }
-    
+
+    private SessionAttributionSourceConfiguration swapToObject(final YamlSessionAttributionSourceConfiguration yamlConfig) {
+        if (null == yamlConfig) {
+            return null;
+        }
+        return new SessionAttributionSourceConfiguration(getValueOrDefault(yamlConfig.getSubjectHeader(), DEFAULT_SUBJECT_HEADER),
+                getValueOrDefault(yamlConfig.getSourceHeader(), DEFAULT_SOURCE_HEADER), getValueOrDefault(yamlConfig.getAttributeHeaderPrefix(), DEFAULT_ATTRIBUTE_HEADER_PREFIX));
+    }
+
     private String getValueOrDefault(final String value, final String defaultValue) {
         String result = Objects.toString(value, "").trim();
         return result.isEmpty() ? defaultValue : result;

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/validator/HttpTransportConfigurationValidator.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/validator/HttpTransportConfigurationValidator.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mcp.bootstrap.config.yaml.validator;
 
 import org.apache.shardingsphere.mcp.bootstrap.config.yaml.config.YamlHttpTransportConfiguration;
+import org.apache.shardingsphere.mcp.bootstrap.config.yaml.config.YamlSessionAttributionSourceConfiguration;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
@@ -28,7 +29,7 @@ import java.util.Objects;
  * HTTP transport configuration validator.
  */
 public final class HttpTransportConfigurationValidator implements ConstraintValidator<ValidHttpTransportConfiguration, YamlHttpTransportConfiguration> {
-    
+
     @Override
     public boolean isValid(final YamlHttpTransportConfiguration value, final ConstraintValidatorContext context) {
         if (null == value) {
@@ -46,9 +47,12 @@ public final class HttpTransportConfigurationValidator implements ConstraintVali
             addViolation(context, "endpointPath", "must be a single absolute path without query or fragment");
             return false;
         }
+        if (!isValidSessionAttributionSource(value.getSessionAttributionSource(), context)) {
+            return false;
+        }
         return true;
     }
-    
+
     private boolean isValidBindHost(final String value) {
         if (null == value) {
             return true;
@@ -59,11 +63,11 @@ public final class HttpTransportConfigurationValidator implements ConstraintVali
         }
         return !actualValue.contains("://");
     }
-    
+
     private boolean isValidPort(final Integer value) {
         return null == value || value >= 0 && value <= 65535;
     }
-    
+
     private boolean isValidEndpointPath(final String value) {
         if (null == value) {
             return true;
@@ -79,7 +83,42 @@ public final class HttpTransportConfigurationValidator implements ConstraintVali
             return false;
         }
     }
-    
+
+    private boolean isValidSessionAttributionSource(final YamlSessionAttributionSourceConfiguration value, final ConstraintValidatorContext context) {
+        if (null == value) {
+            return true;
+        }
+        if (!isValidHeaderName(value.getSubjectHeader())) {
+            addViolation(context, "sessionAttributionSource.subjectHeader", "must be a valid HTTP header name");
+            return false;
+        }
+        if (!isValidHeaderName(value.getSourceHeader())) {
+            addViolation(context, "sessionAttributionSource.sourceHeader", "must be a valid HTTP header name");
+            return false;
+        }
+        if (!isValidHeaderName(value.getAttributeHeaderPrefix())) {
+            addViolation(context, "sessionAttributionSource.attributeHeaderPrefix", "must be a valid HTTP header name prefix");
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isValidHeaderName(final String value) {
+        if (null == value) {
+            return true;
+        }
+        String actualValue = Objects.toString(value, "").trim();
+        if (actualValue.isEmpty()) {
+            return false;
+        }
+        for (char each : actualValue.toCharArray()) {
+            if (Character.isWhitespace(each) || ':' == each) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private void addViolation(final ConstraintValidatorContext context, final String propertyName, final String message) {
         context.disableDefaultConstraintViolation();
         context.buildConstraintViolationWithTemplate(message).addPropertyNode(propertyName).addConstraintViolation();

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/validator/HttpTransportConfigurationValidator.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/validator/HttpTransportConfigurationValidator.java
@@ -112,11 +112,20 @@ public final class HttpTransportConfigurationValidator implements ConstraintVali
             return false;
         }
         for (char each : actualValue.toCharArray()) {
-            if (Character.isWhitespace(each) || ':' == each) {
+            if (!isHttpTokenCharacter(each)) {
                 return false;
             }
         }
         return true;
+    }
+    
+    private boolean isHttpTokenCharacter(final char value) {
+        return value >= '0' && value <= '9' || value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z' || isHttpTokenSymbol(value);
+    }
+    
+    private boolean isHttpTokenSymbol(final char value) {
+        return '!' == value || '#' == value || '$' == value || '%' == value || '&' == value || '\'' == value || '*' == value || '+' == value || '-' == value || '.' == value
+                || '^' == value || '_' == value || '`' == value || '|' == value || '~' == value;
     }
     
     private void addViolation(final ConstraintValidatorContext context, final String propertyName, final String message) {

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/validator/HttpTransportConfigurationValidator.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/validator/HttpTransportConfigurationValidator.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * HTTP transport configuration validator.
  */
 public final class HttpTransportConfigurationValidator implements ConstraintValidator<ValidHttpTransportConfiguration, YamlHttpTransportConfiguration> {
-
+    
     @Override
     public boolean isValid(final YamlHttpTransportConfiguration value, final ConstraintValidatorContext context) {
         if (null == value) {
@@ -52,7 +52,7 @@ public final class HttpTransportConfigurationValidator implements ConstraintVali
         }
         return true;
     }
-
+    
     private boolean isValidBindHost(final String value) {
         if (null == value) {
             return true;
@@ -63,11 +63,11 @@ public final class HttpTransportConfigurationValidator implements ConstraintVali
         }
         return !actualValue.contains("://");
     }
-
+    
     private boolean isValidPort(final Integer value) {
         return null == value || value >= 0 && value <= 65535;
     }
-
+    
     private boolean isValidEndpointPath(final String value) {
         if (null == value) {
             return true;
@@ -83,7 +83,7 @@ public final class HttpTransportConfigurationValidator implements ConstraintVali
             return false;
         }
     }
-
+    
     private boolean isValidSessionAttributionSource(final YamlSessionAttributionSourceConfiguration value, final ConstraintValidatorContext context) {
         if (null == value) {
             return true;
@@ -102,7 +102,7 @@ public final class HttpTransportConfigurationValidator implements ConstraintVali
         }
         return true;
     }
-
+    
     private boolean isValidHeaderName(final String value) {
         if (null == value) {
             return true;
@@ -118,7 +118,7 @@ public final class HttpTransportConfigurationValidator implements ConstraintVali
         }
         return true;
     }
-
+    
     private void addViolation(final ConstraintValidatorContext context, final String propertyName, final String message) {
         context.disableDefaultConstraintViolation();
         context.buildConstraintViolationWithTemplate(message).addPropertyNode(propertyName).addConstraintViolation();

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolver.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolver.java
@@ -107,7 +107,7 @@ public final class SessionAttributionResolver {
         for (String each : headerNames) {
             String actualHeaderName = Objects.toString(each, "").trim();
             if (actualHeaderName.toLowerCase(Locale.ENGLISH).startsWith(normalizedPrefix)) {
-                result.put(actualHeaderName.substring(attributeHeaderPrefix.length()), headerValueReader.read(actualHeaderName));
+                result.put(actualHeaderName.substring(attributeHeaderPrefix.length()).toLowerCase(Locale.ENGLISH), headerValueReader.read(actualHeaderName));
             }
         }
         return result;

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolver.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolver.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.bootstrap.transport.server.http;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.bootstrap.config.SessionAttributionSourceConfiguration;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Session attribution resolver.
+ */
+@Getter
+public final class SessionAttributionResolver {
+
+    private final SessionAttributionSourceConfiguration config;
+
+    public SessionAttributionResolver(final SessionAttributionSourceConfiguration config) {
+        this.config = config;
+    }
+
+    /**
+     * Resolve session attribution from HTTP request.
+     *
+     * @param request HTTP request
+     * @return session attribution
+     */
+    public Optional<MCPSessionAttribution> resolve(final HttpServletRequest request) {
+        if (!isEnabled()) {
+            return Optional.empty();
+        }
+        String subject = getHeaderValue(request, config.getSubjectHeader());
+        if (subject.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new MCPSessionAttribution(subject, getHeaderValue(request, config.getSourceHeader()),
+                resolveAttributes(Collections.list(request.getHeaderNames()), name -> getHeaderValue(request, name))));
+    }
+
+    /**
+     * Resolve session attribution from header map.
+     *
+     * @param headers headers
+     * @return session attribution
+     */
+    public Optional<MCPSessionAttribution> resolve(final Map<String, List<String>> headers) {
+        if (!isEnabled()) {
+            return Optional.empty();
+        }
+        String subject = getHeaderValue(headers, config.getSubjectHeader());
+        if (subject.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new MCPSessionAttribution(subject, getHeaderValue(headers, config.getSourceHeader()),
+                resolveAttributes(headers.keySet(), name -> getHeaderValue(headers, name))));
+    }
+
+    /**
+     * Determine whether session attribution is enabled.
+     *
+     * @return true if enabled
+     */
+    public boolean isEnabled() {
+        return null != config;
+    }
+
+    /**
+     * Get summary for diagnostics.
+     *
+     * @return summary
+     */
+    public String getSummary() {
+        return !isEnabled() ? "disabled" : String.format("trusted-header:%s", config.getSubjectHeader());
+    }
+
+    private Map<String, String> resolveAttributes(final Iterable<String> headerNames, final HeaderValueReader headerValueReader) {
+        Map<String, String> result = new LinkedHashMap<>();
+        String attributeHeaderPrefix = config.getAttributeHeaderPrefix();
+        if (attributeHeaderPrefix.isEmpty()) {
+            return result;
+        }
+        String normalizedPrefix = attributeHeaderPrefix.toLowerCase(Locale.ENGLISH);
+        for (String each : headerNames) {
+            String actualHeaderName = Objects.toString(each, "").trim();
+            if (actualHeaderName.toLowerCase(Locale.ENGLISH).startsWith(normalizedPrefix)) {
+                result.put(actualHeaderName.substring(attributeHeaderPrefix.length()), headerValueReader.read(actualHeaderName));
+            }
+        }
+        return result;
+    }
+
+    private String getHeaderValue(final HttpServletRequest request, final String headerName) {
+        return Objects.toString(request.getHeader(headerName), "").trim();
+    }
+
+    private String getHeaderValue(final Map<String, List<String>> headers, final String headerName) {
+        for (Entry<String, List<String>> entry : headers.entrySet()) {
+            if (headerName.equalsIgnoreCase(entry.getKey()) && !entry.getValue().isEmpty()) {
+                return Objects.toString(entry.getValue().get(0), "").trim();
+            }
+        }
+        return "";
+    }
+
+    @FunctionalInterface
+    private interface HeaderValueReader {
+
+        String read(String headerName);
+    }
+}

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolver.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolver.java
@@ -36,13 +36,13 @@ import java.util.Optional;
  */
 @Getter
 public final class SessionAttributionResolver {
-
+    
     private final SessionAttributionSourceConfiguration config;
-
+    
     public SessionAttributionResolver(final SessionAttributionSourceConfiguration config) {
         this.config = config;
     }
-
+    
     /**
      * Resolve session attribution from HTTP request.
      *
@@ -60,7 +60,7 @@ public final class SessionAttributionResolver {
         return Optional.of(new MCPSessionAttribution(subject, getHeaderValue(request, config.getSourceHeader()),
                 resolveAttributes(Collections.list(request.getHeaderNames()), name -> getHeaderValue(request, name))));
     }
-
+    
     /**
      * Resolve session attribution from header map.
      *
@@ -78,7 +78,7 @@ public final class SessionAttributionResolver {
         return Optional.of(new MCPSessionAttribution(subject, getHeaderValue(headers, config.getSourceHeader()),
                 resolveAttributes(headers.keySet(), name -> getHeaderValue(headers, name))));
     }
-
+    
     /**
      * Determine whether session attribution is enabled.
      *
@@ -87,7 +87,7 @@ public final class SessionAttributionResolver {
     public boolean isEnabled() {
         return null != config;
     }
-
+    
     /**
      * Get summary for diagnostics.
      *
@@ -96,7 +96,7 @@ public final class SessionAttributionResolver {
     public String getSummary() {
         return !isEnabled() ? "disabled" : String.format("trusted-header:%s", config.getSubjectHeader());
     }
-
+    
     private Map<String, String> resolveAttributes(final Iterable<String> headerNames, final HeaderValueReader headerValueReader) {
         Map<String, String> result = new LinkedHashMap<>();
         String attributeHeaderPrefix = config.getAttributeHeaderPrefix();
@@ -112,11 +112,11 @@ public final class SessionAttributionResolver {
         }
         return result;
     }
-
+    
     private String getHeaderValue(final HttpServletRequest request, final String headerName) {
         return Objects.toString(request.getHeader(headerName), "").trim();
     }
-
+    
     private String getHeaderValue(final Map<String, List<String>> headers, final String headerName) {
         for (Entry<String, List<String>> entry : headers.entrySet()) {
             if (headerName.equalsIgnoreCase(entry.getKey()) && !entry.getValue().isEmpty()) {
@@ -125,10 +125,10 @@ public final class SessionAttributionResolver {
         }
         return "";
     }
-
+    
     @FunctionalInterface
     private interface HeaderValueReader {
-
+        
         String read(String headerName);
     }
 }

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServlet.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServlet.java
@@ -44,27 +44,27 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamableServerTransportProvider {
-
+    
     private static final long serialVersionUID = -2320345528569140021L;
-
+    
     private static final String SESSION_HEADER = HttpHeaders.MCP_SESSION_ID;
-
+    
     private static final String PROTOCOL_HEADER = HttpHeaders.PROTOCOL_VERSION;
-
+    
     private static final String JSON_CONTENT_TYPE = "application/json";
-
+    
     private final HttpServletStreamableServerTransportProvider delegate;
-
+    
     private final MCPSessionManager sessionManager;
-
+    
     private final MCPSessionExecutionCoordinator sessionExecutionCoordinator;
-
+    
     private final SessionAttributionResolver sessionAttributionResolver;
-
+    
     private final Map<String, String> sessionProtocolVersions;
-
+    
     private final AtomicBoolean closed;
-
+    
     StreamableHttpMCPServlet(final MCPSessionManager sessionManager, final McpJsonMapper jsonMapper, final HttpTransportConfiguration config) {
         sessionAttributionResolver = new SessionAttributionResolver(config.getSessionAttributionSource());
         delegate = createDelegate(sessionManager, jsonMapper, config.getBindHost(), config.getEndpointPath(), sessionAttributionResolver);
@@ -74,18 +74,18 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
         sessionManager.addSessionCloseListener(sessionProtocolVersions::remove);
         closed = new AtomicBoolean();
     }
-
+    
     private static HttpServletStreamableServerTransportProvider createDelegate(final MCPSessionManager sessionManager, final McpJsonMapper jsonMapper,
                                                                                final String bindHost, final String endpointPath, final SessionAttributionResolver sessionAttributionResolver) {
         return HttpServletStreamableServerTransportProvider.builder().jsonMapper(jsonMapper).mcpEndpoint(endpointPath)
                 .securityValidator(ServerTransportSecurityValidatorFactory.create(sessionManager, bindHost, sessionAttributionResolver)).build();
     }
-
+    
     @Override
     public List<String> protocolVersions() {
         return MCPTransportConstants.SUPPORTED_PROTOCOL_VERSIONS;
     }
-
+    
     @Override
     public void setSessionFactory(final McpStreamableServerSession.Factory sessionFactory) {
         delegate.setSessionFactory(initializeRequest -> {
@@ -97,34 +97,34 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
             return result;
         });
     }
-
+    
     private McpSchema.InitializeRequest negotiateInitializeRequest(final McpSchema.InitializeRequest initializeRequest) {
         String negotiatedProtocolVersion = negotiateProtocolVersion(initializeRequest.protocolVersion());
         return negotiatedProtocolVersion.equals(initializeRequest.protocolVersion())
                 ? initializeRequest
                 : new McpSchema.InitializeRequest(negotiatedProtocolVersion, initializeRequest.capabilities(), initializeRequest.clientInfo(), initializeRequest.meta());
     }
-
+    
     private String negotiateProtocolVersion(final String requestedProtocolVersion) {
         String actualRequestedProtocolVersion = Objects.toString(requestedProtocolVersion, "").trim();
         return protocolVersions().contains(actualRequestedProtocolVersion) ? actualRequestedProtocolVersion : MCPTransportConstants.PROTOCOL_VERSION;
     }
-
+    
     @Override
     public Mono<Void> notifyClients(final String method, final Object params) {
         return delegate.notifyClients(method, params);
     }
-
+    
     @Override
     public Mono<Void> notifyClient(final String sessionId, final String method, final Object params) {
         return delegate.notifyClient(sessionId, method, params);
     }
-
+    
     @Override
     protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {
         serviceRequest(request, response);
     }
-
+    
     private void serviceWithApplicationClassLoader(final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {
         ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         try {
@@ -134,7 +134,7 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
             Thread.currentThread().setContextClassLoader(originalClassLoader);
         }
     }
-
+    
     @Override
     protected void doPost(final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {
         if (!isJsonContentType(request)) {
@@ -145,17 +145,17 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
         serviceRequest(request, actualResponse);
         bindSessionAttribution(request, actualResponse);
     }
-
+    
     private boolean isJsonContentType(final HttpServletRequest request) {
         String contentType = Objects.toString(request.getContentType(), "").trim();
         return contentType.isEmpty() || JSON_CONTENT_TYPE.equalsIgnoreCase(contentType.split(";", 2)[0].trim());
     }
-
+    
     private void serviceRequest(final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {
         setUtf8Encoding(request, response);
         serviceWithApplicationClassLoader(request, response);
     }
-
+    
     @Override
     protected void doDelete(final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {
         String sessionId = Objects.toString(request.getHeader(SESSION_HEADER), "").trim();
@@ -164,17 +164,17 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
             sessionExecutionCoordinator.closeSession(sessionId);
         }
     }
-
+    
     private void setUtf8Encoding(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
         request.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
     }
-
+    
     @Override
     public Mono<Void> closeGracefully() {
         return closed.compareAndSet(false, true) ? delegate.closeGracefully().doFinally(ignored -> sessionExecutionCoordinator.closeAllSessions()) : Mono.empty();
     }
-
+    
     @Override
     public void destroy() {
         try {
@@ -183,7 +183,7 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
             super.destroy();
         }
     }
-
+    
     private void bindSessionAttribution(final HttpServletRequest request, final SessionAwareHttpServletResponse response) {
         String sessionId = response.getSessionId();
         if (sessionId.isEmpty()) {
@@ -191,16 +191,16 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
         }
         sessionAttributionResolver.resolve(request).ifPresent(sessionAttribution -> sessionManager.bindSessionAttribution(sessionId, sessionAttribution));
     }
-
+    
     private SessionAwareHttpServletResponse withInitializeProtocolHeader(final HttpServletResponse response) {
         return new SessionAwareHttpServletResponse(response) {
-
+            
             @Override
             public void setHeader(final String name, final String value) {
                 super.setHeader(name, value);
                 addNegotiatedProtocolHeader(this, name, value);
             }
-
+            
             @Override
             public void addHeader(final String name, final String value) {
                 super.addHeader(name, value);
@@ -208,30 +208,30 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
             }
         };
     }
-
+    
     private void addNegotiatedProtocolHeader(final SessionAwareHttpServletResponse response, final String name, final String sessionId) {
         if (SESSION_HEADER.equalsIgnoreCase(name)) {
             response.setSessionId(sessionId);
             response.setHeader(PROTOCOL_HEADER, findNegotiatedProtocolVersion(sessionId));
         }
     }
-
+    
     private String findNegotiatedProtocolVersion(final String sessionId) {
         return sessionProtocolVersions.getOrDefault(Objects.toString(sessionId, ""), MCPTransportConstants.PROTOCOL_VERSION);
     }
-
+    
     private abstract static class SessionAwareHttpServletResponse extends HttpServletResponseWrapper {
-
+        
         private String sessionId = "";
-
+        
         SessionAwareHttpServletResponse(final HttpServletResponse response) {
             super(response);
         }
-
+        
         protected final String getSessionId() {
             return sessionId;
         }
-
+        
         protected final void setSessionId(final String sessionId) {
             this.sessionId = Objects.toString(sessionId, "").trim();
         }

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServlet.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServlet.java
@@ -44,45 +44,48 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamableServerTransportProvider {
-    
+
     private static final long serialVersionUID = -2320345528569140021L;
-    
+
     private static final String SESSION_HEADER = HttpHeaders.MCP_SESSION_ID;
-    
+
     private static final String PROTOCOL_HEADER = HttpHeaders.PROTOCOL_VERSION;
-    
+
     private static final String JSON_CONTENT_TYPE = "application/json";
-    
+
     private final HttpServletStreamableServerTransportProvider delegate;
-    
+
     private final MCPSessionManager sessionManager;
-    
+
     private final MCPSessionExecutionCoordinator sessionExecutionCoordinator;
-    
+
+    private final SessionAttributionResolver sessionAttributionResolver;
+
     private final Map<String, String> sessionProtocolVersions;
-    
+
     private final AtomicBoolean closed;
-    
+
     StreamableHttpMCPServlet(final MCPSessionManager sessionManager, final McpJsonMapper jsonMapper, final HttpTransportConfiguration config) {
-        delegate = createDelegate(sessionManager, jsonMapper, config.getBindHost(), config.getEndpointPath());
+        sessionAttributionResolver = new SessionAttributionResolver(config.getSessionAttributionSource());
+        delegate = createDelegate(sessionManager, jsonMapper, config.getBindHost(), config.getEndpointPath(), sessionAttributionResolver);
         this.sessionManager = sessionManager;
         sessionExecutionCoordinator = new MCPSessionExecutionCoordinator(sessionManager);
         sessionProtocolVersions = new ConcurrentHashMap<>();
         sessionManager.addSessionCloseListener(sessionProtocolVersions::remove);
         closed = new AtomicBoolean();
     }
-    
+
     private static HttpServletStreamableServerTransportProvider createDelegate(final MCPSessionManager sessionManager, final McpJsonMapper jsonMapper,
-                                                                               final String bindHost, final String endpointPath) {
+                                                                               final String bindHost, final String endpointPath, final SessionAttributionResolver sessionAttributionResolver) {
         return HttpServletStreamableServerTransportProvider.builder().jsonMapper(jsonMapper).mcpEndpoint(endpointPath)
-                .securityValidator(ServerTransportSecurityValidatorFactory.create(sessionManager, bindHost)).build();
+                .securityValidator(ServerTransportSecurityValidatorFactory.create(sessionManager, bindHost, sessionAttributionResolver)).build();
     }
-    
+
     @Override
     public List<String> protocolVersions() {
         return MCPTransportConstants.SUPPORTED_PROTOCOL_VERSIONS;
     }
-    
+
     @Override
     public void setSessionFactory(final McpStreamableServerSession.Factory sessionFactory) {
         delegate.setSessionFactory(initializeRequest -> {
@@ -94,34 +97,34 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
             return result;
         });
     }
-    
+
     private McpSchema.InitializeRequest negotiateInitializeRequest(final McpSchema.InitializeRequest initializeRequest) {
         String negotiatedProtocolVersion = negotiateProtocolVersion(initializeRequest.protocolVersion());
         return negotiatedProtocolVersion.equals(initializeRequest.protocolVersion())
                 ? initializeRequest
                 : new McpSchema.InitializeRequest(negotiatedProtocolVersion, initializeRequest.capabilities(), initializeRequest.clientInfo(), initializeRequest.meta());
     }
-    
+
     private String negotiateProtocolVersion(final String requestedProtocolVersion) {
         String actualRequestedProtocolVersion = Objects.toString(requestedProtocolVersion, "").trim();
         return protocolVersions().contains(actualRequestedProtocolVersion) ? actualRequestedProtocolVersion : MCPTransportConstants.PROTOCOL_VERSION;
     }
-    
+
     @Override
     public Mono<Void> notifyClients(final String method, final Object params) {
         return delegate.notifyClients(method, params);
     }
-    
+
     @Override
     public Mono<Void> notifyClient(final String sessionId, final String method, final Object params) {
         return delegate.notifyClient(sessionId, method, params);
     }
-    
+
     @Override
     protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {
         serviceRequest(request, response);
     }
-    
+
     private void serviceWithApplicationClassLoader(final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {
         ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         try {
@@ -131,26 +134,28 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
             Thread.currentThread().setContextClassLoader(originalClassLoader);
         }
     }
-    
+
     @Override
     protected void doPost(final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {
         if (!isJsonContentType(request)) {
             response.sendError(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE, "Content-Type must be application/json.");
             return;
         }
-        serviceRequest(request, withInitializeProtocolHeader(response));
+        SessionAwareHttpServletResponse actualResponse = withInitializeProtocolHeader(response);
+        serviceRequest(request, actualResponse);
+        bindSessionAttribution(request, actualResponse);
     }
-    
+
     private boolean isJsonContentType(final HttpServletRequest request) {
         String contentType = Objects.toString(request.getContentType(), "").trim();
         return contentType.isEmpty() || JSON_CONTENT_TYPE.equalsIgnoreCase(contentType.split(";", 2)[0].trim());
     }
-    
+
     private void serviceRequest(final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {
         setUtf8Encoding(request, response);
         serviceWithApplicationClassLoader(request, response);
     }
-    
+
     @Override
     protected void doDelete(final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {
         String sessionId = Objects.toString(request.getHeader(SESSION_HEADER), "").trim();
@@ -159,17 +164,17 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
             sessionExecutionCoordinator.closeSession(sessionId);
         }
     }
-    
+
     private void setUtf8Encoding(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
         request.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
     }
-    
+
     @Override
     public Mono<Void> closeGracefully() {
         return closed.compareAndSet(false, true) ? delegate.closeGracefully().doFinally(ignored -> sessionExecutionCoordinator.closeAllSessions()) : Mono.empty();
     }
-    
+
     @Override
     public void destroy() {
         try {
@@ -178,31 +183,57 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
             super.destroy();
         }
     }
-    
-    private HttpServletResponse withInitializeProtocolHeader(final HttpServletResponse response) {
-        return new HttpServletResponseWrapper(response) {
-            
+
+    private void bindSessionAttribution(final HttpServletRequest request, final SessionAwareHttpServletResponse response) {
+        String sessionId = response.getSessionId();
+        if (sessionId.isEmpty()) {
+            return;
+        }
+        sessionAttributionResolver.resolve(request).ifPresent(sessionAttribution -> sessionManager.bindSessionAttribution(sessionId, sessionAttribution));
+    }
+
+    private SessionAwareHttpServletResponse withInitializeProtocolHeader(final HttpServletResponse response) {
+        return new SessionAwareHttpServletResponse(response) {
+
             @Override
             public void setHeader(final String name, final String value) {
                 super.setHeader(name, value);
-                addNegotiatedProtocolHeader(name, value);
+                addNegotiatedProtocolHeader(this, name, value);
             }
-            
+
             @Override
             public void addHeader(final String name, final String value) {
                 super.addHeader(name, value);
-                addNegotiatedProtocolHeader(name, value);
-            }
-            
-            private void addNegotiatedProtocolHeader(final String name, final String sessionId) {
-                if (SESSION_HEADER.equalsIgnoreCase(name)) {
-                    super.setHeader(PROTOCOL_HEADER, findNegotiatedProtocolVersion(sessionId));
-                }
+                addNegotiatedProtocolHeader(this, name, value);
             }
         };
     }
-    
+
+    private void addNegotiatedProtocolHeader(final SessionAwareHttpServletResponse response, final String name, final String sessionId) {
+        if (SESSION_HEADER.equalsIgnoreCase(name)) {
+            response.setSessionId(sessionId);
+            response.setHeader(PROTOCOL_HEADER, findNegotiatedProtocolVersion(sessionId));
+        }
+    }
+
     private String findNegotiatedProtocolVersion(final String sessionId) {
         return sessionProtocolVersions.getOrDefault(Objects.toString(sessionId, ""), MCPTransportConstants.PROTOCOL_VERSION);
+    }
+
+    private abstract static class SessionAwareHttpServletResponse extends HttpServletResponseWrapper {
+
+        private String sessionId = "";
+
+        SessionAwareHttpServletResponse(final HttpServletResponse response) {
+            super(response);
+        }
+
+        protected final String getSessionId() {
+            return sessionId;
+        }
+
+        protected final void setSessionId(final String sessionId) {
+            this.sessionId = Objects.toString(sessionId, "").trim();
+        }
     }
 }

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ServerTransportSecurityValidatorFactory.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ServerTransportSecurityValidatorFactory.java
@@ -21,6 +21,7 @@ import io.modelcontextprotocol.server.transport.ServerTransportSecurityValidator
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.bootstrap.transport.HttpTransportHostUtils;
+import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.SessionAttributionResolver;
 import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator.constraint.OriginHeaderConstraint;
 import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator.constraint.ProtocolVersionHeaderConstraint;
 import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator.constraint.TransportHeaderConstraint;
@@ -40,10 +41,11 @@ public final class ServerTransportSecurityValidatorFactory {
      *
      * @param sessionManager session manager
      * @param bindHost bind host
+     * @param sessionAttributionResolver session attribution resolver
      * @return transport security validator
      */
-    public static ServerTransportSecurityValidator create(final MCPSessionManager sessionManager, final String bindHost) {
-        return new ShardingSphereServerTransportSecurityValidator(sessionManager, createConstraints(bindHost));
+    public static ServerTransportSecurityValidator create(final MCPSessionManager sessionManager, final String bindHost, final SessionAttributionResolver sessionAttributionResolver) {
+        return new ShardingSphereServerTransportSecurityValidator(sessionManager, createConstraints(bindHost), sessionAttributionResolver);
     }
     
     private static List<TransportHeaderConstraint> createConstraints(final String bindHost) {

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidator.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidator.java
@@ -21,6 +21,8 @@ import io.modelcontextprotocol.server.transport.ServerTransportSecurityException
 import io.modelcontextprotocol.server.transport.ServerTransportSecurityValidator;
 import io.modelcontextprotocol.spec.HttpHeaders;
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.SessionAttributionResolver;
 import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator.constraint.SessionRequiredTransportHeaderConstraint;
 import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator.constraint.TransportHeaderConstraint;
 import org.apache.shardingsphere.mcp.core.session.MCPSessionManager;
@@ -28,19 +30,23 @@ import org.apache.shardingsphere.mcp.core.session.MCPSessionManager;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * ShardingSphere server transport security validator.
  */
 @RequiredArgsConstructor
 public final class ShardingSphereServerTransportSecurityValidator implements ServerTransportSecurityValidator {
-    
+
     private final MCPSessionManager sessionManager;
-    
+
     private final List<TransportHeaderConstraint> constraints;
-    
+
+    private final SessionAttributionResolver sessionAttributionResolver;
+
     @Override
     public void validateHeaders(final Map<String, List<String>> headers) throws ServerTransportSecurityException {
+        validateSessionAttribution(headers);
         for (TransportHeaderConstraint each : constraints) {
             if (each instanceof SessionRequiredTransportHeaderConstraint) {
                 String sessionId = getFirstHeaderValue(headers, HttpHeaders.MCP_SESSION_ID);
@@ -51,7 +57,22 @@ public final class ShardingSphereServerTransportSecurityValidator implements Ser
             each.validate(getFirstHeaderValue(headers, each.getConstraintKey()));
         }
     }
-    
+
+    private void validateSessionAttribution(final Map<String, List<String>> headers) throws ServerTransportSecurityException {
+        String sessionId = getFirstHeaderValue(headers, HttpHeaders.MCP_SESSION_ID);
+        if (sessionId.isEmpty() || !sessionManager.hasSession(sessionId) || !sessionAttributionResolver.isEnabled()) {
+            return;
+        }
+        Optional<MCPSessionAttribution> sessionAttribution = sessionAttributionResolver.resolve(headers);
+        if (sessionAttribution.isPresent()) {
+            try {
+                sessionManager.bindSessionAttribution(sessionId, sessionAttribution.get());
+            } catch (final IllegalStateException ex) {
+                throw new ServerTransportSecurityException(400, ex.getMessage());
+            }
+        }
+    }
+
     private String getFirstHeaderValue(final Map<String, List<String>> headers, final String headerName) {
         return headers.entrySet().stream()
                 .filter(entry -> headerName.equalsIgnoreCase(entry.getKey()) && !entry.getValue().isEmpty()).findFirst().map(optional -> Objects.toString(optional.getValue().get(0), "").trim())

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidator.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidator.java
@@ -64,12 +64,15 @@ public final class ShardingSphereServerTransportSecurityValidator implements Ser
             return;
         }
         Optional<MCPSessionAttribution> sessionAttribution = sessionAttributionResolver.resolve(headers);
-        if (sessionAttribution.isPresent()) {
-            try {
-                sessionManager.bindSessionAttribution(sessionId, sessionAttribution.get());
-            } catch (final IllegalStateException ex) {
-                throw new ServerTransportSecurityException(400, ex.getMessage());
-            }
+        if (sessionAttribution.isEmpty()) {
+            return;
+        }
+        Optional<MCPSessionAttribution> boundSessionAttribution = sessionManager.findSessionAttribution(sessionId);
+        if (boundSessionAttribution.isEmpty()) {
+            throw new ServerTransportSecurityException(400, String.format("Session attribution is not bound for session `%s`.", sessionId));
+        }
+        if (!boundSessionAttribution.get().equals(sessionAttribution.get())) {
+            throw new ServerTransportSecurityException(400, String.format("Session attribution does not match existing binding for session `%s`.", sessionId));
         }
     }
     

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidator.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidator.java
@@ -37,13 +37,13 @@ import java.util.Optional;
  */
 @RequiredArgsConstructor
 public final class ShardingSphereServerTransportSecurityValidator implements ServerTransportSecurityValidator {
-
+    
     private final MCPSessionManager sessionManager;
-
+    
     private final List<TransportHeaderConstraint> constraints;
-
+    
     private final SessionAttributionResolver sessionAttributionResolver;
-
+    
     @Override
     public void validateHeaders(final Map<String, List<String>> headers) throws ServerTransportSecurityException {
         validateSessionAttribution(headers);
@@ -57,7 +57,7 @@ public final class ShardingSphereServerTransportSecurityValidator implements Ser
             each.validate(getFirstHeaderValue(headers, each.getConstraintKey()));
         }
     }
-
+    
     private void validateSessionAttribution(final Map<String, List<String>> headers) throws ServerTransportSecurityException {
         String sessionId = getFirstHeaderValue(headers, HttpHeaders.MCP_SESSION_ID);
         if (sessionId.isEmpty() || !sessionManager.hasSession(sessionId) || !sessionAttributionResolver.isEnabled()) {
@@ -72,7 +72,7 @@ public final class ShardingSphereServerTransportSecurityValidator implements Ser
             }
         }
     }
-
+    
     private String getFirstHeaderValue(final Map<String, List<String>> headers, final String headerName) {
         return headers.entrySet().stream()
                 .filter(entry -> headerName.equalsIgnoreCase(entry.getKey()) && !entry.getValue().isEmpty()).findFirst().map(optional -> Objects.toString(optional.getValue().get(0), "").trim())

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/swapper/YamlHttpTransportConfigurationSwapperTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/swapper/YamlHttpTransportConfigurationSwapperTest.java
@@ -18,25 +18,29 @@
 package org.apache.shardingsphere.mcp.bootstrap.config.yaml.swapper;
 
 import org.apache.shardingsphere.mcp.bootstrap.config.HttpTransportConfiguration;
+import org.apache.shardingsphere.mcp.bootstrap.config.SessionAttributionSourceConfiguration;
 import org.apache.shardingsphere.mcp.bootstrap.config.yaml.config.YamlHttpTransportConfiguration;
+import org.apache.shardingsphere.mcp.bootstrap.config.yaml.config.YamlSessionAttributionSourceConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class YamlHttpTransportConfigurationSwapperTest {
-    
+
     private final YamlHttpTransportConfigurationSwapper swapper = new YamlHttpTransportConfigurationSwapper();
-    
+
     @Test
     void assertSwapToObject() {
         HttpTransportConfiguration actual = swapper.swapToObject(createYamlConfig("127.0.0.1", 18088, "/mcp"));
         assertThat(actual.getBindHost(), is("127.0.0.1"));
         assertThat(actual.getPort(), is(18088));
         assertThat(actual.getEndpointPath(), is("/mcp"));
+        assertNull(actual.getSessionAttributionSource());
     }
-    
+
     @Test
     void assertSwapToObjectWithDefaults() {
         HttpTransportConfiguration actual = swapper.swapToObject(null);
@@ -44,7 +48,7 @@ class YamlHttpTransportConfigurationSwapperTest {
         assertThat(actual.getPort(), is(18088));
         assertThat(actual.getEndpointPath(), is("/mcp"));
     }
-    
+
     @Test
     void assertSwapToObjectWithPartialDefaults() {
         YamlHttpTransportConfiguration yamlConfig = new YamlHttpTransportConfiguration();
@@ -54,75 +58,99 @@ class YamlHttpTransportConfigurationSwapperTest {
         assertThat(actual.getPort(), is(0));
         assertThat(actual.getEndpointPath(), is("/mcp"));
     }
-    
+
     @Test
     void assertSwapToObjectWithLocalhostBindHost() {
         HttpTransportConfiguration actual = swapper.swapToObject(createYamlConfig("localhost", 18088, "/mcp"));
         assertThat(actual.getBindHost(), is("localhost"));
     }
-    
+
     @Test
     void assertSwapToObjectWithRemoteBindHost() {
         HttpTransportConfiguration actual = swapper.swapToObject(createYamlConfig("0.0.0.0", 18088, "/mcp"));
         assertThat(actual.getBindHost(), is("0.0.0.0"));
     }
-    
+
     @Test
     void assertSwapToObjectWithUrlBindHost() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("http://127.0.0.1:18088", 18088, "/mcp")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `bindHost` must be a local bind host or IP address."));
     }
-    
+
     @Test
     void assertSwapToObjectWithBlankBindHost() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("", 18088, "/mcp")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `bindHost` must be a local bind host or IP address."));
     }
-    
+
     @Test
     void assertSwapToObjectWithNegativePort() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("127.0.0.1", -1, "/mcp")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `port` must be between 0 and 65535."));
     }
-    
+
     @Test
     void assertSwapToObjectWithPortOutOfRange() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("127.0.0.1", 65536, "/mcp")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `port` must be between 0 and 65535."));
     }
-    
+
     @Test
     void assertSwapToObjectWithEndpointPathMissingLeadingSlash() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("127.0.0.1", 18088, "gateway")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `endpointPath` must be a single absolute path without query or fragment."));
     }
-    
+
     @Test
     void assertSwapToObjectWithEndpointPathDoubleSlash() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("127.0.0.1", 18088, "//mcp")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `endpointPath` must be a single absolute path without query or fragment."));
     }
-    
+
     @Test
     void assertSwapToObjectWithEndpointPathQuery() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("127.0.0.1", 18088, "/mcp?debug=true")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `endpointPath` must be a single absolute path without query or fragment."));
     }
-    
+
     @Test
     void assertSwapToObjectWithEndpointPathFragment() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("127.0.0.1", 18088, "/mcp#debug")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `endpointPath` must be a single absolute path without query or fragment."));
     }
-    
+
     @Test
     void assertSwapToYamlConfiguration() {
         YamlHttpTransportConfiguration actual = swapper.swapToYamlConfiguration(new HttpTransportConfiguration("127.0.0.1", 18088, "/mcp"));
         assertThat(actual.getBindHost(), is("127.0.0.1"));
         assertThat(actual.getPort(), is(18088));
         assertThat(actual.getEndpointPath(), is("/mcp"));
+        assertNull(actual.getSessionAttributionSource());
     }
-    
+
+    @Test
+    void assertSwapToObjectWithSessionAttributionSource() {
+        YamlSessionAttributionSourceConfiguration sessionAttributionSource = new YamlSessionAttributionSourceConfiguration();
+        sessionAttributionSource.setSubjectHeader("X-Test-Subject");
+        sessionAttributionSource.setSourceHeader("X-Test-Source");
+        sessionAttributionSource.setAttributeHeaderPrefix("X-Test-Attr-");
+        YamlHttpTransportConfiguration yamlConfig = createYamlConfig("127.0.0.1", 18088, "/mcp");
+        yamlConfig.setSessionAttributionSource(sessionAttributionSource);
+        HttpTransportConfiguration actual = swapper.swapToObject(yamlConfig);
+        assertThat(actual.getSessionAttributionSource().getSubjectHeader(), is("X-Test-Subject"));
+        assertThat(actual.getSessionAttributionSource().getSourceHeader(), is("X-Test-Source"));
+        assertThat(actual.getSessionAttributionSource().getAttributeHeaderPrefix(), is("X-Test-Attr-"));
+    }
+
+    @Test
+    void assertSwapToYamlConfigurationWithSessionAttributionSource() {
+        YamlHttpTransportConfiguration actual = swapper.swapToYamlConfiguration(
+                new HttpTransportConfiguration("127.0.0.1", 18088, "/mcp", new SessionAttributionSourceConfiguration("X-Test-Subject", "X-Test-Source", "X-Test-Attr-")));
+        assertThat(actual.getSessionAttributionSource().getSubjectHeader(), is("X-Test-Subject"));
+        assertThat(actual.getSessionAttributionSource().getSourceHeader(), is("X-Test-Source"));
+        assertThat(actual.getSessionAttributionSource().getAttributeHeaderPrefix(), is("X-Test-Attr-"));
+    }
+
     private YamlHttpTransportConfiguration createYamlConfig(final String bindHost, final Integer port, final String endpointPath) {
         YamlHttpTransportConfiguration result = new YamlHttpTransportConfiguration();
         result.setBindHost(bindHost);

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/swapper/YamlHttpTransportConfigurationSwapperTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/swapper/YamlHttpTransportConfigurationSwapperTest.java
@@ -130,16 +130,36 @@ class YamlHttpTransportConfigurationSwapperTest {
     
     @Test
     void assertSwapToObjectWithSessionAttributionSource() {
-        YamlSessionAttributionSourceConfiguration sessionAttributionSource = new YamlSessionAttributionSourceConfiguration();
-        sessionAttributionSource.setSubjectHeader("X-Test-Subject");
-        sessionAttributionSource.setSourceHeader("X-Test-Source");
-        sessionAttributionSource.setAttributeHeaderPrefix("X-Test-Attr-");
         YamlHttpTransportConfiguration yamlConfig = createYamlConfig("127.0.0.1", 18088, "/mcp");
-        yamlConfig.setSessionAttributionSource(sessionAttributionSource);
+        yamlConfig.setSessionAttributionSource(createSessionAttributionSource("X-Test-Subject", "X-Test-Source", "X-Test-Attr-"));
         HttpTransportConfiguration actual = swapper.swapToObject(yamlConfig);
         assertThat(actual.getSessionAttributionSource().getSubjectHeader(), is("X-Test-Subject"));
         assertThat(actual.getSessionAttributionSource().getSourceHeader(), is("X-Test-Source"));
         assertThat(actual.getSessionAttributionSource().getAttributeHeaderPrefix(), is("X-Test-Attr-"));
+    }
+    
+    @Test
+    void assertSwapToObjectWithInvalidSessionAttributionSubjectHeader() {
+        YamlHttpTransportConfiguration yamlConfig = createYamlConfig("127.0.0.1", 18088, "/mcp");
+        yamlConfig.setSessionAttributionSource(createSessionAttributionSource("X-Test,Subject", "X-Test-Source", "X-Test-Attr-"));
+        IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(yamlConfig));
+        assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `sessionAttributionSource.subjectHeader` must be a valid HTTP header name."));
+    }
+    
+    @Test
+    void assertSwapToObjectWithInvalidSessionAttributionSourceHeader() {
+        YamlHttpTransportConfiguration yamlConfig = createYamlConfig("127.0.0.1", 18088, "/mcp");
+        yamlConfig.setSessionAttributionSource(createSessionAttributionSource("X-Test-Subject", "X/Test-Source", "X-Test-Attr-"));
+        IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(yamlConfig));
+        assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `sessionAttributionSource.sourceHeader` must be a valid HTTP header name."));
+    }
+    
+    @Test
+    void assertSwapToObjectWithInvalidSessionAttributionAttributeHeaderPrefix() {
+        YamlHttpTransportConfiguration yamlConfig = createYamlConfig("127.0.0.1", 18088, "/mcp");
+        yamlConfig.setSessionAttributionSource(createSessionAttributionSource("X-Test-Subject", "X-Test-Source", "X-Test-Attr("));
+        IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(yamlConfig));
+        assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `sessionAttributionSource.attributeHeaderPrefix` must be a valid HTTP header name prefix."));
     }
     
     @Test
@@ -156,6 +176,14 @@ class YamlHttpTransportConfigurationSwapperTest {
         result.setBindHost(bindHost);
         result.setPort(port);
         result.setEndpointPath(endpointPath);
+        return result;
+    }
+    
+    private YamlSessionAttributionSourceConfiguration createSessionAttributionSource(final String subjectHeader, final String sourceHeader, final String attributeHeaderPrefix) {
+        YamlSessionAttributionSourceConfiguration result = new YamlSessionAttributionSourceConfiguration();
+        result.setSubjectHeader(subjectHeader);
+        result.setSourceHeader(sourceHeader);
+        result.setAttributeHeaderPrefix(attributeHeaderPrefix);
         return result;
     }
 }

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/swapper/YamlHttpTransportConfigurationSwapperTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/swapper/YamlHttpTransportConfigurationSwapperTest.java
@@ -29,9 +29,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class YamlHttpTransportConfigurationSwapperTest {
-
+    
     private final YamlHttpTransportConfigurationSwapper swapper = new YamlHttpTransportConfigurationSwapper();
-
+    
     @Test
     void assertSwapToObject() {
         HttpTransportConfiguration actual = swapper.swapToObject(createYamlConfig("127.0.0.1", 18088, "/mcp"));
@@ -40,7 +40,7 @@ class YamlHttpTransportConfigurationSwapperTest {
         assertThat(actual.getEndpointPath(), is("/mcp"));
         assertNull(actual.getSessionAttributionSource());
     }
-
+    
     @Test
     void assertSwapToObjectWithDefaults() {
         HttpTransportConfiguration actual = swapper.swapToObject(null);
@@ -48,7 +48,7 @@ class YamlHttpTransportConfigurationSwapperTest {
         assertThat(actual.getPort(), is(18088));
         assertThat(actual.getEndpointPath(), is("/mcp"));
     }
-
+    
     @Test
     void assertSwapToObjectWithPartialDefaults() {
         YamlHttpTransportConfiguration yamlConfig = new YamlHttpTransportConfiguration();
@@ -58,67 +58,67 @@ class YamlHttpTransportConfigurationSwapperTest {
         assertThat(actual.getPort(), is(0));
         assertThat(actual.getEndpointPath(), is("/mcp"));
     }
-
+    
     @Test
     void assertSwapToObjectWithLocalhostBindHost() {
         HttpTransportConfiguration actual = swapper.swapToObject(createYamlConfig("localhost", 18088, "/mcp"));
         assertThat(actual.getBindHost(), is("localhost"));
     }
-
+    
     @Test
     void assertSwapToObjectWithRemoteBindHost() {
         HttpTransportConfiguration actual = swapper.swapToObject(createYamlConfig("0.0.0.0", 18088, "/mcp"));
         assertThat(actual.getBindHost(), is("0.0.0.0"));
     }
-
+    
     @Test
     void assertSwapToObjectWithUrlBindHost() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("http://127.0.0.1:18088", 18088, "/mcp")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `bindHost` must be a local bind host or IP address."));
     }
-
+    
     @Test
     void assertSwapToObjectWithBlankBindHost() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("", 18088, "/mcp")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `bindHost` must be a local bind host or IP address."));
     }
-
+    
     @Test
     void assertSwapToObjectWithNegativePort() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("127.0.0.1", -1, "/mcp")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `port` must be between 0 and 65535."));
     }
-
+    
     @Test
     void assertSwapToObjectWithPortOutOfRange() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("127.0.0.1", 65536, "/mcp")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `port` must be between 0 and 65535."));
     }
-
+    
     @Test
     void assertSwapToObjectWithEndpointPathMissingLeadingSlash() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("127.0.0.1", 18088, "gateway")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `endpointPath` must be a single absolute path without query or fragment."));
     }
-
+    
     @Test
     void assertSwapToObjectWithEndpointPathDoubleSlash() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("127.0.0.1", 18088, "//mcp")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `endpointPath` must be a single absolute path without query or fragment."));
     }
-
+    
     @Test
     void assertSwapToObjectWithEndpointPathQuery() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("127.0.0.1", 18088, "/mcp?debug=true")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `endpointPath` must be a single absolute path without query or fragment."));
     }
-
+    
     @Test
     void assertSwapToObjectWithEndpointPathFragment() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> swapper.swapToObject(createYamlConfig("127.0.0.1", 18088, "/mcp#debug")));
         assertThat(actual.getMessage(), is("MCP HTTP transport configuration property `endpointPath` must be a single absolute path without query or fragment."));
     }
-
+    
     @Test
     void assertSwapToYamlConfiguration() {
         YamlHttpTransportConfiguration actual = swapper.swapToYamlConfiguration(new HttpTransportConfiguration("127.0.0.1", 18088, "/mcp"));
@@ -127,7 +127,7 @@ class YamlHttpTransportConfigurationSwapperTest {
         assertThat(actual.getEndpointPath(), is("/mcp"));
         assertNull(actual.getSessionAttributionSource());
     }
-
+    
     @Test
     void assertSwapToObjectWithSessionAttributionSource() {
         YamlSessionAttributionSourceConfiguration sessionAttributionSource = new YamlSessionAttributionSourceConfiguration();
@@ -141,7 +141,7 @@ class YamlHttpTransportConfigurationSwapperTest {
         assertThat(actual.getSessionAttributionSource().getSourceHeader(), is("X-Test-Source"));
         assertThat(actual.getSessionAttributionSource().getAttributeHeaderPrefix(), is("X-Test-Attr-"));
     }
-
+    
     @Test
     void assertSwapToYamlConfigurationWithSessionAttributionSource() {
         YamlHttpTransportConfiguration actual = swapper.swapToYamlConfiguration(
@@ -150,7 +150,7 @@ class YamlHttpTransportConfigurationSwapperTest {
         assertThat(actual.getSessionAttributionSource().getSourceHeader(), is("X-Test-Source"));
         assertThat(actual.getSessionAttributionSource().getAttributeHeaderPrefix(), is("X-Test-Attr-"));
     }
-
+    
     private YamlHttpTransportConfiguration createYamlConfig(final String bindHost, final Integer port, final String endpointPath) {
         YamlHttpTransportConfiguration result = new YamlHttpTransportConfiguration();
         result.setBindHost(bindHost);

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolverTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolverTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.bootstrap.transport.server.http;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.shardingsphere.mcp.bootstrap.config.SessionAttributionSourceConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SessionAttributionResolverTest {
+    
+    @Test
+    void assertResolveFromRequest() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("X-Test-Subject")).thenReturn("subject");
+        when(request.getHeader("X-Test-Source")).thenReturn("gateway");
+        when(request.getHeaderNames()).thenReturn(java.util.Collections.enumeration(List.of("X-Test-Subject", "X-Test-Source", "X-Test-Attr-region")));
+        when(request.getHeader("X-Test-Attr-region")).thenReturn("ap-south");
+        SessionAttributionResolver resolver = new SessionAttributionResolver(new SessionAttributionSourceConfiguration("X-Test-Subject", "X-Test-Source", "X-Test-Attr-"));
+        assertThat(resolver.resolve(request).map(each -> each.getAttributes().get("region")), is(Optional.of("ap-south")));
+    }
+    
+    @Test
+    void assertResolveFromHeaders() {
+        SessionAttributionResolver resolver = new SessionAttributionResolver(new SessionAttributionSourceConfiguration("X-Test-Subject", "X-Test-Source", "X-Test-Attr-"));
+        assertThat(resolver.resolve(Map.of("X-Test-Subject", List.of("subject"), "X-Test-Source", List.of("gateway"))).get().getSubject(), is("subject"));
+    }
+}

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolverTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolverTest.java
@@ -21,6 +21,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.apache.shardingsphere.mcp.bootstrap.config.SessionAttributionSourceConfiguration;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -37,8 +38,8 @@ class SessionAttributionResolverTest {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getHeader("X-Test-Subject")).thenReturn("subject");
         when(request.getHeader("X-Test-Source")).thenReturn("gateway");
-        when(request.getHeaderNames()).thenReturn(java.util.Collections.enumeration(List.of("X-Test-Subject", "X-Test-Source", "X-Test-Attr-region")));
-        when(request.getHeader("X-Test-Attr-region")).thenReturn("ap-south");
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of("X-Test-Subject", "X-Test-Source", "X-Test-ATTR-Region")));
+        when(request.getHeader("X-Test-ATTR-Region")).thenReturn("ap-south");
         SessionAttributionResolver resolver = new SessionAttributionResolver(new SessionAttributionSourceConfiguration("X-Test-Subject", "X-Test-Source", "X-Test-Attr-"));
         assertThat(resolver.resolve(request).map(each -> each.getAttributes().get("region")), is(Optional.of("ap-south")));
     }
@@ -46,6 +47,7 @@ class SessionAttributionResolverTest {
     @Test
     void assertResolveFromHeaders() {
         SessionAttributionResolver resolver = new SessionAttributionResolver(new SessionAttributionSourceConfiguration("X-Test-Subject", "X-Test-Source", "X-Test-Attr-"));
-        assertThat(resolver.resolve(Map.of("X-Test-Subject", List.of("subject"), "X-Test-Source", List.of("gateway"))).get().getSubject(), is("subject"));
+        assertThat(resolver.resolve(Map.of("X-Test-Subject", List.of("subject"), "X-Test-Source", List.of("gateway"), "x-test-attr-Region", List.of("ap-south"))).get()
+                .getAttributes().get("region"), is("ap-south"));
     }
 }

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServletTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServletTest.java
@@ -26,7 +26,9 @@ import io.modelcontextprotocol.spec.ProtocolVersions;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
 import org.apache.shardingsphere.mcp.bootstrap.config.HttpTransportConfiguration;
+import org.apache.shardingsphere.mcp.bootstrap.config.SessionAttributionSourceConfiguration;
 import org.apache.shardingsphere.mcp.bootstrap.transport.MCPTransportConstants;
 import org.apache.shardingsphere.mcp.bootstrap.transport.MCPTransportJsonMapperFactory;
 import org.apache.shardingsphere.mcp.core.session.MCPSessionExecutionCoordinator;
@@ -42,6 +44,7 @@ import reactor.core.publisher.Mono;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -229,6 +232,30 @@ class StreamableHttpMCPServletTest {
         actual.service(request, response);
         verify(response).setHeader(HttpHeaders.MCP_SESSION_ID, "session-id");
         verify(response).setHeader(HttpHeaders.PROTOCOL_VERSION, MCPTransportConstants.PROTOCOL_VERSION);
+    }
+    
+    @Test
+    void assertServicePostBindSessionAttribution() throws ServletException, IOException, ReflectiveOperationException {
+        HttpServletStreamableServerTransportProvider delegate = mock(HttpServletStreamableServerTransportProvider.class);
+        MCPSessionManager sessionManager = mock(MCPSessionManager.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getHeader(HttpHeaders.ACCEPT)).thenReturn(ACCEPT);
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of("X-Test-Subject", "X-Test-Source", "X-Test-ATTR-Region")));
+        when(request.getHeader("X-Test-Subject")).thenReturn("subject");
+        when(request.getHeader("X-Test-Source")).thenReturn("gateway");
+        when(request.getHeader("X-Test-ATTR-Region")).thenReturn("ap-south");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(delegate.closeGracefully()).thenReturn(Mono.empty());
+        HttpTransportConfiguration config = new HttpTransportConfiguration("127.0.0.1", 18088, "/mcp",
+                new SessionAttributionSourceConfiguration("X-Test-Subject", "X-Test-Source", "X-Test-Attr-"));
+        StreamableHttpMCPServlet actual = createServlet(delegate, sessionManager, mock(MCPSessionExecutionCoordinator.class), config);
+        doAnswer(invocation -> {
+            ((HttpServletResponse) invocation.getArgument(1)).setHeader(HttpHeaders.MCP_SESSION_ID, "session-id");
+            return null;
+        }).when(delegate).service(any(HttpServletRequest.class), any(HttpServletResponse.class));
+        actual.service(request, response);
+        verify(sessionManager).bindSessionAttribution("session-id", new MCPSessionAttribution("subject", "gateway", Map.of("region", "ap-south")));
     }
     
     @Test

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ServerTransportSecurityValidatorFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ServerTransportSecurityValidatorFactoryTest.java
@@ -36,9 +36,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class ServerTransportSecurityValidatorFactoryTest {
-
+    
     private static final SessionAttributionResolver DISABLED_SESSION_ATTRIBUTION_RESOLVER = new SessionAttributionResolver(null);
-
+    
     @Test
     void assertCreateWithoutOptionalRules() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
@@ -46,7 +46,7 @@ class ServerTransportSecurityValidatorFactoryTest {
         assertDoesNotThrow(() -> actual.validateHeaders(Map.of()));
         verifyNoInteractions(sessionManager);
     }
-
+    
     @Test
     void assertCreateWithLoopbackOrigin() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
@@ -54,7 +54,7 @@ class ServerTransportSecurityValidatorFactoryTest {
         assertDoesNotThrow(() -> actual.validateHeaders(Map.of("Origin", List.of("http://127.0.0.1:8080"))));
         verifyNoInteractions(sessionManager);
     }
-
+    
     @Test
     void assertCreateWithLoopbackOriginRejectsRemoteOrigin() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
@@ -65,7 +65,7 @@ class ServerTransportSecurityValidatorFactoryTest {
         assertThat(ex.getStatusCode(), is(403));
         verify(sessionManager).hasSession("session-id");
     }
-
+    
     @Test
     void assertCreateWithNonLoopbackBindingAcceptsMissingOrigin() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
@@ -73,7 +73,7 @@ class ServerTransportSecurityValidatorFactoryTest {
         assertDoesNotThrow(() -> actual.validateHeaders(Map.of()));
         verifyNoInteractions(sessionManager);
     }
-
+    
     @Test
     void assertCreateWithNonLoopbackBindingRejectsPresentOrigin() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
@@ -83,7 +83,7 @@ class ServerTransportSecurityValidatorFactoryTest {
         assertThat(ex.getStatusCode(), is(403));
         verifyNoInteractions(sessionManager);
     }
-
+    
     @Test
     void assertCreateRejectsInvalidOrigin() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
@@ -92,7 +92,7 @@ class ServerTransportSecurityValidatorFactoryTest {
         assertThat(ex.getStatusCode(), is(403));
         verifyNoInteractions(sessionManager);
     }
-
+    
     @Test
     void assertCreateWithProtocolVersionConstraintLast() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ServerTransportSecurityValidatorFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ServerTransportSecurityValidatorFactoryTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator;
 
 import io.modelcontextprotocol.server.transport.ServerTransportSecurityException;
 import io.modelcontextprotocol.server.transport.ServerTransportSecurityValidator;
+import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.SessionAttributionResolver;
 import org.apache.shardingsphere.mcp.core.session.MCPSessionManager;
 import org.junit.jupiter.api.Test;
 
@@ -30,69 +31,73 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class ServerTransportSecurityValidatorFactoryTest {
-    
+
+    private static final SessionAttributionResolver DISABLED_SESSION_ATTRIBUTION_RESOLVER = new SessionAttributionResolver(null);
+
     @Test
     void assertCreateWithoutOptionalRules() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
-        ServerTransportSecurityValidator actual = ServerTransportSecurityValidatorFactory.create(sessionManager, "127.0.0.1");
+        ServerTransportSecurityValidator actual = ServerTransportSecurityValidatorFactory.create(sessionManager, "127.0.0.1", DISABLED_SESSION_ATTRIBUTION_RESOLVER);
         assertDoesNotThrow(() -> actual.validateHeaders(Map.of()));
         verifyNoInteractions(sessionManager);
     }
-    
+
     @Test
     void assertCreateWithLoopbackOrigin() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
-        ServerTransportSecurityValidator actual = ServerTransportSecurityValidatorFactory.create(sessionManager, "127.0.0.1");
+        ServerTransportSecurityValidator actual = ServerTransportSecurityValidatorFactory.create(sessionManager, "127.0.0.1", DISABLED_SESSION_ATTRIBUTION_RESOLVER);
         assertDoesNotThrow(() -> actual.validateHeaders(Map.of("Origin", List.of("http://127.0.0.1:8080"))));
         verifyNoInteractions(sessionManager);
     }
-    
+
     @Test
     void assertCreateWithLoopbackOriginRejectsRemoteOrigin() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
-        ServerTransportSecurityValidator validator = ServerTransportSecurityValidatorFactory.create(sessionManager, "127.0.0.1");
+        when(sessionManager.hasSession("session-id")).thenReturn(true);
+        ServerTransportSecurityValidator validator = ServerTransportSecurityValidatorFactory.create(sessionManager, "127.0.0.1", DISABLED_SESSION_ATTRIBUTION_RESOLVER);
         ServerTransportSecurityException ex = assertThrows(ServerTransportSecurityException.class,
                 () -> validator.validateHeaders(Map.of("Origin", List.of("http://example.com:8080"), "Mcp-Session-Id", List.of("session-id"))));
         assertThat(ex.getStatusCode(), is(403));
-        verifyNoInteractions(sessionManager);
+        verify(sessionManager).hasSession("session-id");
     }
-    
+
     @Test
     void assertCreateWithNonLoopbackBindingAcceptsMissingOrigin() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
-        ServerTransportSecurityValidator actual = ServerTransportSecurityValidatorFactory.create(sessionManager, "0.0.0.0");
+        ServerTransportSecurityValidator actual = ServerTransportSecurityValidatorFactory.create(sessionManager, "0.0.0.0", DISABLED_SESSION_ATTRIBUTION_RESOLVER);
         assertDoesNotThrow(() -> actual.validateHeaders(Map.of()));
         verifyNoInteractions(sessionManager);
     }
-    
+
     @Test
     void assertCreateWithNonLoopbackBindingRejectsPresentOrigin() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
-        ServerTransportSecurityValidator validator = ServerTransportSecurityValidatorFactory.create(sessionManager, "0.0.0.0");
+        ServerTransportSecurityValidator validator = ServerTransportSecurityValidatorFactory.create(sessionManager, "0.0.0.0", DISABLED_SESSION_ATTRIBUTION_RESOLVER);
         ServerTransportSecurityException ex = assertThrows(ServerTransportSecurityException.class,
                 () -> validator.validateHeaders(Map.of("Origin", List.of("https://gateway.example.test"))));
         assertThat(ex.getStatusCode(), is(403));
         verifyNoInteractions(sessionManager);
     }
-    
+
     @Test
     void assertCreateRejectsInvalidOrigin() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
-        ServerTransportSecurityValidator validator = ServerTransportSecurityValidatorFactory.create(sessionManager, "127.0.0.1");
+        ServerTransportSecurityValidator validator = ServerTransportSecurityValidatorFactory.create(sessionManager, "127.0.0.1", DISABLED_SESSION_ATTRIBUTION_RESOLVER);
         ServerTransportSecurityException ex = assertThrows(ServerTransportSecurityException.class, () -> validator.validateHeaders(Map.of("Origin", List.of("://bad-origin"))));
         assertThat(ex.getStatusCode(), is(403));
         verifyNoInteractions(sessionManager);
     }
-    
+
     @Test
     void assertCreateWithProtocolVersionConstraintLast() {
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
         when(sessionManager.hasSession("session-id")).thenReturn(true);
-        ServerTransportSecurityValidator validator = ServerTransportSecurityValidatorFactory.create(sessionManager, "127.0.0.1");
+        ServerTransportSecurityValidator validator = ServerTransportSecurityValidatorFactory.create(sessionManager, "127.0.0.1", DISABLED_SESSION_ATTRIBUTION_RESOLVER);
         ServerTransportSecurityException ex = assertThrows(ServerTransportSecurityException.class,
                 () -> validator.validateHeaders(Map.of("Mcp-Session-Id", List.of("session-id"))));
         assertThat(ex.getStatusCode(), is(400));

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidatorTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidatorTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -56,5 +57,18 @@ class ShardingSphereServerTransportSecurityValidatorTest {
         ServerTransportSecurityException exception = assertThrows(ServerTransportSecurityException.class, () -> actual.validateHeaders(
                 Map.of(HttpHeaders.MCP_SESSION_ID, List.of("session-1"), "X-Test-Subject", List.of("other"), "X-Test-Source", List.of("gateway"))));
         assertThat(exception.getMessage(), is("Session attribution does not match existing binding for session `session-1`."));
+    }
+    
+    @Test
+    void assertValidateHeadersWithUnboundSessionAttribution() {
+        MCPSessionManager sessionManager = new MCPSessionManager(Map.of());
+        sessionManager.createSession("session-1");
+        ShardingSphereServerTransportSecurityValidator actual = new ShardingSphereServerTransportSecurityValidator(sessionManager, List.of(),
+                new SessionAttributionResolver(new SessionAttributionSourceConfiguration("X-Test-Subject", "X-Test-Source", "X-Test-Attr-")));
+        ServerTransportSecurityException exception = assertThrows(ServerTransportSecurityException.class, () -> actual.validateHeaders(
+                Map.of(HttpHeaders.MCP_SESSION_ID, List.of("session-1"), "X-Test-Subject", List.of("subject"), "X-Test-Source", List.of("gateway"))));
+        assertThat(exception.getStatusCode(), is(400));
+        assertThat(exception.getMessage(), is("Session attribution is not bound for session `session-1`."));
+        assertThat(sessionManager.findSessionAttribution("session-1"), is(Optional.empty()));
     }
 }

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidatorTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidatorTest.java
@@ -19,94 +19,42 @@ package org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator;
 
 import io.modelcontextprotocol.server.transport.ServerTransportSecurityException;
 import io.modelcontextprotocol.spec.HttpHeaders;
-import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator.constraint.ProtocolVersionHeaderConstraint;
-import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator.constraint.SessionRequiredTransportHeaderConstraint;
-import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator.constraint.TransportHeaderConstraint;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.bootstrap.config.SessionAttributionSourceConfiguration;
+import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.SessionAttributionResolver;
 import org.apache.shardingsphere.mcp.core.session.MCPSessionManager;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 class ShardingSphereServerTransportSecurityValidatorTest {
     
     @Test
-    void assertValidateHeadersWithNoFailure() {
-        ShardingSphereServerTransportSecurityValidator validator = new ShardingSphereServerTransportSecurityValidator(mock(), List.of());
-        assertDoesNotThrow(() -> validator.validateHeaders(Map.of()));
+    void assertValidateHeadersWithMatchedSessionAttribution() {
+        MCPSessionManager sessionManager = new MCPSessionManager(Map.of());
+        sessionManager.createSession("session-1");
+        sessionManager.bindSessionAttribution("session-1", new MCPSessionAttribution("subject", "gateway", Map.of()));
+        ShardingSphereServerTransportSecurityValidator actual = new ShardingSphereServerTransportSecurityValidator(sessionManager, List.of(),
+                new SessionAttributionResolver(new SessionAttributionSourceConfiguration("X-Test-Subject", "X-Test-Source", "X-Test-Attr-")));
+        assertDoesNotThrow(() -> actual.validateHeaders(Map.of(HttpHeaders.MCP_SESSION_ID, List.of("session-1"), "X-Test-Subject", List.of("subject"),
+                "X-Test-Source", List.of("gateway"))));
     }
     
     @Test
-    void assertValidateHeadersWithFailure() throws ServerTransportSecurityException {
-        TransportHeaderConstraint first = mock(TransportHeaderConstraint.class);
-        doThrow(new ServerTransportSecurityException(401, "Unauthorized.")).when(first).validate("");
-        TransportHeaderConstraint second = mock(TransportHeaderConstraint.class);
-        ShardingSphereServerTransportSecurityValidator validator = new ShardingSphereServerTransportSecurityValidator(mock(), List.of(first, second));
-        ServerTransportSecurityException actual = assertThrows(ServerTransportSecurityException.class, () -> validator.validateHeaders(Map.of()));
-        assertThat(actual.getStatusCode(), is(401));
-        assertThat(actual.getMessage(), is("Unauthorized."));
-        verifyNoInteractions(second);
-    }
-    
-    @Test
-    void assertValidateHeadersWithExistingSessionMissingProtocolVersion() {
-        MCPSessionManager sessionManager = mock(MCPSessionManager.class);
-        when(sessionManager.hasSession("session-id")).thenReturn(true);
-        ShardingSphereServerTransportSecurityValidator validator = new ShardingSphereServerTransportSecurityValidator(sessionManager, List.of(new ProtocolVersionHeaderConstraint()));
-        ServerTransportSecurityException actual = assertThrows(ServerTransportSecurityException.class,
-                () -> validator.validateHeaders(Map.of(HttpHeaders.MCP_SESSION_ID, List.of("session-id"))));
-        assertThat(actual.getStatusCode(), is(400));
-        assertThat(actual.getMessage(), is("MCP-Protocol-Version header is required."));
-        verify(sessionManager).hasSession("session-id");
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("assertValidateHeadersWithSessionConstraintArguments")
-    void assertValidateHeadersWithSessionConstraint(final String name, final Map<String, List<String>> headers,
-                                                    final String expectedSessionId, final boolean sessionExists, final String expectedConstraintValue) throws ServerTransportSecurityException {
-        MCPSessionManager sessionManager = mock(MCPSessionManager.class);
-        SessionRequiredTransportHeaderConstraint constraint = mock(SessionRequiredTransportHeaderConstraint.class);
-        ShardingSphereServerTransportSecurityValidator validator = new ShardingSphereServerTransportSecurityValidator(sessionManager, List.of(constraint));
-        if (null != expectedSessionId) {
-            when(sessionManager.hasSession(expectedSessionId)).thenReturn(sessionExists);
-        }
-        if (null != expectedConstraintValue) {
-            when(constraint.getConstraintKey()).thenReturn("Authorization");
-        }
-        assertDoesNotThrow(() -> validator.validateHeaders(headers));
-        if (null == expectedSessionId) {
-            verifyNoInteractions(sessionManager);
-        } else {
-            verify(sessionManager).hasSession(expectedSessionId);
-        }
-        if (null == expectedConstraintValue) {
-            verifyNoInteractions(constraint);
-        } else {
-            verify(constraint).getConstraintKey();
-            verify(constraint).validate(expectedConstraintValue);
-        }
-    }
-    
-    private static Stream<Arguments> assertValidateHeadersWithSessionConstraintArguments() {
-        return Stream.of(
-                Arguments.of("skip without session id", Map.of("Authorization", List.of("Bearer foo_token")), null, false, null),
-                Arguments.of("skip with empty session header", Map.of("Mcp-Session-Id", List.<String>of()), null, false, null),
-                Arguments.of("skip for unknown session", Map.of("Mcp-Session-Id", List.of("session-id")), "session-id", false, null),
-                Arguments.of("validate with existing session",
-                        Map.of("mcp-session-id", List.of(" session-id "), "authorization", List.of(" Bearer foo_token ")), "session-id", true, "Bearer foo_token"));
+    void assertValidateHeadersWithMismatchedSessionAttribution() {
+        MCPSessionManager sessionManager = new MCPSessionManager(Map.of());
+        sessionManager.createSession("session-1");
+        sessionManager.bindSessionAttribution("session-1", new MCPSessionAttribution("subject", "gateway", Map.of()));
+        ShardingSphereServerTransportSecurityValidator actual = new ShardingSphereServerTransportSecurityValidator(sessionManager, List.of(),
+                new SessionAttributionResolver(new SessionAttributionSourceConfiguration("X-Test-Subject", "X-Test-Source", "X-Test-Attr-")));
+        ServerTransportSecurityException exception = assertThrows(ServerTransportSecurityException.class, () -> actual.validateHeaders(
+                Map.of(HttpHeaders.MCP_SESSION_ID, List.of("session-1"), "X-Test-Subject", List.of("other"), "X-Test-Source", List.of("gateway"))));
+        assertThat(exception.getMessage(), is("Session attribution does not match existing binding for session `session-1`."));
     }
 }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/completion/MCPCompletionService.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/completion/MCPCompletionService.java
@@ -136,7 +136,7 @@ public final class MCPCompletionService {
         MCPCompletionRequestContext requestContext = new MCPCompletionRequestContext(sessionId, descriptor, argumentName, contextArguments);
         for (MCPCompletionProvider<?> each : completionProviders) {
             if (each.supports(requestContext)) {
-                try (MCPRequestScope requestScope = new MCPRequestScope(runtimeContext)) {
+                try (MCPRequestScope requestScope = new MCPRequestScope(runtimeContext, sessionId)) {
                     return completeCandidates(requestScope, each, requestContext);
                 }
             }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/context/MCPRequestScope.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/context/MCPRequestScope.java
@@ -41,25 +41,25 @@ import java.util.Optional;
  */
 @Getter
 public final class MCPRequestScope implements MCPServiceHandlerContext, MCPDatabaseHandlerContext, MCPWorkflowHandlerContext, AutoCloseable {
-
+    
     private final String activeTransport;
-
+    
     @Getter(AccessLevel.NONE)
     private final MCPDatabaseCapabilityProvider databaseCapabilityProvider;
-
+    
     @Getter(AccessLevel.NONE)
     private final RequestScopedMetadataContext metadataContext;
-
+    
     private final Optional<MCPSessionAttribution> sessionAttribution;
-
+    
     private final WorkflowSessionContext workflowSessionContext;
-
+    
     private final MCPMetadataQueryFacade metadataQueryFacade;
-
+    
     private final MCPFeatureExecutionFacade executionFacade;
-
+    
     private final MCPFeatureQueryFacade queryFacade;
-
+    
     /**
      * Create MCP request scope.
      *
@@ -68,7 +68,7 @@ public final class MCPRequestScope implements MCPServiceHandlerContext, MCPDatab
     public MCPRequestScope(final MCPRuntimeContext runtimeContext) {
         this(runtimeContext, "");
     }
-
+    
     /**
      * Create MCP request scope.
      *
@@ -86,22 +86,22 @@ public final class MCPRequestScope implements MCPServiceHandlerContext, MCPDatab
         executionFacade = new MCPSQLExecutionFacade(databaseCapabilityProvider, sessionManager);
         queryFacade = new WorkflowProxyQueryService(sessionManager, databaseCapabilityProvider);
     }
-
+    
     @Override
     public MCPDatabaseHandlerContext getDatabaseContext() {
         return this;
     }
-
+    
     @Override
     public MCPFeatureCapabilityFacade getCapabilityFacade() {
         return databaseCapabilityProvider;
     }
-
+    
     @Override
     public Optional<MCPSessionAttribution> findSessionAttribution() {
         return sessionAttribution;
     }
-
+    
     @Override
     public void close() {
         metadataContext.close();

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/context/MCPRequestScope.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/context/MCPRequestScope.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.mcp.core.context;
 
 import lombok.AccessLevel;
 import lombok.Getter;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
 import org.apache.shardingsphere.mcp.core.session.MCPSessionManager;
 import org.apache.shardingsphere.mcp.core.tool.handler.execute.MCPSQLExecutionFacade;
 import org.apache.shardingsphere.mcp.core.workflow.WorkflowProxyQueryService;
@@ -33,54 +34,74 @@ import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade
 import org.apache.shardingsphere.mcp.support.workflow.MCPWorkflowHandlerContext;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 
+import java.util.Optional;
+
 /**
  * MCP request scope.
  */
 @Getter
 public final class MCPRequestScope implements MCPServiceHandlerContext, MCPDatabaseHandlerContext, MCPWorkflowHandlerContext, AutoCloseable {
-    
+
     private final String activeTransport;
-    
+
     @Getter(AccessLevel.NONE)
     private final MCPDatabaseCapabilityProvider databaseCapabilityProvider;
-    
+
     @Getter(AccessLevel.NONE)
     private final RequestScopedMetadataContext metadataContext;
-    
+
+    private final Optional<MCPSessionAttribution> sessionAttribution;
+
     private final WorkflowSessionContext workflowSessionContext;
-    
+
     private final MCPMetadataQueryFacade metadataQueryFacade;
-    
+
     private final MCPFeatureExecutionFacade executionFacade;
-    
+
     private final MCPFeatureQueryFacade queryFacade;
-    
+
     /**
      * Create MCP request scope.
      *
      * @param runtimeContext runtime context
      */
     public MCPRequestScope(final MCPRuntimeContext runtimeContext) {
+        this(runtimeContext, "");
+    }
+
+    /**
+     * Create MCP request scope.
+     *
+     * @param runtimeContext runtime context
+     * @param sessionId session id
+     */
+    public MCPRequestScope(final MCPRuntimeContext runtimeContext, final String sessionId) {
         MCPSessionManager sessionManager = runtimeContext.getSessionManager();
         activeTransport = runtimeContext.getActiveTransport();
         databaseCapabilityProvider = runtimeContext.getDatabaseCapabilityProvider();
         metadataContext = new RequestScopedMetadataContext(sessionManager.getTransactionResourceManager().getRuntimeDatabases(), databaseCapabilityProvider);
+        sessionAttribution = sessionManager.findSessionAttribution(sessionId);
         workflowSessionContext = runtimeContext.getWorkflowSessionContext();
         metadataQueryFacade = new MetadataQueryService(databaseCapabilityProvider, metadataContext);
         executionFacade = new MCPSQLExecutionFacade(databaseCapabilityProvider, sessionManager);
         queryFacade = new WorkflowProxyQueryService(sessionManager, databaseCapabilityProvider);
     }
-    
+
     @Override
     public MCPDatabaseHandlerContext getDatabaseContext() {
         return this;
     }
-    
+
     @Override
     public MCPFeatureCapabilityFacade getCapabilityFacade() {
         return databaseCapabilityProvider;
     }
-    
+
+    @Override
+    public Optional<MCPSessionAttribution> findSessionAttribution() {
+        return sessionAttribution;
+    }
+
     @Override
     public void close() {
         metadataContext.close();

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/session/MCPSessionManager.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/session/MCPSessionManager.java
@@ -37,20 +37,20 @@ import java.util.function.Consumer;
  * MCP session manager.
  */
 public final class MCPSessionManager {
-
+    
     @Getter
     private final MCPJdbcTransactionResourceManager transactionResourceManager;
-
+    
     private final Map<String, ReentrantLock> sessions = new ConcurrentHashMap<>();
-
+    
     private final Map<String, MCPSessionAttribution> sessionAttributions = new ConcurrentHashMap<>();
-
+    
     private final List<Consumer<String>> sessionCloseListeners = new CopyOnWriteArrayList<>();
-
+    
     public MCPSessionManager(final Map<String, RuntimeDatabaseConfiguration> databases) {
         transactionResourceManager = new MCPJdbcTransactionResourceManager(databases);
     }
-
+    
     /**
      * Create a new session.
      *
@@ -59,7 +59,7 @@ public final class MCPSessionManager {
     public void createSession(final String sessionId) {
         ShardingSpherePreconditions.checkState(null == sessions.putIfAbsent(sessionId, new ReentrantLock(true)), () -> new IllegalStateException("Session already exists."));
     }
-
+    
     /**
      * Bind session attribution to one existing session.
      *
@@ -72,7 +72,7 @@ public final class MCPSessionManager {
         ShardingSpherePreconditions.checkState(null == existing || existing.equals(sessionAttribution),
                 () -> new IllegalStateException(String.format("Session attribution does not match existing binding for session `%s`.", sessionId)));
     }
-
+    
     /**
      * Find session attribution.
      *
@@ -82,7 +82,7 @@ public final class MCPSessionManager {
     public Optional<MCPSessionAttribution> findSessionAttribution(final String sessionId) {
         return Optional.ofNullable(sessionAttributions.get(sessionId));
     }
-
+    
     /**
      * Determine whether a session exists.
      *
@@ -92,7 +92,7 @@ public final class MCPSessionManager {
     public boolean hasSession(final String sessionId) {
         return sessions.containsKey(sessionId);
     }
-
+    
     /**
      * Add a callback invoked after one session is closed.
      *
@@ -101,7 +101,7 @@ public final class MCPSessionManager {
     public void addSessionCloseListener(final Consumer<String> sessionCloseListener) {
         sessionCloseListeners.add(sessionCloseListener);
     }
-
+    
     /**
      * Close the session and rollback any pending work.
      *
@@ -121,7 +121,7 @@ public final class MCPSessionManager {
             }
         }
     }
-
+    
     /**
      * Close all current sessions.
      */
@@ -130,11 +130,11 @@ public final class MCPSessionManager {
             closeSession(each);
         }
     }
-
+    
     ReentrantLock findExecutionLock(final String sessionId) {
         return sessions.get(sessionId);
     }
-
+    
     ReentrantLock getRequiredExecutionLock(final String sessionId) {
         ReentrantLock result = findExecutionLock(sessionId);
         if (null == result) {
@@ -142,11 +142,11 @@ public final class MCPSessionManager {
         }
         return result;
     }
-
+    
     Set<String> getSessionIds() {
         return new LinkedHashSet<>(sessions.keySet());
     }
-
+    
     private void notifySessionCloseListeners(final String sessionId) {
         for (Consumer<String> each : sessionCloseListeners) {
             each.accept(sessionId);

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/session/MCPSessionManager.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/session/MCPSessionManager.java
@@ -19,12 +19,14 @@ package org.apache.shardingsphere.mcp.core.session;
 
 import lombok.Getter;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
 import org.apache.shardingsphere.mcp.core.tool.handler.execute.MCPJdbcTransactionResourceManager;
 
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ConcurrentHashMap;
@@ -35,18 +37,20 @@ import java.util.function.Consumer;
  * MCP session manager.
  */
 public final class MCPSessionManager {
-    
+
     @Getter
     private final MCPJdbcTransactionResourceManager transactionResourceManager;
-    
+
     private final Map<String, ReentrantLock> sessions = new ConcurrentHashMap<>();
-    
+
+    private final Map<String, MCPSessionAttribution> sessionAttributions = new ConcurrentHashMap<>();
+
     private final List<Consumer<String>> sessionCloseListeners = new CopyOnWriteArrayList<>();
-    
+
     public MCPSessionManager(final Map<String, RuntimeDatabaseConfiguration> databases) {
         transactionResourceManager = new MCPJdbcTransactionResourceManager(databases);
     }
-    
+
     /**
      * Create a new session.
      *
@@ -55,7 +59,30 @@ public final class MCPSessionManager {
     public void createSession(final String sessionId) {
         ShardingSpherePreconditions.checkState(null == sessions.putIfAbsent(sessionId, new ReentrantLock(true)), () -> new IllegalStateException("Session already exists."));
     }
-    
+
+    /**
+     * Bind session attribution to one existing session.
+     *
+     * @param sessionId session id
+     * @param sessionAttribution session attribution
+     */
+    public void bindSessionAttribution(final String sessionId, final MCPSessionAttribution sessionAttribution) {
+        ShardingSpherePreconditions.checkState(hasSession(sessionId), MCPSessionNotExistedException::new);
+        MCPSessionAttribution existing = sessionAttributions.putIfAbsent(sessionId, sessionAttribution);
+        ShardingSpherePreconditions.checkState(null == existing || existing.equals(sessionAttribution),
+                () -> new IllegalStateException(String.format("Session attribution does not match existing binding for session `%s`.", sessionId)));
+    }
+
+    /**
+     * Find session attribution.
+     *
+     * @param sessionId session id
+     * @return session attribution
+     */
+    public Optional<MCPSessionAttribution> findSessionAttribution(final String sessionId) {
+        return Optional.ofNullable(sessionAttributions.get(sessionId));
+    }
+
     /**
      * Determine whether a session exists.
      *
@@ -65,7 +92,7 @@ public final class MCPSessionManager {
     public boolean hasSession(final String sessionId) {
         return sessions.containsKey(sessionId);
     }
-    
+
     /**
      * Add a callback invoked after one session is closed.
      *
@@ -74,7 +101,7 @@ public final class MCPSessionManager {
     public void addSessionCloseListener(final Consumer<String> sessionCloseListener) {
         sessionCloseListeners.add(sessionCloseListener);
     }
-    
+
     /**
      * Close the session and rollback any pending work.
      *
@@ -89,11 +116,12 @@ public final class MCPSessionManager {
             transactionResourceManager.closeSession(sessionId);
         } finally {
             if (sessions.remove(sessionId, executionLock)) {
+                sessionAttributions.remove(sessionId);
                 notifySessionCloseListeners(sessionId);
             }
         }
     }
-    
+
     /**
      * Close all current sessions.
      */
@@ -102,11 +130,11 @@ public final class MCPSessionManager {
             closeSession(each);
         }
     }
-    
+
     ReentrantLock findExecutionLock(final String sessionId) {
         return sessions.get(sessionId);
     }
-    
+
     ReentrantLock getRequiredExecutionLock(final String sessionId) {
         ReentrantLock result = findExecutionLock(sessionId);
         if (null == result) {
@@ -114,11 +142,11 @@ public final class MCPSessionManager {
         }
         return result;
     }
-    
+
     Set<String> getSessionIds() {
         return new LinkedHashSet<>(sessions.keySet());
     }
-    
+
     private void notifySessionCloseListeners(final String sessionId) {
         for (Consumer<String> each : sessionCloseListeners) {
             each.accept(sessionId);

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/MCPToolController.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/MCPToolController.java
@@ -70,7 +70,7 @@ public final class MCPToolController {
     public MCPResponse handle(final String sessionId, final MCPToolDefinition toolDefinition, final Map<String, Object> arguments) {
         try {
             toolCallLimiter.acquire(sessionId, toolDefinition.getDescriptor().getName());
-            try (MCPRequestScope requestScope = new MCPRequestScope(runtimeContext)) {
+            try (MCPRequestScope requestScope = new MCPRequestScope(runtimeContext, sessionId)) {
                 return ToolDefinitionRegistry.dispatch(requestScope, toolDefinition, sessionId, arguments);
             }
             // CHECKSTYLE:OFF

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/context/MCPRequestScopeTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/context/MCPRequestScopeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.core.context;
+
+import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.core.session.MCPSessionManager;
+import org.apache.shardingsphere.mcp.support.database.capability.MCPDatabaseCapabilityProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class MCPRequestScopeTest {
+    
+    @Test
+    void assertFindSessionAttribution() {
+        MCPSessionManager sessionManager = new MCPSessionManager(Map.of());
+        MCPSessionAttribution sessionAttribution = new MCPSessionAttribution("subject", "gateway", Map.of("cluster", "demo"));
+        sessionManager.createSession("session-1");
+        sessionManager.bindSessionAttribution("session-1", sessionAttribution);
+        MCPRuntimeContext runtimeContext = new MCPRuntimeContext(sessionManager, new MCPDatabaseCapabilityProvider(Map.of()), "http");
+        try (MCPRequestScope requestScope = new MCPRequestScope(runtimeContext, "session-1")) {
+            assertThat(requestScope.findSessionAttribution(), is(Optional.of(sessionAttribution)));
+        }
+    }
+    
+    @Test
+    void assertFindSessionAttributionWithoutSession() {
+        MCPRuntimeContext runtimeContext = new MCPRuntimeContext(new MCPSessionManager(Map.of()), new MCPDatabaseCapabilityProvider(Map.of()), "http");
+        try (MCPRequestScope requestScope = new MCPRequestScope(runtimeContext)) {
+            assertThat(requestScope.findSessionAttribution(), is(Optional.empty()));
+        }
+    }
+}

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandlerTest.java
@@ -194,7 +194,7 @@ class ServerCapabilitiesHandlerTest {
         assertTrue(actual.containsKey("stdio_stdout"));
         Map<?, ?> actualClientSafetyPolicy = (Map<?, ?>) actual.get("client_safety_policy");
         assertThat(actualClientSafetyPolicy.get("identity_scope"), is("mcp_session"));
-        assertTrue(String.valueOf(actualClientSafetyPolicy.get("transport_scope")).contains("no built-in authorization"));
+        assertTrue(String.valueOf(actualClientSafetyPolicy.get("transport_scope")).contains("trusted session attribution"));
         assertThat(((Map<?, ?>) actualClientSafetyPolicy.get("tool_call_limit")).get("scope"), is("session"));
         assertTrue(String.valueOf(actualClientSafetyPolicy.get("abuse_guard")).contains("counted before dispatch"));
     }

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/session/MCPSessionManagerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/session/MCPSessionManagerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mcp.core.session;
 
+import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +27,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -40,12 +42,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MCPSessionManagerTest {
-    
+
     @Test
     void assertCreateSession() {
         assertDoesNotThrow(() -> new MCPSessionManager(Collections.emptyMap()).createSession("session-1"));
     }
-    
+
     @Test
     void assertCreateSessionWithDuplicateSessionId() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
@@ -53,14 +55,14 @@ class MCPSessionManagerTest {
         IllegalStateException actual = assertThrows(IllegalStateException.class, () -> sessionManager.createSession("session-1"));
         assertThat(actual.getMessage(), is("Session already exists."));
     }
-    
+
     @Test
     void assertHasSession() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
         sessionManager.createSession("session-1");
         assertTrue(sessionManager.hasSession("session-1"));
     }
-    
+
     @Test
     void assertCloseSession() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
@@ -69,7 +71,7 @@ class MCPSessionManagerTest {
         sessionManager.closeSession("session-1");
         assertFalse(sessionManager.hasSession("session-1"));
     }
-    
+
     @Test
     void assertCloseSessionInvokesSessionCloseListener() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
@@ -79,7 +81,7 @@ class MCPSessionManagerTest {
         sessionManager.closeSession("session-1");
         assertThat(actualClosedSessions, is(List.of("session-1")));
     }
-    
+
     @Test
     void assertCloseSessionWithTransactionResourceManager() throws SQLException {
         Connection connection = mock(Connection.class);
@@ -94,7 +96,7 @@ class MCPSessionManagerTest {
         verify(connection).close();
         assertFalse(sessionManager.hasSession("session-1"));
     }
-    
+
     @Test
     void assertCloseSessionWithTransactionResourceManagerFailure() throws SQLException {
         Connection connection = mock(Connection.class);
@@ -110,7 +112,7 @@ class MCPSessionManagerTest {
         verify(connection).close();
         assertFalse(sessionManager.hasSession("session-1"));
     }
-    
+
     @Test
     void assertCloseAllSessions() throws SQLException {
         Connection firstConnection = mock(Connection.class);
@@ -131,5 +133,33 @@ class MCPSessionManagerTest {
         verify(secondConnection).close();
         assertFalse(sessionManager.hasSession("session-1"));
         assertFalse(sessionManager.hasSession("session-2"));
+    }
+
+    @Test
+    void assertBindSessionAttribution() {
+        MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
+        MCPSessionAttribution sessionAttribution = new MCPSessionAttribution("subject", "gateway", Map.of("region", "ap-south"));
+        sessionManager.createSession("session-1");
+        assertDoesNotThrow(() -> sessionManager.bindSessionAttribution("session-1", sessionAttribution));
+        assertThat(sessionManager.findSessionAttribution("session-1"), is(Optional.of(sessionAttribution)));
+    }
+
+    @Test
+    void assertBindSessionAttributionWithDifferentBinding() {
+        MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
+        sessionManager.createSession("session-1");
+        sessionManager.bindSessionAttribution("session-1", new MCPSessionAttribution("subject", "gateway", Map.of()));
+        IllegalStateException actual = assertThrows(IllegalStateException.class,
+                () -> sessionManager.bindSessionAttribution("session-1", new MCPSessionAttribution("other", "gateway", Map.of())));
+        assertThat(actual.getMessage(), is("Session attribution does not match existing binding for session `session-1`."));
+    }
+
+    @Test
+    void assertCloseSessionRemovesSessionAttribution() {
+        MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
+        sessionManager.createSession("session-1");
+        sessionManager.bindSessionAttribution("session-1", new MCPSessionAttribution("subject", "gateway", Map.of()));
+        sessionManager.closeSession("session-1");
+        assertThat(sessionManager.findSessionAttribution("session-1"), is(Optional.empty()));
     }
 }

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/session/MCPSessionManagerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/session/MCPSessionManagerTest.java
@@ -42,12 +42,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MCPSessionManagerTest {
-
+    
     @Test
     void assertCreateSession() {
         assertDoesNotThrow(() -> new MCPSessionManager(Collections.emptyMap()).createSession("session-1"));
     }
-
+    
     @Test
     void assertCreateSessionWithDuplicateSessionId() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
@@ -55,14 +55,14 @@ class MCPSessionManagerTest {
         IllegalStateException actual = assertThrows(IllegalStateException.class, () -> sessionManager.createSession("session-1"));
         assertThat(actual.getMessage(), is("Session already exists."));
     }
-
+    
     @Test
     void assertHasSession() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
         sessionManager.createSession("session-1");
         assertTrue(sessionManager.hasSession("session-1"));
     }
-
+    
     @Test
     void assertCloseSession() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
@@ -71,7 +71,7 @@ class MCPSessionManagerTest {
         sessionManager.closeSession("session-1");
         assertFalse(sessionManager.hasSession("session-1"));
     }
-
+    
     @Test
     void assertCloseSessionInvokesSessionCloseListener() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
@@ -81,7 +81,7 @@ class MCPSessionManagerTest {
         sessionManager.closeSession("session-1");
         assertThat(actualClosedSessions, is(List.of("session-1")));
     }
-
+    
     @Test
     void assertCloseSessionWithTransactionResourceManager() throws SQLException {
         Connection connection = mock(Connection.class);
@@ -96,7 +96,7 @@ class MCPSessionManagerTest {
         verify(connection).close();
         assertFalse(sessionManager.hasSession("session-1"));
     }
-
+    
     @Test
     void assertCloseSessionWithTransactionResourceManagerFailure() throws SQLException {
         Connection connection = mock(Connection.class);
@@ -112,7 +112,7 @@ class MCPSessionManagerTest {
         verify(connection).close();
         assertFalse(sessionManager.hasSession("session-1"));
     }
-
+    
     @Test
     void assertCloseAllSessions() throws SQLException {
         Connection firstConnection = mock(Connection.class);
@@ -134,7 +134,7 @@ class MCPSessionManagerTest {
         assertFalse(sessionManager.hasSession("session-1"));
         assertFalse(sessionManager.hasSession("session-2"));
     }
-
+    
     @Test
     void assertBindSessionAttribution() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
@@ -143,7 +143,7 @@ class MCPSessionManagerTest {
         assertDoesNotThrow(() -> sessionManager.bindSessionAttribution("session-1", sessionAttribution));
         assertThat(sessionManager.findSessionAttribution("session-1"), is(Optional.of(sessionAttribution)));
     }
-
+    
     @Test
     void assertBindSessionAttributionWithDifferentBinding() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
@@ -153,7 +153,7 @@ class MCPSessionManagerTest {
                 () -> sessionManager.bindSessionAttribution("session-1", new MCPSessionAttribution("other", "gateway", Map.of())));
         assertThat(actual.getMessage(), is("Session attribution does not match existing binding for session `session-1`."));
     }
-
+    
     @Test
     void assertCloseSessionRemovesSessionAttribution() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/security/MCPClientSafetyPolicy.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/security/MCPClientSafetyPolicy.java
@@ -52,7 +52,10 @@ public final class MCPClientSafetyPolicy {
     public static Map<String, Object> createModelFacingPayload() {
         Map<String, Object> result = new LinkedHashMap<>(5, 1F);
         result.put("identity_scope", "mcp_session");
-        result.put("transport_scope", "HTTP transport has no built-in authorization in this release; STDIO inherits the local process boundary.");
+        result.put("transport_scope",
+                "HTTP transport can bind trusted session attribution when configured; "
+                        + "authentication and authorization remain outside the runtime in this release. "
+                        + "STDIO inherits the local process boundary.");
         result.put("tool_call_limit", createToolCallLimitPayload());
         result.put("abuse_guard", "Every tool call is counted before dispatch, including invalid calls, so runaway model loops stop at the session quota.");
         result.put("external_model_boundary", "The MCP runtime never calls external model providers; live LLM E2E clients call configured endpoints outside the server.");

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPModelFirstContractPayloadBuilderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPModelFirstContractPayloadBuilderTest.java
@@ -85,7 +85,7 @@ class MCPModelFirstContractPayloadBuilderTest {
         assertTrue(String.valueOf(actual.get("origin_header")).contains("loopback origins"));
         Map<?, ?> actualClientSafetyPolicy = castToMap(actual.get("client_safety_policy"));
         assertThat(actualClientSafetyPolicy.get("identity_scope"), is("mcp_session"));
-        assertTrue(String.valueOf(actualClientSafetyPolicy.get("transport_scope")).contains("no built-in authorization"));
+        assertTrue(String.valueOf(actualClientSafetyPolicy.get("transport_scope")).contains("trusted session attribution"));
         assertThat(castToMap(actualClientSafetyPolicy.get("tool_call_limit")).get("scope"), is("session"));
         assertTrue(String.valueOf(actualClientSafetyPolicy.get("external_model_boundary")).contains("never calls external model providers"));
     }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/security/MCPClientSafetyPolicyTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/security/MCPClientSafetyPolicyTest.java
@@ -44,6 +44,7 @@ class MCPClientSafetyPolicyTest {
     void assertCreateModelFacingPayload() {
         Map<String, Object> actual = MCPClientSafetyPolicy.createModelFacingPayload();
         assertThat(actual.get("identity_scope"), is("mcp_session"));
+        assertTrue(String.valueOf(actual.get("transport_scope")).contains("trusted session attribution"));
         assertTrue(String.valueOf(actual.get("external_model_boundary")).contains("never calls external model providers"));
         Map<?, ?> actualToolCallLimit = (Map<?, ?>) actual.get("tool_call_limit");
         assertThat(actualToolCallLimit.get("scope"), is("session"));


### PR DESCRIPTION
Introduce trusted HTTP session attribution source configuration and resolver, bind attribution to MCP sessions, and propagate it through request scope for handler access. Update runtime logging and safety policy wording, and add regression coverage for configuration, validator, servlet, and session lifecycle behavior.

For #35294.