### PR TITLE
Separate MCP config field markers

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-mcp/configuration.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/configuration.cn.md
@@ -53,16 +53,16 @@ runtimeDatabases:
 
 | *名称* | *说明* |
 | --- | --- |
-| `databaseType (+)` | 连接端点的数据库协议或方言类型，例如 `MySQL` 或 `PostgreSQL`。它用于正确读取目标数据库元数据，不表示连接目标一定是真实数据库或 ShardingSphere-Proxy。 |
-| `jdbcUrl (+)` | MCP Server 连接运行时数据库的 JDBC URL；使用 ShardingSphere 规则能力时应指向 Proxy 逻辑库。 |
-| `username (+)` | 连接运行时数据库的用户名，通常是 ShardingSphere-Proxy 逻辑库用户名。 |
-| `password (?)` | 连接运行时数据库的密码。 |
-| `driverClassName (+)` | JDBC 驱动类名，例如 MySQL 驱动使用 `com.mysql.cj.jdbc.Driver`。 |
+| `databaseType` (+) | 连接端点的数据库协议或方言类型，例如 `MySQL` 或 `PostgreSQL`。它用于正确读取目标数据库元数据，不表示连接目标一定是真实数据库或 ShardingSphere-Proxy。 |
+| `jdbcUrl` (+) | MCP Server 连接运行时数据库的 JDBC URL；使用 ShardingSphere 规则能力时应指向 Proxy 逻辑库。 |
+| `username` (+) | 连接运行时数据库的用户名，通常是 ShardingSphere-Proxy 逻辑库用户名。 |
+| `password` (?) | 连接运行时数据库的密码。 |
+| `driverClassName` (+) | JDBC 驱动类名，例如 MySQL 驱动使用 `com.mysql.cj.jdbc.Driver`。 |
 
 说明：
 
-- `(+)` 表示必填项。
-- `(?)` 表示可选项。
+- (+) 表示必填项。
+- (?) 表示可选项。
 
 注意事项：
 

--- a/docs/document/content/user-manual/shardingsphere-mcp/configuration.en.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/configuration.en.md
@@ -53,16 +53,16 @@ runtimeDatabases:
 
 | *Name* | *Description* |
 | --- | --- |
-| `databaseType (+)` | Database protocol or dialect type of the connection endpoint, such as `MySQL` or `PostgreSQL`. It is used to read target database metadata correctly; it does not mean the endpoint is necessarily a physical database or ShardingSphere-Proxy. |
-| `jdbcUrl (+)` | JDBC URL used by the MCP Server to connect to the runtime database. Point it to a Proxy logical database when using ShardingSphere rule capabilities. |
-| `username (+)` | Username for the runtime database, usually the ShardingSphere-Proxy logical database username. |
-| `password (?)` | Password for the runtime database. |
-| `driverClassName (+)` | JDBC driver class name, such as `com.mysql.cj.jdbc.Driver` for the MySQL driver. |
+| `databaseType` (+) | Database protocol or dialect type of the connection endpoint, such as `MySQL` or `PostgreSQL`. It is used to read target database metadata correctly; it does not mean the endpoint is necessarily a physical database or ShardingSphere-Proxy. |
+| `jdbcUrl` (+) | JDBC URL used by the MCP Server to connect to the runtime database. Point it to a Proxy logical database when using ShardingSphere rule capabilities. |
+| `username` (+) | Username for the runtime database, usually the ShardingSphere-Proxy logical database username. |
+| `password` (?) | Password for the runtime database. |
+| `driverClassName` (+) | JDBC driver class name, such as `com.mysql.cj.jdbc.Driver` for the MySQL driver. |
 
 Legend:
 
-- `(+)` means required.
-- `(?)` means optional.
+- (+) means required.
+- (?) means optional.
 
 Notes:
 


### PR DESCRIPTION
Keep required and optional markers outside configuration field code spans so copied field names do not include marker text.

Apply the same formatting to the Chinese and English ShardingSphere-MCP configuration pages.

For #35294.