### PR TITLE
Refactor FirebirdFetchStatementCommandExecutor

### DIFF
--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutor.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.statement.fetch;
 
-import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.database.protocol.binary.BinaryCell;
 import org.apache.shardingsphere.database.protocol.binary.BinaryRow;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.FirebirdBinaryColumnType;
@@ -28,45 +27,67 @@ import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.response.data.QueryResponseCell;
 import org.apache.shardingsphere.proxy.backend.response.data.QueryResponseRow;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
-import org.apache.shardingsphere.proxy.frontend.command.executor.CommandExecutor;
+import org.apache.shardingsphere.proxy.frontend.command.executor.QueryCommandExecutor;
+import org.apache.shardingsphere.proxy.frontend.command.executor.ResponseType;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.Collections;
 import java.util.List;
 
 /**
  * Firebird fetch statement command executor.
  */
-@RequiredArgsConstructor
-public final class FirebirdFetchStatementCommandExecutor implements CommandExecutor {
+public final class FirebirdFetchStatementCommandExecutor implements QueryCommandExecutor {
     
     private final FirebirdFetchStatementPacket packet;
     
     private final ConnectionSession connectionSession;
     
+    private final ProxyBackendHandler proxyBackendHandler;
+    
+    private int fetchCount;
+    
+    public FirebirdFetchStatementCommandExecutor(final FirebirdFetchStatementPacket packet, final ConnectionSession connectionSession) {
+        this.packet = packet;
+        this.connectionSession = connectionSession;
+        proxyBackendHandler = FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(connectionSession.getConnectionId(), packet.getStatementId());
+    }
+    
     @Override
     public Collection<DatabasePacket> execute() throws SQLException {
-        Collection<DatabasePacket> result = new LinkedList<>();
-        ProxyBackendHandler proxyBackendHandler = FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(connectionSession.getConnectionId(), packet.getStatementId());
-        if (null == proxyBackendHandler) {
-            result.add(FirebirdFetchResponsePacket.getFetchNoMoreRowsPacket());
-            return result;
+        if (proxyBackendHandler == null) {
+            fetchCount = packet.getFetchSize() + 1;
+            return Collections.singletonList(FirebirdFetchResponsePacket.getFetchNoMoreRowsPacket());
         }
-        for (int i = 0; i < packet.getFetchSize(); i++) {
+        return Collections.singletonList(getQueryRowPacket());
+    }
+    
+    @Override
+    public ResponseType getResponseType() {
+        return ResponseType.QUERY;
+    }
+    
+    @Override
+    public boolean next() throws SQLException {
+        return fetchCount <= packet.getFetchSize();
+    }
+    
+    @Override
+    public DatabasePacket getQueryRowPacket() throws SQLException {
+        fetchCount++;
+        if (fetchCount <= packet.getFetchSize()) {
             if (proxyBackendHandler.next()) {
-                QueryResponseRow queryResponseRow = proxyBackendHandler.getRowData();
-                BinaryRow row = createBinaryRow(queryResponseRow);
-                result.add(FirebirdFetchResponsePacket.getFetchRowPacket(row));
+                BinaryRow row = createBinaryRow(proxyBackendHandler.getRowData());
+                return FirebirdFetchResponsePacket.getFetchRowPacket(row);
             } else {
                 connectionSession.getDatabaseConnectionManager().unmarkResourceInUse(proxyBackendHandler);
-                result.add(FirebirdFetchResponsePacket.getFetchNoMoreRowsPacket());
-                return result;
+                fetchCount = packet.getFetchSize() + 1;
+                return FirebirdFetchResponsePacket.getFetchNoMoreRowsPacket();
             }
         }
-        result.add(FirebirdFetchResponsePacket.getFetchEndPacket());
-        return result;
+        return FirebirdFetchResponsePacket.getFetchEndPacket();
     }
     
     private BinaryRow createBinaryRow(final QueryResponseRow queryResponseRow) {

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutor.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutor.java
@@ -41,8 +41,6 @@ import java.util.List;
  */
 public final class FirebirdFetchStatementCommandExecutor implements QueryCommandExecutor {
     
-    private final FirebirdFetchStatementPacket packet;
-    
     private final ConnectionSession connectionSession;
     
     private final ProxyBackendHandler proxyBackendHandler;
@@ -50,15 +48,15 @@ public final class FirebirdFetchStatementCommandExecutor implements QueryCommand
     private int fetchCount;
     
     public FirebirdFetchStatementCommandExecutor(final FirebirdFetchStatementPacket packet, final ConnectionSession connectionSession) {
-        this.packet = packet;
         this.connectionSession = connectionSession;
         proxyBackendHandler = FirebirdFetchStatementCache.getInstance().getFetchBackendHandler(connectionSession.getConnectionId(), packet.getStatementId());
+        fetchCount = packet.getFetchSize();
     }
     
     @Override
     public Collection<DatabasePacket> execute() throws SQLException {
         if (proxyBackendHandler == null) {
-            fetchCount = packet.getFetchSize() + 1;
+            fetchCount = -1;
             return Collections.singletonList(FirebirdFetchResponsePacket.getFetchNoMoreRowsPacket());
         }
         return Collections.singletonList(getQueryRowPacket());
@@ -71,19 +69,19 @@ public final class FirebirdFetchStatementCommandExecutor implements QueryCommand
     
     @Override
     public boolean next() throws SQLException {
-        return fetchCount <= packet.getFetchSize();
+        return 0 <= fetchCount;
     }
     
     @Override
     public DatabasePacket getQueryRowPacket() throws SQLException {
-        fetchCount++;
-        if (fetchCount <= packet.getFetchSize()) {
+        fetchCount--;
+        if (0 <= fetchCount) {
             if (proxyBackendHandler.next()) {
                 BinaryRow row = createBinaryRow(proxyBackendHandler.getRowData());
                 return FirebirdFetchResponsePacket.getFetchRowPacket(row);
             } else {
                 connectionSession.getDatabaseConnectionManager().unmarkResourceInUse(proxyBackendHandler);
-                fetchCount = packet.getFetchSize() + 1;
+                fetchCount = -1;
                 return FirebirdFetchResponsePacket.getFetchNoMoreRowsPacket();
             }
         }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.proxy.backend.response.data.QueryResponseCell;
 import org.apache.shardingsphere.proxy.backend.response.data.QueryResponseRow;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.connector.ProxyDatabaseConnectionManager;
+import org.apache.shardingsphere.proxy.frontend.command.executor.ResponseType;
 import org.firebirdsql.gds.ISCConstants;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +43,8 @@ import java.util.Iterator;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -96,50 +99,72 @@ class FirebirdFetchStatementCommandExecutorTest {
     }
     
     @Test
-    void assertExecuteWithRowsAndFetchEnd() throws SQLException {
-        FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
-        when(packet.getFetchSize()).thenReturn(2);
-        QueryResponseRow responseRow = new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.INTEGER, 1)));
-        when(proxyBackendHandler.next()).thenReturn(true, true);
-        when(proxyBackendHandler.getRowData()).thenReturn(responseRow, responseRow);
+    void assertGetResponseType() {
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
-        Collection<DatabasePacket> actualPackets = executor.execute();
-        Iterator<DatabasePacket> packetIterator = actualPackets.iterator();
-        FirebirdFetchResponsePacket actualFirstPacket = (FirebirdFetchResponsePacket) packetIterator.next();
-        assertThat(actualPackets.size(), is(3));
-        assertThat(actualFirstPacket.getStatus(), is(ISCConstants.FETCH_OK));
-        assertThat(actualFirstPacket.getCount(), is(1));
-        assertNotNull(actualFirstPacket.getRow());
-        FirebirdFetchResponsePacket actualSecondPacket = (FirebirdFetchResponsePacket) packetIterator.next();
-        assertThat(actualSecondPacket.getStatus(), is(ISCConstants.FETCH_OK));
-        assertThat(actualSecondPacket.getCount(), is(1));
-        assertNotNull(actualSecondPacket.getRow());
-        FirebirdFetchResponsePacket actualEndPacket = (FirebirdFetchResponsePacket) packetIterator.next();
-        assertThat(actualEndPacket.getStatus(), is(ISCConstants.FETCH_OK));
-        assertThat(actualEndPacket.getCount(), is(0));
-        assertNull(actualEndPacket.getRow());
+        assertThat(executor.getResponseType(), is(ResponseType.QUERY));
     }
     
     @Test
-    void assertExecuteStopsWhenRowsExhausted() throws SQLException {
+    void assertNextReturnsFalseWhenFetchCountExceeded() throws SQLException {
+        executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
+        executor.execute();
+        assertFalse(executor.next());
+    }
+    
+    @Test
+    void assertNextReturnsTrueWhenFetchCountNotExceeded() throws SQLException {
+        FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
+        when(packet.getFetchSize()).thenReturn(2);
+        when(proxyBackendHandler.next()).thenReturn(true);
+        QueryResponseRow responseRow = new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.INTEGER, 1)));
+        when(proxyBackendHandler.getRowData()).thenReturn(responseRow);
+        executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
+        executor.execute();
+        assertTrue(executor.next());
+    }
+    
+    @Test
+    void assertExecuteWhenBackendHandlerReturnsRow() throws SQLException {
         FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
         when(packet.getFetchSize()).thenReturn(2);
         QueryResponseRow responseRow = new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.INTEGER, 1)));
-        when(proxyBackendHandler.next()).thenReturn(true, false);
+        when(proxyBackendHandler.next()).thenReturn(true);
         when(proxyBackendHandler.getRowData()).thenReturn(responseRow);
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
         Collection<DatabasePacket> actualPackets = executor.execute();
-        Iterator<DatabasePacket> packetIterator = actualPackets.iterator();
-        FirebirdFetchResponsePacket actualRowPacket = (FirebirdFetchResponsePacket) packetIterator.next();
-        assertThat(actualPackets.size(), is(2));
-        assertThat(actualRowPacket.getStatus(), is(ISCConstants.FETCH_OK));
-        assertThat(actualRowPacket.getCount(), is(1));
-        assertNotNull(actualRowPacket.getRow());
-        FirebirdFetchResponsePacket actualNoMorePacket = (FirebirdFetchResponsePacket) packetIterator.next();
-        assertThat(actualNoMorePacket.getStatus(), is(ISCConstants.FETCH_NO_MORE_ROWS));
-        assertThat(actualNoMorePacket.getCount(), is(0));
-        assertNull(actualNoMorePacket.getRow());
+        assertThat(actualPackets.size(), is(1));
+        FirebirdFetchResponsePacket actualPacket = (FirebirdFetchResponsePacket) actualPackets.iterator().next();
+        assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_OK));
+        assertThat(actualPacket.getCount(), is(1));
+        assertNotNull(actualPacket.getRow());
+    }
+    
+    @Test
+    void assertExecuteWhenBackendHandlerReturnsNoMoreRows() throws SQLException {
+        FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
+        when(packet.getFetchSize()).thenReturn(2);
+        when(proxyBackendHandler.next()).thenReturn(false);
+        executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
+        Collection<DatabasePacket> actualPackets = executor.execute();
+        assertThat(actualPackets.size(), is(1));
+        FirebirdFetchResponsePacket actualPacket = (FirebirdFetchResponsePacket) actualPackets.iterator().next();
+        assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_NO_MORE_ROWS));
+        assertThat(actualPacket.getCount(), is(0));
+        assertNull(actualPacket.getRow());
         verify(databaseConnectionManager).unmarkResourceInUse(proxyBackendHandler);
