### PR TITLE
Fix length assert for local file url loader test on Windows

### DIFF
--- a/infra/url/type/absolutepath/src/test/java/org/apache/shardingsphere/infra/url/absolutepath/AbsolutePathLocalFileURLLoaderTest.java
+++ b/infra/url/type/absolutepath/src/test/java/org/apache/shardingsphere/infra/url/absolutepath/AbsolutePathLocalFileURLLoaderTest.java
@@ -38,7 +38,7 @@ class AbsolutePathLocalFileURLLoaderTest {
     @Test
     @EnabledOnOs(OS.WINDOWS)
     void assertGetContentOnWindows() {
-        assertGetContent(1839);
+        assertGetContent(1932);
     }
     
     private void assertGetContent(final int expectedLength) {

--- a/infra/url/type/classpath/src/test/java/org/apache/shardingsphere/infra/url/classpath/ClassPathLocalFileURLLoaderTest.java
+++ b/infra/url/type/classpath/src/test/java/org/apache/shardingsphere/infra/url/classpath/ClassPathLocalFileURLLoaderTest.java
@@ -37,7 +37,7 @@ class ClassPathLocalFileURLLoaderTest {
     @Test
     @EnabledOnOs(OS.WINDOWS)
     void assertGetContentOnWindows() {
-        assertGetContent(1839);
+        assertGetContent(1932);
     }
     
     private void assertGetContent(final int expectedLength) {


### PR DESCRIPTION
Fix nightly-ci: https://github.com/apache/shardingsphere/actions/workflows/nightly-ci.yml

Error:
<img width="1530" height="788" alt="PixPin_2026-06-01_11-52-02" src="https://github.com/user-attachments/assets/fe81283e-7dac-40f7-ac3d-6c42e52874ab" />


The GitHub Action failure was caused by stale Windows-specific expected lengths in two URL loader tests, not by an actual loader behavior regression.

  Both ClassPathLocalFileURLLoader and AbsolutePathLocalFileURLLoader read the YAML fixture line by line and then rebuild the content using System.lineSeparator(). This means the returned
  string length is OS-dependent:

  - On Linux/macOS, System.lineSeparator() is \n, so each joined line separator contributes 1 character.
  - On Windows, System.lineSeparator() is \r\n, so each joined line separator contributes 2 characters.

  The fixture was changed in commit 526ac5aaf30 (Remove keyGenerateStrategy for ShardingTableRuleConfiguration (#38609)). That commit updated the Linux/macOS expected length from 1783 to
  1872, but the Windows expected length was left at the old value 1839.

  With the current fixture:

  `61 lines, 1873 bytes`

  Because the file has Linux line endings and ends with a newline:
```
  Non-line-separator characters = 1873 - 61 = 1812
  Joined separators between 61 lines = 60
```
  So the expected lengths are:
```
  Linux/macOS: 1812 + 60 * 1 = 1872
  Windows:     1812 + 60 * 2 = 1932
```
  The CI failure reported:
```plain
  Expected: is <1839>
       but: was <1932>
```
  That matches the correct current Windows length. Therefore, the root cause is that the Windows assertion values in ClassPathLocalFileURLLoaderTest and AbsolutePathLocalFileURLLoaderTest were not updated after the fixture content changed. The fix is to update the Windows expected length from 1839 to 1932 in both tests.
