### PR TITLE
Standardize feature completion templates

### DIFF
--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptFeatureDefinitionTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptFeatureDefinitionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.feature.encrypt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class EncryptFeatureDefinitionTest {
+    
+    @Test
+    void assertConstants() {
+        assertThat(EncryptFeatureDefinition.WORKFLOW_KIND.getValue(), is("encrypt.rule"));
+        assertThat(EncryptFeatureDefinition.PLAN_TOOL_NAME, is("database_gateway_plan_encrypt_rule"));
+        assertThat(EncryptFeatureDefinition.PLAN_PROMPT_NAME, is("plan_encrypt_rule"));
+        assertThat(EncryptFeatureDefinition.ALGORITHMS_RESOURCE_URI, is("shardingsphere://features/encrypt/algorithms"));
+        assertThat(EncryptFeatureDefinition.RULES_RESOURCE_URI, is("shardingsphere://features/encrypt/databases/{database}/rules"));
+        assertThat(EncryptFeatureDefinition.RULE_RESOURCE_URI, is("shardingsphere://features/encrypt/databases/{database}/tables/{table}/rules"));
+    }
+}

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/MaskFeatureDefinitionTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/MaskFeatureDefinitionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.feature.mask;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class MaskFeatureDefinitionTest {
+    
+    @Test
+    void assertConstants() {
+        assertThat(MaskFeatureDefinition.WORKFLOW_KIND.getValue(), is("mask.rule"));
+        assertThat(MaskFeatureDefinition.PLAN_TOOL_NAME, is("database_gateway_plan_mask_rule"));
+        assertThat(MaskFeatureDefinition.PLAN_PROMPT_NAME, is("plan_mask_rule"));
+        assertThat(MaskFeatureDefinition.ALGORITHMS_RESOURCE_URI, is("shardingsphere://features/mask/algorithms"));
+        assertThat(MaskFeatureDefinition.RULES_RESOURCE_URI, is("shardingsphere://features/mask/databases/{database}/rules"));
+        assertThat(MaskFeatureDefinition.RULE_RESOURCE_URI, is("shardingsphere://features/mask/databases/{database}/tables/{table}/rules"));
+    }
+}

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/completion/ReadwriteSplittingLoadBalanceAlgorithmCompletionProvider.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/completion/ReadwriteSplittingLoadBalanceAlgorithmCompletionProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.feature.readwritesplitting.completion;
+
+import org.apache.shardingsphere.mcp.feature.readwritesplitting.ReadwriteSplittingFeatureDefinition;
+import org.apache.shardingsphere.mcp.feature.readwritesplitting.tool.service.ReadwriteSplittingInspectionService;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionCandidate;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProvider;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProviderResult;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionRequestContext;
+import org.apache.shardingsphere.mcp.support.database.MCPDatabaseHandlerContext;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Readwrite-splitting load-balance algorithm completion provider.
+ */
+public final class ReadwriteSplittingLoadBalanceAlgorithmCompletionProvider implements MCPCompletionProvider<MCPDatabaseHandlerContext> {
+    
+    private final ReadwriteSplittingInspectionService inspectionService = new ReadwriteSplittingInspectionService();
+    
+    @Override
+    public Class<MCPDatabaseHandlerContext> getContextType() {
+        return MCPDatabaseHandlerContext.class;
+    }
+    
+    @Override
+    public boolean supports(final MCPCompletionRequestContext requestContext) {
+        return ReadwriteSplittingFeatureDefinition.LOAD_BALANCER_TYPE_FIELD.equals(requestContext.getArgumentName()) && isReadwriteSplittingReference(requestContext);
+    }
+    
+    private boolean isReadwriteSplittingReference(final MCPCompletionRequestContext requestContext) {
+        String reference = requestContext.getDescriptor().getReference();
+        return ReadwriteSplittingFeatureDefinition.PLAN_RULE_PROMPT_NAME.equals(reference)
+                || ReadwriteSplittingFeatureDefinition.LOAD_BALANCE_ALGORITHM_PLUGINS_RESOURCE_URI.equals(reference);
+    }
+    
+    @Override
+    public MCPCompletionProviderResult complete(final MCPDatabaseHandlerContext handlerContext, final MCPCompletionRequestContext requestContext) {
+        return new MCPCompletionProviderResult(inspectionService.queryLoadBalanceAlgorithmPlugins(handlerContext.getQueryFacade()).stream()
+                .map(this::createAlgorithmCandidate).filter(each -> !each.getValue().isEmpty()).toList());
+    }
+    
+    private MCPCompletionCandidate createAlgorithmCandidate(final Map<String, Object> row) {
+        String value = Objects.toString(row.getOrDefault("type", row.getOrDefault("name", "")), "").trim();
+        String label = Objects.toString(row.getOrDefault("description", "load-balance algorithm"), "load-balance algorithm");
+        return new MCPCompletionCandidate(value, label, "readwrite-splitting-load-balance-algorithm");
+    }
+}

--- a/mcp/features/readwrite-splitting/src/main/resources/META-INF/services/org.apache.shardingsphere.mcp.support.completion.MCPCompletionProvider
+++ b/mcp/features/readwrite-splitting/src/main/resources/META-INF/services/org.apache.shardingsphere.mcp.support.completion.MCPCompletionProvider
@@ -1,0 +1,1 @@
+org.apache.shardingsphere.mcp.feature.readwritesplitting.completion.ReadwriteSplittingLoadBalanceAlgorithmCompletionProvider

--- a/mcp/features/readwrite-splitting/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-readwrite-splitting.yaml
+++ b/mcp/features/readwrite-splitting/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-readwrite-splitting.yaml
@@ -206,6 +206,17 @@ prompts:
       org.apache.shardingsphere/ask-user-conditions:
         - "Ask when database, rule name, read storage unit, or target status is unclear."
         - "Ask before applying generated readwrite-splitting status DistSQL that changes runtime state."
