### PR TITLE
DistSQL: Fix case-sensitive matching for SHOW RULES USED STORAGE UNIT

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -27,6 +27,7 @@
 1. Pipeline: Fix escape MySQL JSON binlog control characters - [#38800](https://github.com/apache/shardingsphere/pull/38800)
 1. Sharding: Support ORDER BY MySQL VARBINARY column by wrapping byte[] values in a Comparable adapter - [#38699](https://github.com/apache/shardingsphere/pull/38699)
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)
+1. DistSQL: Fix case-sensitive storage unit matching in `SHOW RULES USED STORAGE UNIT` - [#38848](https://github.com/apache/shardingsphere/pull/38848)
 
 ### Enhancements
 

--- a/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/InUsedReadwriteSplittingStorageUnitRetriever.java
+++ b/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/InUsedReadwriteSplittingStorageUnitRetriever.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.readwritesplitting.distsql.handler.query;
 
-import com.cedarsoftware.util.CaseInsensitiveSet;
 import org.apache.shardingsphere.distsql.handler.executor.rql.resource.InUsedStorageUnitRetriever;
 import org.apache.shardingsphere.distsql.statement.type.rql.rule.database.ShowRulesUsedStorageUnitStatement;
 import org.apache.shardingsphere.readwritesplitting.config.rule.ReadwriteSplittingDataSourceGroupRuleConfiguration;
@@ -35,10 +34,10 @@ public final class InUsedReadwriteSplittingStorageUnitRetriever implements InUse
     public Collection<String> getInUsedResources(final ShowRulesUsedStorageUnitStatement sqlStatement, final ReadwriteSplittingRule rule) {
         Collection<String> result = new HashSet<>(1, 1F);
         for (ReadwriteSplittingDataSourceGroupRuleConfiguration each : rule.getConfiguration().getDataSourceGroups()) {
-            if (each.getWriteDataSourceName().equalsIgnoreCase(sqlStatement.getStorageUnitName())) {
+            if (sqlStatement.getStorageUnitName().equals(each.getWriteDataSourceName())) {
                 result.add(each.getName());
             }
-            if (new CaseInsensitiveSet<>(each.getReadDataSourceNames()).contains(sqlStatement.getStorageUnitName())) {
+            if (each.getReadDataSourceNames().contains(sqlStatement.getStorageUnitName())) {
                 result.add(each.getName());
             }
         }

--- a/features/readwrite-splitting/distsql/handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/InUsedReadwriteSplittingStorageUnitRetrieverTest.java
+++ b/features/readwrite-splitting/distsql/handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/InUsedReadwriteSplittingStorageUnitRetrieverTest.java
@@ -49,6 +49,12 @@ class InUsedReadwriteSplittingStorageUnitRetrieverTest {
         assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.singleton("foo_ds")));
     }
     
+    @Test
+    void assertGetInUsedResourcesWithDifferentCaseDataSource() {
+        ShowRulesUsedStorageUnitStatement sqlStatement = new ShowRulesUsedStorageUnitStatement("FOO_UNIT_READ", null);
+        assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.emptySet()));
+    }
+    
     private ReadwriteSplittingRule mockRule() {
         ReadwriteSplittingRule result = mock(ReadwriteSplittingRule.class, RETURNS_DEEP_STUBS);
         ReadwriteSplittingDataSourceGroupRuleConfiguration dataSourceGroupRuleConfig = new ReadwriteSplittingDataSourceGroupRuleConfiguration(

--- a/features/shadow/distsql/handler/src/main/java/org/apache/shardingsphere/shadow/distsql/handler/query/InUsedShadowStorageUnitRetriever.java
+++ b/features/shadow/distsql/handler/src/main/java/org/apache/shardingsphere/shadow/distsql/handler/query/InUsedShadowStorageUnitRetriever.java
@@ -33,8 +33,8 @@ public final class InUsedShadowStorageUnitRetriever implements InUsedStorageUnit
     @Override
     public Collection<String> getInUsedResources(final ShowRulesUsedStorageUnitStatement sqlStatement, final ShadowRule rule) {
         return rule.getConfiguration().getDataSources().stream()
-                .filter(each -> each.getShadowDataSourceName().equalsIgnoreCase(sqlStatement.getStorageUnitName())
-                        || each.getProductionDataSourceName().equalsIgnoreCase(sqlStatement.getStorageUnitName()))
+                .filter(each -> each.getShadowDataSourceName().equals(sqlStatement.getStorageUnitName())
+                        || each.getProductionDataSourceName().equals(sqlStatement.getStorageUnitName()))
                 .map(ShadowDataSourceConfiguration::getName).collect(Collectors.toList());
     }
     

--- a/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/handler/query/InUsedShadowStorageUnitRetrieverTest.java
+++ b/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/handler/query/InUsedShadowStorageUnitRetrieverTest.java
@@ -38,15 +38,21 @@ class InUsedShadowStorageUnitRetrieverTest {
     private final InUsedStorageUnitRetriever<ShadowRule> retriever = TypedSPILoader.getService(InUsedStorageUnitRetriever.class, ShadowRule.class);
     
     @Test
-    void assertGetInUsedResourcesWithShadowDataSource() {
+    void assertGetInUsedResourcesWithProductionDataSource() {
         ShowRulesUsedStorageUnitStatement sqlStatement = new ShowRulesUsedStorageUnitStatement("prod_ds", null);
         assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.singletonList("foo_ds")));
     }
     
     @Test
-    void assertGetInUsedResourcesWithProductionDataSource() {
+    void assertGetInUsedResourcesWithShadowDataSource() {
         ShowRulesUsedStorageUnitStatement sqlStatement = new ShowRulesUsedStorageUnitStatement("shadow_ds", null);
         assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.singletonList("foo_ds")));
+    }
+    
+    @Test
+    void assertGetInUsedResourcesWithDifferentCaseDataSource() {
+        ShowRulesUsedStorageUnitStatement sqlStatement = new ShowRulesUsedStorageUnitStatement("PROD_DS", null);
+        assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.emptyList()));
     }
     
     private ShadowRule mockRule() {

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/query/InUsedShardingStorageUnitRetriever.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/query/InUsedShardingStorageUnitRetriever.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.sharding.distsql.handler.query;
 
-import com.cedarsoftware.util.CaseInsensitiveSet;
 import org.apache.shardingsphere.distsql.handler.executor.rql.resource.InUsedStorageUnitRetriever;
 import org.apache.shardingsphere.distsql.statement.type.rql.rule.database.ShowRulesUsedStorageUnitStatement;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
@@ -35,7 +34,7 @@ public final class InUsedShardingStorageUnitRetriever implements InUsedStorageUn
     public Collection<String> getInUsedResources(final ShowRulesUsedStorageUnitStatement sqlStatement, final ShardingRule rule) {
         Collection<String> result = new HashSet<>(rule.getShardingTables().size(), 1F);
         for (ShardingTable each : rule.getShardingTables().values()) {
-            if (new CaseInsensitiveSet<>(each.getActualDataSourceNames()).contains(sqlStatement.getStorageUnitName())) {
+            if (each.getActualDataSourceNames().contains(sqlStatement.getStorageUnitName())) {
                 result.add(each.getLogicTable());
             }
         }

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/handler/query/InUsedShardingStorageUnitRetrieverTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/handler/query/InUsedShardingStorageUnitRetrieverTest.java
@@ -43,6 +43,12 @@ class InUsedShardingStorageUnitRetrieverTest {
         assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.singleton("foo_tbl")));
     }
     
+    @Test
+    void assertGetInUsedResourcesWithDifferentCaseStorageUnit() {
+        ShowRulesUsedStorageUnitStatement sqlStatement = new ShowRulesUsedStorageUnitStatement("FOO_DS", null);
+        assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.emptySet()));
+    }
+    
     private ShardingRule mockRule() {
         ShardingRule result = mock(ShardingRule.class);
         ShardingTable fooTbl = mock(ShardingTable.class);

--- a/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/query/InUsedSingleStorageUnitRetriever.java
+++ b/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/query/InUsedSingleStorageUnitRetriever.java
@@ -39,7 +39,7 @@ public final class InUsedSingleStorageUnitRetriever implements InUsedStorageUnit
         Collection<String> result = new HashSet<>(dataNodes.size(), 1F);
         for (Collection<DataNode> each : dataNodes.values()) {
             String storageUnitName = each.iterator().next().getDataSourceName();
-            if (storageUnitName.equalsIgnoreCase(sqlStatement.getStorageUnitName())) {
+            if (sqlStatement.getStorageUnitName().equals(storageUnitName)) {
                 result.add(each.iterator().next().getTableName());
             }
         }

--- a/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/InUsedSingleStorageUnitRetrieverTest.java
+++ b/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/InUsedSingleStorageUnitRetrieverTest.java
@@ -44,6 +44,12 @@ class InUsedSingleStorageUnitRetrieverTest {
         assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.singleton("foo_table")));
     }
     
