### PR TITLE
Revert "Fix default schema naming for schema-unavailable databases (#38843)"

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/type/DatabaseTypeRegistry.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/type/DatabaseTypeRegistry.java
@@ -19,12 +19,10 @@ package org.apache.shardingsphere.database.connector.core.type;
 
 import lombok.Getter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
 
 import java.util.Collection;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -59,12 +57,7 @@ public final class DatabaseTypeRegistry {
      * @return default schema name
      */
     public String getDefaultSchemaName(final String databaseName) {
-        DialectSchemaOption schemaOption = dialectDatabaseMetaData.getSchemaOption();
-        Optional<String> defaultSchema = schemaOption.getDefaultSchema();
-        if (defaultSchema.isPresent() || null == databaseName) {
-            return defaultSchema.orElse(null);
-        }
-        return schemaOption.isSchemaAvailable() ? formatIdentifierPattern(databaseName) : databaseName;
+        return dialectDatabaseMetaData.getSchemaOption().getDefaultSchema().orElse(null == databaseName ? null : formatIdentifierPattern(databaseName));
     }
     
     /**

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoaderTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/data/loader/type/SchemaMetaDataLoaderTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.database.connector.core.metadata.data.loader.type;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.system.DialectSystemDatabase;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
@@ -43,6 +44,7 @@ import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -65,14 +67,15 @@ class SchemaMetaDataLoaderTest {
     void assertLoadSchemaTableNamesWithoutDefaultSchema() throws SQLException {
         DialectSchemaOption schemaOption = mock(DialectSchemaOption.class);
         when(schemaOption.getDefaultSchema()).thenReturn(Optional.empty());
+        when(schemaOption.getSchema(any())).thenReturn("public");
         DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class);
         when(dialectDatabaseMetaData.getSchemaOption()).thenReturn(schemaOption);
+        when(dialectDatabaseMetaData.getIdentifierPatternType()).thenReturn(IdentifierPatternType.KEEP_ORIGIN);
         try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, databaseType)).thenReturn(dialectDatabaseMetaData);
             try (MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class)) {
                 typedSPILoader.when(() -> TypedSPILoader.getService(DialectDatabaseMetaData.class, null)).thenReturn(dialectDatabaseMetaData);
                 Connection connection = dataSourceWithoutDefaultSchema.getConnection();
-                when(schemaOption.getSchema(connection)).thenReturn("public");
                 when(connection.getCatalog()).thenReturn("catalog");
                 ResultSet tableResultSet = mock(ResultSet.class);
                 when(tableResultSet.next()).thenReturn(true, true, true, true, true, false);
@@ -87,17 +90,18 @@ class SchemaMetaDataLoaderTest {
     }
     
     @Test
-    void assertLoadSchemaTableNamesKeepsDatabaseNameWithoutDefaultSchema() throws SQLException {
+    void assertLoadSchemaTableNamesNormalizesDatabaseNameWithoutDefaultSchema() throws SQLException {
         DialectSchemaOption schemaOption = mock(DialectSchemaOption.class);
         when(schemaOption.getDefaultSchema()).thenReturn(Optional.empty());
+        when(schemaOption.getSchema(any())).thenReturn("public");
         DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class);
         when(dialectDatabaseMetaData.getSchemaOption()).thenReturn(schemaOption);
+        when(dialectDatabaseMetaData.getIdentifierPatternType()).thenReturn(IdentifierPatternType.UPPER_CASE);
         try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, databaseType)).thenReturn(dialectDatabaseMetaData);
             try (MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class)) {
                 typedSPILoader.when(() -> TypedSPILoader.getService(DialectDatabaseMetaData.class, null)).thenReturn(dialectDatabaseMetaData);
                 Connection connection = dataSourceWithoutDefaultSchema.getConnection();
-                when(schemaOption.getSchema(connection)).thenReturn("public");
                 when(connection.getCatalog()).thenReturn("catalog");
                 ResultSet tableResultSet = mock(ResultSet.class);
                 when(tableResultSet.next()).thenReturn(true, false);
@@ -105,7 +109,7 @@ class SchemaMetaDataLoaderTest {
                 when(connection.getMetaData().getTables("catalog", "public", null, TABLE_TYPES)).thenReturn(tableResultSet);
                 Map<String, Collection<String>> actual = new SchemaMetaDataLoader(databaseType)
                         .loadSchemaTableNames("logic_db", dataSourceWithoutDefaultSchema, Collections.emptySet(), Collections.emptySet());
-                Map<String, Collection<String>> expected = Collections.singletonMap("logic_db", new LinkedHashSet<>(Collections.singleton("tbl")));
+                Map<String, Collection<String>> expected = Collections.singletonMap("LOGIC_DB", new LinkedHashSet<>(Collections.singleton("tbl")));
                 assertThat(actual, is(expected));
             }
         }
@@ -115,14 +119,15 @@ class SchemaMetaDataLoaderTest {
     void assertLoadSchemaTableNamesWithIncludedTables() throws SQLException {
         DialectSchemaOption schemaOption = mock(DialectSchemaOption.class);
         when(schemaOption.getDefaultSchema()).thenReturn(Optional.empty());
+        when(schemaOption.getSchema(any())).thenReturn("public");
         DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class);
         when(dialectDatabaseMetaData.getSchemaOption()).thenReturn(schemaOption);
+        when(dialectDatabaseMetaData.getIdentifierPatternType()).thenReturn(IdentifierPatternType.KEEP_ORIGIN);
         try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, databaseType)).thenReturn(dialectDatabaseMetaData);
             try (MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class)) {
                 typedSPILoader.when(() -> TypedSPILoader.getService(DialectDatabaseMetaData.class, null)).thenReturn(dialectDatabaseMetaData);
                 Connection connection = dataSourceWithoutDefaultSchema.getConnection();
-                when(schemaOption.getSchema(connection)).thenReturn("public");
                 when(connection.getCatalog()).thenReturn("catalog");
                 ResultSet tableResultSet = mock(ResultSet.class);
                 when(tableResultSet.next()).thenReturn(true, true, false);
@@ -140,14 +145,15 @@ class SchemaMetaDataLoaderTest {
     void assertLoadSchemaTableNamesWithWildcardIncludedTables() throws SQLException {
         DialectSchemaOption schemaOption = mock(DialectSchemaOption.class);
         when(schemaOption.getDefaultSchema()).thenReturn(Optional.empty());
+        when(schemaOption.getSchema(any())).thenReturn("public");
         DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class);
         when(dialectDatabaseMetaData.getSchemaOption()).thenReturn(schemaOption);
+        when(dialectDatabaseMetaData.getIdentifierPatternType()).thenReturn(IdentifierPatternType.KEEP_ORIGIN);
         try (MockedStatic<DatabaseTypedSPILoader> databaseTypedSPILoader = mockStatic(DatabaseTypedSPILoader.class)) {
             databaseTypedSPILoader.when(() -> DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, databaseType)).thenReturn(dialectDatabaseMetaData);
             try (MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class)) {
                 typedSPILoader.when(() -> TypedSPILoader.getService(DialectDatabaseMetaData.class, null)).thenReturn(dialectDatabaseMetaData);
                 Connection connection = dataSourceWithoutDefaultSchema.getConnection();
-                when(schemaOption.getSchema(connection)).thenReturn("public");
                 when(connection.getCatalog()).thenReturn("catalog");
                 ResultSet tableResultSet = mock(ResultSet.class);
                 when(tableResultSet.next()).thenReturn(true, true, false);

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/type/DatabaseTypeRegistryTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/type/DatabaseTypeRegistryTest.java
@@ -60,16 +60,16 @@ class DatabaseTypeRegistryTest {
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("getDefaultSchemaNameWithIdentifierPatternArguments")
-    void assertGetDefaultSchemaNameWithIdentifierPattern(final String name, final IdentifierPatternType identifierPatternType, final boolean schemaAvailable,
+    void assertGetDefaultSchemaNameWithIdentifierPattern(final String name, final IdentifierPatternType identifierPatternType,
                                                          final String databaseName, final String expectedSchemaName) throws ReflectiveOperationException {
-        DatabaseTypeRegistry databaseTypeRegistry = createDatabaseTypeRegistry(identifierPatternType, schemaAvailable, null);
+        DatabaseTypeRegistry databaseTypeRegistry = createDatabaseTypeRegistry(identifierPatternType, null);
         assertThat(databaseTypeRegistry.getDefaultSchemaName(databaseName), is(expectedSchemaName));
     }
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("formatIdentifierPatternArguments")
     void assertFormatIdentifierPattern(final String name, final IdentifierPatternType identifierPatternType, final String expectedIdentifierPattern) throws ReflectiveOperationException {
-        DatabaseTypeRegistry databaseTypeRegistry = createDatabaseTypeRegistry(identifierPatternType, false, null);
+        DatabaseTypeRegistry databaseTypeRegistry = createDatabaseTypeRegistry(identifierPatternType, null);
         assertThat(databaseTypeRegistry.formatIdentifierPattern("Foo"), is(expectedIdentifierPattern));
     }
     
@@ -82,12 +82,10 @@ class DatabaseTypeRegistryTest {
     
     private static Stream<Arguments> getDefaultSchemaNameWithIdentifierPatternArguments() {
         return Stream.of(
-                Arguments.of("schema available upper case identifier pattern formats default schema", IdentifierPatternType.UPPER_CASE, true, "foo_db", "FOO_DB"),
-                Arguments.of("schema available lower case identifier pattern formats default schema", IdentifierPatternType.LOWER_CASE, true, "FOO_DB", "foo_db"),
-                Arguments.of("schema available keep origin identifier pattern keeps default schema", IdentifierPatternType.KEEP_ORIGIN, true, "Foo_Db", "Foo_Db"),
-                Arguments.of("schema unavailable upper case identifier pattern keeps database name", IdentifierPatternType.UPPER_CASE, false, "logical_db", "logical_db"),
-                Arguments.of("schema unavailable keep origin identifier pattern keeps database name", IdentifierPatternType.KEEP_ORIGIN, false, "Logical_DB", "Logical_DB"),
-                Arguments.of("null database name keeps null default schema", IdentifierPatternType.UPPER_CASE, false, null, null));
+                Arguments.of("upper case identifier pattern formats default schema", IdentifierPatternType.UPPER_CASE, "foo_db", "FOO_DB"),
+                Arguments.of("lower case identifier pattern formats default schema", IdentifierPatternType.LOWER_CASE, "FOO_DB", "foo_db"),
+                Arguments.of("keep origin identifier pattern keeps default schema", IdentifierPatternType.KEEP_ORIGIN, "Foo_Db", "Foo_Db"),
+                Arguments.of("null database name keeps null default schema", IdentifierPatternType.UPPER_CASE, null, null));
     }
     
     private static Stream<Arguments> formatIdentifierPatternArguments() {
@@ -97,11 +95,10 @@ class DatabaseTypeRegistryTest {
                 Arguments.of("identifier pattern keep origin", IdentifierPatternType.KEEP_ORIGIN, "Foo"));
     }
     
-    private DatabaseTypeRegistry createDatabaseTypeRegistry(final IdentifierPatternType identifierPatternType, final boolean schemaAvailable,
-                                                            final String defaultSchema) throws ReflectiveOperationException {
+    private DatabaseTypeRegistry createDatabaseTypeRegistry(final IdentifierPatternType identifierPatternType, final String defaultSchema) throws ReflectiveOperationException {
         DatabaseTypeRegistry result = new DatabaseTypeRegistry(trunkDatabaseType);
         Plugins.getMemberAccessor().set(DatabaseTypeRegistry.class.getDeclaredField("dialectDatabaseMetaData"),
-                result, new FixtureDialectDatabaseMetaData(identifierPatternType, schemaAvailable, defaultSchema));
+                result, new FixtureDialectDatabaseMetaData(identifierPatternType, defaultSchema));
         return result;
     }
     
@@ -111,9 +108,9 @@ class DatabaseTypeRegistryTest {
         
         private final DefaultSchemaOption schemaOption;
         
-        private FixtureDialectDatabaseMetaData(final IdentifierPatternType identifierPatternType, final boolean schemaAvailable, final String defaultSchema) {
+        private FixtureDialectDatabaseMetaData(final IdentifierPatternType identifierPatternType, final String defaultSchema) {
             this.identifierPatternType = identifierPatternType;
-            schemaOption = new DefaultSchemaOption(schemaAvailable, defaultSchema);
+            schemaOption = new DefaultSchemaOption(false, defaultSchema);
         }
         
         @Override

--- a/database/connector/dialect/firebird/src/test/java/org/apache/shardingsphere/database/connector/firebird/metadata/data/loader/FirebirdSchemaMetaDataLoaderTest.java
+++ b/database/connector/dialect/firebird/src/test/java/org/apache/shardingsphere/database/connector/firebird/metadata/data/loader/FirebirdSchemaMetaDataLoaderTest.java
@@ -80,7 +80,7 @@ class FirebirdSchemaMetaDataLoaderTest {
     
     @Test
     void assertLoadSchemaTableNames() throws SQLException {
-        Map<String, Collection<String>> schemaTableNames = Collections.singletonMap("foo_db", new CaseInsensitiveSet<>(Arrays.asList("tbl", "partitioned_tbl")));
+        Map<String, Collection<String>> schemaTableNames = Collections.singletonMap("FOO_DB", new CaseInsensitiveSet<>(Arrays.asList("tbl", "partitioned_tbl")));
         assertThat(new SchemaMetaDataLoader(databaseType).loadSchemaTableNames("foo_db", dataSource, Collections.emptySet(), Collections.emptySet()), is(schemaTableNames));
     }
     

--- a/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/identifier/OracleIdentifierCaseRuleProvider.java
+++ b/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/identifier/OracleIdentifierCaseRuleProvider.java
@@ -17,15 +17,11 @@
 
 package org.apache.shardingsphere.database.connector.oracle.metadata.identifier;
 
-import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRule;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleProvider;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleProviderContext;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSet;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSets;
-import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 
-import java.util.EnumMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -37,9 +33,7 @@ public final class OracleIdentifierCaseRuleProvider implements IdentifierCaseRul
     @Override
     public Optional<IdentifierCaseRuleSet> provide(final IdentifierCaseRuleProviderContext context) {
         Objects.requireNonNull(context, "context cannot be null.");
-        Map<IdentifierScope, IdentifierCaseRule> scopedRules = new EnumMap<>(IdentifierScope.class);
-        scopedRules.put(IdentifierScope.SCHEMA, IdentifierCaseRuleSets.newInsensitiveRuleSet().getRule(IdentifierScope.SCHEMA));
-        return Optional.of(new IdentifierCaseRuleSet(IdentifierCaseRuleSets.newUpperCaseRuleSet().getRule(IdentifierScope.TABLE), scopedRules));
+        return Optional.of(IdentifierCaseRuleSets.newUpperCaseRuleSet());
     }
     
     @Override

--- a/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/identifier/OracleIdentifierCaseRuleProviderTest.java
+++ b/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/identifier/OracleIdentifierCaseRuleProviderTest.java
@@ -53,12 +53,4 @@ class OracleIdentifierCaseRuleProviderTest {
         assertTrue(actual.matches("FOO", "foo", QuoteCharacter.NONE));
         assertFalse(actual.matches("Foo", "foo", QuoteCharacter.NONE));
     }
-    
-    @Test
-    void assertProvideSchemaRule() {
-        IdentifierCaseRule actual = provider.provide(new IdentifierCaseRuleProviderContext(databaseType, null)).orElseThrow(AssertionError::new).getRule(IdentifierScope.SCHEMA);
-        assertThat(actual.getLookupMode(QuoteCharacter.NONE), is(LookupMode.NORMALIZED));
-        assertTrue(actual.matches("foo_schema", "FOO_SCHEMA", QuoteCharacter.NONE));
-        assertTrue(actual.matches("FOO_SCHEMA", "foo_schema", QuoteCharacter.NONE));
-    }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
@@ -151,7 +151,7 @@ class DataNodeTest {
                 Arguments.of("mysql_without_schema_support", "test_db", MYSQL_DATABASE_TYPE, "ds.tbl", "ds", "test_db", "tbl"),
                 Arguments.of("mysql_three_segments_kept_as_table_suffix", "test_db", MYSQL_DATABASE_TYPE, "ds.schema.tbl", "ds", "test_db", "schema.tbl"),
                 Arguments.of("postgresql_preserves_table_case", "test_db", POSTGRESQL_DATABASE_TYPE, "ds.schema.TABLE", "ds", "schema", "TABLE"),
-                Arguments.of("oracle_keeps_database_schema", "logic_db", ORACLE_DATABASE_TYPE, "ds.tbl", "ds", "logic_db", "tbl"));
+                Arguments.of("oracle_normalizes_database_schema", "logic_db", ORACLE_DATABASE_TYPE, "ds.tbl", "ds", "LOGIC_DB", "tbl"));
     }
     
     private static Stream<Arguments> formatArguments() {

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilderTest.java
@@ -22,7 +22,6 @@ import org.apache.shardingsphere.database.connector.core.metadata.data.model.Sch
 import org.apache.shardingsphere.database.connector.core.metadata.data.model.TableMetaData;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
-import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
 import org.apache.shardingsphere.infra.metadata.database.resource.unit.StorageUnit;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContextFactory;
@@ -141,42 +140,6 @@ class GenericSchemaBuilderTest {
         assertTrue(actualSchema.getAllTables().isEmpty());
         assertNull(actualSchema.getTable("foo_tbl"));
         assertThat(actualSchema.getName(), is("foo_schema"));
-    }
-    
-    @Test
-    void assertBuildWithMySQLProtocolAndOracleStorage() throws SQLException {
-        DatabaseType protocolType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
-        DatabaseType storageType = TypedSPILoader.getService(DatabaseType.class, "Oracle");
-        GenericSchemaBuilderMaterial newMaterial = createMaterial(storageType, protocolType);
-        when(MetaDataLoader.load(any())).thenReturn(createOracleSchemaMetaDataMap());
-        Map<String, ShardingSphereSchema> actual = GenericSchemaBuilder.build(Collections.singleton("t_log"), protocolType, newMaterial);
-        ShardingSphereSchema actualSchema = actual.get("logical_db");
-        assertThat(actualSchema.getName(), is("logical_db"));
-        assertThat(actualSchema.getAllTables().iterator().next().getName(), is("T_LOG"));
-    }
-    
-    @Test
-    void assertBuildWithOracleProtocolAndOracleStorage() throws SQLException {
-        DatabaseType protocolType = TypedSPILoader.getService(DatabaseType.class, "Oracle");
-        GenericSchemaBuilderMaterial newMaterial = createMaterial(protocolType, protocolType);
-        when(MetaDataLoader.load(any())).thenReturn(createOracleSchemaMetaDataMap());
-        Map<String, ShardingSphereSchema> actual = GenericSchemaBuilder.build(Collections.singleton("t_log"), protocolType, newMaterial);
-        ShardingSphereSchema actualSchema = actual.get("logical_db");
-        assertThat(actualSchema.getName(), is("logical_db"));
-        assertThat(actualSchema.getAllTables().iterator().next().getName(), is("T_LOG"));
-    }
-    
-    private GenericSchemaBuilderMaterial createMaterial(final DatabaseType storageType, final DatabaseType protocolType) {
-        StorageUnit storageUnit = mock(StorageUnit.class);
-        when(storageUnit.getStorageType()).thenReturn(storageType);
-        Map<String, StorageUnit> storageUnits = Collections.singletonMap("ds_0", storageUnit);
-        return new GenericSchemaBuilderMaterial(storageUnits, Collections.emptyList(), new ConfigurationProperties(new Properties()), "logical_db",
-                DatabaseIdentifierContextFactory.create(protocolType, new ResourceMetaData(Collections.emptyMap(), storageUnits), new ConfigurationProperties(new Properties())));
-    }
-    
-    private Map<String, SchemaMetaData> createOracleSchemaMetaDataMap() {
-        return Collections.singletonMap("logical_db", new SchemaMetaData("logical_db",
-                Collections.singleton(new TableMetaData("T_LOG", Collections.emptyList(), Collections.emptyList(), Collections.emptyList()))));
     }
     
     private Map<String, SchemaMetaData> createSchemaMetaDataMap(final Collection<String> tableNames, final GenericSchemaBuilderMaterial material) {

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -171,22 +171,6 @@ class DatabaseIdentifierContextFactoryTest {
         assertTrue(actualTableRule.matches("T_ORDER", "t_order", QuoteCharacter.NONE));
     }
     
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("createWithOracleUnavailableSchemaLookupArguments")
-    void assertCreateFindsOracleUnavailableSchemaInsensitive(final String name, final IdentifierValue lookupIdentifier) {
-        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
-        IdentifierIndex<String> schemaIndex = createIdentifierIndex(actual, IdentifierScope.SCHEMA, "logical_db");
-        assertThat(schemaIndex.find(lookupIdentifier), is(Optional.of("logical_db")));
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("createWithOracleTableLookupArguments")
-    void assertCreateFindsOracleTableUpperCase(final String name, final IdentifierValue lookupIdentifier) {
-        DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.create(ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, new ConfigurationProperties(new Properties()));
-        IdentifierIndex<String> tableIndex = createIdentifierIndex(actual, IdentifierScope.TABLE, "T_LOG");
-        assertThat(tableIndex.find(lookupIdentifier), is(Optional.of("T_LOG")));
-    }
-    
     @Test
     void assertRefreshUsesProtocolRuleForLogicalTableAndEnablesHeterogeneousLookup() {
         DatabaseIdentifierContext actual = DatabaseIdentifierContextFactory.createDefault();
@@ -458,20 +442,8 @@ class DatabaseIdentifierContextFactoryTest {
                 createNormalizedLookupArguments("mysql schema", MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, "foo_schema", "`"),
                 createInsensitiveQuotedExactLookupArguments("postgresql schema", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
                 createInsensitiveQuotedExactLookupArguments("openGauss schema", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
-                createInsensitiveQuotedExactLookupArguments("oracle schema", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_schema", "\""))
+                createUpperCaseLookupArguments("oracle schema", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_schema", "\""))
                 .flatMap(each -> each);
-    }
-    
-    private static Stream<Arguments> createWithOracleUnavailableSchemaLookupArguments() {
-        return Stream.of(
-                Arguments.of("oracle schema finds lower logical database", new IdentifierValue("logical_db")),
-                Arguments.of("oracle schema finds upper logical database", new IdentifierValue("LOGICAL_DB")));
-    }
-    
-    private static Stream<Arguments> createWithOracleTableLookupArguments() {
-        return Stream.of(
-                Arguments.of("oracle table finds lower lookup", new IdentifierValue("t_log")),
-                Arguments.of("oracle table finds upper lookup", new IdentifierValue("T_LOG")));
     }
     
     private static Stream<Arguments> createWithSupportedDatabaseTableLookupArguments() {
@@ -527,7 +499,7 @@ class DatabaseIdentifierContextFactoryTest {
                 createNormalizedMixedLookupArguments("mysql schema", MYSQL_DATABASE_TYPE, MYSQL_INSENSITIVE_RESOURCE_META_DATA, "foo_schema", "`"),
                 createInsensitiveQuotedExactMixedLookupArguments("postgresql schema", POSTGRESQL_DATABASE_TYPE, POSTGRESQL_RESOURCE_META_DATA, "foo_schema", "\""),
                 createInsensitiveQuotedExactMixedLookupArguments("openGauss schema", OPEN_GAUSS_DATABASE_TYPE, OPEN_GAUSS_RESOURCE_META_DATA, "foo_schema", "\""),
-                createInsensitiveQuotedExactMixedLookupArguments("oracle schema", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_schema", "\""))
+                createUpperCaseMixedLookupArguments("oracle schema", ORACLE_DATABASE_TYPE, ORACLE_RESOURCE_META_DATA, "foo_schema", "\""))
                 .flatMap(each -> each);
     }
     

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/metadata/DatabaseMetaDataPersistFacadeTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/metadata/DatabaseMetaDataPersistFacadeTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mode.metadata.persist.metadata;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DefaultSchemaOption;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
@@ -230,6 +231,7 @@ class DatabaseMetaDataPersistFacadeTest {
     private DialectDatabaseMetaData createDialectDatabaseMetaData() {
         DialectDatabaseMetaData result = mock(DialectDatabaseMetaData.class);
         when(result.getSchemaOption()).thenReturn(new DefaultSchemaOption(false, null));
+        when(result.getIdentifierPatternType()).thenReturn(IdentifierPatternType.KEEP_ORIGIN);
         return result;
     }
     

--- a/test/it/binder/src/test/resources/cases/dml/select-function.xml
+++ b/test/it/binder/src/test/resources/cases/dml/select-function.xml
@@ -43,7 +43,7 @@
                                                                                     <owner name="i" start-index="46" stop-index="46" />
                                                                                     <column-bound>
                                                                                         <original-database name="foo_db_1" />
-                                                                                        <original-schema name="foo_db_1" />
+                                                                                        <original-schema name="FOO_DB_1" />
                                                                                         <original-table name="t_order_item" />
                                                                                         <original-column name="item_id" start-delimiter="&quot;" end-delimiter="&quot;" />
                                                                                         <table-source-type name="PHYSICAL_TABLE"/>
@@ -54,7 +54,7 @@
                                                                                 <simple-table name="t_order_item" alias="i" start-index="61" stop-index="74">
                                                                                     <table-bound>
                                                                                         <original-database name="foo_db_1" />
-                                                                                        <original-schema name="foo_db_1" />
+                                                                                        <original-schema name="FOO_DB_1" />
                                                                                     </table-bound>
                                                                                 </simple-table>
                                                                             </from>
@@ -66,7 +66,7 @@
                                                                                                 <owner name="i" start-index="82" stop-index="82" />
                                                                                                 <column-bound>
                                                                                                     <original-database name="foo_db_1" />
-                                                                                                <original-schema name="foo_db_1" />
+                                                                                                    <original-schema name="FOO_DB_1" />
                                                                                                     <original-table name="t_order_item" />
                                                                                                     <original-column name="item_id" start-delimiter="&quot;" end-delimiter="&quot;" />
                                                                                                     <table-source-type name="PHYSICAL_TABLE"/>
@@ -117,7 +117,7 @@
             <simple-table name="DUAL" start-index="151" stop-index="154">
                 <table-bound>
                     <original-database name="foo_db_1" />
-                    <original-schema name="foo_db_1" />
+                    <original-schema name="FOO_DB_1" />
                 </table-bound>
             </simple-table>
         </from>

--- a/test/it/binder/src/test/resources/cases/dml/select.xml
+++ b/test/it/binder/src/test/resources/cases/dml/select.xml
@@ -1558,7 +1558,7 @@
                     <simple-table alias="o" name="t_order" start-index="23" stop-index="31">
                         <table-bound start-index="0" stop-index="0">
                             <original-database name="foo_db_1" start-index="0" stop-index="0"/>
-                            <original-schema name="foo_db_1" start-index="0" stop-index="0"/>
+                            <original-schema name="FOO_DB_1" start-index="0" stop-index="0"/>
                         </table-bound>
                     </simple-table>
                 </left>
@@ -1566,7 +1566,7 @@
                     <simple-table alias="i" name="t_order_item" start-index="34" stop-index="47">
                         <table-bound start-index="0" stop-index="0">
                             <original-database name="foo_db_1" start-index="0" stop-index="0"/>
-                            <original-schema name="foo_db_1" start-index="0" stop-index="0"/>
+                            <original-schema name="FOO_DB_1" start-index="0" stop-index="0"/>
                         </table-bound>
                     </simple-table>
                 </right>
@@ -1585,7 +1585,7 @@
                             <owner name="o" start-index="55" stop-index="55"/>
                             <column-bound start-index="0" stop-index="0">
                                 <original-database name="foo_db_1" start-index="0" stop-index="0"/>
-                                <original-schema name="foo_db_1" start-index="0" stop-index="0"/>
+                                <original-schema name="FOO_DB_1" start-index="0" stop-index="0"/>
                                 <original-table name="t_order" start-index="0" stop-index="0"/>
                                 <original-column name="order_id" start-delimiter="&quot;" end-delimiter="&quot;" start-index="0" stop-index="0"/>
                                 <table-source-type name="PHYSICAL_TABLE" start-index="0" stop-index="0"/>
@@ -1599,7 +1599,7 @@
                                 <owner name="i" start-index="68" stop-index="68"/>
                                 <column-bound start-index="0" stop-index="0">
                                     <original-database name="foo_db_1" start-index="0" stop-index="0"/>
-                                    <original-schema name="foo_db_1" start-index="0" stop-index="0"/>
+                                    <original-schema name="FOO_DB_1" start-index="0" stop-index="0"/>
                                     <original-table name="t_order_item" start-index="0" stop-index="0"/>
                                     <original-column name="order_id" start-delimiter="&quot;" end-delimiter="&quot;" start-index="0" stop-index="0"/>
                                     <table-source-type name="PHYSICAL_TABLE" start-index="0" stop-index="0"/>


### PR DESCRIPTION

This reverts commit db5f49f744adb408cb6d449f49aa23c211546118.

Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