+    }
+    
+    @Test
+    void assertGetQueryRowPacketWhenEnd() throws SQLException {
+        FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
+        when(packet.getFetchSize()).thenReturn(0);
+        executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
+        Collection<DatabasePacket> actualPackets = executor.execute();
+        assertThat(actualPackets.size(), is(1));
+        FirebirdFetchResponsePacket actualPacket = (FirebirdFetchResponsePacket) actualPackets.iterator().next();
+        assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_OK));
+        assertThat(actualPacket.getCount(), is(0));
+        assertNull(actualPacket.getRow());
     }
     
     private void assertNoMoreRowsResponse(final Collection<DatabasePacket> actualPackets) {

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
@@ -90,7 +90,7 @@ class FirebirdFetchStatementCommandExecutorTest {
         Collection<DatabasePacket> actualPackets = executor.execute();
         assertThat(actualPackets.size(), is(1));
         assertNoMoreRowsResponse((FirebirdFetchResponsePacket) actualPackets.iterator().next());
-        assertThat(executor.next(), is(false));
+        assertFalse(executor.next());
     }
     
     @Test
@@ -101,7 +101,7 @@ class FirebirdFetchStatementCommandExecutorTest {
         Collection<DatabasePacket> actualPackets = executor.execute();
         assertThat(actualPackets.size(), is(1));
         assertNoMoreRowsResponse((FirebirdFetchResponsePacket) actualPackets.iterator().next());
-        assertThat(executor.next(), is(false));
+        assertFalse(executor.next());
     }
     
     @Test
@@ -141,11 +141,11 @@ class FirebirdFetchStatementCommandExecutorTest {
         Collection<DatabasePacket> actualPackets = executor.execute();
         assertThat(actualPackets.size(), is(1));
         assertFetchRowResponse((FirebirdFetchResponsePacket) actualPackets.iterator().next());
-        assertThat(executor.next(), is(true));
+        assertTrue(executor.next());
         assertFetchRowResponse((FirebirdFetchResponsePacket) executor.getQueryRowPacket());
-        assertThat(executor.next(), is(true));
+        assertTrue(executor.next());
         assertFetchEndResponse((FirebirdFetchResponsePacket) executor.getQueryRowPacket());
-        assertThat(executor.next(), is(false));
+        assertFalse(executor.next());
         FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
     }
     
@@ -159,7 +159,7 @@ class FirebirdFetchStatementCommandExecutorTest {
         assertThat(actualPackets.size(), is(1));
         assertNoMoreRowsResponse((FirebirdFetchResponsePacket) actualPackets.iterator().next());
         verify(databaseConnectionManager).unmarkResourceInUse(proxyBackendHandler);
-        assertThat(executor.next(), is(false));
+        assertFalse(executor.next());
         FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
     }
     
@@ -171,23 +171,23 @@ class FirebirdFetchStatementCommandExecutorTest {
         Collection<DatabasePacket> actualPackets = executor.execute();
         assertThat(actualPackets.size(), is(1));
         assertFetchEndResponse((FirebirdFetchResponsePacket) actualPackets.iterator().next());
-        assertThat(executor.next(), is(false));
+        assertFalse(executor.next());
         FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
     }
     
-    private void assertNoMoreRowsResponse(FirebirdFetchResponsePacket actualPacket) {
+    private void assertNoMoreRowsResponse(final FirebirdFetchResponsePacket actualPacket) {
         assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_NO_MORE_ROWS));
         assertThat(actualPacket.getCount(), is(0));
         assertNull(actualPacket.getRow());
     }
     
