### PR TITLE
Fix locale-sensitive number formatting in AutoIntervalShardingAlgorithm

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithm.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithm.java
@@ -31,12 +31,14 @@ import org.apache.shardingsphere.sharding.exception.data.InvalidDatetimeFormatEx
 import org.apache.shardingsphere.sharding.exception.data.NullShardingValueException;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.ParsePosition;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Properties;
 
 /**
@@ -99,7 +101,7 @@ public final class AutoIntervalShardingAlgorithm implements StandardShardingAlgo
     }
     
     private int doSharding(final long shardingValue) {
-        String position = new DecimalFormat("0.00").format((double) shardingValue / shardingSeconds);
+        String position = new DecimalFormat("0.00", DecimalFormatSymbols.getInstance(Locale.ROOT)).format((double) shardingValue / shardingSeconds);
         return Math.min(Math.max(0, (int) Math.ceil(Double.parseDouble(position))), autoTablesAmount - 1);
     }
     

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithmTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithmTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
@@ -70,6 +71,25 @@ class AutoIntervalShardingAlgorithmTest {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3", "t_order_4", "t_order_5");
         assertThat(shardingAlgorithm.doSharding(availableTargetNames,
                 new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_INFO, "2021-01-01 00:00:02")), is("t_order_5"));
+    }
+    
+    @Test
+    void assertDoShardingWithCommaDecimalDefaultLocale() {
+        Locale defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.GERMANY);
+        try {
+            List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3", "t_order_4");
+            assertThat(shardingAlgorithm.doSharding(availableTargetNames,
+                    new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_INFO, "2020-01-01 00:00:01")), is("t_order_1"));
+            Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames,
+                    new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("2020-01-01 00:00:04", "2020-01-01 00:00:10")));
+            assertThat(actual.size(), is(3));
+            assertTrue(actual.contains("t_order_1"));
+            assertTrue(actual.contains("t_order_2"));
+            assertTrue(actual.contains("t_order_3"));
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
     
     @Test


### PR DESCRIPTION
Fixes #38805.

Changes proposed in this pull request:
    - Use `DecimalFormatSymbols.getInstance(Locale.ROOT)` in `AutoIntervalShardingAlgorithm.doSharding(long)` so the `DecimalFormat` format/parse round-trip no longer depends on the JVM default locale. On comma-decimal locales
  (e.g. `ru_RU`, `de_DE`) the previous code formatted values as `"11,00"`, which `Double.parseDouble(...)` then failed to parse with `NumberFormatException`.

  ---
  
  Before committing this PR, I'm sure that I have checked the following options:
  - [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
  - [x] I have self-reviewed the commit code.
  - [ ] I have (or in comment I request) added corresponding labels for the pull request.
  - [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
  - [ ] I have made corresponding changes to the documentation.
  - [ ] I have added corresponding unit tests for my changes.
  - [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