+completionTargets:
+  - referenceType: prompt
+    reference: plan_readwrite_splitting_rule
+    arguments:
+      - load_balancer_type
+    maxValues: 50
+  - referenceType: resource
+    reference: shardingsphere://features/readwrite-splitting/load-balance-algorithm-plugins
+    arguments:
+      - load_balancer_type
+    maxValues: 50
 resourceNavigation:
   - from: shardingsphere://features/readwrite-splitting/databases/{database}/rules
     to: database_gateway_plan_readwrite_splitting_rule

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/completion/ReadwriteSplittingLoadBalanceAlgorithmCompletionProviderTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/completion/ReadwriteSplittingLoadBalanceAlgorithmCompletionProviderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.feature.readwritesplitting.completion;
+
+import org.apache.shardingsphere.mcp.feature.readwritesplitting.ReadwriteSplittingFeatureDefinition;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionCandidate;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProvider;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProviderResult;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionRequestContext;
+import org.apache.shardingsphere.mcp.support.database.MCPDatabaseHandlerContext;
+import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ReadwriteSplittingLoadBalanceAlgorithmCompletionProviderTest {
+    
+    @Test
+    void assertGetContextType() {
+        assertThat(new ReadwriteSplittingLoadBalanceAlgorithmCompletionProvider().getContextType(), is(MCPDatabaseHandlerContext.class));
+    }
+    
+    @Test
+    void assertSupports() {
+        assertTrue(new ReadwriteSplittingLoadBalanceAlgorithmCompletionProvider().supports(createRequestContext(ReadwriteSplittingFeatureDefinition.PLAN_RULE_PROMPT_NAME)));
+    }
+    
+    @Test
+    void assertSupportsWithAlgorithmResource() {
+        assertTrue(new ReadwriteSplittingLoadBalanceAlgorithmCompletionProvider().supports(createRequestContext(
+                ReadwriteSplittingFeatureDefinition.LOAD_BALANCE_ALGORITHM_PLUGINS_RESOURCE_URI)));
+    }
+    
+    @Test
+    void assertSupportsWithForeignReference() {
+        assertFalse(new ReadwriteSplittingLoadBalanceAlgorithmCompletionProvider().supports(createRequestContext("plan_shadow_rule")));
+    }
+    
+    @Test
+    void assertComplete() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.queryWithAnyDatabase("SHOW LOAD BALANCE ALGORITHM PLUGINS")).thenReturn(List.of(
+                Map.of("type", "ROUND_ROBIN", "description", "Round robin load balance", "secret", "hidden"),
+                Map.of("type", "")));
+        MCPDatabaseHandlerContext handlerContext = mock(MCPDatabaseHandlerContext.class);
+        when(handlerContext.getQueryFacade()).thenReturn(queryFacade);
+        MCPCompletionProviderResult actual = new ReadwriteSplittingLoadBalanceAlgorithmCompletionProvider().complete(handlerContext,
+                createRequestContext(ReadwriteSplittingFeatureDefinition.PLAN_RULE_PROMPT_NAME));
+        List<MCPCompletionCandidate> actualCandidates = new ArrayList<>(actual.getCandidates());
+        assertThat(actualCandidates.size(), is(1));
+        assertThat(actualCandidates.getFirst().getValue(), is("ROUND_ROBIN"));
+        assertThat(actualCandidates.getFirst().getLabel(), is("Round robin load balance"));
+        assertThat(actualCandidates.getFirst().getSource(), is("readwrite-splitting-load-balance-algorithm"));
+    }
+    
+    @Test
+    void assertSPIRegistration() {
+        assertTrue(ServiceLoader.load(MCPCompletionProvider.class).stream().anyMatch(each -> ReadwriteSplittingLoadBalanceAlgorithmCompletionProvider.class.equals(each.type())));
+    }
+    
+    private MCPCompletionRequestContext createRequestContext(final String reference) {
+        String referenceType = reference.startsWith("shardingsphere://") ? "resource" : "prompt";
+        return new MCPCompletionRequestContext("session-1",
+                new MCPCompletionTargetDescriptor(referenceType, reference, List.of(ReadwriteSplittingFeatureDefinition.LOAD_BALANCER_TYPE_FIELD), 50, Map.of()),
+                ReadwriteSplittingFeatureDefinition.LOAD_BALANCER_TYPE_FIELD, Map.of("database", "logic_db"));
+    }
+}

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/descriptor/ReadwriteSplittingToolDescriptorValidatorTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/descriptor/ReadwriteSplittingToolDescriptorValidatorTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.mcp.feature.readwritesplitting.descriptor;
 import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptDescriptor;
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.feature.readwritesplitting.ReadwriteSplittingFeatureDefinition;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogIndex;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPShardingSphereMetadataKeys;
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,16 @@ class ReadwriteSplittingToolDescriptorValidatorTest {
         ReadwriteSplittingToolDescriptorValidator validator = new ReadwriteSplittingToolDescriptorValidator();
         assertTrue(validator.supports(MCPDescriptorCatalogIndex.getRequiredToolDescriptor(ReadwriteSplittingFeatureDefinition.PLAN_RULE_TOOL_NAME)));
         assertTrue(validator.supports(MCPDescriptorCatalogIndex.getRequiredToolDescriptor(ReadwriteSplittingFeatureDefinition.PLAN_STATUS_TOOL_NAME)));
+    }
+    
+    @Test
+    void assertExposeCompletionTargets() {
+        MCPCompletionTargetDescriptor promptCompletionTarget = findCompletionTarget("prompt", ReadwriteSplittingFeatureDefinition.PLAN_RULE_PROMPT_NAME);
+        assertThat(promptCompletionTarget.getArguments(), is(List.of(ReadwriteSplittingFeatureDefinition.LOAD_BALANCER_TYPE_FIELD)));
+        assertThat(promptCompletionTarget.getMaxValues(), is(50));
+        MCPCompletionTargetDescriptor resourceCompletionTarget = findCompletionTarget("resource", ReadwriteSplittingFeatureDefinition.LOAD_BALANCE_ALGORITHM_PLUGINS_RESOURCE_URI);
+        assertThat(resourceCompletionTarget.getArguments(), is(List.of(ReadwriteSplittingFeatureDefinition.LOAD_BALANCER_TYPE_FIELD)));
+        assertThat(resourceCompletionTarget.getMaxValues(), is(50));
     }
     
     @Test