-    private void assertFetchRowResponse(FirebirdFetchResponsePacket actualPacket) {
+    private void assertFetchRowResponse(final FirebirdFetchResponsePacket actualPacket) {
         assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_OK));
         assertThat(actualPacket.getCount(), is(1));
         assertNotNull(actualPacket.getRow());
     }
     
-    private void assertFetchEndResponse(FirebirdFetchResponsePacket actualPacket) {
+    private void assertFetchEndResponse(final FirebirdFetchResponsePacket actualPacket) {
         assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_OK));
         assertThat(actualPacket.getCount(), is(0));
         assertNull(actualPacket.getRow());

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
@@ -39,7 +39,6 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -88,7 +87,10 @@ class FirebirdFetchStatementCommandExecutorTest {
     void assertExecuteWhenNoBackendHandler() throws SQLException {
         when(packet.getFetchSize()).thenReturn(Integer.MAX_VALUE);
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
-        assertNoMoreRowsResponse(executor.execute());
+        Collection<DatabasePacket> actualPackets = executor.execute();
+        assertThat(actualPackets.size(), is(1));
+        assertNoMoreRowsResponse((FirebirdFetchResponsePacket) actualPackets.iterator().next());
+        assertThat(executor.next(), is(false));
     }
     
     @Test
@@ -96,7 +98,10 @@ class FirebirdFetchStatementCommandExecutorTest {
         FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
         FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
-        assertNoMoreRowsResponse(executor.execute());
+        Collection<DatabasePacket> actualPackets = executor.execute();
+        assertThat(actualPackets.size(), is(1));
+        assertNoMoreRowsResponse((FirebirdFetchResponsePacket) actualPackets.iterator().next());
+        assertThat(executor.next(), is(false));
     }
     
     @Test
@@ -122,6 +127,7 @@ class FirebirdFetchStatementCommandExecutorTest {
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
         executor.execute();
         assertTrue(executor.next());
+        FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
     }
     
     @Test
@@ -134,10 +140,13 @@ class FirebirdFetchStatementCommandExecutorTest {
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
         Collection<DatabasePacket> actualPackets = executor.execute();
         assertThat(actualPackets.size(), is(1));
-        FirebirdFetchResponsePacket actualPacket = (FirebirdFetchResponsePacket) actualPackets.iterator().next();
-        assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_OK));
-        assertThat(actualPacket.getCount(), is(1));
-        assertNotNull(actualPacket.getRow());
+        assertFetchRowResponse((FirebirdFetchResponsePacket) actualPackets.iterator().next());
+        assertThat(executor.next(), is(true));
+        assertFetchRowResponse((FirebirdFetchResponsePacket) executor.getQueryRowPacket());
+        assertThat(executor.next(), is(true));
+        assertFetchEndResponse((FirebirdFetchResponsePacket) executor.getQueryRowPacket());
+        assertThat(executor.next(), is(false));
+        FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
     }
     
     @Test