+    @Test
+    void assertGetInUsedResourcesWithDifferentCaseStorageUnit() {
+        ShowRulesUsedStorageUnitStatement sqlStatement = new ShowRulesUsedStorageUnitStatement("FOO_DS", null);
+        assertThat(retriever.getInUsedResources(sqlStatement, mockRule()), is(Collections.emptySet()));
+    }
+    
     private SingleRule mockRule() {
         SingleRule result = mock(SingleRule.class);
         SingleDataNodeRuleAttribute attribute = mock(SingleDataNodeRuleAttribute.class);


### PR DESCRIPTION
Fixes #38846.

  ### Motivation

  `storageUnitName` is documented as case-sensitive for `REGISTER STORAGE UNIT`, and the `SHOW RULES USED STORAGE UNIT` executor already checks storage unit
  existence with exact key matching.

  However, the rule-specific retrievers used by `SHOW RULES USED STORAGE UNIT` matched storage unit names case-insensitively. When storage units such as `ds_0`
  and `DS_0` existed at the same time, the statement could not distinguish the requested storage unit correctly.

  ### Changes

  - Use exact storage unit name matching in `SHOW RULES USED STORAGE UNIT` retrievers for:
    - Readwrite-splitting rule
    - Sharding rule
    - Shadow rule
    - Single rule
  - Remove unnecessary case-insensitive matching from the affected retrievers.
  - Add regression tests for storage unit names that differ only by case.

  ### Compatibility

  This restores the documented case-sensitive storage unit name behavior.

  No SQL grammar, DistSQL syntax, API/SPI contract, configuration format, metadata storage format, or protocol behavior is changed.

  ### Verification

  - `./mvnw -pl features/readwrite-splitting/distsql/handler -DskipITs -Dspotless.skip=true -Dtest=InUsedReadwriteSplittingStorageUnitRetrieverTest
  -DfailIfNoTests=true -Dsurefire.failIfNoSpecifiedTests=false test`
  - `./mvnw -pl features/sharding/distsql/handler -DskipITs -Dspotless.skip=true -Dtest=InUsedShardingStorageUnitRetrieverTest -DfailIfNoTests=true
  -Dsurefire.failIfNoSpecifiedTests=false test`
  - `./mvnw -pl features/shadow/distsql/handler -DskipITs -Dspotless.skip=true -Dtest=InUsedShadowStorageUnitRetrieverTest -DfailIfNoTests=true
  -Dsurefire.failIfNoSpecifiedTests=false test`
  - `./mvnw -pl kernel/single/distsql/handler -DskipITs -Dspotless.skip=true -Dtest=InUsedSingleStorageUnitRetrieverTest -DfailIfNoTests=true
  -Dsurefire.failIfNoSpecifiedTests=false test`
  - `./mvnw -pl features/readwrite-splitting/distsql/handler,features/sharding/distsql/handler,features/shadow/distsql/handler,kernel/single/distsql/handler
  -am -DskipITs -Dspotless.skip=true
  -Dtest=InUsedReadwriteSplittingStorageUnitRetrieverTest,InUsedShardingStorageUnitRetrieverTest,InUsedShadowStorageUnitRetrieverTest,InUsedSingleStorageUnitRe
  trieverTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
  - `./mvnw -pl features/readwrite-splitting/distsql/handler,features/sharding/distsql/handler,features/shadow/distsql/handler,kernel/single/distsql/handler
  spotless:check -Pcheck -T1C`
  - `./mvnw -pl features/readwrite-splitting/distsql/handler,features/sharding/distsql/handler,features/shadow/distsql/handler,kernel/single/distsql/handler
  checkstyle:check -Pcheck -T1C`