@@ -96,6 +107,11 @@ class ReadwriteSplittingToolDescriptorValidatorTest {
     
     private MCPPromptDescriptor findPrompt(final String promptName) {
         return MCPDescriptorCatalogIndex.getPromptDescriptors().stream().filter(each -> promptName.equals(each.getName())).findFirst().orElseThrow();
+    }
+    
+    private MCPCompletionTargetDescriptor findCompletionTarget(final String referenceType, final String reference) {
+        return MCPDescriptorCatalogIndex.getCompletionTargetDescriptors().stream()
+                .filter(each -> referenceType.equals(each.getReferenceType()) && reference.equals(each.getReference())).findFirst().orElseThrow();
     }
     
     private String readResource(final String resourceName) throws IOException {

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/completion/ShadowAlgorithmCompletionProvider.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/completion/ShadowAlgorithmCompletionProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.feature.shadow.completion;
+
+import org.apache.shardingsphere.mcp.feature.shadow.ShadowFeatureDefinition;
+import org.apache.shardingsphere.mcp.feature.shadow.tool.service.ShadowInspectionService;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionCandidate;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProvider;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProviderResult;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionRequestContext;
+import org.apache.shardingsphere.mcp.support.database.MCPDatabaseHandlerContext;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Shadow algorithm completion provider.
+ */
+public final class ShadowAlgorithmCompletionProvider implements MCPCompletionProvider<MCPDatabaseHandlerContext> {
+    
+    private final ShadowInspectionService inspectionService = new ShadowInspectionService();
+    
+    @Override
+    public Class<MCPDatabaseHandlerContext> getContextType() {
+        return MCPDatabaseHandlerContext.class;
+    }
+    
+    @Override
+    public boolean supports(final MCPCompletionRequestContext requestContext) {
+        return ShadowFeatureDefinition.ALGORITHM_TYPE_FIELD.equals(requestContext.getArgumentName()) && isShadowReference(requestContext);
+    }
+    
+    private boolean isShadowReference(final MCPCompletionRequestContext requestContext) {
+        String reference = requestContext.getDescriptor().getReference();
+        return ShadowFeatureDefinition.PLAN_RULE_PROMPT_NAME.equals(reference)
+                || ShadowFeatureDefinition.PLAN_DEFAULT_ALGORITHM_PROMPT_NAME.equals(reference)
+                || ShadowFeatureDefinition.ALGORITHM_PLUGINS_RESOURCE_URI.equals(reference);
+    }
+    
+    @Override
+    public MCPCompletionProviderResult complete(final MCPDatabaseHandlerContext handlerContext, final MCPCompletionRequestContext requestContext) {
+        return new MCPCompletionProviderResult(inspectionService.queryAlgorithmPlugins(handlerContext.getQueryFacade()).stream()
+                .map(this::createAlgorithmCandidate).filter(each -> !each.getValue().isEmpty()).toList());
+    }
+    
+    private MCPCompletionCandidate createAlgorithmCandidate(final Map<String, Object> row) {
+        String value = Objects.toString(row.getOrDefault("type", row.getOrDefault("name", "")), "").trim();
+        String label = Objects.toString(row.getOrDefault("description", "shadow algorithm"), "shadow algorithm");
+        return new MCPCompletionCandidate(value, label, "shadow-algorithm");
+    }
+}

--- a/mcp/features/shadow/src/main/resources/META-INF/services/org.apache.shardingsphere.mcp.support.completion.MCPCompletionProvider
+++ b/mcp/features/shadow/src/main/resources/META-INF/services/org.apache.shardingsphere.mcp.support.completion.MCPCompletionProvider
@@ -1,0 +1,1 @@
+org.apache.shardingsphere.mcp.feature.shadow.completion.ShadowAlgorithmCompletionProvider

--- a/mcp/features/shadow/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-shadow.yaml
+++ b/mcp/features/shadow/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-shadow.yaml
@@ -271,6 +271,22 @@ prompts:
       org.apache.shardingsphere/ask-user-conditions:
         - "Ask when database or algorithm name is unclear."
         - "Ask before applying generated shadow algorithm cleanup DistSQL that changes runtime state."
+completionTargets:
+  - referenceType: prompt
+    reference: plan_shadow_rule
+    arguments:
+      - algorithm_type
+    maxValues: 50
+  - referenceType: prompt
+    reference: plan_default_shadow_algorithm
+    arguments:
+      - algorithm_type
+    maxValues: 50
+  - referenceType: resource
+    reference: shardingsphere://features/shadow/algorithm-plugins
+    arguments:
+      - algorithm_type
+    maxValues: 50
 resourceNavigation:
   - from: shardingsphere://features/shadow/databases/{database}/rules
     to: database_gateway_plan_shadow_rule

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/completion/ShadowAlgorithmCompletionProviderTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/completion/ShadowAlgorithmCompletionProviderTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.feature.shadow.completion;
+
+import org.apache.shardingsphere.mcp.feature.shadow.ShadowFeatureDefinition;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionCandidate;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProvider;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProviderResult;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionRequestContext;
+import org.apache.shardingsphere.mcp.support.database.MCPDatabaseHandlerContext;
+import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ShadowAlgorithmCompletionProviderTest {
+    
+    @Test
+    void assertGetContextType() {
+        assertThat(new ShadowAlgorithmCompletionProvider().getContextType(), is(MCPDatabaseHandlerContext.class));
+    }
+    
+    @Test
+    void assertSupports() {
+        assertTrue(new ShadowAlgorithmCompletionProvider().supports(createRequestContext(ShadowFeatureDefinition.PLAN_RULE_PROMPT_NAME)));
+    }
+    
+    @Test
+    void assertSupportsWithDefaultAlgorithmPrompt() {
+        assertTrue(new ShadowAlgorithmCompletionProvider().supports(createRequestContext(ShadowFeatureDefinition.PLAN_DEFAULT_ALGORITHM_PROMPT_NAME)));
+    }
+    
+    @Test
+    void assertSupportsWithAlgorithmResource() {
+        assertTrue(new ShadowAlgorithmCompletionProvider().supports(createRequestContext(ShadowFeatureDefinition.ALGORITHM_PLUGINS_RESOURCE_URI)));
+    }
+    
+    @Test
+    void assertSupportsWithForeignReference() {
+        assertFalse(new ShadowAlgorithmCompletionProvider().supports(createRequestContext("plan_mask_rule")));
+    }
+    
+    @Test
+    void assertComplete() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.queryWithAnyDatabase("SHOW SHADOW ALGORITHM PLUGINS")).thenReturn(List.of(
+                Map.of("type", "VALUE_MATCH", "description", "Value match shadow algorithm", "password", "hidden"),
+                Map.of("type", "")));
+        MCPDatabaseHandlerContext handlerContext = mock(MCPDatabaseHandlerContext.class);
+        when(handlerContext.getQueryFacade()).thenReturn(queryFacade);
+        MCPCompletionProviderResult actual = new ShadowAlgorithmCompletionProvider().complete(handlerContext,
+                createRequestContext(ShadowFeatureDefinition.PLAN_RULE_PROMPT_NAME));
+        List<MCPCompletionCandidate> actualCandidates = new ArrayList<>(actual.getCandidates());
+        assertThat(actualCandidates.size(), is(1));
+        assertThat(actualCandidates.getFirst().getValue(), is("VALUE_MATCH"));
+        assertThat(actualCandidates.getFirst().getLabel(), is("Value match shadow algorithm"));
+        assertThat(actualCandidates.getFirst().getSource(), is("shadow-algorithm"));
+    }
+    
+    @Test
+    void assertSPIRegistration() {
+        assertTrue(ServiceLoader.load(MCPCompletionProvider.class).stream().anyMatch(each -> ShadowAlgorithmCompletionProvider.class.equals(each.type())));
+    }
+    
+    private MCPCompletionRequestContext createRequestContext(final String reference) {
+        String referenceType = reference.startsWith("shardingsphere://") ? "resource" : "prompt";
+        return new MCPCompletionRequestContext("session-1",
+                new MCPCompletionTargetDescriptor(referenceType, reference, List.of(ShadowFeatureDefinition.ALGORITHM_TYPE_FIELD), 50, Map.of()),
+                ShadowFeatureDefinition.ALGORITHM_TYPE_FIELD, Map.of("database", "logic_db"));
+    }
+}

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/descriptor/ShadowToolDescriptorValidatorTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/descriptor/ShadowToolDescriptorValidatorTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.mcp.feature.shadow.descriptor;
 
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.feature.shadow.ShadowFeatureDefinition;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogIndex;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,6 +44,16 @@ class ShadowToolDescriptorValidatorTest {
         assertTrue(validator.supports(MCPDescriptorCatalogIndex.getRequiredToolDescriptor(ShadowFeatureDefinition.PLAN_RULE_TOOL_NAME)));
         assertTrue(validator.supports(MCPDescriptorCatalogIndex.getRequiredToolDescriptor(ShadowFeatureDefinition.PLAN_DEFAULT_ALGORITHM_TOOL_NAME)));
         assertTrue(validator.supports(MCPDescriptorCatalogIndex.getRequiredToolDescriptor(ShadowFeatureDefinition.PLAN_ALGORITHM_CLEANUP_TOOL_NAME)));
+    }
+    
+    @Test
+    void assertExposeCompletionTargets() {
+        MCPCompletionTargetDescriptor rulePromptCompletionTarget = findCompletionTarget("prompt", ShadowFeatureDefinition.PLAN_RULE_PROMPT_NAME);
+        assertThat(rulePromptCompletionTarget.getArguments(), is(List.of(ShadowFeatureDefinition.ALGORITHM_TYPE_FIELD)));
+        MCPCompletionTargetDescriptor defaultPromptCompletionTarget = findCompletionTarget("prompt", ShadowFeatureDefinition.PLAN_DEFAULT_ALGORITHM_PROMPT_NAME);
+        assertThat(defaultPromptCompletionTarget.getArguments(), is(List.of(ShadowFeatureDefinition.ALGORITHM_TYPE_FIELD)));
+        MCPCompletionTargetDescriptor resourceCompletionTarget = findCompletionTarget("resource", ShadowFeatureDefinition.ALGORITHM_PLUGINS_RESOURCE_URI);
+        assertThat(resourceCompletionTarget.getArguments(), is(List.of(ShadowFeatureDefinition.ALGORITHM_TYPE_FIELD)));
     }
     
     @Test
