### PR TITLE
Fix SHOW UNLOADED SINGLE TABLES for uppercase loaded table names

### DIFF
--- a/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutor.java
+++ b/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutor.java
@@ -71,7 +71,7 @@ public final class ShowUnloadedSingleTablesExecutor implements DistSQLQueryExecu
         for (Entry<String, Collection<DataNode>> entry : rule.getSingleTableDataNodes().entrySet()) {
             if (actualDataNodes.containsKey(entry.getKey())) {
                 if (entry.getValue().containsAll(actualDataNodes.get(entry.getKey()))) {
-                    actualDataNodes.remove(entry.getKey().toLowerCase());
+                    actualDataNodes.remove(entry.getKey());
                     continue;
                 }
                 Collection<DataNode> tableNodes = actualDataNodes.get(entry.getKey());

--- a/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutorTest.java
+++ b/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutorTest.java
@@ -245,6 +245,10 @@ class ShowUnloadedSingleTablesExecutorTest {
                 Collections.singletonMap("t_order", Collections.singleton(new DataNode("ds_0", (String) null, "t_order"))));
         Map<String, Collection<DataNode>> allLoadedRuleDataNodes = new HashMap<>(
                 Collections.singletonMap("t_order", Collections.singleton(new DataNode("ds_0", (String) null, "t_order"))));
+        Map<String, Collection<DataNode>> allLoadedUpperCaseActualDataNodes = new HashMap<>(
+                Collections.singletonMap("T_ORDER", Collections.singleton(new DataNode("ds_0", (String) null, "T_ORDER"))));
+        Map<String, Collection<DataNode>> allLoadedUpperCaseRuleDataNodes = new HashMap<>(
+                Collections.singletonMap("T_ORDER", Collections.singleton(new DataNode("ds_0", (String) null, "T_ORDER"))));
         Map<String, Collection<DataNode>> partiallyLoadedActualDataNodes = new HashMap<>(
                 Collections.singletonMap("t_order", new LinkedList<>(Arrays.asList(new DataNode("ds_0", "public", "t_order"), new DataNode("ds_1", "public", "t_order")))));
         Map<String, Collection<DataNode>> partiallyLoadedRuleDataNodes = new HashMap<>(
@@ -262,6 +266,7 @@ class ShowUnloadedSingleTablesExecutorTest {
                 Collections.singletonMap("t_order", new LinkedList<>(Arrays.asList(new DataNode("ds_0", "schema_b", "t_order"), new DataNode("ds_0", "schema_a", "t_order")))));
         return Stream.of(
                 Arguments.of("all loaded tables are excluded", false, allLoadedActualDataNodes, allLoadedRuleDataNodes, Collections.<List<String>>emptyList()),
+                Arguments.of("all loaded uppercase tables are excluded", false, allLoadedUpperCaseActualDataNodes, allLoadedUpperCaseRuleDataNodes, Collections.<List<String>>emptyList()),
                 Arguments.of("remaining tables are sorted by table name",
                         false, unorderedActualDataNodes, Collections.emptyMap(), Arrays.asList(Arrays.asList("t_order", "ds_0"), Arrays.asList("t_order_item", "ds_1"))),
                 Arguments.of("partially loaded table keeps remaining nodes",


### PR DESCRIPTION
Fixes #38862.

### Type of Change

  - Bug fix

  ### What Changed

  This PR fixes `SHOW UNLOADED SINGLE TABLES` when loaded single table names contain uppercase letters.

  Previously, `ShowUnloadedSingleTablesExecutor` checked whether `actualDataNodes` contained the original loaded table key, but removed the lower-case form of that key. For an
  uppercase table such as `T_ORDER`, the executor matched `T_ORDER` but attempted to remove `t_order`, so the already-loaded table could still appear in the unloaded single
  table result.

  This PR removes the exact matched key instead.

  ### Why This Change Is Needed

  `SHOW UNLOADED SINGLE TABLES` should only return single tables that have not been loaded. A table that has already been loaded should not remain in the result set just
  because its name contains uppercase letters.

  ### Testing

  - `./mvnw -pl kernel/single/distsql/handler -am -DskipITs -Dspotless.skip=true -Dtest=ShowUnloadedSingleTablesExecutorTest -DfailIfNoTests=false
  -Dsurefire.failIfNoSpecifiedTests=false test`
  - `./mvnw -pl kernel/single/distsql/handler checkstyle:check -Pcheck -T1C`
  - `./mvnw -pl kernel/single/distsql/handler spotless:check -Pcheck -T1C`

  ### Coverage

  A regression test was added for the fully-loaded uppercase table case:

  - actual data node key: `T_ORDER`
  - loaded data node key: `T_ORDER`
  - expected unloaded result: empty

  Target class coverage after the change:

  - `ShowUnloadedSingleTablesExecutor`
    - CLASS: `100.00%`
    - LINE: `100.00%`
    - BRANCH: `100.00%`
