### PR TITLE
Refine ShardingSphere-MCP overview

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-mcp/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/_index.cn.md
@@ -6,14 +6,17 @@ chapter = true
 +++
 
 ShardingSphere-MCP 是 Apache ShardingSphere 的 MCP Server，可以独立启动。
-它把 ShardingSphere 逻辑库接入支持 MCP 的客户端，使用户能够通过自然语言查看元数据、执行受控 SQL 查询，并规划可审查的治理变更。
+MCP 是连接 AI 应用与外部数据源和工具的开放协议，协议说明参见 [MCP 官方文档](https://modelcontextprotocol.io/docs/learn/architecture)。
+
+用户在支持 MCP 的大模型客户端中描述数据库任务后，可以通过 ShardingSphere-MCP 查看 ShardingSphere 逻辑库元数据、执行受控 SQL 查询，并生成可审查的治理变更计划。
+治理变更计划用于描述数据加密、数据脱敏等规则变更的目标对象、影响范围和待执行语句，便于用户在执行前审查。
 
 ShardingSphere-MCP 的配置以数据库为核心：先配置 MCP Server 可以连接的 ShardingSphere 逻辑库，再在客户端中描述要完成的数据库任务。
 
-## 通过自然语言使用 MCP
+## 在大模型客户端中使用
 
 ShardingSphere-MCP 面向支持 MCP 的客户端、IDE 插件和 Agent 平台使用。
-完成客户端集成后，用户可以在客户端对话中直接描述数据库任务。
+完成客户端集成后，用户可以在客户端对话中通过自然语言描述数据库任务。
 
 常见任务示例：
 
@@ -28,9 +31,12 @@ ShardingSphere-MCP 面向支持 MCP 的客户端、IDE 插件和 Agent 平台使
 ## 文档结构
 
 - 快速开始：构建发行包，配置一个可连接的逻辑库，启动 HTTP MCP Server，并验证基础任务。
-- 功能介绍：说明 MCP Server 可以完成的数据库任务、可读取的信息和使用边界。
+- 能力清单：说明 MCP Server 可以完成的数据库任务、可读取的信息和使用边界。
 - 配置说明：说明传输方式、`runtimeDatabases`、插件目录和启动参数。
 - 客户端集成：说明如何通过 HTTP 或 STDIO 把 MCP Server 接入客户端，以及集成后的使用方式。
-- 功能插件：说明官方 MCP 功能插件能力，以及插件变更的审查、执行和校验流程。
 - 部署说明：说明发行包、OCI 镜像和安全部署建议。
 - 常见问题：排查 MCP Server、连接、配置、元数据和 SQL 执行的通用问题。
+- 功能插件：说明官方 MCP 功能插件能力，以及插件变更的审查、执行和校验流程。
+  - 插件工作流：说明插件变更任务的确认、预览、执行和校验流程。
+  - 数据加密：说明如何通过 MCP 功能插件规划、执行和校验数据加密规则变更。
+  - 数据脱敏：说明如何通过 MCP 功能插件规划、执行和校验数据脱敏规则变更。

--- a/docs/document/content/user-manual/shardingsphere-mcp/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/_index.en.md
@@ -6,14 +6,17 @@ chapter = true
 +++
 
 ShardingSphere-MCP is the MCP Server for Apache ShardingSphere. It can run independently.
-It connects ShardingSphere logical databases to MCP-capable clients, so users can inspect metadata, run controlled SQL queries, and plan reviewable governance changes through natural language.
+MCP is an open protocol for connecting AI applications to external data sources and tools. For protocol details, see the [official MCP documentation](https://modelcontextprotocol.io/docs/learn/architecture).
+
+After users describe database tasks in an MCP-capable AI client, ShardingSphere-MCP can inspect ShardingSphere logical database metadata, run controlled SQL queries, and generate reviewable governance change plans.
+Governance change plans describe the target objects, impact scope, and statements to be executed for rule changes such as data encryption and data masking, so users can review them before execution.
 
 ShardingSphere-MCP configuration starts from databases: configure the ShardingSphere logical databases that the MCP Server can connect to, then describe database tasks in the client.
 
-## Use MCP through natural language
+## Use in AI Clients
 
 ShardingSphere-MCP is designed for MCP-capable clients, IDE extensions, and agent platforms.
-After client integration, users can describe database tasks directly in the client conversation.
+After client integration, users can describe database tasks in natural language in the client conversation.
 
 Common task examples:
 
@@ -28,9 +31,12 @@ Tasks with side effects should create or preview a plan first, then run only aft
 ## Structure
 
 - Quick Start: build the distribution, configure a reachable logical database, start the HTTP MCP Server, and verify basic tasks.
-- Capabilities: understand the database tasks, readable information, and usage boundaries provided by the MCP Server.
+- Capability Catalog: understand the database tasks, readable information, and usage boundaries provided by the MCP Server.
 - Configuration: configure transport, `runtimeDatabases`, plugin directories, and launch parameters.
 - Client Integration: connect the MCP Server to a client through HTTP or STDIO, and understand how to use it after integration.
-- Feature Plugins: use official MCP feature plugins and understand how to review, apply, and validate plugin changes.
 - Deployment: deploy the binary distribution and OCI image safely.
 - Troubleshooting: diagnose common MCP Server, connection, configuration, metadata, and SQL execution issues.
+- Feature Plugins: use official MCP feature plugins and understand how to review, apply, and validate plugin changes.
+  - Plugin Workflows: understand confirmation, preview, execution, and validation for plugin change tasks.
+  - Data Encryption: plan, apply, and validate data encryption rule changes through MCP feature plugins.
+  - Data Masking: plan, apply, and validate data masking rule changes through MCP feature plugins.


### PR DESCRIPTION
Briefly introduce MCP with a link to the official documentation, clarify how users work with ShardingSphere-MCP from AI clients, and explain reviewable governance change plans.

Align the overview structure with the current ShardingSphere-MCP menu names and feature plugin pages in both Chinese and English.

For #35294.