@@ -81,5 +93,10 @@ class ShadowToolDescriptorValidatorTest {
         try (InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName)) {
             return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
         }
+    }
+    
+    private MCPCompletionTargetDescriptor findCompletionTarget(final String referenceType, final String reference) {
+        return MCPDescriptorCatalogIndex.getCompletionTargetDescriptors().stream()
+                .filter(each -> referenceType.equals(each.getReferenceType()) && reference.equals(each.getReference())).findFirst().orElseThrow();
     }
 }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingFeatureDefinition.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingFeatureDefinition.java
@@ -48,6 +48,18 @@ public final class ShardingFeatureDefinition {
     
     public static final String PLAN_COMPONENT_CLEANUP_TOOL_NAME = "database_gateway_plan_sharding_rule_component_cleanup";
     
+    public static final String PLAN_TABLE_RULE_PROMPT_NAME = "plan_sharding_table_rule";
+    
+    public static final String PLAN_TABLE_REFERENCE_PROMPT_NAME = "plan_sharding_table_reference_rule";
+    
+    public static final String PLAN_DEFAULT_STRATEGY_PROMPT_NAME = "plan_sharding_default_strategy";
+    
+    public static final String PLAN_KEY_GENERATOR_PROMPT_NAME = "plan_sharding_key_generator";
+    
+    public static final String PLAN_KEY_GENERATE_STRATEGY_PROMPT_NAME = "plan_sharding_key_generate_strategy";
+    
+    public static final String PLAN_COMPONENT_CLEANUP_PROMPT_NAME = "plan_sharding_rule_component_cleanup";
+    
     public static final String ALGORITHM_PLUGINS_RESOURCE_URI = "shardingsphere://features/sharding/algorithm-plugins";
     
     public static final String KEY_GENERATE_ALGORITHM_PLUGINS_RESOURCE_URI = "shardingsphere://features/sharding/key-generate-algorithm-plugins";

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/completion/ShardingAlgorithmCompletionProvider.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/completion/ShardingAlgorithmCompletionProvider.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.feature.sharding.completion;
+
+import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingInspectionService;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionCandidate;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProvider;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProviderResult;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionRequestContext;
+import org.apache.shardingsphere.mcp.support.database.MCPDatabaseHandlerContext;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Sharding algorithm completion provider.
+ */
+public final class ShardingAlgorithmCompletionProvider implements MCPCompletionProvider<MCPDatabaseHandlerContext> {
+    
+    private static final String ALGORITHM_TYPE_FIELD = "algorithm_type";
+    
+    private static final String KEY_GENERATOR_TYPE_FIELD = "key_generator_type";
+    
+    private static final Set<String> SHARDING_ALGORITHM_PROMPTS = Set.of(
+            ShardingFeatureDefinition.PLAN_TABLE_RULE_PROMPT_NAME, ShardingFeatureDefinition.PLAN_DEFAULT_STRATEGY_PROMPT_NAME);
+    
+    private static final Set<String> KEY_GENERATOR_PROMPTS = Set.of(
+            ShardingFeatureDefinition.PLAN_KEY_GENERATOR_PROMPT_NAME, ShardingFeatureDefinition.PLAN_KEY_GENERATE_STRATEGY_PROMPT_NAME);
+    
+    private final ShardingInspectionService inspectionService = new ShardingInspectionService();
+    
+    @Override
+    public Class<MCPDatabaseHandlerContext> getContextType() {
+        return MCPDatabaseHandlerContext.class;
+    }
+    
+    @Override
+    public boolean supports(final MCPCompletionRequestContext requestContext) {
+        return isShardingAlgorithmCompletion(requestContext) || isKeyGeneratorCompletion(requestContext);
+    }
+    
+    private boolean isShardingAlgorithmCompletion(final MCPCompletionRequestContext requestContext) {
+        String reference = requestContext.getDescriptor().getReference();
+        return ALGORITHM_TYPE_FIELD.equals(requestContext.getArgumentName())
+                && (SHARDING_ALGORITHM_PROMPTS.contains(reference) || ShardingFeatureDefinition.ALGORITHM_PLUGINS_RESOURCE_URI.equals(reference));
+    }
+    
+    private boolean isKeyGeneratorCompletion(final MCPCompletionRequestContext requestContext) {
+        String reference = requestContext.getDescriptor().getReference();
+        return KEY_GENERATOR_TYPE_FIELD.equals(requestContext.getArgumentName())
+                && (KEY_GENERATOR_PROMPTS.contains(reference) || ShardingFeatureDefinition.KEY_GENERATE_ALGORITHM_PLUGINS_RESOURCE_URI.equals(reference));
+    }
+    
+    @Override
+    public MCPCompletionProviderResult complete(final MCPDatabaseHandlerContext handlerContext, final MCPCompletionRequestContext requestContext) {
+        return new MCPCompletionProviderResult(queryPlugins(handlerContext, requestContext).stream()
+                .map(each -> createAlgorithmCandidate(each, requestContext.getArgumentName())).filter(each -> !each.getValue().isEmpty()).toList());
+    }
+    
+    private List<Map<String, Object>> queryPlugins(final MCPDatabaseHandlerContext handlerContext, final MCPCompletionRequestContext requestContext) {
+        return KEY_GENERATOR_TYPE_FIELD.equals(requestContext.getArgumentName())
+                ? inspectionService.queryKeyGenerateAlgorithmPlugins(handlerContext.getQueryFacade())
+                : inspectionService.queryAlgorithmPlugins(handlerContext.getQueryFacade());
+    }
+    
+    private MCPCompletionCandidate createAlgorithmCandidate(final Map<String, Object> row, final String argumentName) {
+        String value = Objects.toString(row.getOrDefault("type", row.getOrDefault("name", "")), "").trim();
+        String label = Objects.toString(row.getOrDefault("description", "sharding algorithm"), "sharding algorithm");
+        return new MCPCompletionCandidate(value, label, KEY_GENERATOR_TYPE_FIELD.equals(argumentName) ? "sharding-key-generate-algorithm" : "sharding-algorithm");
+    }
+}

--- a/mcp/features/sharding/src/main/resources/META-INF/services/org.apache.shardingsphere.mcp.support.completion.MCPCompletionProvider
+++ b/mcp/features/sharding/src/main/resources/META-INF/services/org.apache.shardingsphere.mcp.support.completion.MCPCompletionProvider
@@ -1,0 +1,1 @@
+org.apache.shardingsphere.mcp.feature.sharding.completion.ShardingAlgorithmCompletionProvider

--- a/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-sharding.yaml
+++ b/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-sharding.yaml
@@ -423,6 +423,17 @@ prompts:
       org.apache.shardingsphere/ask-user-conditions:
         - "Ask when database, component type, or component name is unclear."
         - "Ask before applying generated component cleanup DistSQL that changes runtime state."
+completionTargets:
+  - referenceType: resource
+    reference: shardingsphere://features/sharding/algorithm-plugins
+    arguments:
+      - algorithm_type
+    maxValues: 50
+  - referenceType: resource
+    reference: shardingsphere://features/sharding/key-generate-algorithm-plugins
+    arguments:
+      - key_generator_type
+    maxValues: 50
 tools:
   - name: database_gateway_plan_sharding_table_rule
     title: Plan Sharding Table Rule

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingFeatureDefinitionTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingFeatureDefinitionTest.java
@@ -33,6 +33,12 @@ class ShardingFeatureDefinitionTest {
         assertThat(ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND.getValue(), is("sharding.key.generate.strategy"));
         assertThat(ShardingFeatureDefinition.COMPONENT_CLEANUP_WORKFLOW_KIND.getValue(), is("sharding.component.cleanup"));
         assertThat(ShardingFeatureDefinition.PLAN_TABLE_RULE_TOOL_NAME, is("database_gateway_plan_sharding_table_rule"));
+        assertThat(ShardingFeatureDefinition.PLAN_TABLE_RULE_PROMPT_NAME, is("plan_sharding_table_rule"));
+        assertThat(ShardingFeatureDefinition.PLAN_TABLE_REFERENCE_PROMPT_NAME, is("plan_sharding_table_reference_rule"));
+        assertThat(ShardingFeatureDefinition.PLAN_DEFAULT_STRATEGY_PROMPT_NAME, is("plan_sharding_default_strategy"));
+        assertThat(ShardingFeatureDefinition.PLAN_KEY_GENERATOR_PROMPT_NAME, is("plan_sharding_key_generator"));
+        assertThat(ShardingFeatureDefinition.PLAN_KEY_GENERATE_STRATEGY_PROMPT_NAME, is("plan_sharding_key_generate_strategy"));
+        assertThat(ShardingFeatureDefinition.PLAN_COMPONENT_CLEANUP_PROMPT_NAME, is("plan_sharding_rule_component_cleanup"));
         assertThat(ShardingFeatureDefinition.ALGORITHM_PLUGINS_RESOURCE_URI, is("shardingsphere://features/sharding/algorithm-plugins"));
         assertThat(ShardingFeatureDefinition.RULE_COUNT_RESOURCE_URI, is("shardingsphere://features/sharding/databases/{database}/rule-count"));
     }

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/completion/ShardingAlgorithmCompletionProviderTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/completion/ShardingAlgorithmCompletionProviderTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.feature.sharding.completion;
+
+import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionCandidate;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProvider;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionProviderResult;
+import org.apache.shardingsphere.mcp.support.completion.MCPCompletionRequestContext;
+import org.apache.shardingsphere.mcp.support.database.MCPDatabaseHandlerContext;
+import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ShardingAlgorithmCompletionProviderTest {
+    
+    @Test
+    void assertGetContextType() {
+        assertThat(new ShardingAlgorithmCompletionProvider().getContextType(), is(MCPDatabaseHandlerContext.class));
+    }
+    
+    @Test
+    void assertSupportsShardingAlgorithm() {
+        assertTrue(new ShardingAlgorithmCompletionProvider().supports(createRequestContext(ShardingFeatureDefinition.ALGORITHM_PLUGINS_RESOURCE_URI, "algorithm_type")));
+    }
+    
+    @Test
+    void assertSupportsKeyGeneratorAlgorithm() {
+        assertTrue(new ShardingAlgorithmCompletionProvider().supports(createRequestContext(ShardingFeatureDefinition.KEY_GENERATE_ALGORITHM_PLUGINS_RESOURCE_URI, "key_generator_type")));
+    }
+    
+    @Test
+    void assertSupportsWithForeignReference() {
+        assertFalse(new ShardingAlgorithmCompletionProvider().supports(createRequestContext("plan_mask_rule", "algorithm_type")));
+    }
+    
+    @Test
+    void assertCompleteShardingAlgorithm() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.queryWithAnyDatabase("SHOW SHARDING ALGORITHM PLUGINS")).thenReturn(List.of(
+                Map.of("type", "INLINE", "description", "Inline sharding algorithm", "secret", "hidden"),
+                Map.of("type", "")));
+        MCPCompletionProviderResult actual = new ShardingAlgorithmCompletionProvider().complete(createHandlerContext(queryFacade),
+                createRequestContext(ShardingFeatureDefinition.ALGORITHM_PLUGINS_RESOURCE_URI, "algorithm_type"));
+        List<MCPCompletionCandidate> actualCandidates = new ArrayList<>(actual.getCandidates());
+        assertThat(actualCandidates.size(), is(1));
+        assertThat(actualCandidates.getFirst().getValue(), is("INLINE"));
+        assertThat(actualCandidates.getFirst().getLabel(), is("Inline sharding algorithm"));
+        assertThat(actualCandidates.getFirst().getSource(), is("sharding-algorithm"));
+    }
+    
+    @Test
+    void assertCompleteKeyGeneratorAlgorithm() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.queryWithAnyDatabase("SHOW KEY GENERATE ALGORITHM PLUGINS")).thenReturn(List.of(
+                Map.of("type", "SNOWFLAKE", "description", "Snowflake key generator")));
+        MCPCompletionProviderResult actual = new ShardingAlgorithmCompletionProvider().complete(createHandlerContext(queryFacade),
+                createRequestContext(ShardingFeatureDefinition.KEY_GENERATE_ALGORITHM_PLUGINS_RESOURCE_URI, "key_generator_type"));
+        List<MCPCompletionCandidate> actualCandidates = new ArrayList<>(actual.getCandidates());
+        assertThat(actualCandidates.size(), is(1));
+        assertThat(actualCandidates.getFirst().getValue(), is("SNOWFLAKE"));
+        assertThat(actualCandidates.getFirst().getSource(), is("sharding-key-generate-algorithm"));
+    }
+    
+    @Test
+    void assertSPIRegistration() {
+        assertTrue(ServiceLoader.load(MCPCompletionProvider.class).stream().anyMatch(each -> ShardingAlgorithmCompletionProvider.class.equals(each.type())));
+    }
+    
+    private MCPDatabaseHandlerContext createHandlerContext(final MCPFeatureQueryFacade queryFacade) {
+        MCPDatabaseHandlerContext result = mock(MCPDatabaseHandlerContext.class);
+        when(result.getQueryFacade()).thenReturn(queryFacade);
+        return result;
+    }
+    
+    private MCPCompletionRequestContext createRequestContext(final String reference, final String argumentName) {
+        return new MCPCompletionRequestContext("session-1",
+                new MCPCompletionTargetDescriptor("resource", reference, List.of(argumentName), 50, Map.of()), argumentName, Map.of("database", "logic_db"));
+    }
+}

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/descriptor/ShardingToolDescriptorValidatorTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/descriptor/ShardingToolDescriptorValidatorTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.mcp.feature.sharding.descriptor;
 
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogIndex;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidator;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 
@@ -47,6 +49,16 @@ class ShardingToolDescriptorValidatorTest {
         assertTrue(validator.supports(MCPDescriptorCatalogIndex.getRequiredToolDescriptor(ShardingFeatureDefinition.PLAN_KEY_GENERATOR_TOOL_NAME)));
         assertTrue(validator.supports(MCPDescriptorCatalogIndex.getRequiredToolDescriptor(ShardingFeatureDefinition.PLAN_KEY_GENERATE_STRATEGY_TOOL_NAME)));
         assertTrue(validator.supports(MCPDescriptorCatalogIndex.getRequiredToolDescriptor(ShardingFeatureDefinition.PLAN_COMPONENT_CLEANUP_TOOL_NAME)));
+    }
+    
+    @Test
+    void assertExposeCompletionTargets() {
+        MCPCompletionTargetDescriptor algorithmCompletionTarget = findCompletionTarget("resource", ShardingFeatureDefinition.ALGORITHM_PLUGINS_RESOURCE_URI);
+        assertThat(algorithmCompletionTarget.getArguments(), is(List.of("algorithm_type")));
+        assertThat(algorithmCompletionTarget.getMaxValues(), is(50));
+        MCPCompletionTargetDescriptor keyGeneratorCompletionTarget = findCompletionTarget("resource", ShardingFeatureDefinition.KEY_GENERATE_ALGORITHM_PLUGINS_RESOURCE_URI);
+        assertThat(keyGeneratorCompletionTarget.getArguments(), is(List.of("key_generator_type")));
+        assertThat(keyGeneratorCompletionTarget.getMaxValues(), is(50));
     }
     
     @Test
