### PR TITLE
Fix unsupported MySQL temporary table DDL before backend execution

### DIFF
--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/ddl/CreateTableStatementBinder.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/ddl/CreateTableStatementBinder.java
@@ -57,6 +57,7 @@ public final class CreateTableStatementBinder implements SQLStatementBinder<Crea
                 .table(boundTable)
                 .selectStatement(boundSelectStatement)
                 .ifNotExists(sqlStatement.isIfNotExists())
+                .temporary(sqlStatement.isTemporary())
                 .likeTable(sqlStatement.getLikeTable().orElse(null))
                 .createTableOption(sqlStatement.getCreateTableOption().orElse(null))
                 .columnDefinitions(boundColumnDefinitions)

--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/ddl/DropTableStatementBinder.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/ddl/DropTableStatementBinder.java
@@ -41,7 +41,7 @@ public final class DropTableStatementBinder implements SQLStatementBinder<DropTa
     }
     
     private DropTableStatement copy(final DropTableStatement sqlStatement, final Collection<SimpleTableSegment> boundTables) {
-        DropTableStatement result = new DropTableStatement(sqlStatement.getDatabaseType(), boundTables, sqlStatement.isIfExists(), sqlStatement.isContainsCascade());
+        DropTableStatement result = new DropTableStatement(sqlStatement.getDatabaseType(), boundTables, sqlStatement.isIfExists(), sqlStatement.isTemporary(), sqlStatement.isContainsCascade());
         SQLStatementCopyUtils.copyAttributes(sqlStatement, result);
         return result;
     }

--- a/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/kernel/KernelProcessor.java
+++ b/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/kernel/KernelProcessor.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.infra.connection.kernel;
 
-import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.annotation.HighFrequencyInvocation;
 import org.apache.shardingsphere.infra.checker.SupportedSQLCheckEngine;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