@@ -148,11 +157,10 @@ class FirebirdFetchStatementCommandExecutorTest {
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
         Collection<DatabasePacket> actualPackets = executor.execute();
         assertThat(actualPackets.size(), is(1));
-        FirebirdFetchResponsePacket actualPacket = (FirebirdFetchResponsePacket) actualPackets.iterator().next();
-        assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_NO_MORE_ROWS));
-        assertThat(actualPacket.getCount(), is(0));
-        assertNull(actualPacket.getRow());
+        assertNoMoreRowsResponse((FirebirdFetchResponsePacket) actualPackets.iterator().next());
         verify(databaseConnectionManager).unmarkResourceInUse(proxyBackendHandler);
+        assertThat(executor.next(), is(false));
+        FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
     }
     
     @Test
@@ -162,17 +170,25 @@ class FirebirdFetchStatementCommandExecutorTest {
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
         Collection<DatabasePacket> actualPackets = executor.execute();
         assertThat(actualPackets.size(), is(1));
-        FirebirdFetchResponsePacket actualPacket = (FirebirdFetchResponsePacket) actualPackets.iterator().next();
-        assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_OK));
+        assertFetchEndResponse((FirebirdFetchResponsePacket) actualPackets.iterator().next());
+        assertThat(executor.next(), is(false));
+        FirebirdFetchStatementCache.getInstance().unregisterStatement(CONNECTION_ID, STATEMENT_ID);
+    }
+    
+    private void assertNoMoreRowsResponse(FirebirdFetchResponsePacket actualPacket) {
+        assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_NO_MORE_ROWS));
         assertThat(actualPacket.getCount(), is(0));
         assertNull(actualPacket.getRow());
     }
     
