### PR TITLE
Fix MySQL user variable handling in Proxy SET statements

### DIFF
--- a/parser/sql/engine/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/engine/mysql/visitor/statement/type/MySQLDALStatementVisitor.java
+++ b/parser/sql/engine/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/engine/mysql/visitor/statement/type/MySQLDALStatementVisitor.java
@@ -135,6 +135,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.ShowFilte
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.ShowLikeSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableAssignSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableSegment.VariableType;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.index.IndexSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
@@ -822,13 +823,15 @@ public final class MySQLDALStatementVisitor extends MySQLStatementVisitor implem
             return getVariableAssignSegment(ctx.optionValueNoOptionType());
         }
         VariableSegment variable = new VariableSegment(
-                ctx.internalVariableName().start.getStartIndex(), ctx.internalVariableName().stop.getStopIndex(), ctx.internalVariableName().getText(), ctx.optionType().getText());
+                ctx.internalVariableName().start.getStartIndex(), ctx.internalVariableName().stop.getStopIndex(), ctx.internalVariableName().getText(), ctx.optionType().getText())
+                .withVariableType(VariableType.INTERNAL);
         return new VariableAssignSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), variable, ctx.setExprOrDefault().getText());
     }
     
     private VariableAssignSegment getVariableAssignSegment(final OptionValueListContext ctx) {
         VariableSegment variable = new VariableSegment(
-                ctx.internalVariableName().start.getStartIndex(), ctx.internalVariableName().stop.getStopIndex(), ctx.internalVariableName().getText(), ctx.optionType().getText());
+                ctx.internalVariableName().start.getStartIndex(), ctx.internalVariableName().stop.getStopIndex(), ctx.internalVariableName().getText(), ctx.optionType().getText())
+                .withVariableType(VariableType.INTERNAL);
         return new VariableAssignSegment(ctx.start.getStartIndex(), ctx.setExprOrDefault().stop.getStopIndex(), variable, ctx.setExprOrDefault().getText());
     }
     