@@ -70,10 +69,6 @@ public final class KernelProcessor {
     }
     
     private void checkUnsupportedTemporaryTableDDL(final QueryContext queryContext) {
-        ShardingSphereDatabase database = queryContext.getUsedDatabase();
-        if (!isMySQL(database.getProtocolType())) {
-            return;
-        }
         SQLStatement sqlStatement = queryContext.getSqlStatementContext().getSqlStatement();
         if (sqlStatement instanceof CreateTableStatement && ((CreateTableStatement) sqlStatement).isTemporary()) {
             throw new UnsupportedSQLOperationException("CREATE TEMPORARY TABLE");
@@ -81,10 +76,6 @@ public final class KernelProcessor {
         if (sqlStatement instanceof DropTableStatement && ((DropTableStatement) sqlStatement).isTemporary()) {
             throw new UnsupportedSQLOperationException("DROP TEMPORARY TABLE");
         }
-    }
-    
-    private boolean isMySQL(final DatabaseType databaseType) {
-        return "MySQL".equalsIgnoreCase(databaseType.getType());
     }
     
     private RouteContext route(final QueryContext queryContext, final RuleMetaData globalRuleMetaData, final ConfigurationProperties props) {

--- a/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/kernel/KernelProcessor.java
+++ b/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/kernel/KernelProcessor.java
@@ -17,10 +17,12 @@
 
 package org.apache.shardingsphere.infra.connection.kernel;
 
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.annotation.HighFrequencyInvocation;
 import org.apache.shardingsphere.infra.checker.SupportedSQLCheckEngine;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionContext;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionContextBuilder;
 import org.apache.shardingsphere.infra.executor.sql.log.SQLLogger;
@@ -31,6 +33,9 @@ import org.apache.shardingsphere.infra.rewrite.engine.result.SQLRewriteResult;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.route.engine.SQLRouteEngine;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.table.CreateTableStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.table.DropTableStatement;
 
 /**
  * Kernel processor.
@@ -56,11 +61,30 @@ public final class KernelProcessor {
     }
     
     private void check(final QueryContext queryContext) {
+        checkUnsupportedTemporaryTableDDL(queryContext);
         if (queryContext.getHintValueContext().isSkipMetadataValidate()) {
             return;
         }
         ShardingSphereDatabase database = queryContext.getUsedDatabase();
         new SupportedSQLCheckEngine().checkSQL(database.getRuleMetaData().getRules(), queryContext.getSqlStatementContext(), database);
+    }
+    
+    private void checkUnsupportedTemporaryTableDDL(final QueryContext queryContext) {
+        ShardingSphereDatabase database = queryContext.getUsedDatabase();
+        if (!isMySQL(database.getProtocolType())) {
+            return;
+        }
+        SQLStatement sqlStatement = queryContext.getSqlStatementContext().getSqlStatement();
+        if (sqlStatement instanceof CreateTableStatement && ((CreateTableStatement) sqlStatement).isTemporary()) {
+            throw new UnsupportedSQLOperationException("CREATE TEMPORARY TABLE");
+        }
+        if (sqlStatement instanceof DropTableStatement && ((DropTableStatement) sqlStatement).isTemporary()) {
+            throw new UnsupportedSQLOperationException("DROP TEMPORARY TABLE");
+        }
+    }
+    
+    private boolean isMySQL(final DatabaseType databaseType) {
+        return "MySQL".equalsIgnoreCase(databaseType.getType());
     }
     
     private RouteContext route(final QueryContext queryContext, final RuleMetaData globalRuleMetaData, final ConfigurationProperties props) {

--- a/infra/context/src/test/java/org/apache/shardingsphere/infra/connection/kernel/KernelProcessorTest.java
+++ b/infra/context/src/test/java/org/apache/shardingsphere/infra/connection/kernel/KernelProcessorTest.java
@@ -59,10 +59,10 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Properties;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -106,21 +106,21 @@ class KernelProcessorTest {
     
     @Test
     void assertGenerateExecutionContextWithTemporaryCreateTable() {
-        QueryContext queryContext = createQueryContext(createTemporaryCreateTableStatement(), false, createMySQLDatabaseType());
+        QueryContext queryContext = createQueryContext(createTemporaryCreateTableStatement(databaseType), false, databaseType);
         assertThrows(UnsupportedSQLOperationException.class,
                 () -> new KernelProcessor().generateExecutionContext(queryContext, new RuleMetaData(Arrays.asList(mockSQLTranslatorRule(), mockAggregatedDataSourceRule())), createProps(false)));
     }
     
     @Test
     void assertGenerateExecutionContextWithTemporaryDropTable() {
-        QueryContext queryContext = createQueryContext(createTemporaryDropTableStatement(), false, createMySQLDatabaseType());
+        QueryContext queryContext = createQueryContext(createTemporaryDropTableStatement(databaseType), false, databaseType);
         assertThrows(UnsupportedSQLOperationException.class,
                 () -> new KernelProcessor().generateExecutionContext(queryContext, new RuleMetaData(Arrays.asList(mockSQLTranslatorRule(), mockAggregatedDataSourceRule())), createProps(false)));
     }
     
     @Test
     void assertGenerateExecutionContextWithTemporaryCreateTableWhenSkipMetadataValidate() {
-        QueryContext queryContext = createQueryContext(createTemporaryCreateTableStatement(), true, createMySQLDatabaseType());
+        QueryContext queryContext = createQueryContext(createTemporaryCreateTableStatement(databaseType), true, databaseType);
         try (
                 MockedConstruction<SupportedSQLCheckEngine> mockedCheckEngines = mockConstruction(SupportedSQLCheckEngine.class);
                 MockedStatic<SQLLogger> mockedSQLLogger = mockStatic(SQLLogger.class)) {
@@ -172,22 +172,16 @@ class KernelProcessorTest {
         return new ConfigurationProperties(PropertiesBuilder.build(new Property(ConfigurationPropertyKey.SQL_SHOW.getKey(), Boolean.toString(sqlShow))));
     }
     
-    private CreateTableStatement createTemporaryCreateTableStatement() {
+    private CreateTableStatement createTemporaryCreateTableStatement(final DatabaseType databaseType) {
         return CreateTableStatement.builder()
-                .databaseType(createMySQLDatabaseType())
+                .databaseType(databaseType)
                 .table(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))))
                 .temporary(true)
                 .build();
     }
     
-    private DropTableStatement createTemporaryDropTableStatement() {
-        return new DropTableStatement(createMySQLDatabaseType(),
+    private DropTableStatement createTemporaryDropTableStatement(final DatabaseType databaseType) {
+        return new DropTableStatement(databaseType,
                 Collections.singletonList(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")))), false, true, false);
-    }
-    
-    private DatabaseType createMySQLDatabaseType() {
-        DatabaseType result = mock(DatabaseType.class);
-        when(result.getType()).thenReturn("MySQL");
-        return result;
     }
 }

--- a/infra/context/src/test/java/org/apache/shardingsphere/infra/connection/kernel/KernelProcessorTest.java
+++ b/infra/context/src/test/java/org/apache/shardingsphere/infra/connection/kernel/KernelProcessorTest.java
@@ -18,11 +18,12 @@
 package org.apache.shardingsphere.infra.connection.kernel;
 
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.type.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.checker.SupportedSQLCheckEngine;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionContext;
 import org.apache.shardingsphere.infra.executor.sql.log.SQLLogger;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
@@ -39,7 +40,13 @@ import org.apache.shardingsphere.infra.session.query.QueryContext;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.infra.util.props.PropertiesBuilder;
 import org.apache.shardingsphere.infra.util.props.PropertiesBuilder.Property;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.table.CreateTableStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.table.DropTableStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sqltranslator.context.SQLTranslatorContext;
 import org.apache.shardingsphere.sqltranslator.rule.SQLTranslatorRule;
 import org.junit.jupiter.api.Test;
@@ -55,6 +62,7 @@ import java.util.Properties;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -96,6 +104,33 @@ class KernelProcessorTest {
         }
     }
     
+    @Test
+    void assertGenerateExecutionContextWithTemporaryCreateTable() {
+        QueryContext queryContext = createQueryContext(createTemporaryCreateTableStatement(), false, createMySQLDatabaseType());
+        assertThrows(UnsupportedSQLOperationException.class,
+                () -> new KernelProcessor().generateExecutionContext(queryContext, new RuleMetaData(Arrays.asList(mockSQLTranslatorRule(), mockAggregatedDataSourceRule())), createProps(false)));
+    }
+    
+    @Test
+    void assertGenerateExecutionContextWithTemporaryDropTable() {
+        QueryContext queryContext = createQueryContext(createTemporaryDropTableStatement(), false, createMySQLDatabaseType());
+        assertThrows(UnsupportedSQLOperationException.class,
+                () -> new KernelProcessor().generateExecutionContext(queryContext, new RuleMetaData(Arrays.asList(mockSQLTranslatorRule(), mockAggregatedDataSourceRule())), createProps(false)));
+    }
+    
+    @Test
+    void assertGenerateExecutionContextWithTemporaryCreateTableWhenSkipMetadataValidate() {
+        QueryContext queryContext = createQueryContext(createTemporaryCreateTableStatement(), true, createMySQLDatabaseType());
+        try (
+                MockedConstruction<SupportedSQLCheckEngine> mockedCheckEngines = mockConstruction(SupportedSQLCheckEngine.class);
+                MockedStatic<SQLLogger> mockedSQLLogger = mockStatic(SQLLogger.class)) {
+            assertThrows(UnsupportedSQLOperationException.class,
+                    () -> new KernelProcessor().generateExecutionContext(queryContext, new RuleMetaData(Arrays.asList(mockSQLTranslatorRule(), mockAggregatedDataSourceRule())), createProps(false)));
+            assertTrue(mockedCheckEngines.constructed().isEmpty());
+            mockedSQLLogger.verifyNoInteractions();
+        }
+    }
+    
     private SQLTranslatorRule mockSQLTranslatorRule() {
         SQLTranslatorRule result = mock(SQLTranslatorRule.class);
         when(result.getAttributes()).thenReturn(new RuleAttributes());
@@ -112,6 +147,10 @@ class KernelProcessorTest {
     }
     
     private QueryContext createQueryContext(final boolean skipMetadataValidate) {
+        return createQueryContext(SelectStatement.builder().databaseType(databaseType).build(), skipMetadataValidate, databaseType);
+    }
+    
+    private QueryContext createQueryContext(final SQLStatement sqlStatement, final boolean skipMetadataValidate, final DatabaseType databaseType) {
         HintValueContext hintValueContext = new HintValueContext();
         hintValueContext.setSkipMetadataValidate(skipMetadataValidate);
         ConnectionContext connectionContext = mock(ConnectionContext.class);
@@ -125,11 +164,30 @@ class KernelProcessorTest {
                 new ConfigurationProperties(new Properties()));
         when(metaData.getDatabase("foo_db")).thenReturn(database);
         when(metaData.getProps()).thenReturn(new ConfigurationProperties(new Properties()));
-        SQLStatementContext sqlStatementContext = new CommonSQLStatementContext(SelectStatement.builder().databaseType(databaseType).build());
+        SQLStatementContext sqlStatementContext = new CommonSQLStatementContext(sqlStatement);
         return new QueryContext(sqlStatementContext, "SELECT * FROM tbl", Collections.emptyList(), hintValueContext, connectionContext, metaData);
     }
     
     private ConfigurationProperties createProps(final boolean sqlShow) {
         return new ConfigurationProperties(PropertiesBuilder.build(new Property(ConfigurationPropertyKey.SQL_SHOW.getKey(), Boolean.toString(sqlShow))));
+    }
+    
+    private CreateTableStatement createTemporaryCreateTableStatement() {
+        return CreateTableStatement.builder()
+                .databaseType(createMySQLDatabaseType())
+                .table(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))))
+                .temporary(true)
+                .build();
+    }
+    
+    private DropTableStatement createTemporaryDropTableStatement() {
+        return new DropTableStatement(createMySQLDatabaseType(),
+                Collections.singletonList(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")))), false, true, false);
+    }
+    
+    private DatabaseType createMySQLDatabaseType() {
+        DatabaseType result = mock(DatabaseType.class);
+        when(result.getType()).thenReturn("MySQL");
+        return result;
     }
 }

--- a/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/doris/src/main/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisDDLStatementVisitor.java
@@ -634,6 +634,7 @@ public final class DorisDDLStatementVisitor extends DorisStatementVisitor implem
                 .databaseType(getDatabaseType())
                 .table((SimpleTableSegment) visit(ctx.tableName()))
                 .ifNotExists(null != ctx.ifNotExists())
+                .temporary(null != ctx.TEMPORARY())
                 .likeTable(likeTable)
                 .createTableOption(createTableOption)
                 .selectStatement(selectStatement)
@@ -1244,7 +1245,8 @@ public final class DorisDDLStatementVisitor extends DorisStatementVisitor implem
     @SuppressWarnings("unchecked")
     @Override
     public ASTNode visitDropTable(final DropTableContext ctx) {
-        return new DropTableStatement(getDatabaseType(), ((CollectionValue<SimpleTableSegment>) visit(ctx.tableList())).getValue(), null != ctx.ifExists(), false);
+        return new DropTableStatement(getDatabaseType(), ((CollectionValue<SimpleTableSegment>) visit(ctx.tableList())).getValue(),
+                null != ctx.ifExists(), null != ctx.TEMPORARY(), false);
     }
     
     @Override

--- a/parser/sql/engine/dialect/doris/src/test/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisStatementVisitorTest.java
+++ b/parser/sql/engine/dialect/doris/src/test/java/org/apache/shardingsphere/sql/parser/engine/doris/visitor/statement/type/DorisStatementVisitorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.engine.doris.visitor.statement.type;
+
+import org.apache.shardingsphere.sql.parser.engine.api.CacheOption;
+import org.apache.shardingsphere.sql.parser.engine.api.SQLParserEngine;
+import org.apache.shardingsphere.sql.parser.engine.api.SQLStatementVisitorEngine;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.table.CreateTableStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.table.DropTableStatement;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DorisStatementVisitorTest {
+    
+    private static final CacheOption CACHE_OPTION = new CacheOption(128, 1024L);
+    
+    @Test
+    void assertVisitCreateTemporaryTable() {
+        CreateTableStatement statement = (CreateTableStatement) parse("CREATE TEMPORARY TABLE t_order (order_id INT)");
+        assertTrue(statement.isTemporary());
+    }
+    
+    @Test
+    void assertVisitCreateTableWithoutTemporary() {
+        CreateTableStatement statement = (CreateTableStatement) parse("CREATE TABLE t_order (order_id INT)");
+        assertFalse(statement.isTemporary());
+    }
+    
+    @Test
+    void assertVisitDropTemporaryTable() {
+        DropTableStatement statement = (DropTableStatement) parse("DROP TEMPORARY TABLE t_order");
+        assertTrue(statement.isTemporary());
+    }
+    
+    @Test
+    void assertVisitDropTableWithoutTemporary() {
+        DropTableStatement statement = (DropTableStatement) parse("DROP TABLE t_order");
+        assertFalse(statement.isTemporary());
+    }
+    
+    private Object parse(final String sql) {
+        return new SQLStatementVisitorEngine("Doris").visit(new SQLParserEngine("Doris", CACHE_OPTION).parse(sql, false));
+    }
+}

--- a/parser/sql/engine/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/engine/mysql/visitor/statement/type/MySQLDDLStatementVisitor.java
+++ b/parser/sql/engine/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/engine/mysql/visitor/statement/type/MySQLDDLStatementVisitor.java
@@ -284,6 +284,7 @@ public final class MySQLDDLStatementVisitor extends MySQLStatementVisitor implem
                 .databaseType(getDatabaseType())
                 .table((SimpleTableSegment) visit(ctx.tableName()))
                 .ifNotExists(null != ctx.ifNotExists())
+                .temporary(null != ctx.TEMPORARY())
                 .likeTable(null == ctx.createLikeClause() ? null : (SimpleTableSegment) visit(ctx.createLikeClause()))
                 .createTableOption(null == ctx.createTableOptions() ? null : (CreateTableOptionSegment) visit(ctx.createTableOptions()))
                 .columnDefinitions(columnDefinitions)
@@ -690,7 +691,7 @@ public final class MySQLDDLStatementVisitor extends MySQLStatementVisitor implem
     @SuppressWarnings("unchecked")
     @Override
     public ASTNode visitDropTable(final DropTableContext ctx) {
-        return new DropTableStatement(getDatabaseType(), ((CollectionValue<SimpleTableSegment>) visit(ctx.tableList())).getValue(), null != ctx.ifExists(), false);
+        return new DropTableStatement(getDatabaseType(), ((CollectionValue<SimpleTableSegment>) visit(ctx.tableList())).getValue(), null != ctx.ifExists(), null != ctx.TEMPORARY(), false);
     }
     
     @Override

--- a/parser/sql/engine/dialect/mysql/src/test/java/org/apache/shardingsphere/sql/parser/engine/mysql/visitor/statement/MySQLStatementVisitorTest.java
+++ b/parser/sql/engine/dialect/mysql/src/test/java/org/apache/shardingsphere/sql/parser/engine/mysql/visitor/statement/MySQLStatementVisitorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.engine.mysql.visitor.statement;
+
+import org.apache.shardingsphere.sql.parser.engine.api.CacheOption;
+import org.apache.shardingsphere.sql.parser.engine.api.SQLParserEngine;
+import org.apache.shardingsphere.sql.parser.engine.api.SQLStatementVisitorEngine;
+import org.apache.shardingsphere.sql.parser.engine.core.ParseASTNode;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.table.CreateTableStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.table.DropTableStatement;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MySQLStatementVisitorTest {
+    
+    private static final CacheOption CACHE_OPTION = new CacheOption(128, 1024L);
+    
+    @Test
+    void assertVisitCreateTemporaryTable() {
+        CreateTableStatement statement = (CreateTableStatement) parse("CREATE TEMPORARY TABLE t_order (order_id INT)");
+        assertTrue(statement.isTemporary());
+    }
+    
+    @Test
+    void assertVisitCreateTableWithoutTemporary() {
+        CreateTableStatement statement = (CreateTableStatement) parse("CREATE TABLE t_order (order_id INT)");
+        assertFalse(statement.isTemporary());
+    }
+    
+    @Test
+    void assertVisitDropTemporaryTable() {
+        DropTableStatement statement = (DropTableStatement) parse("DROP TEMPORARY TABLE t_order");
+        assertTrue(statement.isTemporary());
+    }
+    
+    @Test
+    void assertVisitDropTableWithoutTemporary() {
+        DropTableStatement statement = (DropTableStatement) parse("DROP TABLE t_order");
+        assertFalse(statement.isTemporary());
+    }
+    
+    private Object parse(final String sql) {
+        ParseASTNode parseASTNode = new SQLParserEngine("MySQL", CACHE_OPTION).parse(sql, false);
+        return new SQLStatementVisitorEngine("MySQL").visit(parseASTNode);
+    }
+}

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/type/ddl/table/CreateTableStatement.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/type/ddl/table/CreateTableStatement.java
@@ -54,6 +54,8 @@ public final class CreateTableStatement extends DDLStatement {
     
     private final boolean ifNotExists;
     
+    private final boolean temporary;
+    
     private final SimpleTableSegment likeTable;
     
     private final CreateTableOptionSegment createTableOption;
@@ -70,13 +72,14 @@ public final class CreateTableStatement extends DDLStatement {
     
     @Builder
     private CreateTableStatement(final DatabaseType databaseType, final SimpleTableSegment table, final SelectStatement selectStatement,
-                                 final boolean ifNotExists, final SimpleTableSegment likeTable, final CreateTableOptionSegment createTableOption,
+                                 final boolean ifNotExists, final boolean temporary, final SimpleTableSegment likeTable, final CreateTableOptionSegment createTableOption,
                                  final Collection<ColumnDefinitionSegment> columnDefinitions, final Collection<ConstraintDefinitionSegment> constraintDefinitions,
                                  final List<ColumnSegment> columns, final Collection<RollupSegment> rollups) {
         super(databaseType);
         this.table = table;
         this.selectStatement = selectStatement;
         this.ifNotExists = ifNotExists;
+        this.temporary = temporary;
         this.likeTable = likeTable;
         this.createTableOption = createTableOption;
         this.columnDefinitions = null == columnDefinitions ? Collections.emptyList() : columnDefinitions;

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/type/ddl/table/DropTableStatement.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/type/ddl/table/DropTableStatement.java
@@ -36,14 +36,21 @@ public final class DropTableStatement extends DDLStatement {
     
     private final boolean ifExists;
     
+    private final boolean temporary;
+    
     private final boolean containsCascade;
     
     private final SQLStatementAttributes attributes;
     
     public DropTableStatement(final DatabaseType databaseType, final Collection<SimpleTableSegment> tables, final boolean ifExists, final boolean containsCascade) {
+        this(databaseType, tables, ifExists, false, containsCascade);
+    }
+    
+    public DropTableStatement(final DatabaseType databaseType, final Collection<SimpleTableSegment> tables, final boolean ifExists, final boolean temporary, final boolean containsCascade) {
         super(databaseType);
         this.tables = tables;
         this.ifExists = ifExists;
+        this.temporary = temporary;
         this.containsCascade = containsCascade;
         attributes = new SQLStatementAttributes(new TableSQLStatementAttribute(tables));
     }

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/connector/StandardDatabaseProxyConnectorTest.java
@@ -33,6 +33,7 @@ import org.apache.shardingsphere.infra.binder.context.statement.type.dml.InsertS
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.connection.kernel.KernelProcessor;
+import org.apache.shardingsphere.infra.exception.generic.UnsupportedSQLOperationException;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.resource.storageunit.EmptyStorageUnitException;
 import org.apache.shardingsphere.infra.exception.kernel.metadata.rule.EmptyRuleException;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionContext;
@@ -75,9 +76,12 @@ import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResp
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sql.parser.engine.api.CacheOption;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.cursor.CursorNameSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.CloseStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.CursorStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.table.CreateTableStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.InsertStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
@@ -302,6 +306,25 @@ class StandardDatabaseProxyConnectorTest {
             assertThat(mockedDatabaseTypeRegistry.constructed().size(), is(1));
             PushDownMetaDataRefreshEngine pushDownMetaDataRefreshEngine = mockedPushDownMetaDataRefreshEngine.constructed().iterator().next();
             verify(pushDownMetaDataRefreshEngine).refresh(any(), eq(database), any(ConfigurationProperties.class), any(Collection.class));
+        }
+    }
+    
+    @Test
+    void assertExecuteWithUnsupportedTemporaryTableDDL() {
+        SQLStatementContext sqlStatementContext = createSQLStatementContext(CreateTableStatement.builder()
+                .databaseType(TypedSPILoader.getService(DatabaseType.class, "MySQL"))
+                .table(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))))
+                .temporary(true)
+                .build());
+        DatabaseProxyConnector engine = createDatabaseProxyConnector(JDBCDriverType.STATEMENT, createQueryContext(sqlStatementContext, mockDatabase()));
+        try (
+                MockedConstruction<KernelProcessor> mockedKernelProcessor = mockConstruction(KernelProcessor.class,
+                        (mock, context) -> when(mock.generateExecutionContext(any(QueryContext.class), any(RuleMetaData.class), any(ConfigurationProperties.class)))
+                                .thenThrow(new UnsupportedSQLOperationException("CREATE TEMPORARY TABLE")));
+                MockedConstruction<PushDownMetaDataRefreshEngine> mockedPushDownMetaDataRefreshEngine = mockConstruction(PushDownMetaDataRefreshEngine.class)) {
+            assertThrows(UnsupportedSQLOperationException.class, engine::execute);
+            assertThat(mockedKernelProcessor.constructed().size(), is(1));
+            assertTrue(mockedPushDownMetaDataRefreshEngine.constructed().isEmpty());
         }
     }
     


### PR DESCRIPTION
Fixes #38709.
### Changes
Changes proposed in this pull request:
  - Preserve MySQL `TEMPORARY` semantics in `CreateTableStatement` and `DropTableStatement`
  - Populate the temporary-table flag in `MySQLDDLStatementVisitor`
  - Preserve the temporary flag during statement binding
  - Add a pre-execution guard in `KernelProcessor` to reject `CREATE TEMPORARY TABLE` and `DROP TEMPORARY TABLE`
  - Throw `UnsupportedSQLOperationException` before SQL is sent to backend
  - Add regression tests for parser semantics, kernel guard behavior, and proxy execution flow
### Tests

Added regression coverage for:

- MySQL parser / visitor temporary semantics
- kernel-level pre-execution rejection
- proxy execution flow to verify temporary table DDL does not enter metadata refresh

Executed tests:

```bash
mvn -pl parser/sql/engine/dialect/mysql -am -Dtest=MySQLStatementVisitorTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test
mvn -pl infra/context -am -Dtest=KernelProcessorTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test
mvn -pl proxy/backend/core -am -Dtest=StandardDatabaseProxyConnectorTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test
```
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)