### PR TITLE
Refine ShardingSphere-MCP AI application guidance

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-mcp/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/_index.cn.md
@@ -8,15 +8,18 @@ chapter = true
 ShardingSphere-MCP 是 Apache ShardingSphere 的 MCP Server，可以独立启动。
 MCP 是连接 AI 应用与外部数据源和工具的开放协议，协议说明参见 [MCP 官方文档](https://modelcontextprotocol.io/docs/learn/architecture)。
 
-用户在支持 MCP 的大模型客户端中描述数据库任务后，可以通过 ShardingSphere-MCP 查看 ShardingSphere 逻辑库元数据、执行受控 SQL 查询，并生成可审查的治理变更计划。
+AI 应用开发者可以将 ShardingSphere-MCP 作为数据库访问能力接入应用。
+用户通过自然语言描述数据库任务后，AI 应用在需要数据库上下文或数据库操作时，通过 MCP Client 调用 ShardingSphere-MCP；ShardingSphere-MCP 再访问 ShardingSphere 逻辑库或普通数据库。
+
+通过这种方式，AI 应用可以查看 ShardingSphere 逻辑库元数据、执行受控 SQL 查询，并生成可审查的治理变更计划。
 治理变更计划用于描述数据加密、数据脱敏等规则变更的目标对象、影响范围和待执行语句，便于用户在执行前审查。
 
-ShardingSphere-MCP 的配置以数据库为核心：先配置 MCP Server 可以连接的 ShardingSphere 逻辑库，再在客户端中描述要完成的数据库任务。
+ShardingSphere-MCP 的配置以数据库为核心：先配置 MCP Server 可以连接的 ShardingSphere 逻辑库或普通数据库，再在 AI 应用中完成 MCP 集成。
 
-## 在大模型客户端中使用
+## 面向 AI 应用的数据库访问
 
-ShardingSphere-MCP 面向支持 MCP 的客户端、IDE 插件和 Agent 平台使用。
-完成客户端集成后，用户可以在客户端对话中通过自然语言描述数据库任务。
+ShardingSphere-MCP 面向支持 MCP 的 AI 应用、IDE 插件和 Agent 平台使用。
+完成 MCP 集成后，用户可以在 AI 应用中通过自然语言描述数据库任务。
 
 常见任务示例：
 
@@ -33,7 +36,7 @@ ShardingSphere-MCP 面向支持 MCP 的客户端、IDE 插件和 Agent 平台使
 - 快速开始：构建发行包，配置一个可连接的逻辑库，启动 HTTP MCP Server，并验证基础任务。
 - 能力清单：说明 MCP Server 可以完成的数据库任务、可读取的信息和使用边界。
 - 配置说明：说明传输方式、`runtimeDatabases`、插件目录和启动参数。
-- 客户端集成：说明如何通过 HTTP 或 STDIO 把 MCP Server 接入客户端，以及集成后的使用方式。
+- 客户端集成：说明如何通过 HTTP 或 STDIO 把 MCP Server 接入 AI 应用或 MCP 客户端，以及集成后的使用方式。
 - 部署说明：说明发行包、OCI 镜像和安全部署建议。
 - 常见问题：排查 MCP Server、连接、配置、元数据和 SQL 执行的通用问题。
 - 功能插件：说明官方 MCP 功能插件能力，以及插件变更的审查、执行和校验流程。

--- a/docs/document/content/user-manual/shardingsphere-mcp/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/_index.en.md
@@ -8,15 +8,18 @@ chapter = true
 ShardingSphere-MCP is the MCP Server for Apache ShardingSphere. It can run independently.
 MCP is an open protocol for connecting AI applications to external data sources and tools. For protocol details, see the [official MCP documentation](https://modelcontextprotocol.io/docs/learn/architecture).
 
-After users describe database tasks in an MCP-capable AI client, ShardingSphere-MCP can inspect ShardingSphere logical database metadata, run controlled SQL queries, and generate reviewable governance change plans.
+AI application developers can integrate ShardingSphere-MCP as a database access capability.
+After users describe database tasks in natural language, the AI application calls ShardingSphere-MCP through an MCP Client when it needs database context or database operations. ShardingSphere-MCP then accesses ShardingSphere logical databases or regular databases.
+
+In this way, AI applications can inspect ShardingSphere logical database metadata, run controlled SQL queries, and generate reviewable governance change plans.
 Governance change plans describe the target objects, impact scope, and statements to be executed for rule changes such as data encryption and data masking, so users can review them before execution.
 
-ShardingSphere-MCP configuration starts from databases: configure the ShardingSphere logical databases that the MCP Server can connect to, then describe database tasks in the client.
+ShardingSphere-MCP configuration starts from databases: configure the ShardingSphere logical databases or regular databases that the MCP Server can connect to, then complete MCP integration in the AI application.
 
-## Use in AI Clients
+## Database Access for AI Applications
 
-ShardingSphere-MCP is designed for MCP-capable clients, IDE extensions, and agent platforms.
-After client integration, users can describe database tasks in natural language in the client conversation.
+ShardingSphere-MCP is designed for MCP-capable AI applications, IDE extensions, and agent platforms.
+After MCP integration, users can describe database tasks in natural language in the AI application.
 
 Common task examples:
 
@@ -33,7 +36,7 @@ Tasks with side effects should create or preview a plan first, then run only aft
 - Quick Start: build the distribution, configure a reachable logical database, start the HTTP MCP Server, and verify basic tasks.
 - Capability Catalog: understand the database tasks, readable information, and usage boundaries provided by the MCP Server.
 - Configuration: configure transport, `runtimeDatabases`, plugin directories, and launch parameters.
-- Client Integration: connect the MCP Server to a client through HTTP or STDIO, and understand how to use it after integration.
+- Client Integration: connect the MCP Server to an AI application or MCP client through HTTP or STDIO, and understand how to use it after integration.
 - Deployment: deploy the binary distribution and OCI image safely.
 - Troubleshooting: diagnose common MCP Server, connection, configuration, metadata, and SQL execution issues.
 - Feature Plugins: use official MCP feature plugins and understand how to review, apply, and validate plugin changes.

--- a/docs/document/content/user-manual/shardingsphere-mcp/capabilities.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/capabilities.cn.md
@@ -3,18 +3,19 @@ title = "能力清单"
 weight = 2
 +++
 
-本页从用户任务角度说明 ShardingSphere-MCP 可以读取哪些信息、执行哪些动作，以及不同连接目标下的使用边界。
-客户端会自动发现当前 MCP Server 实际可用的能力；用户通常只需要在客户端中描述要完成的数据库任务。
+本页从 AI 应用开发者和集成者视角说明 ShardingSphere-MCP 可以读取哪些信息、执行哪些动作，以及不同连接目标下的使用边界。
+集成 MCP 的 AI 应用会发现当前 MCP Server 实际可用的能力；用户通常只需要在 AI 应用中描述要完成的数据库任务。
 
 ## 能力发现
 
-能力发现用于让客户端确认当前 MCP Server 可以访问哪些数据库、支持哪些任务，以及哪些任务可能产生副作用。
+能力发现是 MCP 客户端或集成 MCP 的 AI 应用读取 ShardingSphere-MCP 可用能力的过程。
+使用现成客户端时，用户通常只需要描述数据库任务；AI 应用开发者需要在应用建立 MCP 连接后读取工具、资源、资源模板和提示，并把这些能力提供给模型或应用编排逻辑。
 
-| 发现内容 | 用途 | 用户侧效果 |
-| --- | --- | --- |
-| 基础能力列表 | 确认当前 MCP Server 可读取的信息和可执行的动作。 | 客户端可以判断是否支持元数据查看、SQL 查询或治理变更。 |
-| ShardingSphere 能力摘要 | 汇总运行时数据库、连接目标、功能插件和副作用边界。 | 用户可以询问“这个逻辑库支持哪些治理任务？” |
-| 数据库能力摘要 | 确认某个运行时数据库支持的 SQL、事务、schema 和元数据对象能力。 | 用户可以询问“这个库支持只读查询和规则规划吗？” |
+| 入口 | 类型 | 返回内容 | 使用场景 |
+| --- | --- | --- | --- |
+| `tools/list`、`resources/list`、`resources/templates/list`、`prompts/list` | MCP 协议能力 | 当前 MCP Server 暴露的工具、资源、资源模板和提示。 | AI 应用建立可调用能力清单，并按任务选择可用上下文或动作。 |
+| `shardingsphere://capabilities` | ShardingSphere 服务能力 | 运行时数据库、连接目标、功能插件和副作用边界。 | 判断当前 MCP Server 可用于元数据查看、SQL 执行或治理变更。 |
+| `shardingsphere://databases/{database}/capabilities` | 数据库能力 | 指定运行时数据库的 SQL、事务、schema 和元数据对象能力。 | 针对某个数据库判断可用操作和限制。 |
 
 能力发现结果代表当前 MCP Server 实际对外可用的内容；实际能否使用某项能力，还取决于 `runtimeDatabases` 连接的是 ShardingSphere-Proxy 还是普通数据库。
 客户端会根据连接目标选择可用能力。
@@ -79,28 +80,13 @@ weight = 2
 | 工具 | 用途 | 自然语言示例 | 副作用 |
 | --- | --- | --- | --- |
 | `database_gateway_search_metadata` | 按名称片段和对象类型搜索运行时数据库元数据，并返回后续资源读取提示。 | “查找名字包含 `order` 的表。” | 无。 |
-| `database_gateway_validate_proxy_connectivity` | 在正式接入前校验已配置的运行时数据库，包括驱动加载、JDBC 连通性、metadata 可读性和数据库可见性。 | “先检查已配置的 `logic_db` 能不能接入，再注册。” | 无。 |
+| `database_gateway_validate_proxy_connectivity` | 校验运行时数据库配置是否可用，用于接入失败时定位连接问题。 | “检查 `logic_db` 为什么无法访问。” | 无。 |
 | `database_gateway_execute_query` | 执行一个已判定为查询类的 `SELECT` 或 `EXPLAIN ANALYZE`。 | “查询 `orders` 表前 10 行。” | 无；拒绝 DML、DDL、DCL、事务控制、savepoint 和其他有副作用 SQL。 |
 | `database_gateway_execute_update` | 预览或执行一个可能修改数据、元数据、规则或事务状态的 SQL。 | “预览这条变更 SQL，先不要执行。” | 有；应先预览并确认。 |
 | `database_gateway_apply_workflow` | 预览、执行或导出功能插件生成的治理变更计划。 | “先预览刚才的加密规则计划。” | 取决于执行方式；预览和人工执行包不修改运行时状态。 |
 | `database_gateway_validate_workflow` | 插件工作流执行后，根据可见元数据和生成产物校验结果。 | “校验刚才的脱敏规则是否生效。” | 无。 |
 
 插件工具在对应插件页面说明。
-
-### Proxy 预检结果
-
-`database_gateway_validate_proxy_connectivity` 返回固定结构的校验结果，顶层字段包括：
-
-- `response_mode`
-- `status`
-- `database`
-- `checks`
-- `category`
-- `recovery`
-
-常见失败分类包括 `missing_jdbc_driver`、`authentication_failed`、`authorization_failed`、`connection_timeout`、`invalid_configuration`、`database_unavailable`、`connection_failed` 和 `database_not_visible`。
-`recovery` 字段沿用运行时数据库连接失败的 secret-safe 恢复风格。
-该工具只接受已配置的 `database` 名称。JDBC URL、用户名、密码和驱动类名等连接细节保留在运行时配置中。
 
 ## 提示
 

--- a/docs/document/content/user-manual/shardingsphere-mcp/capabilities.en.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/capabilities.en.md
@@ -3,18 +3,19 @@ title = "Capability Catalog"
 weight = 2
 +++
 
-This page explains the information that ShardingSphere-MCP can read, the actions it can perform, and the usage boundaries for different connection targets.
-Clients discover the capabilities currently available from the MCP Server automatically. Users usually only need to describe the database task they want to complete.
+This page explains the information that ShardingSphere-MCP can read, the actions it can perform, and the usage boundaries for different connection targets from the perspective of AI application developers and integrators.
+AI applications that integrate MCP discover the capabilities currently available from the MCP Server. Users usually only need to describe the database task they want to complete in the AI application.
 
 ## Capability discovery
 
-Capability discovery lets clients confirm which databases the current MCP Server can access, which tasks it supports, and which tasks may have side effects.
+Capability discovery is the process by which an MCP client or an AI application that integrates MCP reads the capabilities available from ShardingSphere-MCP.
+When using an existing client, users usually only describe database tasks. AI application developers need to read tools, resources, resource templates, and prompts after the application establishes an MCP connection, then make those capabilities available to the model or application orchestration logic.
 
-| Discovery content | Purpose | User-facing result |
-| --- | --- | --- |
-| Basic capability list | Confirms readable information and executable actions from the current MCP Server. | The client can determine whether metadata inspection, SQL query, or governance changes are supported. |
-| ShardingSphere capability summary | Summarizes runtime databases, connection targets, feature plugins, and side-effect boundaries. | Users can ask, "Which governance tasks does this logical database support?" |
-| Database capability summary | Confirms SQL, transaction, schema, and metadata-object capabilities for one runtime database. | Users can ask, "Does this database support read-only queries and rule planning?" |
+| Entry | Type | Returned content | Usage scenario |
+| --- | --- | --- | --- |
+| `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list` | MCP protocol capabilities | Tools, resources, resource templates, and prompts exposed by the current MCP Server. | Build the callable capability catalog for an AI application and select available context or actions by task. |
+| `shardingsphere://capabilities` | ShardingSphere service capability | Runtime databases, connection targets, feature plugins, and side-effect boundaries. | Determine whether the current MCP Server can be used for metadata inspection, SQL execution, or governance changes. |
+| `shardingsphere://databases/{database}/capabilities` | Database capability | SQL, transaction, schema, and metadata-object capabilities of the specified runtime database. | Determine available operations and limits for a specific database. |
 
 Capability discovery represents what the current MCP Server actually makes available. Whether a capability is actually useful still depends on whether `runtimeDatabases` connects to ShardingSphere-Proxy or to a regular database.
 Clients select available capabilities according to the connection target.
@@ -79,28 +80,13 @@ Actions with side effects should be previewed or reviewed first.
 | Tool | Purpose | Natural language example | Side effects |
 | --- | --- | --- | --- |
 | `database_gateway_search_metadata` | Search runtime database metadata by name fragment and object type, and return resource hints for follow-up reads. | "Find tables whose names contain `order`." | None. |
-| `database_gateway_validate_proxy_connectivity` | Validate a configured runtime database, including driver loading, JDBC connectivity, metadata readability, and database visibility before formal onboarding. | "Check whether configured database `logic_db` is ready before we register it." | None. |
+| `database_gateway_validate_proxy_connectivity` | Validate whether the runtime database configuration is usable, for diagnosing connection issues during integration. | "Check why `logic_db` cannot be accessed." | None. |
 | `database_gateway_execute_query` | Execute exactly one classifier-approved `SELECT` or `EXPLAIN ANALYZE` statement. | "Query the first 10 rows from `orders`." | None; rejects DML, DDL, DCL, transaction control, savepoints, and other side-effecting SQL. |
 | `database_gateway_execute_update` | Preview or execute one SQL statement that may mutate data, metadata, rules, or transaction state. | "Preview this change SQL without executing it." | Yes; preview and confirmation are recommended first. |
 | `database_gateway_apply_workflow` | Preview, execute, or export a governance change plan created by a feature plugin. | "Preview the previous encryption rule plan first." | Depends on the execution choice; preview and manual packages do not change runtime state. |
 | `database_gateway_validate_workflow` | After plugin workflow execution, validate the result against visible metadata and generated artifacts. | "Validate whether the previous masking rule has taken effect." | None. |
 
 Plugin tools are documented on the corresponding plugin pages.
-
-### Proxy preflight validation output
-
-`database_gateway_validate_proxy_connectivity` returns a structured validation payload with these top-level fields:
-
-- `response_mode`
-- `status`
-- `database`
-- `checks`
-- `category`
-- `recovery`
-
-Common failure categories include `missing_jdbc_driver`, `authentication_failed`, `authorization_failed`, `connection_timeout`, `invalid_configuration`, `database_unavailable`, `connection_failed`, and `database_not_visible`.
-The `recovery` field follows the same secret-safe runtime recovery style used by runtime database connection failures.
-The tool only accepts the configured `database` name. Connection details such as JDBC URL, username, password, and driver class stay in the runtime configuration.
 
 ## Prompts
 

--- a/docs/document/content/user-manual/shardingsphere-mcp/deployment.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/deployment.cn.md
@@ -55,7 +55,10 @@ docker run --rm -p 18088:18088 \
   ghcr.io/apache/shardingsphere-mcp:${latest.release.version}
 ```
 
-配置文件中的 `runtimeDatabases` 需要指向用户已准备好的 ShardingSphere-Proxy 逻辑库。
+根据目标能力边界配置 `runtimeDatabases`：
+
+- 使用 ShardingSphere 规则能力或功能插件工作流时，指向用户已准备好的 ShardingSphere-Proxy 逻辑库。
+- 仅使用通用 JDBC 元数据、元数据搜索和受控 SQL 能力时，可以指向任意可连接的 JDBC 数据库。
 
 ## 安全部署建议
 

--- a/docs/document/content/user-manual/shardingsphere-mcp/deployment.en.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/deployment.en.md
@@ -55,7 +55,10 @@ docker run --rm -p 18088:18088 \
   ghcr.io/apache/shardingsphere-mcp:${latest.release.version}
 ```
 
-`runtimeDatabases` in the configuration file must point to a ShardingSphere-Proxy logical database prepared by the user.
+Configure `runtimeDatabases` according to the target capability boundary:
+
+- Point it to a ShardingSphere-Proxy logical database when using ShardingSphere rule capabilities or feature plugin workflows.
+- Point it to any reachable JDBC database only for general JDBC metadata, metadata search, and controlled SQL capabilities.
 
 ## Secure deployment
 

--- a/docs/document/content/user-manual/shardingsphere-mcp/troubleshooting.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/troubleshooting.cn.md
@@ -28,6 +28,21 @@ weight = 7
 - 使用 `manual-only` 后，应先人工执行返回的 SQL 或 DistSQL，再调用校验工具。
 - 人工执行包中的密钥占位符应由执行人员在受控环境替换。
 
+## 连接错误分类
+
+当运行时数据库或 ShardingSphere-Proxy 连接失败时，MCP 响应会返回连接错误分类，用于帮助定位问题。分类只描述失败原因，不暴露 JDBC URL、密码、环境变量或堆栈信息。
+
+| 分类 | 含义 |
+| --- | --- |
+| `missing_jdbc_driver` | 未找到配置的 JDBC 驱动。 |
+| `authentication_failed` | 用户名或密码认证失败。 |
+| `authorization_failed` | 当前账号没有访问目标数据库或元数据的权限。 |
+| `connection_timeout` | 连接超时，通常需要检查地址、端口、网络或超时设置。 |
+| `invalid_configuration` | 运行时数据库配置不完整或不一致。 |
+| `database_unavailable` | 目标数据库或 ShardingSphere-Proxy 当前不可用。 |
+| `connection_failed` | 连接失败，但无法归类为更具体的原因。 |
+| `database_not_visible` | 指定逻辑库对当前连接不可见。 |
+
 ## SQL 工具选择
 
 | SQL 类型 | 工具 | 建议 |

--- a/docs/document/content/user-manual/shardingsphere-mcp/troubleshooting.en.md
+++ b/docs/document/content/user-manual/shardingsphere-mcp/troubleshooting.en.md
@@ -28,6 +28,21 @@ Additional notes:
 - After `manual-only`, execute the returned SQL or DistSQL manually before calling validation.
 - Secret placeholders in manual packages should be replaced by operators in a controlled environment.
 
+## Connection Failure Categories
+
+When a runtime database or ShardingSphere-Proxy connection fails, MCP responses return a connection failure category to help locate the issue. Categories describe the failure cause without exposing JDBC URLs, passwords, environment variables, or stack traces.
+
+| Category | Meaning |
+| --- | --- |
+| `missing_jdbc_driver` | The configured JDBC driver cannot be found. |
+| `authentication_failed` | Username or password authentication failed. |
+| `authorization_failed` | The current account does not have permission to access the target database or metadata. |
+| `connection_timeout` | The connection timed out. Check the address, port, network, or timeout settings. |
+| `invalid_configuration` | Runtime database configuration is incomplete or inconsistent. |
+| `database_unavailable` | The target database or ShardingSphere-Proxy is currently unavailable. |
+| `connection_failed` | The connection failed, but cannot be classified into a more specific cause. |
+| `database_not_visible` | The specified logical database is not visible to the current connection. |
+
 ## SQL tool selection
 
 | SQL type | Tool | Recommendation |


### PR DESCRIPTION
Clarify that ShardingSphere-MCP is integrated by AI applications through MCP clients, instead of being limited to existing LLM clients.

Rework capability discovery around protocol entries, capability types, returned content, and usage scenarios. Keep Proxy connectivity validation as a tool-level diagnostic capability and move connection failure categories to troubleshooting.

Apply the updates to both Chinese and English ShardingSphere-MCP docs.

For #35294.