### PR TITLE
Use insensitive rule for COLUMN INDEX and CONSTRAINT

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCaseRuleSets.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCaseRuleSets.java
@@ -67,12 +67,21 @@ public final class IdentifierCaseRuleSets {
     }
     
     /**
+     * Create quoted and unquoted case-insensitive rule set.
+     *
+     * @return quoted and unquoted case-insensitive rule set
+     */
+    public static IdentifierCaseRuleSet newQuotedInsensitiveRuleSet() {
+        return new IdentifierCaseRuleSet(new StandardIdentifierCaseRule(LookupMode.NORMALIZED, LookupMode.NORMALIZED, IdentifierCaseRuleSets::toLowerCase, each -> true));
+    }
+    
+    /**
      * Create MySQL case-insensitive rule set.
      *
      * @return MySQL case-insensitive rule set
      */
     public static IdentifierCaseRuleSet newMySQLInsensitiveRuleSet() {
-        return new IdentifierCaseRuleSet(new StandardIdentifierCaseRule(LookupMode.NORMALIZED, LookupMode.NORMALIZED, IdentifierCaseRuleSets::toLowerCase, each -> true));
+        return newQuotedInsensitiveRuleSet();
     }
     
     /**

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCaseRuleSetsTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/identifier/IdentifierCaseRuleSetsTest.java
@@ -63,6 +63,14 @@ class IdentifierCaseRuleSetsTest {
     }
     
     @Test
+    void assertNewQuotedInsensitiveRuleSet() {
+        IdentifierCaseRule actual = IdentifierCaseRuleSets.newQuotedInsensitiveRuleSet().getRule(IdentifierScope.TABLE);
+        assertThat(actual.getLookupMode(QuoteCharacter.QUOTE), is(LookupMode.NORMALIZED));
+        assertThat(actual.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
+        assertTrue(actual.matches("t_mask", "T_MASK", QuoteCharacter.BACK_QUOTE));
+    }
+    
+    @Test
     void assertNewMySQLInsensitiveRuleSet() {
         IdentifierCaseRule actual = IdentifierCaseRuleSets.newMySQLInsensitiveRuleSet().getRule(IdentifierScope.TABLE);
         assertThat(actual.getLookupMode(QuoteCharacter.QUOTE), is(LookupMode.NORMALIZED));

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactory.java
@@ -129,16 +129,25 @@ public final class DatabaseIdentifierContextFactory {
     
     private static IdentifierCaseRuleSet createScopeAwareRuleSet(final IdentifierCaseRuleSet protocolRuleSet, final IdentifierCaseRuleSet storageRuleSet) {
         IdentifierCaseRuleSet databaseRuleSet = IdentifierCaseRuleSets.newInsensitiveRuleSet();
+        IdentifierCaseRuleSet storageObjectRuleSet = IdentifierCaseRuleSets.newQuotedInsensitiveRuleSet();
         Map<IdentifierScope, IdentifierCaseRule> scopedRules = new EnumMap<>(IdentifierScope.class);
         for (IdentifierScope each : IdentifierScope.values()) {
             if (IdentifierScope.DATABASE == each) {
                 scopedRules.put(each, databaseRuleSet.getRule(each));
                 continue;
             }
+            if (isStorageObjectScope(each)) {
+                scopedRules.put(each, storageObjectRuleSet.getRule(each));
+                continue;
+            }
             scopedRules.put(each, IdentifierScope.SCHEMA == each ? protocolRuleSet.getRule(each) : storageRuleSet.getRule(each));
         }
         scopedRules.put(IdentifierScope.LOGICAL_TABLE, protocolRuleSet.getRule(IdentifierScope.LOGICAL_TABLE));
         return new IdentifierCaseRuleSet(storageRuleSet.getRule(IdentifierScope.TABLE), scopedRules);
+    }
+    
+    private static boolean isStorageObjectScope(final IdentifierScope identifierScope) {
+        return IdentifierScope.COLUMN == identifierScope || IdentifierScope.INDEX == identifierScope || IdentifierScope.CONSTRAINT == identifierScope;
     }
     
     private static Optional<DatabaseType> getIdentifierRuleDatabaseType(final ResourceMetaData resourceMetaData) {

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseIdentifierTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseIdentifierTest.java
@@ -132,7 +132,7 @@ class ShardingSphereDatabaseIdentifierTest {
         database.refreshIdentifierContext(new ConfigurationProperties(props));
         assertFalse(database.containsSchema("FOO_SCHEMA"));
         assertFalse(database.getSchema("foo_schema").containsTable("FOO_TBL"));
-        assertFalse(database.getSchema("foo_schema").getTable("foo_tbl").containsColumn("FOO_COL"));
+        assertTrue(database.getSchema("foo_schema").getTable("foo_tbl").containsColumn("FOO_COL"));
     }
     
     private ShardingSphereDatabase createDatabase(final DatabaseType databaseType, final String schemaName) {

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -267,6 +267,29 @@ class DatabaseIdentifierContextFactoryTest {
     }
     
     @ParameterizedTest(name = "{0}")
+    @MethodSource("storageObjectScopes")
+    void assertCreateUsesInsensitiveRuleForStorageObjectScope(final String name, final IdentifierScope identifierScope) {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(MYSQL_DATABASE_TYPE, MYSQL_SENSITIVE_STORAGE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        IdentifierCaseRule actualRule = actual.getRule(identifierScope);
+        assertThat(actualRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
+        assertThat(actualRule.getLookupMode(QuoteCharacter.BACK_QUOTE), is(LookupMode.NORMALIZED));
+        assertTrue(actualRule.matches("foo_name", "FOO_NAME", QuoteCharacter.NONE));
+        assertTrue(actualRule.matches("foo_name", "FOO_NAME", QuoteCharacter.BACK_QUOTE));
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("storageObjectScopes")
+    void assertRefreshUsesInsensitiveRuleForStorageObjectScope(final String name, final IdentifierScope identifierScope) {
+        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.createDefault();
+        DatabaseIdentifierContextFactory.refresh(actual, MYSQL_DATABASE_TYPE, MYSQL_SENSITIVE_STORAGE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
+        IdentifierCaseRule actualRule = actual.getRule(identifierScope);
+        assertThat(actualRule.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
+        assertThat(actualRule.getLookupMode(QuoteCharacter.BACK_QUOTE), is(LookupMode.NORMALIZED));
+        assertTrue(actualRule.matches("foo_name", "FOO_NAME", QuoteCharacter.NONE));
+        assertTrue(actualRule.matches("foo_name", "FOO_NAME", QuoteCharacter.BACK_QUOTE));
+    }
+    
+    @ParameterizedTest(name = "{0}")
     @MethodSource("createWithSupportedDatabaseSchemaLookupArguments")
     void assertCreateFindSupportedDatabaseSchemaIdentifiers(final String name, final DatabaseType protocolType, final ResourceMetaData resourceMetaData,
                                                             final String actualSchemaName, final IdentifierValue lookupIdentifier, final String expectedSchemaName) {
@@ -437,9 +460,9 @@ class DatabaseIdentifierContextFactoryTest {
         return Stream.of(
                 createNormalizedLookupArguments("mysql column lower_case_table_names=1", MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, "foo_col", "`"),
                 createNormalizedLookupArguments("mysql column lower_case_table_names=2", MYSQL_DATABASE_TYPE, MYSQL_QUOTED_INSENSITIVE_RESOURCE_META_DATA, "foo_col", "`"),
-                createLowerCaseLookupArguments("postgresql column", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_col", "\""),
-                createLowerCaseLookupArguments("openGauss column", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_col", "\""),
-                createUpperCaseLookupArguments("oracle column", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_col", "\""))
+                createNormalizedLookupArguments("postgresql column", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_col", "\""),
+                createNormalizedLookupArguments("openGauss column", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_col", "\""),
+                createNormalizedLookupArguments("oracle column", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_col", "\""))
                 .flatMap(each -> each);
     }
     
@@ -494,9 +517,9 @@ class DatabaseIdentifierContextFactoryTest {
         return Stream.of(
                 createNormalizedMixedLookupArguments("mysql column lower_case_table_names=1", MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, "foo_col", "`"),
                 createNormalizedMixedLookupArguments("mysql column lower_case_table_names=2", MYSQL_DATABASE_TYPE, MYSQL_QUOTED_INSENSITIVE_RESOURCE_META_DATA, "foo_col", "`"),
-                createLowerCaseMixedLookupArguments("postgresql column", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_col", "\""),
-                createLowerCaseMixedLookupArguments("openGauss column", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_col", "\""),
-                createUpperCaseMixedLookupArguments("oracle column", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_col", "\""))
+                createNormalizedMixedLookupArguments("postgresql column", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_col", "\""),
+                createNormalizedMixedLookupArguments("openGauss column", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_col", "\""),
+                createNormalizedMixedLookupArguments("oracle column", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_col", "\""))
                 .flatMap(each -> each);
     }
     
@@ -514,6 +537,13 @@ class DatabaseIdentifierContextFactoryTest {
     
     private static ConfigurationProperties createConfigurationProperties(final MetadataIdentifierCaseSensitivity caseSensitivity) {
         return new ConfigurationProperties(PropertiesBuilder.build(new Property(ConfigurationPropertyKey.METADATA_IDENTIFIER_CASE_SENSITIVITY.getKey(), caseSensitivity.name())));
+    }
+    
+    private static Stream<Arguments> storageObjectScopes() {
+        return Stream.of(
+                Arguments.of("column", IdentifierScope.COLUMN),
+                Arguments.of("index", IdentifierScope.INDEX),
+                Arguments.of("constraint", IdentifierScope.CONSTRAINT));
     }
     
     private static IdentifierIndex<String> createIdentifierIndex(final DatabaseIdentifierContext identifierContext, final IdentifierScope identifierScope, final String... actualNames) {


### PR DESCRIPTION

Changes proposed in this pull request:
  - Use insensitive rule for COLUMN INDEX and CONSTRAINT

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
