### PR TITLE
Remove redundant MCP LLM model size metadata

### DIFF
--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/config/LLME2EConfiguration.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/config/LLME2EConfiguration.java
@@ -206,22 +206,12 @@ public final class LLME2EConfiguration {
         }
     }
     
-    private static long readRequiredLong(final Properties props, final String propertyName) {
-        String result = readRequiredString(props, propertyName);
-        try {
-            return Long.parseLong(result);
-        } catch (final NumberFormatException ex) {
-            throw new IllegalStateException(String.format("MCP LLM E2E property `%s` must be a long value.", propertyName), ex);
-        }
-    }
-    
     private static ModelMetadata readModelMetadata(final Properties props) {
         return new ModelMetadata(
                 readRequiredString(props, "mcp.llm.model-repository"),
                 readRequiredString(props, "mcp.llm.model-file-name"),
                 readRequiredString(props, "mcp.llm.model-quantization"),
                 readRequiredString(props, "mcp.llm.model-revision"),
-                readRequiredLong(props, "mcp.llm.model-size-bytes"),
                 readRequiredString(props, "mcp.llm.model-sha256"));
     }
     
@@ -248,8 +238,6 @@ public final class LLME2EConfiguration {
         private final String quantization;
         
         private final String revision;
-        
-        private final long sizeBytes;
         
         private final String sha256;
         

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/config/LLME2EConfigurationTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/config/LLME2EConfigurationTest.java
@@ -57,8 +57,6 @@ class LLME2EConfigurationTest {
     
     private String originalModelRevision;
     
-    private String originalModelSizeBytes;
-    
     private String originalModelSha256;
     
     @BeforeEach
@@ -75,7 +73,6 @@ class LLME2EConfigurationTest {
         originalModelFileName = System.getProperty("mcp.llm.model-file-name");
         originalModelQuantization = System.getProperty("mcp.llm.model-quantization");
         originalModelRevision = System.getProperty("mcp.llm.model-revision");
-        originalModelSizeBytes = System.getProperty("mcp.llm.model-size-bytes");
         originalModelSha256 = System.getProperty("mcp.llm.model-sha256");
         System.clearProperty("mcp.llm.model");
         System.clearProperty("mcp.llm.api-key");
@@ -88,7 +85,6 @@ class LLME2EConfigurationTest {
         System.clearProperty("mcp.llm.model-file-name");
         System.clearProperty("mcp.llm.model-quantization");
         System.clearProperty("mcp.llm.model-revision");
-        System.clearProperty("mcp.llm.model-size-bytes");
         System.clearProperty("mcp.llm.model-sha256");
     }
     
@@ -106,7 +102,6 @@ class LLME2EConfigurationTest {
         restoreProperty("mcp.llm.model-file-name", originalModelFileName);
         restoreProperty("mcp.llm.model-quantization", originalModelQuantization);
         restoreProperty("mcp.llm.model-revision", originalModelRevision);
-        restoreProperty("mcp.llm.model-size-bytes", originalModelSizeBytes);
         restoreProperty("mcp.llm.model-sha256", originalModelSha256);
     }
     
@@ -128,7 +123,6 @@ class LLME2EConfigurationTest {
         assertThat(actual.getModelMetadata().getFileName(), is(expectedProps.getProperty("mcp.llm.model-file-name")));
         assertThat(actual.getModelMetadata().getQuantization(), is(expectedProps.getProperty("mcp.llm.model-quantization")));
         assertThat(actual.getModelMetadata().getRevision(), is(expectedProps.getProperty("mcp.llm.model-revision")));
-        assertThat(actual.getModelMetadata().getSizeBytes(), is(Long.parseLong(expectedProps.getProperty("mcp.llm.model-size-bytes"))));
         assertFalse(actual.getModelSha256().isBlank());
     }
     
@@ -172,7 +166,6 @@ class LLME2EConfigurationTest {
         System.setProperty("mcp.llm.model-file-name", "Qwen3-1.7B-Q4_K_M.gguf");
         System.setProperty("mcp.llm.model-quantization", "Q4_K_M");
         System.setProperty("mcp.llm.model-revision", "daeb8e2d528a760970442092f6bf1e55c3b659eb");
-        System.setProperty("mcp.llm.model-size-bytes", "1282439264");
         System.setProperty("mcp.llm.model-sha256", "configured-model-sha256");
         LLME2EConfiguration actual = LLME2EConfiguration.load();
         assertThat(actual.getServerRuntime(), is("test-runtime"));
@@ -183,7 +176,6 @@ class LLME2EConfigurationTest {
         assertThat(actual.getModelMetadata().getFileName(), is("Qwen3-1.7B-Q4_K_M.gguf"));
         assertThat(actual.getModelMetadata().getQuantization(), is("Q4_K_M"));
         assertThat(actual.getModelMetadata().getRevision(), is("daeb8e2d528a760970442092f6bf1e55c3b659eb"));
-        assertThat(actual.getModelMetadata().getSizeBytes(), is(1282439264L));
         assertThat(actual.getModelName(), is("ggml-org/Qwen3-1.7B-GGUF:Q4_K_M"));
         assertThat(actual.getModelSha256(), is("configured-model-sha256"));
     }
@@ -218,7 +210,7 @@ class LLME2EConfigurationTest {
     private LLME2EConfiguration createConfiguration(final RuntimeMode runtimeMode) {
         return new LLME2EConfiguration("http://127.0.0.1:8080/v1", "openai-compatible", "ggml-org/Qwen3-1.7B-GGUF:Q4_K_M", "mcp-llm-score", 600, 240, 10,
                 Path.of("target/llm-e2e"), "run-id", runtimeMode, "llama.cpp", "apache/shardingsphere-mcp-llm-runtime:local", "ghcr.io/ggml-org/llama.cpp:server", "",
-                new LLME2EConfiguration.ModelMetadata("ggml-org/Qwen3-1.7B-GGUF", "Qwen3-1.7B-Q4_K_M.gguf", "Q4_K_M", "daeb8e2d528a760970442092f6bf1e55c3b659eb", 1282439264L,
+                new LLME2EConfiguration.ModelMetadata("ggml-org/Qwen3-1.7B-GGUF", "Qwen3-1.7B-Q4_K_M.gguf", "Q4_K_M", "daeb8e2d528a760970442092f6bf1e55c3b659eb",
                         "configured-model-sha256"));
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/artifact/LLME2EArtifactWriter.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/artifact/LLME2EArtifactWriter.java
@@ -39,7 +39,7 @@ public final class LLME2EArtifactWriter {
     
     private static final List<String> REQUIRED_SCORE_EVIDENCE_KEYS = List.of(
             "runtimeMode", "dockerOwned", "provider", "serverRuntime", "serverImage", "serverImageId", "baseServerImage", "modelReference", "servedModelId",
-            "modelQuantization", "modelSizeBytes", "modelRevision", "modelFileName", "modelSha256", "modelPackaging", "baseUrlOwnedByTest", "scoreClosing");
+            "modelQuantization", "modelRevision", "modelFileName", "modelSha256", "modelPackaging", "baseUrlOwnedByTest", "scoreClosing");
     
     /**
      * Write.
@@ -85,10 +85,6 @@ public final class LLME2EArtifactWriter {
         }
         if (!Boolean.TRUE.equals(runtimeEvidence.get("dockerOwned")) || !Boolean.TRUE.equals(runtimeEvidence.get("baseUrlOwnedByTest"))) {
             throw new IllegalStateException("Score-closing LLM runtime evidence must be Docker-owned and test-owned.");
-        }
-        Object modelSizeBytes = runtimeEvidence.get("modelSizeBytes");
-        if (!(modelSizeBytes instanceof Number) || 0L >= ((Number) modelSizeBytes).longValue()) {
-            throw new IllegalStateException("Score-closing LLM runtime evidence must include a positive modelSizeBytes value.");
         }
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/artifact/LLME2EArtifactWriterTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/artifact/LLME2EArtifactWriterTest.java
@@ -84,7 +84,6 @@ class LLME2EArtifactWriterTest {
                 Map.entry("modelReference", MODEL_NAME),
                 Map.entry("servedModelId", MODEL_NAME),
                 Map.entry("modelQuantization", "Q4_K_M"),
-                Map.entry("modelSizeBytes", 1282439264L),
                 Map.entry("modelRevision", "daeb8e2d528a760970442092f6bf1e55c3b659eb"),
                 Map.entry("modelFileName", "Qwen3-1.7B-Q4_K_M.gguf"),
                 Map.entry("modelSha256", "configured-model-sha256"),

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/client/LLMChatModelClientTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/client/LLMChatModelClientTest.java
@@ -52,7 +52,7 @@ class LLMChatModelClientTest {
     private static final String REQUIRED_MODEL = "ggml-org/Qwen3-1.7B-GGUF:Q4_K_M";
     
     private static final LLME2EConfiguration.ModelMetadata MODEL_METADATA = new LLME2EConfiguration.ModelMetadata(
-            "ggml-org/Qwen3-1.7B-GGUF", "Qwen3-1.7B-Q4_K_M.gguf", "Q4_K_M", "daeb8e2d528a760970442092f6bf1e55c3b659eb", 1282439264L, "configured-model-sha256");
+            "ggml-org/Qwen3-1.7B-GGUF", "Qwen3-1.7B-Q4_K_M.gguf", "Q4_K_M", "daeb8e2d528a760970442092f6bf1e55c3b659eb", "configured-model-sha256");
     
     @Test
     void assertWaitUntilReady() throws IOException, InterruptedException {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/fixture/LLMRuntimeSupport.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/fixture/LLMRuntimeSupport.java
@@ -175,7 +175,7 @@ public final class LLMRuntimeSupport {
         }
         
         private static Map<String, Object> createScoreClosingEvidence(final LLME2EConfiguration config, final String serverImageId) {
-            Map<String, Object> result = new LinkedHashMap<>(18, 1F);
+            Map<String, Object> result = new LinkedHashMap<>(17, 1F);
             result.put("runtimeMode", config.getRuntimeMode().getValue());
             result.put("dockerOwned", true);
             result.put("provider", config.getModelProvider());
@@ -187,7 +187,6 @@ public final class LLMRuntimeSupport {
             result.put("modelReference", config.getModelName());
             result.put("servedModelId", config.getModelName());
             result.put("modelQuantization", config.getModelMetadata().getQuantization());
-            result.put("modelSizeBytes", config.getModelMetadata().getSizeBytes());
             result.put("modelRevision", config.getModelMetadata().getRevision());
             result.put("modelFileName", config.getModelMetadata().getFileName());
             result.put("modelSha256", config.getModelSha256());

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/fixture/LLMRuntimeSupportTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/fixture/LLMRuntimeSupportTest.java
@@ -42,7 +42,7 @@ class LLMRuntimeSupportTest {
     private static final String REQUIRED_MODEL = "ggml-org/Qwen3-1.7B-GGUF:Q4_K_M";
     
     private static final LLME2EConfiguration.ModelMetadata MODEL_METADATA = new LLME2EConfiguration.ModelMetadata(
-            "ggml-org/Qwen3-1.7B-GGUF", "Qwen3-1.7B-Q4_K_M.gguf", "Q4_K_M", "daeb8e2d528a760970442092f6bf1e55c3b659eb", 1282439264L, "configured-model-sha256");
+            "ggml-org/Qwen3-1.7B-GGUF", "Qwen3-1.7B-Q4_K_M.gguf", "Q4_K_M", "daeb8e2d528a760970442092f6bf1e55c3b659eb", "configured-model-sha256");
     
     private static final String DOCKER_REQUIRED_MESSAGE = "Docker is required to start the prepackaged llama.cpp server for MCP LLM E2E.";
     

--- a/test/e2e/mcp/src/test/resources/env/e2e-env.properties
+++ b/test/e2e/mcp/src/test/resources/env/e2e-env.properties
@@ -43,5 +43,4 @@ mcp.llm.model-repository=ggml-org/Qwen3-1.7B-GGUF
 mcp.llm.model-quantization=Q4_K_M
 mcp.llm.model-revision=daeb8e2d528a760970442092f6bf1e55c3b659eb
 mcp.llm.model-file-name=Qwen3-1.7B-Q4_K_M.gguf
-mcp.llm.model-size-bytes=1282439264
 mcp.llm.model-sha256=d2387ca2dbfee2ffabce7120d3770dadca0b293052bc2f0e138fdc940d9bc7b5


### PR DESCRIPTION
Remove mcp.llm.model-size-bytes from MCP LLM E2E configuration and runtime evidence because model revision and SHA-256 already provide the required reproducibility and content verification.

Keep model revision and checksum validation unchanged.

For #35294.