@@ -838,10 +841,11 @@ public final class MySQLDALStatementVisitor extends MySQLStatementVisitor implem
     
     private VariableSegment getVariableSegment(final OptionValueNoOptionTypeContext ctx) {
         if (null != ctx.internalVariableName()) {
-            return new VariableSegment(ctx.internalVariableName().start.getStartIndex(), ctx.internalVariableName().stop.getStopIndex(), ctx.internalVariableName().getText());
+            return new VariableSegment(ctx.internalVariableName().start.getStartIndex(), ctx.internalVariableName().stop.getStopIndex(), ctx.internalVariableName().getText())
+                    .withVariableType(VariableType.INTERNAL);
         }
         if (null != ctx.userVariable()) {
-            return new VariableSegment(ctx.userVariable().start.getStartIndex(), ctx.userVariable().stop.getStopIndex(), ctx.userVariable().getText());
+            return new VariableSegment(ctx.userVariable().start.getStartIndex(), ctx.userVariable().stop.getStopIndex(), ctx.userVariable().getText()).withVariableType(VariableType.USER);
         }
         if (null != ctx.setSystemVariable()) {
             VariableSegment result = new VariableSegment(

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dal/VariableSegment.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dal/VariableSegment.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.sql.parser.statement.core.segment.dal;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -28,11 +27,18 @@ import java.util.Optional;
 /**
  * Variable segment.
  */
-@AllArgsConstructor
 @RequiredArgsConstructor
 @Getter
 @Setter
 public final class VariableSegment implements ExpressionSegment {
+    
+    /**
+     * Variable type.
+     */
+    public enum VariableType {
+        
+        USER, SYSTEM, INTERNAL
+    }
     
     private final int startIndex;
     
@@ -41,6 +47,34 @@ public final class VariableSegment implements ExpressionSegment {
     private final String variable;
     
     private String scope;
+    
+    private VariableType variableType = VariableType.SYSTEM;
+    
+    /**
+     * Create variable segment with scope.
+     *
+     * @param startIndex start index
+     * @param stopIndex stop index
+     * @param variable variable
+     * @param scope scope
+     */
+    public VariableSegment(final int startIndex, final int stopIndex, final String variable, final String scope) {
+        this.startIndex = startIndex;
+        this.stopIndex = stopIndex;
+        this.variable = variable;
+        this.scope = scope;
+    }
+    
+    /**
+     * Set variable type.
+     *
+     * @param variableType variable type
+     * @return variable segment
+     */
+    public VariableSegment withVariableType(final VariableType variableType) {
+        this.variableType = variableType;
+        return this;
+    }
     
     /**
      * Get scope.

--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutor.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutor.java
@@ -69,6 +69,9 @@ public final class MySQLSetVariableAdminExecutor implements DatabaseAdminUpdateE
     
     private void validateSessionVariables(final Collection<String> sessionVariables) {
         for (String each : sessionVariables) {
+            if (each.startsWith("@")) {
+                continue;
+            }
             MySQLSystemVariable systemVariable = MySQLSystemVariable.findSystemVariable(each).orElseThrow(() -> new UnknownSystemVariableException(each));
             systemVariable.validateSetTargetScope(MySQLSystemVariableScope.SESSION);
         }

--- a/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutor.java
+++ b/proxy/backend/dialect/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutor.java
@@ -34,6 +34,8 @@ import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysv
 import org.apache.shardingsphere.proxy.backend.mysql.handler.admin.executor.sysvar.MySQLSystemVariableScope;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableAssignSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableSegment.VariableType;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.SetStatement;
 
@@ -55,7 +57,7 @@ public final class MySQLSetVariableAdminExecutor implements DatabaseAdminUpdateE
     @Override
     public void execute(final ConnectionSession connectionSession, final ShardingSphereMetaData metaData) throws SQLException {
         Map<String, String> sessionVariables = extractSessionVariables();
-        validateSessionVariables(sessionVariables.keySet());
+        validateSessionVariables(extractSessionVariableSegments());
         CharsetSetExecutor charsetSetExecutor = new CharsetSetExecutor(sqlStatement.getDatabaseType(), connectionSession);
         sessionVariables.forEach(charsetSetExecutor::set);
         new SessionVariableRecordExecutor(sqlStatement.getDatabaseType(), connectionSession).recordVariable(sessionVariables);
@@ -67,12 +69,16 @@ public final class MySQLSetVariableAdminExecutor implements DatabaseAdminUpdateE
                 .collect(Collectors.toMap(each -> each.getVariable().getVariable(), VariableAssignSegment::getAssignValue));
     }
     
-    private void validateSessionVariables(final Collection<String> sessionVariables) {
-        for (String each : sessionVariables) {
-            if (each.startsWith("@")) {
+    private Collection<VariableSegment> extractSessionVariableSegments() {
+        return sqlStatement.getVariableAssigns().stream().map(VariableAssignSegment::getVariable).filter(each -> !"global".equalsIgnoreCase(each.getScope().orElse(""))).collect(Collectors.toList());
+    }
+    
+    private void validateSessionVariables(final Collection<VariableSegment> sessionVariables) {
+        for (VariableSegment each : sessionVariables) {
+            if (VariableType.USER == each.getVariableType()) {
                 continue;
             }
-            MySQLSystemVariable systemVariable = MySQLSystemVariable.findSystemVariable(each).orElseThrow(() -> new UnknownSystemVariableException(each));
+            MySQLSystemVariable systemVariable = MySQLSystemVariable.findSystemVariable(each.getVariable()).orElseThrow(() -> new UnknownSystemVariableException(each.getVariable()));
             systemVariable.validateSetTargetScope(MySQLSystemVariableScope.SESSION);
         }
     }

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutorTest.java
@@ -57,9 +57,9 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MySQLSetVariableAdminExecutorTest {
-    
+
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
-    
+
     @Test
     void assertExecute() throws SQLException {
         SetStatement setStatement = prepareSetStatement();
@@ -77,7 +77,7 @@ class MySQLSetVariableAdminExecutorTest {
         }
         assertThat(connectionSession.getAttributeMap().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.UTF_8));
     }
-    
+
     @Test
     void assertExecuteWithCharacterSetResults() throws SQLException {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(
@@ -88,7 +88,7 @@ class MySQLSetVariableAdminExecutorTest {
         executor.execute(connectionSession, mock());
         assertThat(connectionSession.getAttributeMap().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.UTF_8));
     }
-    
+
     @Test
     void assertExecuteWithCharacterSetResultsAsNull() throws SQLException {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(
@@ -101,7 +101,7 @@ class MySQLSetVariableAdminExecutorTest {
         executor.execute(connectionSession, mock());
         assertThat(connectionSession.getAttributeMap().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.UTF_8));
     }
-    
+
     @Test
     void assertExecuteWithUserVariable() throws SQLException {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "@test_var"), "1")));
@@ -118,7 +118,7 @@ class MySQLSetVariableAdminExecutorTest {
         when(result.getCurrentDatabaseName()).thenReturn(Optional.of("foo_db"));
         return result;
     }
-    
+
     private SetStatement prepareSetStatement() {
         VariableSegment maxConnectionVariableSegment = new VariableSegment(0, 0, "max_connections", "global");
         VariableAssignSegment setGlobalMaxConnectionAssignSegment = new VariableAssignSegment(0, 0, maxConnectionVariableSegment, "151");
@@ -126,20 +126,20 @@ class MySQLSetVariableAdminExecutorTest {
         VariableAssignSegment setCharacterSetClientVariableSegment = new VariableAssignSegment(0, 0, characterSetClientSegment, "'utf8mb4'");
         return new SetStatement(databaseType, Arrays.asList(setGlobalMaxConnectionAssignSegment, setCharacterSetClientVariableSegment));
     }
-    
+
     private ShardingSphereMetaData mockMetaData() {
         ShardingSphereMetaData result = mock(ShardingSphereMetaData.class);
         when(result.getGlobalRuleMetaData()).thenReturn(new RuleMetaData(Collections.singleton(new SQLParserRule(new SQLParserRuleConfiguration(new CacheOption(1, 1L), new CacheOption(1, 1L))))));
         return result;
     }
-    
+
     @Test
     void assertSetUnknownSystemVariable() {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "unknown_variable"), "")));
         MySQLSetVariableAdminExecutor executor = new MySQLSetVariableAdminExecutor(setStatement);
         assertThrows(UnknownSystemVariableException.class, () -> executor.execute(mock(), mock()));
     }
-    
+
     @Test
     void assertSetVariableWithIncorrectScope() {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "max_connections"), "")));

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutorTest.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.parser.rule.SQLParserRule;
 import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
 import org.apache.shardingsphere.proxy.backend.connector.StandardDatabaseProxyConnector;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.backend.session.RequiredSessionVariableRecorder;
 import org.apache.shardingsphere.sql.parser.engine.api.CacheOption;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableAssignSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableSegment;
@@ -101,6 +102,17 @@ class MySQLSetVariableAdminExecutorTest {
         assertThat(connectionSession.getAttributeMap().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.UTF_8));
     }
     
+    @Test
+    void assertExecuteWithUserVariable() throws SQLException {
+        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "@test_var"), "1")));
+        MySQLSetVariableAdminExecutor executor = new MySQLSetVariableAdminExecutor(setStatement);
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        RequiredSessionVariableRecorder recorder = new RequiredSessionVariableRecorder();
+        when(connectionSession.getRequiredSessionVariableRecorder()).thenReturn(recorder);
+        executor.execute(connectionSession, mock());
+        assertThat(recorder.toSetSQLs(databaseType.getType()), is(Collections.singletonList("SET @test_var=1")));
+    }
+
     private ConnectionContext mockConnectionContext() {
         ConnectionContext result = mock(ConnectionContext.class);
         when(result.getCurrentDatabaseName()).thenReturn(Optional.of("foo_db"));

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutorTest.java
@@ -35,6 +35,8 @@ import org.apache.shardingsphere.proxy.backend.session.RequiredSessionVariableRe
 import org.apache.shardingsphere.sql.parser.engine.api.CacheOption;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableAssignSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.VariableSegment.VariableType;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dal.SetStatement;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -103,8 +105,21 @@ class MySQLSetVariableAdminExecutorTest {
     }
     
     @Test
-    void assertExecuteWithUserVariable() throws SQLException {
-        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "@test_var"), "1")));
+    void assertExecuteWithUserVariableEqualsOperator() throws SQLException {
+        SetStatement setStatement = parseSetStatement("SET @test_var = 1");
+        assertThat(setStatement.getVariableAssigns().iterator().next().getVariable().getVariableType(), is(VariableType.USER));
+        MySQLSetVariableAdminExecutor executor = new MySQLSetVariableAdminExecutor(setStatement);
+        ConnectionSession connectionSession = mock(ConnectionSession.class);
+        RequiredSessionVariableRecorder recorder = new RequiredSessionVariableRecorder();
+        when(connectionSession.getRequiredSessionVariableRecorder()).thenReturn(recorder);
+        executor.execute(connectionSession, mock());
+        assertThat(recorder.toSetSQLs(databaseType.getType()), is(Collections.singletonList("SET @test_var=1")));
+    }
+    
+    @Test
+    void assertExecuteWithUserVariableAssignmentOperator() throws SQLException {
+        SetStatement setStatement = parseSetStatement("SET @test_var := 1");
+        assertThat(setStatement.getVariableAssigns().iterator().next().getVariable().getVariableType(), is(VariableType.USER));
         MySQLSetVariableAdminExecutor executor = new MySQLSetVariableAdminExecutor(setStatement);
         ConnectionSession connectionSession = mock(ConnectionSession.class);
         RequiredSessionVariableRecorder recorder = new RequiredSessionVariableRecorder();
@@ -135,9 +150,10 @@ class MySQLSetVariableAdminExecutorTest {
     
     @Test
     void assertSetUnknownSystemVariable() {
-        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "unknown_variable"), "")));
+        SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "unknown_var", "SESSION"), "1")));
         MySQLSetVariableAdminExecutor executor = new MySQLSetVariableAdminExecutor(setStatement);
-        assertThrows(UnknownSystemVariableException.class, () -> executor.execute(mock(), mock()));
+        UnknownSystemVariableException actual = assertThrows(UnknownSystemVariableException.class, () -> executor.execute(mock(), mock()));
+        assertThat(actual.getVariableName(), is("unknown_var"));
     }
     
     @Test
@@ -145,5 +161,10 @@ class MySQLSetVariableAdminExecutorTest {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "max_connections"), "")));
         MySQLSetVariableAdminExecutor executor = new MySQLSetVariableAdminExecutor(setStatement);
         assertThrows(ErrorGlobalVariableException.class, () -> executor.execute(mock(), mock()));
+    }
+    
+    private SetStatement parseSetStatement(final String sql) {
+        SQLStatement result = new SQLParserRule(new SQLParserRuleConfiguration(new CacheOption(1, 1L), new CacheOption(1, 1L))).getSQLParserEngine(databaseType).parse(sql, false);
+        return (SetStatement) result;
     }
 }

--- a/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutorTest.java
+++ b/proxy/backend/dialect/mysql/src/test/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSetVariableAdminExecutorTest.java
@@ -57,9 +57,9 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MySQLSetVariableAdminExecutorTest {
-
+    
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
-
+    
     @Test
     void assertExecute() throws SQLException {
         SetStatement setStatement = prepareSetStatement();
@@ -77,7 +77,7 @@ class MySQLSetVariableAdminExecutorTest {
         }
         assertThat(connectionSession.getAttributeMap().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.UTF_8));
     }
-
+    
     @Test
     void assertExecuteWithCharacterSetResults() throws SQLException {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(
@@ -88,7 +88,7 @@ class MySQLSetVariableAdminExecutorTest {
         executor.execute(connectionSession, mock());
         assertThat(connectionSession.getAttributeMap().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.UTF_8));
     }
-
+    
     @Test
     void assertExecuteWithCharacterSetResultsAsNull() throws SQLException {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(
@@ -101,7 +101,7 @@ class MySQLSetVariableAdminExecutorTest {
         executor.execute(connectionSession, mock());
         assertThat(connectionSession.getAttributeMap().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get(), is(StandardCharsets.UTF_8));
     }
-
+    
     @Test
     void assertExecuteWithUserVariable() throws SQLException {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "@test_var"), "1")));
@@ -112,13 +112,13 @@ class MySQLSetVariableAdminExecutorTest {
         executor.execute(connectionSession, mock());
         assertThat(recorder.toSetSQLs(databaseType.getType()), is(Collections.singletonList("SET @test_var=1")));
     }
-
+    
     private ConnectionContext mockConnectionContext() {
         ConnectionContext result = mock(ConnectionContext.class);
         when(result.getCurrentDatabaseName()).thenReturn(Optional.of("foo_db"));
         return result;
     }
-
+    
     private SetStatement prepareSetStatement() {
         VariableSegment maxConnectionVariableSegment = new VariableSegment(0, 0, "max_connections", "global");
         VariableAssignSegment setGlobalMaxConnectionAssignSegment = new VariableAssignSegment(0, 0, maxConnectionVariableSegment, "151");
@@ -126,20 +126,20 @@ class MySQLSetVariableAdminExecutorTest {
         VariableAssignSegment setCharacterSetClientVariableSegment = new VariableAssignSegment(0, 0, characterSetClientSegment, "'utf8mb4'");
         return new SetStatement(databaseType, Arrays.asList(setGlobalMaxConnectionAssignSegment, setCharacterSetClientVariableSegment));
     }
-
+    
     private ShardingSphereMetaData mockMetaData() {
         ShardingSphereMetaData result = mock(ShardingSphereMetaData.class);
         when(result.getGlobalRuleMetaData()).thenReturn(new RuleMetaData(Collections.singleton(new SQLParserRule(new SQLParserRuleConfiguration(new CacheOption(1, 1L), new CacheOption(1, 1L))))));
         return result;
     }
-
+    
     @Test
     void assertSetUnknownSystemVariable() {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "unknown_variable"), "")));
         MySQLSetVariableAdminExecutor executor = new MySQLSetVariableAdminExecutor(setStatement);
         assertThrows(UnknownSystemVariableException.class, () -> executor.execute(mock(), mock()));
     }
-
+    
     @Test
     void assertSetVariableWithIncorrectScope() {
         SetStatement setStatement = new SetStatement(databaseType, Collections.singletonList(new VariableAssignSegment(0, 0, new VariableSegment(0, 0, "max_connections"), "")));


### PR DESCRIPTION
### What changed

- Skip MySQL system variable validation for user variables such as `@test_var`.
- Add a unit test to verify `SET @test_var = 1` is recorded as a replayable session variable.

### Why

MySQL user variables are valid session-scoped variables, but ShardingSphere Proxy validated every non-global SET variable through the MySQL system variable registry. This caused `SET @test_var = 1` to fail with `Unknown system variable '@test_var'`.

### Verification

- Manually verified through ShardingSphere Proxy with MySQL protocol:
  - `SET @test_var = 1;` executes successfully.