### PR TITLE
fix: correct font family on the website's docs

### DIFF
--- a/docs/community/static/css/theme-white.css
+++ b/docs/community/static/css/theme-white.css
@@ -1,5 +1,5 @@
 body{
-    font-family: 'roboto,sans-serif';
+    font-family: 'roboto',sans-serif;
     letter-spacing: .33px;
     font-weight: 400;
     text-rendering: optimizeLegibility;
@@ -307,7 +307,7 @@ a:hover{
 }
 
 
-h1, h2, h3, h4, h5, h6{font-weight: bold;font-family:'roboto,sans-serif' ;}
+h1, h2, h3, h4, h5, h6{font-weight: bold;font-family:'roboto',sans-serif;}
 h1{
     text-align: left;
 }

--- a/docs/document/static/css/theme-white.css
+++ b/docs/document/static/css/theme-white.css
@@ -1,5 +1,5 @@
 body{
-    font-family: 'roboto,sans-serif';
+    font-family: 'roboto',sans-serif;
     letter-spacing: .33px;
     font-weight: 400;
     text-rendering: optimizeLegibility;
@@ -329,7 +329,7 @@ a:hover{
 }
 
 
-h1, h2, h3, h4, h5, h6{font-weight: bold;font-family:'roboto,sans-serif' ;}
+h1, h2, h3, h4, h5, h6{font-weight: bold;font-family:'roboto',sans-serif;}
 h1{
     text-align: left;
     font-size: 2.0rem;


### PR DESCRIPTION
Changes proposed in this pull request:
  - correct the CSS `font-family` directive to list 2 fonts : Roboto, then sans-serif as a fallback, instead of "roboto,sans-serif" which is not a valid font.

As the font does not exist, the browser falls back to the default font (configurable by the user in the browser settings, mine is set to Comic Sans)

Docs: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-family

| Before | After |
|----|-----|
| <img width="1189" height="677" alt="image" src="https://github.com/user-attachments/assets/bb2f0957-7806-4341-a5ba-5e35f23a5503" /> | <img width="1189" height="677" alt="Capture d’écran 2026-06-05 à 16 44 22" src="https://github.com/user-attachments/assets/1e1ff5f6-696d-4945-95d9-c66f959a9dc4" /> |

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
