### PR TITLE
Fix: Fix uppercase table name lookup in SHOW UNLOADED SINGLE TABLES.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,7 @@
 1. Sharding: Support ORDER BY MySQL VARBINARY column by wrapping byte[] values in a Comparable adapter - [#38699](https://github.com/apache/shardingsphere/pull/38699)
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)
 1. DistSQL: Fix case-sensitive storage unit matching in `SHOW RULES USED STORAGE UNIT` - [#38848](https://github.com/apache/shardingsphere/pull/38848)
+1. DistSQL: Fix uppercase table names incorrectly shown in `SHOW UNLOADED SINGLE TABLES` - [#38866](https://github.com/apache/shardingsphere/pull/38866)
 
 ### Enhancements
 

--- a/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutor.java
+++ b/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutor.java
@@ -71,7 +71,7 @@ public final class ShowUnloadedSingleTablesExecutor implements DistSQLQueryExecu
         for (Entry<String, Collection<DataNode>> entry : rule.getSingleTableDataNodes().entrySet()) {
             if (actualDataNodes.containsKey(entry.getKey())) {
                 if (entry.getValue().containsAll(actualDataNodes.get(entry.getKey()))) {
-                    actualDataNodes.remove(entry.getKey().toLowerCase());
+                    actualDataNodes.remove(entry.getKey());
                     continue;
                 }
                 Collection<DataNode> tableNodes = actualDataNodes.get(entry.getKey());

--- a/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutorTest.java
+++ b/kernel/single/distsql/handler/src/test/java/org/apache/shardingsphere/single/distsql/handler/query/ShowUnloadedSingleTablesExecutorTest.java
@@ -260,6 +260,18 @@ class ShowUnloadedSingleTablesExecutorTest {
                 Collections.singletonMap("t_order", new LinkedList<>(Arrays.asList(new DataNode("ds_1", "public", "t_order"), new DataNode("ds_0", "public", "t_order")))));
         Map<String, Collection<DataNode>> unorderedSchemaActualDataNodes = new HashMap<>(
                 Collections.singletonMap("t_order", new LinkedList<>(Arrays.asList(new DataNode("ds_0", "schema_b", "t_order"), new DataNode("ds_0", "schema_a", "t_order")))));
+        Map<String, Collection<DataNode>> allLoadedUppercaseActualDataNodes = new HashMap<>(
+                Collections.singletonMap("T_ORDER", Collections.singleton(new DataNode("ds_0", (String) null, "T_ORDER"))));
+        Map<String, Collection<DataNode>> allLoadedUppercaseRuleDataNodes = new HashMap<>(
+                Collections.singletonMap("T_ORDER", Collections.singleton(new DataNode("ds_0", (String) null, "T_ORDER"))));
+        Map<String, Collection<DataNode>> allLoadedMixedCaseActualDataNodes = new HashMap<>(
+                Collections.singletonMap("T_Order", Collections.singleton(new DataNode("ds_0", (String) null, "T_Order"))));
+        Map<String, Collection<DataNode>> allLoadedMixedCaseRuleDataNodes = new HashMap<>(
+                Collections.singletonMap("T_Order", Collections.singleton(new DataNode("ds_0", (String) null, "T_Order"))));
+        Map<String, Collection<DataNode>> partiallyLoadedUppercaseActualDataNodes = new HashMap<>(
+                Collections.singletonMap("T_ORDER", new LinkedList<>(Arrays.asList(new DataNode("ds_0", "public", "T_ORDER"), new DataNode("ds_1", "public", "T_ORDER")))));
+        Map<String, Collection<DataNode>> partiallyLoadedUppercaseRuleDataNodes = new HashMap<>(
+                Collections.singletonMap("T_ORDER", Collections.singleton(new DataNode("ds_0", "public", "T_ORDER"))));
         return Stream.of(
                 Arguments.of("all loaded tables are excluded", false, allLoadedActualDataNodes, allLoadedRuleDataNodes, Collections.<List<String>>emptyList()),
                 Arguments.of("remaining tables are sorted by table name",
@@ -271,6 +283,12 @@ class ShowUnloadedSingleTablesExecutorTest {
                 Arguments.of("same table and storage unit nodes are sorted by schema name",
                         true, unorderedSchemaActualDataNodes, Collections.emptyMap(), Arrays.asList(Arrays.asList("t_order", "ds_0", "schema_a"), Arrays.asList("t_order", "ds_0", "schema_b"))),
                 Arguments.of("unmatched rule key keeps actual table nodes",
-                        false, unmatchedActualDataNodes, unmatchedRuleDataNodes, Collections.singletonList(Arrays.asList("t_order_item", "ds_2"))));
+                        false, unmatchedActualDataNodes, unmatchedRuleDataNodes, Collections.singletonList(Arrays.asList("t_order_item", "ds_2"))),
+                Arguments.of("uppercase table fully loaded is excluded",
+                        false, allLoadedUppercaseActualDataNodes, allLoadedUppercaseRuleDataNodes, Collections.<List<String>>emptyList()),
+                Arguments.of("mixed case table fully loaded is excluded",
+                        false, allLoadedMixedCaseActualDataNodes, allLoadedMixedCaseRuleDataNodes, Collections.<List<String>>emptyList()),
+                Arguments.of("uppercase table partially loaded keeps remaining nodes",
+                        true, partiallyLoadedUppercaseActualDataNodes, partiallyLoadedUppercaseRuleDataNodes, Collections.singletonList(Arrays.asList("T_ORDER", "ds_1", "public"))));
     }
 }


### PR DESCRIPTION
Fixes #38862 

Changes proposed in this pull request:
  - Remove unnecessary toLowerCase() on entry.getKey() when removing fully loaded tables from the unloaded list
  - Add unit tests covering uppercase and mixed-case table name scenarios

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [x] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
