### PR TITLE
Make required checks optional

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -47,10 +47,11 @@ github:
   protected_branches:
     master:
       required_status_checks:
-        contexts:
-          - Check - CheckStyle
-          - Check - Spotless
-          - Check - License
+        contexts: []
+        # Temporarily commented out because GitHub Actions runner capacity is insufficient, causing required checks to take too long to finish.
+        # - Check - CheckStyle
+        # - Check - Spotless
+        # - Check - License
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1


### PR DESCRIPTION
Temporarily comment out the master branch required status check contexts for Checkstyle, Spotless, and License because GitHub Actions runner capacity is insufficient and required checks take too long to finish.

The workflow jobs are kept so the checks still run as ordinary PR checks.