### PR TITLE
Align MCP workflow names

### DIFF
--- a/.github/workflows/e2e-mcp.yml
+++ b/.github/workflows/e2e-mcp.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: MCP - E2E
+name: E2E - MCP
 
 on:
   pull_request:
@@ -26,7 +26,7 @@ on:
       - synchronize
       - ready_for_review
     paths:
-      - '.github/workflows/mcp-e2e.yml'
+      - '.github/workflows/e2e-mcp.yml'
       - 'pom.xml'
       - 'mcp/**'
       - 'test/e2e/pom.xml'
@@ -36,7 +36,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: mcp-e2e-${{ github.workflow }}-${{ github.ref }}
+  group: e2e-mcp-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -51,8 +51,8 @@ env:
   MCP_LLM_BASE_SERVER_IMAGE_DIGEST: sha256:988d2695631987e28a29d98970aaf0e979e23b843a26824abb790ac4245d1d57
 
 jobs:
-  mcp-mysql-runtime-e2e:
-    name: MCP - MySQL Runtime E2E
+  e2e-mcp-mysql-runtime:
+    name: E2E - MCP MySQL Runtime
     if: github.repository == 'apache/shardingsphere'
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -63,7 +63,7 @@ jobs:
       - uses: ./.github/workflows/resources/actions/setup-build-environment
         with:
           java-version: '21'
-          cache-suffix: 'mcp-e2e'
+          cache-suffix: 'e2e-mcp'
           cache-save-enabled: 'false'
           enable-docker-setup: 'true'
       - name: Set Up Docker Buildx
@@ -108,7 +108,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: mcp-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+          name: e2e-mcp-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             test/e2e/mcp/target/llm-e2e
             test/e2e/mcp/target/surefire-reports

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: MCP - Release
+name: Release - MCP
 
 on:
   release:
@@ -28,7 +28,7 @@ on:
         type: string
 
 concurrency:
-  group: mcp-release-${{ github.event_name }}-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}
+  group: release-mcp-${{ github.event_name }}-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}
   cancel-in-progress: true
 
 permissions:
@@ -47,8 +47,8 @@ jobs:
     name: Import Global Environment
     uses: ./.github/workflows/required-reusable.yml
 
-  mcp-release:
-    name: MCP - Release
+  release-mcp:
+    name: Release - MCP
     if: github.repository == 'apache/shardingsphere'
     needs: global-environment
     runs-on: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
         with:
           java-version: '21'
           cache-prefix: ${{ needs.global-environment.outputs.GLOBAL_CACHE_PREFIX }}
-          cache-suffix: 'mcp-release'
+          cache-suffix: 'release-mcp'
           enable-docker-setup: 'true'
       - name: Resolve Release Version
         id: release-version

--- a/docs/community/content/involved/release/shardingsphere.cn.md
+++ b/docs/community/content/involved/release/shardingsphere.cn.md
@@ -605,7 +605,7 @@ docker logout
 
 3.8 ShardingSphere MCP 发布
 
-ShardingSphere MCP 通过仓库中的 [`.github/workflows/mcp-release.yml`](https://github.com/apache/shardingsphere/blob/master/.github/workflows/mcp-release.yml) workflow 发布。
+ShardingSphere MCP 通过仓库中的 [`.github/workflows/release-mcp.yml`](https://github.com/apache/shardingsphere/blob/master/.github/workflows/release-mcp.yml) workflow 发布。
 该 workflow 会构建 MCP 发行包、把 `ghcr.io/apache/shardingsphere-mcp:${RELEASE.VERSION}` 推送到 GHCR，
 稳定版额外更新 `latest`，然后通过 GitHub OIDC 把 `mcp/server.json` 发布到官方 MCP Registry。
 
@@ -617,7 +617,7 @@ ShardingSphere MCP 通过仓库中的 [`.github/workflows/mcp-release.yml`](http
 
 GitHub release 发布后：
 
-- 等待 `MCP - Release` workflow 成功完成
+- 等待 `Release - MCP` workflow 成功完成
 - 确认 [GitHub Packages](https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-mcp) 中存在 `ghcr.io/apache/shardingsphere-mcp:${RELEASE.VERSION}`
 - 通过下面的命令确认官方 MCP Registry 已返回该 server 的 metadata：
 

--- a/docs/community/content/involved/release/shardingsphere.en.md
+++ b/docs/community/content/involved/release/shardingsphere.en.md
@@ -610,7 +610,7 @@ docker logout
 
 3.8 ShardingSphere MCP publication
 
-ShardingSphere MCP is published through the repository workflow [`.github/workflows/mcp-release.yml`](https://github.com/apache/shardingsphere/blob/master/.github/workflows/mcp-release.yml).
+ShardingSphere MCP is published through the repository workflow [`.github/workflows/release-mcp.yml`](https://github.com/apache/shardingsphere/blob/master/.github/workflows/release-mcp.yml).
 The workflow builds the MCP distribution, pushes `ghcr.io/apache/shardingsphere-mcp:${RELEASE.VERSION}` to GHCR,
 pushes `latest` for stable releases, and then publishes `mcp/server.json` to the official MCP Registry through GitHub OIDC.
 
@@ -622,7 +622,7 @@ Edit release version and release notes, select `Set as the latest release`, clic
 
 After the GitHub release is published:
 
-- wait for the `MCP - Release` workflow to finish successfully
+- wait for the `Release - MCP` workflow to finish successfully
 - confirm [GitHub Packages](https://github.com/apache/shardingsphere/pkgs/container/shardingsphere-mcp) contains `ghcr.io/apache/shardingsphere-mcp:${RELEASE.VERSION}`
 - confirm the official MCP Registry returns the published metadata:
 

--- a/docs/document/content/test-manual/mcp-e2e-test/_index.cn.md
+++ b/docs/document/content/test-manual/mcp-e2e-test/_index.cn.md
@@ -97,7 +97,7 @@ test/e2e/mcp/target/llm-e2e/
 
 GitHub Actions 入口：
 
-- `.github/workflows/mcp-e2e.yml`
+- `.github/workflows/e2e-mcp.yml`
 
 这条 workflow 是 MCP runtime E2E 的必跑入口。
 如果超大 PR 因 path filter 限制漏触发，可以使用 `workflow_dispatch` 手动补充 evidence。

--- a/docs/document/content/test-manual/mcp-e2e-test/_index.en.md
+++ b/docs/document/content/test-manual/mcp-e2e-test/_index.en.md
@@ -97,7 +97,7 @@ test/e2e/mcp/target/llm-e2e/
 
 GitHub Actions entry points:
 
-- `.github/workflows/mcp-e2e.yml`
+- `.github/workflows/e2e-mcp.yml`
 
 This workflow is the mandatory MCP runtime E2E entry point.
 If a very large PR misses a path-filter match, use `workflow_dispatch` to add manual evidence.


### PR DESCRIPTION
Rename MCP workflow files to follow the existing action naming order.
Update workflow display names, job identifiers, cache/artifact prefixes,
and documentation references for the MCP E2E and release workflows.

For #35294