-    private void assertNoMoreRowsResponse(final Collection<DatabasePacket> actualPackets) {
-        Iterator<DatabasePacket> packetIterator = actualPackets.iterator();
-        FirebirdFetchResponsePacket actualPacket = (FirebirdFetchResponsePacket) packetIterator.next();
-        assertThat(actualPackets.size(), is(1));
-        assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_NO_MORE_ROWS));
+    private void assertFetchRowResponse(FirebirdFetchResponsePacket actualPacket) {
+        assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_OK));
+        assertThat(actualPacket.getCount(), is(1));
+        assertNotNull(actualPacket.getRow());
+    }
+    
+    private void assertFetchEndResponse(FirebirdFetchResponsePacket actualPacket) {
+        assertThat(actualPacket.getStatus(), is(ISCConstants.FETCH_OK));
         assertThat(actualPacket.getCount(), is(0));
         assertNull(actualPacket.getRow());
     }

--- a/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
+++ b/proxy/frontend/dialect/firebird/src/test/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/statement/fetch/FirebirdFetchStatementCommandExecutorTest.java
@@ -86,6 +86,7 @@ class FirebirdFetchStatementCommandExecutorTest {
     
     @Test
     void assertExecuteWhenNoBackendHandler() throws SQLException {
+        when(packet.getFetchSize()).thenReturn(Integer.MAX_VALUE);
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
         assertNoMoreRowsResponse(executor.execute());
     }
@@ -142,7 +143,7 @@ class FirebirdFetchStatementCommandExecutorTest {
     @Test
     void assertExecuteWhenBackendHandlerReturnsNoMoreRows() throws SQLException {
         FirebirdFetchStatementCache.getInstance().registerStatement(CONNECTION_ID, STATEMENT_ID, proxyBackendHandler);
-        when(packet.getFetchSize()).thenReturn(2);
+        when(packet.getFetchSize()).thenReturn(Integer.MAX_VALUE);
         when(proxyBackendHandler.next()).thenReturn(false);
         executor = new FirebirdFetchStatementCommandExecutor(packet, connectionSession);
         Collection<DatabasePacket> actualPackets = executor.execute();


### PR DESCRIPTION
Changes proposed in this pull request:
  - Refactor FirebirdFetchStatementCommandExecutor to implement QueryCommandExecutor interface

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