@@ -94,5 +106,10 @@ class ShardingToolDescriptorValidatorTest {
         try (InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName)) {
             return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
         }
+    }
+    
+    private MCPCompletionTargetDescriptor findCompletionTarget(final String referenceType, final String reference) {
+        return MCPDescriptorCatalogIndex.getCompletionTargetDescriptors().stream()
+                .filter(each -> referenceType.equals(each.getReferenceType()) && reference.equals(each.getReference())).findFirst().orElseThrow();
     }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportCompletionE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportCompletionE2ETest.java
@@ -77,6 +77,21 @@ class HttpTransportCompletionE2ETest extends AbstractHttpProgrammaticRuntimeE2ET
     }
     
     @Test
+    void assertCompleteFeaturePluginValues() throws IOException, InterruptedException {
+        launchHttpTransport();
+        HttpClient httpClient = HttpClient.newHttpClient();
+        String sessionId = initializeSession(httpClient);
+        assertTrue(completeValues(httpClient, sessionId, createResourceReference("shardingsphere://features/readwrite-splitting/load-balance-algorithm-plugins"),
+                "load_balancer_type", "ROUND", Map.of()).contains("ROUND_ROBIN"));
+        assertTrue(completeValues(httpClient, sessionId, createResourceReference("shardingsphere://features/shadow/algorithm-plugins"),
+                "algorithm_type", "VALUE", Map.of()).contains("VALUE_MATCH"));
+        assertTrue(completeValues(httpClient, sessionId, createResourceReference("shardingsphere://features/sharding/algorithm-plugins"),
+                "algorithm_type", "INLINE", Map.of()).contains("INLINE"));
+        assertTrue(completeValues(httpClient, sessionId, createResourceReference("shardingsphere://features/sharding/key-generate-algorithm-plugins"),
+                "key_generator_type", "SNOW", Map.of()).contains("SNOWFLAKE"));
+    }
+    
+    @Test
     void assertCompleteWorkflowPlanIdsWithinCurrentSession() throws IOException, InterruptedException {
         launchHttpTransport();
         HttpClient httpClient = HttpClient.newHttpClient();

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/MCPInteractionPayloadsTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/MCPInteractionPayloadsTest.java
@@ -64,7 +64,7 @@ class MCPInteractionPayloadsTest {
     @Test
     void assertGetResultContents() {
         Map<String, Object> payload = Map.of("result", Map.of("content", List.of(Map.of("text", "{\"status\":\"ok\"}"))));
-        assertThat(MCPInteractionPayloads.getResultContents(payload).get(0).get("text"), is("{\"status\":\"ok\"}"));
+        assertThat(MCPInteractionPayloads.getResultContents(payload).getFirst().get("text"), is("{\"status\":\"ok\"}"));
     }
     
     @Test
@@ -75,7 +75,7 @@ class MCPInteractionPayloadsTest {
     @Test
     void assertGetListResourcesPayload() {
         Map<String, Object> actualPayload = MCPInteractionPayloads.getListResourcesPayload(Map.of("result", Map.of("resources", List.of(Map.of("uri", "shardingsphere://capabilities")))));
-        assertThat(MCPInteractionPayloads.castToList(actualPayload.get("resources")).get(0).get("uri"), is("shardingsphere://capabilities"));
+        assertThat(MCPInteractionPayloads.castToList(actualPayload.get("resources")).getFirst().get("uri"), is("shardingsphere://capabilities"));
     }
     
     @Test
@@ -88,6 +88,14 @@ class MCPInteractionPayloadsTest {
     void assertGetStructuredContent() {
         Map<String, Object> actualPayload = MCPInteractionPayloads.getStructuredContent(Map.of("result", Map.of("structuredContent", Map.of("status", "ok"))));
         assertThat(actualPayload.get("status"), is("ok"));
+    }
+    
+    @Test
+    void assertGetStructuredContentPrefersStructuredContent() {
+        Map<String, Object> payload = Map.of("result", Map.of(
+                "structuredContent", Map.of("status", "ok"),
+                "content", List.of(Map.of("type", "text", "text", "{\"status\":\"fallback\"}"))));
+        assertThat(MCPInteractionPayloads.getStructuredContent(payload).get("status"), is("ok"));
     }
     
     @Test
@@ -130,6 +138,6 @@ class MCPInteractionPayloadsTest {
     
     @Test
     void assertCastToList() {
-        assertThat(MCPInteractionPayloads.castToList(List.of(Map.of("name", "orders"))).get(0).get("name"), is("orders"));
+        assertThat(MCPInteractionPayloads.castToList(List.of(Map.of("name", "orders"))).getFirst().get("name"), is("orders"));
     }
 }

--- a/test/e2e/mcp/src/test/resources/llm/evaluation/mcp-builder-evaluation.xml
+++ b/test/e2e/mcp/src/test/resources/llm/evaluation/mcp-builder-evaluation.xml
@@ -147,38 +147,43 @@
   </qa_pair>
   <qa_pair id="q08" category="encrypt" read_only="true">
     <question>
-      A user asks for an encrypt rule for a logical column that may need cipher, assisted query, and like query columns. Explain how the model
-      should build a reviewable plan without applying changes to the runtime database.
+      A user asks for reviewable feature-rule plans across encrypt, broadcast, readwrite-splitting, shadow, and sharding modules, but has not
+      approved runtime metadata changes. Explain how the model should discover feature resources, choose the right planning tools, and stop
+      before side effects.
     </question>
-    <answer>metadata|encrypt_algorithms|plan_encrypt_rule|no_apply_execute</answer>
+    <answer>feature_resources|plan_feature_workflows|no_apply_execute</answer>
     <expected_answer>
-      The model should inspect the table and column metadata first, use completion or descriptor information to choose supported encrypt
-      algorithms, and call database_gateway_plan_encrypt_rule with explicit logical, cipher, assisted query, and like query intent where needed.
-      The response should be treated as a reviewable workflow plan containing rule details, DistSQL, physical DDL where applicable, validation
-      layers, and next_actions. It must not call workflow apply in execute mode or perform data migration.
+      The model should first use tools/list, resources/templates/list, and resources/read to discover the feature resources for encrypt,
+      broadcast, readwrite-splitting, shadow, and sharding instead of guessing tool names. It should call the matching database_gateway_plan_*
+      workflow tool only after required logical database, rule, table, storage-unit, or algorithm inputs are known, then report plan_id,
+      reviewable DistSQL artifacts, resources_to_read, and next_actions. It must not call database_gateway_apply_workflow in execute mode,
+      execute SQL updates, create physical metadata, or perform migration while the request is still a read-only review.
     </expected_answer>
     <verification>
-      <step>Confirm the answer starts from table and column metadata rather than guessed columns.</step>
-      <step>Confirm the answer uses database_gateway_plan_encrypt_rule for the encrypt workflow plan.</step>
-      <step>Confirm the answer covers cipher, assisted query, like query, validation, and no data migration.</step>
+      <step>Confirm the answer discovers feature resources and tool schemas before selecting a planning workflow.</step>
+      <step>Confirm the answer mentions representative planning tools for encrypt, broadcast, readwrite-splitting, shadow, and sharding.</step>
+      <step>Confirm the answer preserves plan_id, resources_to_read, next_actions, and forbids workflow execution mode.</step>
     </verification>
   </qa_pair>
   <qa_pair id="q09" category="mask" read_only="true">
     <question>
-      A user asks for a mask rule on a column but gives an algorithm name that may be unsupported and a field semantic that may be incomplete.
-      Describe how the model should recover while staying read-only.
+      A user asks for mask, readwrite-splitting, shadow, and sharding planning but supplies uncertain algorithm or plugin type names. Describe
+      how the model should use completion, resources/read, and shardingsphere:// plugin resources to recover without leaking configuration
+      details or mutating metadata.
     </question>
-    <answer>mask_descriptors_or_completion|plan_mask_rule_when_complete|return_recovery_next_actions</answer>
+    <answer>completion_or_plugin_resources|bounded_candidates|return_next_actions</answer>
     <expected_answer>
-      The model should inspect mask descriptors and algorithm completion data before planning, then call database_gateway_plan_mask_rule only
-      when the table, column, algorithm, and field semantics are specific enough. If the algorithm or semantic details are missing, it should
-      return the recovery message and next_actions from the planning response or ask for the missing information. It must not invent an
-      algorithm, apply a workflow, or alter runtime metadata while recovering.
+      The model should use completion/complete or resources/read against the nearest shardingsphere:// plugin resource before choosing
+      uncertain algorithm fields: mask algorithms, readwrite-splitting load-balance algorithms, shadow algorithm plugins, sharding algorithm
+      plugins, and sharding key-generate algorithm plugins. It should treat returned values as bounded candidates, keep context arguments such
+      as database or resource reference explicit, and avoid exposing secret property values as completion suggestions. If completion has no safe
+      candidate, it should use the recovery message, resources_to_read, and next_actions from the planning response instead of inventing an
+      algorithm or applying a workflow.
     </expected_answer>
     <verification>
-      <step>Confirm the answer uses descriptor or completion evidence before planning a mask rule.</step>
-      <step>Confirm the answer uses database_gateway_plan_mask_rule only after required inputs are specific.</step>
-      <step>Confirm the answer preserves recovery next_actions and forbids invented algorithms or metadata changes.</step>
+      <step>Confirm the answer uses completion/complete or resources/read plugin resources before selecting uncertain algorithm names.</step>
+      <step>Confirm the answer covers mask, readwrite-splitting, shadow, and sharding plugin completion sources.</step>
+      <step>Confirm the answer keeps completion bounded, secret-safe, and uses recovery next_actions instead of mutation.</step>
     </verification>
   </qa_pair>
   <qa_pair id="q10" category="transport_security" read_only="true">


### PR DESCRIPTION
Add MCP completion providers for readwrite-splitting, shadow, and sharding feature plugin metadata, and expose matching descriptor completion targets.

Also add focused feature-definition coverage for encrypt, mask, and sharding, extend MCP completion E2E checks, and update the MCP builder evaluation to cover feature plugin discovery through completion and resource reads.

For #35294.