### PR TITLE
Fix MySQLMetaDataLoader NPE risk when JDBC catalog is null

### DIFF
--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoader.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoader.java
@@ -206,7 +206,7 @@ public final class MySQLMetaDataLoader implements DialectMetaDataLoader {
     }
     
     private String getDatabaseName(final Connection connection, final Collection<String> tableNames) throws SQLException {
-        return "".equals(connection.getCatalog()) ? GlobalDataSourceRegistry.getInstance().getCachedDatabaseTables().get(tableNames.iterator().next()) : connection.getCatalog();
+        return Strings.isNullOrEmpty(connection.getCatalog()) ? GlobalDataSourceRegistry.getInstance().getCachedDatabaseTables().get(tableNames.iterator().next()) : connection.getCatalog();
     }
     
     @Override

--- a/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoader.java
+++ b/database/connector/dialect/mysql/src/main/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoader.java
@@ -206,7 +206,11 @@ public final class MySQLMetaDataLoader implements DialectMetaDataLoader {
     }
     
     private String getDatabaseName(final Connection connection, final Collection<String> tableNames) throws SQLException {
-        return Strings.isNullOrEmpty(connection.getCatalog()) ? GlobalDataSourceRegistry.getInstance().getCachedDatabaseTables().get(tableNames.iterator().next()) : connection.getCatalog();
+        String catalog = connection.getCatalog();
+        if (!Strings.isNullOrEmpty(catalog)) {
+            return catalog;
+        }
+        return tableNames.isEmpty() ? null : GlobalDataSourceRegistry.getInstance().getCachedDatabaseTables().get(tableNames.iterator().next());
     }
     
     @Override

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoaderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoaderTest.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MySQLMetaDataLoaderTest {
@@ -87,7 +88,7 @@ class MySQLMetaDataLoaderTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("loadArguments")
     void assertLoad(final String name, final Collection<String> actualTableNames, final String tableMetaDataSQL,
-                    final boolean emptyCatalog, final boolean includeView, final boolean includeConstraints, final boolean includeCompositeIndex) throws SQLException {
+                    final String catalog, final String expectedDatabaseName, final boolean includeView, final boolean includeConstraints, final boolean includeCompositeIndex) throws SQLException {
         DataSource dataSource = mockDataSource();
         ResultSet tableMetaDataResultSet = mockTableMetaDataResultSet();
         when(dataSource.getConnection().prepareStatement(tableMetaDataSQL).executeQuery()).thenReturn(tableMetaDataResultSet);
@@ -105,10 +106,11 @@ class MySQLMetaDataLoaderTest {
         Map<String, String> cachedDatabaseTables = GlobalDataSourceRegistry.getInstance().getCachedDatabaseTables();
         String previous = cachedDatabaseTables.put("tbl", "fallback_db");
         try {
-            when(dataSource.getConnection().getCatalog()).thenReturn(emptyCatalog ? "" : "sharding_db");
+            when(dataSource.getConnection().getCatalog()).thenReturn(catalog);
             DataTypeRegistry.load(dataSource, "MySQL");
             Collection<SchemaMetaData> actual = dialectMetaDataLoader.load(new MetaDataLoaderMaterial(actualTableNames, "foo_ds", dataSource, databaseType, "sharding_db"));
             assertTableMetaData(actual, includeConstraints, includeCompositeIndex);
+            verify(dataSource.getConnection().prepareStatement(tableMetaDataSQL)).setString(1, expectedDatabaseName);
         } finally {
             if (null == previous) {
                 cachedDatabaseTables.remove("tbl");
@@ -237,8 +239,9 @@ class MySQLMetaDataLoaderTest {
     
     private static Stream<Arguments> loadArguments() {
         return Stream.of(
-                Arguments.of("load without requested table names", Collections.emptyList(), TABLE_METADATA_SQL, false, false, false, false),
-                Arguments.of("load with requested table names", Collections.singletonList("tbl"), TABLE_METADATA_SQL_WITH_TABLE, false, false, false, false),
-                Arguments.of("load with empty catalog fallback and view constraints", Collections.singletonList("tbl"), TABLE_METADATA_SQL_WITH_TABLE, true, true, true, true));
+                Arguments.of("load without requested table names", Collections.emptyList(), TABLE_METADATA_SQL, "sharding_db", "sharding_db", false, false, false),
+                Arguments.of("load with requested table names", Collections.singletonList("tbl"), TABLE_METADATA_SQL_WITH_TABLE, "sharding_db", "sharding_db", false, false, false),
+                Arguments.of("load with empty catalog fallback and view constraints", Collections.singletonList("tbl"), TABLE_METADATA_SQL_WITH_TABLE, "", "fallback_db", true, true, true),
+                Arguments.of("load with null catalog fallback", Collections.singletonList("tbl"), TABLE_METADATA_SQL_WITH_TABLE, null, "fallback_db", true, true, true));
     }
 }

--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoaderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/data/loader/MySQLMetaDataLoaderTest.java
@@ -84,6 +84,17 @@ class MySQLMetaDataLoaderTest {
         assertTrue(actual.iterator().next().getTables().isEmpty());
     }
     
+    @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
+    @Test
+    void assertLoadWithNullCatalogAndNoRequestedTableNames() throws SQLException {
+        DataSource dataSource = mockDataSource();
+        when(dataSource.getConnection().getCatalog()).thenReturn(null);
+        DataTypeRegistry.load(dataSource, "MySQL");
+        Collection<SchemaMetaData> actual = dialectMetaDataLoader.load(new MetaDataLoaderMaterial(Collections.emptyList(), "foo_ds", dataSource, databaseType, "sharding_db"));
+        assertThat(actual.size(), is(1));
+        assertTrue(actual.iterator().next().getTables().isEmpty());
+    }
+    
     @SuppressWarnings({"JDBCResourceOpenedButNotSafelyClosed", "resource"})
     @ParameterizedTest(name = "{0}")
     @MethodSource("loadArguments")


### PR DESCRIPTION
Resolves the null-vs-empty-string catalog handling bug described in
apache/shardingsphere#28469: getDatabaseName() checked catalog with
"".equals(...), which doesn't catch a null catalog (returned by
MySQL's getCatalog() when no schema is selected on the connection),
causing the cached-database-name fallback to be skipped and masking
to fail with TableNotExistsException for a specific, named table.

Replaced the check with Guava's Strings.isNullOrEmpty(), consistent
with existing usage elsewhere in the same file.

Also fixes a related crash this change could otherwise introduce:
when no catalog is selected and no specific table names are requested
(the "load every table" startup case), the null-catalog fallback
previously assumed a table name was always available to look up in
the cache. getDatabaseName() now checks tableNames.isEmpty() first and
returns null gracefully in that case, rather than throwing
NoSuchElementException.

Scope: this PR fixes the specific null-catalog handling bug and the
empty-tableNames crash above. It does not implement fetching/querying
across all schemas when no current schema is selected and no specific
table is requested - the original report also raises that as a
separate question ("I think we need to fetch all schemas in this
case"), which is a meaningfully larger feature (schema enumeration,
cross-schema querying, naming-collision handling) rather than a
regression test that fits this fix.

Partially addresses #28469

Changes proposed in this pull request:
- Fix null-catalog handling in MySQLMetaDataLoader.getDatabaseName()
- Guard against empty tableNames when no catalog fallback is available
- Add regression tests for both the null-catalog fallback and the
  empty-tableNames edge case, each verified to fail without the
  corresponding fix and pass with it

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally: `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)