### PR TITLE
Stabilize GraalVM native test CI

### DIFF
--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/shardingsphere-infra-reachability-metadata/reachability-metadata.json
@@ -2,6 +2,45 @@
   "reflection": [
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.generator.NodePathSegment"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
+      "fields": [
+        {
+          "name": "databaseName"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.generator.NodePathSegment"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath",
+      "fields": [
+        {
+          "name": "database"
+        },
+        {
+          "name": "schemaName"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.generator.NodePathSegment"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath",
+      "fields": [
+        {
+          "name": "schema"
+        },
+        {
+          "name": "tableName"
+        }
+      ]
+    },
+    {
+      "condition": {
         "typeReached": "com.oracle.svm.core.jdk.management.SubstrateCompilationMXBean"
       },
       "type": "com.oracle.svm.core.jdk.management.SubstrateCompilationMXBean",

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/modes/cluster/ZookeeperTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/modes/cluster/ZookeeperTest.java
@@ -56,8 +56,20 @@ class ZookeeperTest {
     
     @AfterEach
     void afterEach() throws SQLException {
-        ResourceUtils.closeJdbcDataSource(logicDataSource);
-        System.clearProperty(systemPropKeyPrefix + "server-lists");
+        try {
+            closeLogicDataSource();
+        } finally {
+            System.clearProperty(systemPropKeyPrefix + "server-lists");
+        }
+    }
+    
+    private void closeLogicDataSource() throws SQLException {
+        if (null == logicDataSource) {
+            return;
+        }
+        DataSource dataSource = logicDataSource;
+        logicDataSource = null;
+        ResourceUtils.closeJdbcDataSource(dataSource);
     }
     
     @Test
@@ -69,6 +81,7 @@ class ZookeeperTest {
             initEnvironment();
             testShardingService.processSuccess();
             testShardingService.cleanEnvironment();
+            closeLogicDataSource();
         }
     }
     

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/modes/cluster/ZookeeperTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/modes/cluster/ZookeeperTest.java
@@ -75,13 +75,16 @@ class ZookeeperTest {
     @Test
     void assertShardingInLocalTransactions() throws Exception {
         try (TestingServer testingServer = new TestingServer()) {
-            String connectString = testingServer.getConnectString();
-            logicDataSource = createDataSource(connectString);
-            testShardingService = new TestShardingService(logicDataSource);
-            initEnvironment();
-            testShardingService.processSuccess();
-            testShardingService.cleanEnvironment();
-            closeLogicDataSource();
+            try {
+                String connectString = testingServer.getConnectString();
+                logicDataSource = createDataSource(connectString);
+                testShardingService = new TestShardingService(logicDataSource);
+                initEnvironment();
+                testShardingService.processSuccess();
+                testShardingService.cleanEnvironment();
+            } finally {
+                closeLogicDataSource();
+            }
         }
     }
     

--- a/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native/reachability-metadata.json
+++ b/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native/reachability-metadata.json
@@ -26,6 +26,45 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.generator.NodePathSegment"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
+      "fields": [
+        {
+          "name": "databaseName"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.generator.NodePathSegment"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath",
+      "fields": [
+        {
+          "name": "database"
+        },
+        {
+          "name": "schemaName"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.generator.NodePathSegment"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath",
+      "fields": [
+        {
+          "name": "schema"
+        },
+        {
+          "name": "tableName"
+        }
+      ]
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.test.natived.jdbc.transactions.xa.NarayanaTest"
       },
       "type": "org.apache.shardingsphere.test.natived.jdbc.transactions.xa.NarayanaTest",

--- a/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native/reachability-metadata.json
+++ b/test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native/reachability-metadata.json
@@ -26,45 +26,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.generator.NodePathSegment"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.generator.NodePathSegment"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "schemaName"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.generator.NodePathSegment"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath",
-      "fields": [
-        {
-          "name": "schema"
-        },
-        {
-          "name": "tableName"
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.test.natived.jdbc.transactions.xa.NarayanaTest"
       },
       "type": "org.apache.shardingsphere.test.natived.jdbc.transactions.xa.NarayanaTest",

--- a/test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
+++ b/test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
@@ -38,3 +38,4 @@ rdctl start --application.start-in-background --container-engine.name=moby --kub
 rdctl shutdown
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
 ./test/native/src/test/resources/test-native/ps1/wait-for-rancher-desktop-backend.ps1
+./test/native/src/test/resources/test-native/ps1/wait-for-docker-daemon.ps1

--- a/test/native/src/test/resources/test-native/ps1/wait-for-docker-daemon.ps1
+++ b/test/native/src/test/resources/test-native/ps1/wait-for-docker-daemon.ps1
@@ -18,7 +18,8 @@
 #
 
 # This file is only used in the PowerShell 7 of ShardingSphere in GitHub Actions environment and should not be executed manually in a development environment.
-# Background information can be found at https://github.com/apache/shardingsphere/pull/35905 .
+# Background information for the Windows Server 2025 Rancher Desktop setup can be found at https://github.com/apache/shardingsphere/pull/35905 .
+# Docker daemon readiness instability on affected WSL2 versions may also relate to https://github.com/microsoft/WSL/pull/40519 .
 param (
     [int] $MaxAttempts = 2,
     [int] $TimeoutMinutes = 5

--- a/test/native/src/test/resources/test-native/ps1/wait-for-docker-daemon.ps1
+++ b/test/native/src/test/resources/test-native/ps1/wait-for-docker-daemon.ps1
@@ -1,0 +1,98 @@
+#Requires -Version 7.4
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file is only used in the PowerShell 7 of ShardingSphere in GitHub Actions environment and should not be executed manually in a development environment.
+# Background information can be found at https://github.com/apache/shardingsphere/pull/35905 .
+param (
+    [int] $MaxAttempts = 2,
+    [int] $TimeoutMinutes = 5
+)
+
+function Invoke-DockerCommand
+{
+    param (
+        [string[]] $Arguments
+    )
+    docker @Arguments
+    if (0 -ne $LASTEXITCODE)
+    {
+        throw "docker $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Wait-DockerDaemon
+{
+    $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+    $lastError = "UNKNOWN"
+    while ((Get-Date) -lt $deadline)
+    {
+        $now = Get-Date
+        $deadlineString = $deadline.ToString("u")
+        Write-Host "Waiting for Docker daemon: ($lastError) $now / $deadlineString"
+        try
+        {
+            Invoke-DockerCommand @("version", "--format", "{{.Server.Version}}")
+            Invoke-DockerCommand @("info", "--format", "{{.ServerVersion}}")
+            Write-Host "Docker daemon is ready."
+            return $true
+        }
+        catch
+        {
+            $lastError = $_.Exception.Message
+            Write-Host "Docker daemon is not ready: $lastError"
+        }
+        Start-Sleep -Seconds 10
+    }
+    Write-Host "Timed out waiting for Docker daemon."
+    Write-Host "Current time: $( Get-Date )"
+    Write-Host "Deadline: $($deadline.ToString("u") )"
+    Write-Host "Last error: $lastError"
+    return $false
+}
+
+function Restart-RancherDesktop
+{
+    Write-Host "Restarting Rancher Desktop before retrying Docker daemon readiness."
+    rdctl shutdown
+    if (0 -ne $LASTEXITCODE)
+    {
+        Write-Host "rdctl shutdown failed with exit code $LASTEXITCODE, continuing with start."
+    }
+    rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
+    if (0 -ne $LASTEXITCODE)
+    {
+        throw "rdctl start failed with exit code $LASTEXITCODE."
+    }
+    ./test/native/src/test/resources/test-native/ps1/wait-for-rancher-desktop-backend.ps1
+}
+
+for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++)
+{
+    Write-Host "Docker daemon readiness attempt $attempt of $MaxAttempts."
+    if (Wait-DockerDaemon)
+    {
+        exit 0
+    }
+    if ($attempt -lt $MaxAttempts)
+    {
+        Restart-RancherDesktop
+    }
+}
+Write-Error "Docker daemon did not become ready after $MaxAttempts attempts."
+exit 1

--- a/test/native/src/test/resources/test-native/ps1/wait-for-docker-daemon.ps1
+++ b/test/native/src/test/resources/test-native/ps1/wait-for-docker-daemon.ps1
@@ -36,6 +36,13 @@ function Invoke-DockerCommand
     }
 }
 
+function Invoke-DockerContainerSmoke
+{
+    $containerName = "shardingsphere-docker-readiness"
+    docker rm -f $containerName 2>$null | Out-Null
+    Invoke-DockerCommand @("run", "--name", $containerName, "--rm", "hello-world")
+}
+
 function Wait-DockerDaemon
 {
     $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
@@ -49,7 +56,8 @@ function Wait-DockerDaemon
         {
             Invoke-DockerCommand @("version", "--format", "{{.Server.Version}}")
             Invoke-DockerCommand @("info", "--format", "{{.ServerVersion}}")
-            Write-Host "Docker daemon is ready."
+            Invoke-DockerContainerSmoke
+            Write-Host "Docker daemon accepted version, info, and container lifecycle commands."
             return $true
         }
         catch


### PR DESCRIPTION
For #38857

  ## Summary

  This PR stabilizes the GraalVM native test CI by fixing three failure paths found in PR CI:

  - Add native reachability metadata for `NodePath` field access used by native tests.
  - Strengthen Windows Docker readiness verification before running Maven tests that depend on Testcontainers.
  - Close the native Zookeeper test datasource before the embedded Zookeeper server shuts down.

  ## Background

  The GraalVM native test workflow failed on both Ubuntu and Windows, with different causes across CI attempts.

  On Ubuntu, the native image test binary failed with `MissingReflectionRegistrationError` when `NodePathSegment` reflected fields from `TableMetaDataNodePath`:

  ```text
  org.graalvm.nativeimage.MissingReflectionRegistrationError:
  The program tried to reflectively read or write field:
  private final SchemaMetaDataNodePath TableMetaDataNodePath.schema
  without it being registered for runtime reflection.
  ```
  NodePathGenerator and NodePathSegment build node paths by reading @NodePathEntity variables through reflection. In native image tests, these fields must be registered in
  reachability metadata.

  On Windows, the CI setup accepted Rancher Desktop readiness, but Testcontainers later failed during Maven execution because Docker was still not usable:

  DockerClientProviderStrategy - Could not find a valid Docker environment.
  NpipeSocketClientProviderStrategy ... MalformedChunkCodingException: Bad chunk header

  This made the failure appear as many downstream native test errors instead of a clear Docker readiness failure.

  After those two issues were addressed, both Ubuntu and Windows native test jobs exposed the same remaining failure in ZookeeperTest cleanup:

  ZookeeperTest.afterEach - ClusterRepositoryPersistException
  Caused by: KeeperException$ConnectionLossException

  The test closed ShardingSphereDataSource from @AfterEach, after the TestingServer created by try-with-resources had already shut down. Closing the datasource closes
  ContextManager, which tries to take the compute node offline from Zookeeper. At that point the embedded Zookeeper server was already unavailable.

  ## Changes

  - Add native reachability metadata for NodePathSegment field access:
      - DatabaseMetaDataNodePath.databaseName
      - SchemaMetaDataNodePath.database
      - SchemaMetaDataNodePath.schemaName
      - TableMetaDataNodePath.schema
      - TableMetaDataNodePath.tableName

  - Update Windows Docker readiness checks:
      - Keep checking Docker server API readiness with:
          - docker version --format "{{.Server.Version}}"
          - docker info --format "{{.ServerVersion}}"

      - Add a short container lifecycle smoke check:
          - remove any stale shardingsphere-docker-readiness container
          - run hello-world with --rm

      - Keep the existing retry path that restarts Rancher Desktop before the final attempt.

  - Update ZookeeperTest cleanup order:
      - close logicDataSource while TestingServer is still alive
      - keep @AfterEach as a fallback cleanup path
      - clear the Zookeeper system property in finally
      - avoid closing the same datasource twice

  ## Motivation

  The native test CI should fail at the real setup, metadata, or resource lifecycle boundary instead of surfacing misleading downstream test errors.

  The reachability metadata change fixes the native image runtime reflection failure for node path generation.

  The Windows Docker smoke check makes the setup script verify that Docker can actually run containers before Maven starts, which better matches what Testcontainers needs
  during -PgenerateMetadata.

  The Zookeeper cleanup change ensures ContextManager.close() can take the compute node offline before the embedded Zookeeper server is closed.

  ## Verification

  Ran locally:

  jq empty test/native/src/test/resources/META-INF/native-image/shardingsphere-test-native/reachability-metadata.json

  Result: success

  Ran locally:

  ./mvnw -pl test/native -am -Dspotless.apply.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -DskipITs
  -Dtest=org.apache.shardingsphere.test.natived.jdbc.modes.cluster.ZookeeperTest -Dsurefire.failIfNoSpecifiedTests=false test

  Result: BUILD SUCCESS

  Note: ZookeeperTest is annotated with @EnabledInNativeImage, so the scoped JVM test verifies compilation and test discovery while the actual execution path is covered by the
  GraalVM native test CI.

  Ran locally:

  ./mvnw spotless:check -Pcheck -T1C

  Result: BUILD SUCCESS

  Ran locally:

  ./mvnw checkstyle:check -Pcheck -T1C

  Result: BUILD SUCCESS

  The PR GraalVM native test CI has passed after the Zookeeper cleanup adjustment.