### PR TITLE
Remove opaque capability fingerprints

### DIFF
--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/RuntimeStatusHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/RuntimeStatusHandler.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.mcp.support.database.MCPDatabaseHandlerContext;
 import org.apache.shardingsphere.mcp.support.database.capability.MCPDatabaseCapability;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConnectionException;
 import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPDatabaseMetadata;
-import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogIndex;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
 import org.apache.shardingsphere.mcp.support.protocol.MCPNextActionUtils;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
@@ -59,7 +58,7 @@ public final class RuntimeStatusHandler implements MCPResourceHandler<MCPDatabas
     public MCPResponse handle(final MCPDatabaseHandlerContext handlerContext, final MCPUriVariables uriVariables) {
         List<MCPDatabaseMetadata> databases = handlerContext.getMetadataQueryFacade().queryDatabases();
         boolean hasConfiguredDatabase = !databases.isEmpty();
-        Map<String, Object> result = new LinkedHashMap<>(14, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(13, 1F);
         result.put("response_mode", MCPResponseMode.RUNTIME);
         result.put("server_status", hasConfiguredDatabase ? "ready" : "configuration_required");
         result.put("status", hasConfiguredDatabase ? "available" : "configuration_required");
@@ -71,7 +70,6 @@ public final class RuntimeStatusHandler implements MCPResourceHandler<MCPDatabas
         result.put("runtime_protection", MCPRuntimeProtectionPolicy.createRuntimeProtectionPayload());
         result.put("redaction_summary", Map.of("categories", List.of(), "redacted_count", 0, "marker", "******"));
         result.put("diagnostics", createDiagnostics(hasConfiguredDatabase));
-        result.put("capability_fingerprint", MCPDescriptorCatalogIndex.getDescriptorCatalogFingerprint());
         result.put(MCPPayloadFieldNames.RESOURCES_TO_READ, createResourcesToRead(hasConfiguredDatabase));
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, createNextActions(hasConfiguredDatabase));
         return new MCPMapResponse(result);

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/performance/MCPPerformanceBudgetSmokeTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/performance/MCPPerformanceBudgetSmokeTest.java
@@ -82,7 +82,7 @@ class MCPPerformanceBudgetSmokeTest {
         try (MCPRequestScope requestScope = new MCPRequestScope(runtimeContext)) {
             ServerCapabilitiesHandler handler = new ServerCapabilitiesHandler();
             Map<String, Object> actual = handler.handle(requestScope, new MCPUriVariables(Map.of())).toPayload();
-            assertTrue(actual.containsKey("fingerprints"));
+            assertFalse(actual.containsKey("fingerprints"));
             long elapsedMillis = measureElapsedMillis(() -> {
                 for (int i = 0; i < DESCRIPTOR_ITERATIONS; i++) {
                     handler.handle(requestScope, new MCPUriVariables(Map.of())).toPayload();

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/CoreResourceHandlerSurfaceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/CoreResourceHandlerSurfaceTest.java
@@ -89,7 +89,7 @@ class CoreResourceHandlerSurfaceTest {
                 assertTrue(((List<?>) actualPayload.get("prompts")).stream().map(String::valueOf).anyMatch(each -> each.contains("inspect_metadata")));
                 assertTrue(((List<?>) actualPayload.get("completionTargets")).stream().map(String::valueOf).anyMatch(each -> each.contains("inspect_metadata")));
                 assertTrue(((List<?>) actualPayload.get("resourceNavigation")).stream().map(String::valueOf).anyMatch(each -> each.contains("database_gateway_apply_workflow")));
-                assertTrue(((Map<?, ?>) actualPayload.get("fingerprints")).containsKey("descriptorCatalog"));
+                assertFalse(actualPayload.containsKey("fingerprints"));
                 assertTrue((Boolean) ((Map<?, ?>) actualPayload.get("protocolAvailability")).get("resourceNavigation"));
                 return;
             }

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/RuntimeStatusHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/RuntimeStatusHandlerTest.java
@@ -47,7 +47,7 @@ class RuntimeStatusHandlerTest {
             assertThat(((Map<?, ?>) actual.get("redaction_summary")).get("marker"), is("******"));
             assertRuntimeDiagnostics(actual, "ready");
             assertRuntimeProtection(actual);
-            assertTrue(String.valueOf(actual.get("capability_fingerprint")).matches("[0-9a-f]{64}"));
+            assertFalse(actual.containsKey("capability_fingerprint"));
             assertRuntimeCapability((List<?>) actual.get("databases"), "logic_db");
             assertThat(extractResourceUris((List<?>) actual.get("resources_to_read")), is(List.of("shardingsphere://capabilities", "shardingsphere://databases")));
             assertThat(actual.get("next_actions"), is(List.of()));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandlerTest.java
@@ -51,7 +51,7 @@ class ServerCapabilitiesHandlerTest {
         assertFalse(((List<?>) actual.get("prompts")).isEmpty());
         assertFalse(((List<?>) actual.get("completionTargets")).isEmpty());
         assertFalse(((List<?>) actual.get("resourceNavigation")).isEmpty());
-        assertTrue(((Map<?, ?>) actual.get("fingerprints")).containsKey("descriptorCatalog"));
+        assertFalse(actual.containsKey("fingerprints"));
         assertModelFirstSummary(actual);
         assertModelContract(actual);
         assertSurfaceSummary(actual);
@@ -78,7 +78,7 @@ class ServerCapabilitiesHandlerTest {
     private void assertBaselineTopLevelKeys(final Map<String, Object> capabilities) {
         assertThat(capabilities.keySet(), is(Set.of("response_mode", "model_first_summary", "supportedResources", "supportedTools", "supportedStatementClasses", "model_contract",
                 "surface_summary", "field_naming_contract", "next_action_contract", "common_flows", "security_hints", "resources", "resourceTemplates", "tools", "prompts",
-                "completionTargets", "resourceNavigation", "protocolAvailability", "fingerprints")));
+                "completionTargets", "resourceNavigation", "protocolAvailability")));
     }
     
     private void assertProtocolAvailability(final Map<String, Object> capabilities) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndex.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndex.java
@@ -210,13 +210,4 @@ public final class MCPDescriptorCatalogIndex {
     public static Map<String, Object> createCapabilityPayload(final Collection<String> supportedResources, final Collection<String> supportedTools, final Collection<?> supportedStatements) {
         return MCPDescriptorCatalogPayloadBuilder.build(CATALOG, supportedResources, supportedTools, supportedStatements);
     }
-    
-    /**
-     * Get descriptor catalog fingerprint.
-     *
-     * @return descriptor catalog fingerprint
-     */
-    public static String getDescriptorCatalogFingerprint() {
-        return MCPDescriptorCatalogPayloadBuilder.createDescriptorCatalogFingerprint(CATALOG);
-    }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilder.java
@@ -26,16 +26,10 @@ import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
 import org.apache.shardingsphere.mcp.support.protocol.MCPResponseMode;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 final class MCPDescriptorCatalogPayloadBuilder {
     
@@ -79,22 +73,7 @@ final class MCPDescriptorCatalogPayloadBuilder {
         result.put("completionTargets", completionTargets);
         result.put("resourceNavigation", resourceNavigation);
         result.put("protocolAvailability", createProtocolAvailability(!resourceNavigation.isEmpty()));
-        result.put("fingerprints", createFingerprints(resources, resourceTemplates, tools, prompts, completionTargets, resourceNavigation));
         return result;
-    }
-    
-    static String createDescriptorCatalogFingerprint(final MCPDescriptorCatalog catalog) {
-        return new MCPDescriptorCatalogPayloadBuilder(catalog).createDescriptorCatalogFingerprint();
-    }
-    
-    private String createDescriptorCatalogFingerprint() {
-        List<Map<String, Object>> resources = catalog.getResourceDescriptors().stream().map(this::toResourcePayload).toList();
-        List<Map<String, Object>> resourceTemplates = catalog.getResourceTemplateDescriptors().stream().map(this::toResourceTemplatePayload).toList();
-        List<Map<String, Object>> tools = catalog.getToolDescriptors().stream().map(this::toToolPayload).toList();
-        List<Map<String, Object>> prompts = catalog.getPromptDescriptors().stream().map(this::toPromptPayload).toList();
-        List<Map<String, Object>> completionTargets = catalog.getCompletionTargetDescriptors().stream().map(this::toCompletionTargetPayload).toList();
-        List<Map<String, Object>> resourceNavigation = catalog.getResourceNavigationDescriptors().stream().map(this::toResourceNavigationPayload).toList();
-        return String.valueOf(createFingerprints(resources, resourceTemplates, tools, prompts, completionTargets, resourceNavigation).get("descriptorCatalog"));
     }
     
     private Map<String, Object> toResourcePayload(final MCPResourceDescriptor descriptor) {
@@ -283,108 +262,5 @@ final class MCPDescriptorCatalogPayloadBuilder {
         result.put("completions", !catalog.getCompletionTargetDescriptors().isEmpty());
         result.put("resourceNavigation", hasResourceNavigation);
         return result;
-    }
-    
-    private Map<String, Object> createFingerprints(final List<Map<String, Object>> resources, final List<Map<String, Object>> resourceTemplates,
-                                                   final List<Map<String, Object>> tools, final List<Map<String, Object>> prompts,
-                                                   final List<Map<String, Object>> completionTargets, final List<Map<String, Object>> resourceNavigation) {
-        Map<String, Object> result = new LinkedHashMap<>(5, 1F);
-        result.put("algorithm", "sha256");
-        result.put("descriptorCatalog", createHash(Map.of(
-                "resources", resources,
-                "resourceTemplates", resourceTemplates,
-                "tools", tools,
-                "prompts", prompts,
-                "completionTargets", completionTargets,
-                "resourceNavigation", resourceNavigation)));
-        result.put("promptSet", createHash(prompts));
-        result.put("resourceNavigation", createHash(resourceNavigation));
-        result.put("modelFacingSchemas", createHash(createModelFacingSchemas(resources, resourceTemplates, tools)));
-        return result;
-    }
-    
-    private List<Map<String, Object>> createModelFacingSchemas(final List<Map<String, Object>> resources, final List<Map<String, Object>> resourceTemplates,
-                                                               final List<Map<String, Object>> tools) {
-        List<Map<String, Object>> result = new LinkedList<>();
-        resources.stream().map(this::createResourceSchema).forEach(result::add);
-        resourceTemplates.stream().map(this::createResourceSchema).forEach(result::add);
-        tools.stream().map(this::createToolSchema).forEach(result::add);
-        return result;
-    }
-    
-    private Map<String, Object> createResourceSchema(final Map<String, Object> resource) {
-        return resource.containsKey("uriTemplate") ? Map.of("uriTemplate", resource.get("uriTemplate")) : Map.of(MCPPayloadFieldNames.URI, resource.get(MCPPayloadFieldNames.URI));
-    }
-    
-    private Map<String, Object> createToolSchema(final Map<String, Object> tool) {
-        return Map.of("name", tool.get("name"), "inputSchema", tool.get("inputSchema"), "outputSchema", tool.get("outputSchema"));
-    }
-    
-    private String createHash(final Object value) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] bytes = digest.digest(canonicalize(value).getBytes(StandardCharsets.UTF_8));
-            return toHex(bytes);
-        } catch (final NoSuchAlgorithmException ex) {
-            throw new IllegalStateException("SHA-256 is not available.", ex);
-        }
-    }
-    
-    private String toHex(final byte[] bytes) {
-        StringBuilder result = new StringBuilder(bytes.length * 2);
-        for (byte each : bytes) {
-            int value = each & 0xFF;
-            if (value < 16) {
-                result.append('0');
-            }
-            result.append(Integer.toHexString(value));
-        }
-        return result.toString();
-    }
-    
-    private String canonicalize(final Object value) {
-        if (null == value) {
-            return "null";
-        }
-        if (value instanceof Map) {
-            return canonicalizeMap((Map<?, ?>) value);
-        }
-        if (value instanceof Collection) {
-            return canonicalizeCollection((Collection<?>) value);
-        }
-        if (value instanceof Number || value instanceof Boolean) {
-            return String.valueOf(value);
-        }
-        return "\"" + escape(String.valueOf(value)) + "\"";
-    }
-    
-    private String canonicalizeMap(final Map<?, ?> value) {
-        StringBuilder result = new StringBuilder("{");
-        List<? extends Entry<?, ?>> entries = value.entrySet().stream()
-                .sorted(Comparator.comparing(each -> String.valueOf(each.getKey()))).toList();
-        for (int index = 0; index < entries.size(); index++) {
-            if (0 < index) {
-                result.append(',');
-            }
-            Entry<?, ?> entry = entries.get(index);
-            result.append(canonicalize(String.valueOf(entry.getKey()))).append(':').append(canonicalize(entry.getValue()));
-        }
-        return result.append('}').toString();
-    }
-    
-    private String canonicalizeCollection(final Collection<?> value) {
-        StringBuilder result = new StringBuilder("[");
-        int index = 0;
-        for (Object each : value) {
-            if (0 < index++) {
-                result.append(',');
-            }
-            result.append(canonicalize(each));
-        }
-        return result.append(']').toString();
-    }
-    
-    private String escape(final String value) {
-        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndexTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndexTest.java
@@ -131,10 +131,6 @@ class MCPDescriptorCatalogIndexTest {
         assertThat(actual.get("supportedResources"), is(List.of("shardingsphere://workflows/{plan_id}")));
         assertThat(actual.get("supportedTools"), is(List.of("database_gateway_apply_workflow")));
         assertThat(actual.get("supportedStatementClasses"), is(List.of("SELECT")));
-    }
-    
-    @Test
-    void assertGetDescriptorCatalogFingerprint() {
-        assertFalse(MCPDescriptorCatalogIndex.getDescriptorCatalogFingerprint().isEmpty());
+        assertFalse(actual.containsKey("fingerprints"));
     }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationArtifacts.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationArtifacts.java
@@ -26,7 +26,6 @@ import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionTr
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 final class LLMMCPConversationArtifacts {
@@ -41,8 +40,6 @@ final class LLMMCPConversationArtifacts {
     
     private final List<String> mcpRuntimeLogLines = new LinkedList<>();
     
-    private Map<String, Object> capabilityFingerprints = Map.of();
-    
     private String finalAnswerJson = "";
     
     void addRawModelOutput(final String rawModelOutput) {
@@ -55,10 +52,6 @@ final class LLMMCPConversationArtifacts {
     
     void addRuntimeLogLine(final String runtimeLogLine) {
         mcpRuntimeLogLines.add(runtimeLogLine);
-    }
-    
-    void setCapabilityFingerprints(final Map<String, Object> capabilityFingerprints) {
-        this.capabilityFingerprints = null == capabilityFingerprints ? Map.of() : capabilityFingerprints;
     }
     
     List<MCPInteractionTraceRecord> getInteractionTrace() {
@@ -79,6 +72,6 @@ final class LLMMCPConversationArtifacts {
     
     LLME2EArtifactBundle createArtifactBundle(final LLME2EScenario scenario, final LLME2EAssertionReport assertionReport) {
         return new LLME2EArtifactBundle(scenario.getScenarioId(), scenario.getSystemPrompt(), scenario.getUserPrompt(), modelProvider, modelName,
-                capabilityFingerprints, finalAnswerJson, rawModelOutputs, interactionTrace, mcpRuntimeLogLines, assertionReport);
+                finalAnswerJson, rawModelOutputs, interactionTrace, mcpRuntimeLogLines, assertionReport);
     }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationArtifactsTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationArtifactsTest.java
@@ -55,20 +55,6 @@ class LLMMCPConversationArtifactsTest {
     }
     
     @Test
-    void assertSetCapabilityFingerprints() {
-        LLMMCPConversationArtifacts artifacts = new LLMMCPConversationArtifacts("provider", "model");
-        artifacts.setCapabilityFingerprints(Map.of("tools", 1));
-        assertThat(artifacts.createArtifactBundle(createScenario(), LLME2EAssertionReport.isSuccess("ok")).getCapabilityFingerprints(), is(Map.of("tools", 1)));
-    }
-    
-    @Test
-    void assertSetCapabilityFingerprintsWithNull() {
-        LLMMCPConversationArtifacts artifacts = new LLMMCPConversationArtifacts("provider", "model");
-        artifacts.setCapabilityFingerprints(null);
-        assertThat(artifacts.createArtifactBundle(createScenario(), LLME2EAssertionReport.isSuccess("ok")).getCapabilityFingerprints(), is(Map.of()));
-    }
-    
-    @Test
     void assertNextSequence() {
         LLMMCPConversationArtifacts artifacts = new LLMMCPConversationArtifacts("provider", "model");
         artifacts.addInteractionTrace(createTrace());
@@ -90,7 +76,6 @@ class LLMMCPConversationArtifactsTest {
     @Test
     void assertCreateArtifactBundle() {
         LLMMCPConversationArtifacts artifacts = new LLMMCPConversationArtifacts("provider", "model");
-        artifacts.setCapabilityFingerprints(Map.of("tools", 1));
         artifacts.setFinalAnswerJson("{\"ok\":true}");
         artifacts.addRawModelOutput("raw-output");
         MCPInteractionTraceRecord traceRecord = createTrace();
@@ -103,7 +88,6 @@ class LLMMCPConversationArtifactsTest {
         assertThat(actual.getUserPrompt(), is("user"));
         assertThat(actual.getModelProvider(), is("provider"));
         assertThat(actual.getModelName(), is("model"));
-        assertThat(actual.getCapabilityFingerprints(), is(Map.of("tools", 1)));
         assertThat(actual.getFinalAnswerJson(), is("{\"ok\":true}"));
         assertThat(actual.getRawModelOutputs(), is(List.of("raw-output")));
         assertThat(actual.getInteractionTrace(), is(List.of(traceRecord)));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunner.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunner.java
@@ -61,26 +61,18 @@ public final class LLMMCPConversationRunner {
     
     private final String modelName;
     
-    private final boolean recordCapabilityFingerprints;
-    
     public LLMMCPConversationRunner(final int maxTurns, final LLMChatModelClient llmChatClient, final MCPInteractionClient mcpInteractionClient) {
-        this(maxTurns, llmChatClient, mcpInteractionClient, "unknown", "unknown", false);
+        this(maxTurns, llmChatClient, mcpInteractionClient, "unknown", "unknown");
     }
     
     public LLMMCPConversationRunner(final int maxTurns, final LLMChatModelClient llmChatClient, final MCPInteractionClient mcpInteractionClient,
                                     final String modelProvider, final String modelName) {
-        this(maxTurns, llmChatClient, mcpInteractionClient, modelProvider, modelName, true);
-    }
-    
-    private LLMMCPConversationRunner(final int maxTurns, final LLMChatModelClient llmChatClient, final MCPInteractionClient mcpInteractionClient,
-                                     final String modelProvider, final String modelName, final boolean recordCapabilityFingerprints) {
         this.maxTurns = maxTurns;
         this.llmChatClient = llmChatClient;
         this.mcpInteractionClient = mcpInteractionClient;
         actionExecutor = new LLMMCPActionExecutor(mcpInteractionClient);
         this.modelProvider = modelProvider;
         this.modelName = modelName;
-        this.recordCapabilityFingerprints = recordCapabilityFingerprints;
     }
     
     /**
@@ -95,7 +87,6 @@ public final class LLMMCPConversationRunner {
         try {
             llmChatClient.waitUntilReady();
             openInteractionClient();
-            artifacts.setCapabilityFingerprints(readCapabilityFingerprintsSafely());
             boolean finalAnswerRequested = false;
             int finalAnswerAttempts = 0;
             for (int turnIndex = 0; turnIndex < maxTurns; turnIndex++) {
@@ -209,12 +200,12 @@ public final class LLMMCPConversationRunner {
         if (hasSideEffectExecutionNextAction(interactionTrace)) {
             List<String> readOnlyToolNames = findMissingReadOnlyToolNames(scenario, interactionTrace);
             if (!readOnlyToolNames.isEmpty()) {
-                return List.of(readOnlyToolNames.get(0));
+                return List.of(readOnlyToolNames.getFirst());
             }
         }
         List<String> missingToolNames = findMissingAllowedToolNames(scenario, interactionTrace);
         if (!missingToolNames.isEmpty()) {
-            return List.of(missingToolNames.get(0));
+            return List.of(missingToolNames.getFirst());
         }
         return scenario.getAllowedToolNames();
     }
@@ -466,18 +457,6 @@ public final class LLMMCPConversationRunner {
         }
     }
     
-    private Map<String, Object> readCapabilityFingerprintsSafely() throws InterruptedException {
-        if (!recordCapabilityFingerprints) {
-            return Map.of();
-        }
-        try {
-            Map<String, Object> capabilities = mcpInteractionClient.readResource("shardingsphere://capabilities");
-            return null == capabilities || !capabilities.containsKey("fingerprints") ? Map.of() : LLMMCPJsonValues.castToMap(capabilities.get("fingerprints"));
-        } catch (final IOException | UnsupportedOperationException ex) {
-            return Map.of();
-        }
-    }
-    
     private void closeInteractionClient() {
         try {
             mcpInteractionClient.close();
@@ -542,7 +521,7 @@ public final class LLMMCPConversationRunner {
         if (rowObjects.isEmpty()) {
             return "";
         }
-        return Objects.toString(rowObjects.get(0).get("total_orders"), "").trim();
+        return Objects.toString(rowObjects.getFirst().get("total_orders"), "").trim();
     }
     
     private String findTotalOrdersInRows(final Map<String, Object> structuredContent) {
@@ -550,8 +529,8 @@ public final class LLMMCPConversationRunner {
         if (rows.isEmpty()) {
             return "";
         }
-        List<Object> row = LLMMCPJsonValues.castToList(rows.get(0));
-        return row.isEmpty() ? "" : Objects.toString(row.get(0), "").trim();
+        List<Object> row = LLMMCPJsonValues.castToList(rows.getFirst());
+        return row.isEmpty() ? "" : Objects.toString(row.getFirst(), "").trim();
     }
     
     private List<String> createComparableInteractionSequence(final List<MCPInteractionTraceRecord> interactionTrace) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunnerTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunnerTest.java
@@ -25,9 +25,6 @@ import org.apache.shardingsphere.test.e2e.mcp.llm.conversation.client.LLMToolCal
 import org.apache.shardingsphere.test.e2e.mcp.llm.scenario.LLME2EScenario;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionActionNames;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionTraceRecord;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -38,6 +35,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -65,14 +65,14 @@ class LLMMCPConversationRunnerTest extends AbstractLLMMCPConversationRunnerTest 
         
         assertTrue(actual.getAssertionReport().isSuccess());
         assertThat(actual.getInteractionTrace().size(), is(1));
-        assertThat(actual.getInteractionTrace().get(0).getActionOrigin(), is(MCPInteractionTraceRecord.MODEL_TOOL_CALL_ORIGIN));
+        assertThat(actual.getInteractionTrace().getFirst().getActionOrigin(), is(MCPInteractionTraceRecord.MODEL_TOOL_CALL_ORIGIN));
         assertThat(actual.getRawModelOutputs(), is(List.of("tool-call-response", "final-answer-response")));
         verify(getLLMChatClient()).complete(anyList(), actualTools.capture(), eq("required"), eq(false));
         verify(getMCPInteractionClient()).open();
         verify(getMCPInteractionClient()).call("database_gateway_execute_query", executeQueryArguments);
         verify(getMCPInteractionClient()).close();
-        assertThat(getToolName(actualTools.getValue().get(0)), is("database_gateway_execute_query"));
-        assertThat(getMap(getFunction(actualTools.getValue().get(0)).get("parameters")).get("required"), is(List.of("database", "sql")));
+        assertThat(getToolName(actualTools.getValue().getFirst()), is("database_gateway_execute_query"));
+        assertThat(getMap(getFunction(actualTools.getValue().getFirst()).get("parameters")).get("required"), is(List.of("database", "sql")));
     }
     
     @Test
@@ -90,8 +90,8 @@ class LLMMCPConversationRunnerTest extends AbstractLLMMCPConversationRunnerTest 
         LLME2EArtifactBundle actual = actualRunner.run(actualScenario);
         
         assertTrue(actual.getAssertionReport().isSuccess());
-        assertThat(actual.getInteractionTrace().get(0).getActionOrigin(), is(MCPInteractionTraceRecord.HARNESS_ARGUMENT_NORMALIZATION_ORIGIN));
-        assertThat(actual.getInteractionTrace().get(0).getArguments(), is(expectedQueryArguments));
+        assertThat(actual.getInteractionTrace().getFirst().getActionOrigin(), is(MCPInteractionTraceRecord.HARNESS_ARGUMENT_NORMALIZATION_ORIGIN));
+        assertThat(actual.getInteractionTrace().getFirst().getArguments(), is(expectedQueryArguments));
         verify(getMCPInteractionClient()).call("database_gateway_execute_query", expectedQueryArguments);
         verify(getLLMChatClient(), never()).complete(anyList(), anyList(), eq("auto"), eq(false));
     }
@@ -122,8 +122,8 @@ class LLMMCPConversationRunnerTest extends AbstractLLMMCPConversationRunnerTest 
         LLME2EArtifactBundle actual = actualRunner.run(actualScenario);
         
         assertTrue(actual.getAssertionReport().isSuccess());
-        assertThat(actual.getInteractionTrace().get(0).getActionOrigin(), is(MCPInteractionTraceRecord.HARNESS_ARGUMENT_NORMALIZATION_ORIGIN));
-        assertThat(actual.getInteractionTrace().get(0).getArguments(), is(expectedSearchArguments));
+        assertThat(actual.getInteractionTrace().getFirst().getActionOrigin(), is(MCPInteractionTraceRecord.HARNESS_ARGUMENT_NORMALIZATION_ORIGIN));
+        assertThat(actual.getInteractionTrace().getFirst().getArguments(), is(expectedSearchArguments));
         verify(getMCPInteractionClient()).call("database_gateway_search_metadata", expectedSearchArguments);
     }
     
@@ -143,7 +143,7 @@ class LLMMCPConversationRunnerTest extends AbstractLLMMCPConversationRunnerTest 
         LLME2EArtifactBundle actual = actualRunner.run(actualScenario);
         
         assertTrue(actual.getAssertionReport().isSuccess());
-        assertThat(actual.getInteractionTrace().get(0).getArguments(), is(expectedQueryArguments));
+        assertThat(actual.getInteractionTrace().getFirst().getArguments(), is(expectedQueryArguments));
         verify(getLLMChatClient(), never()).complete(anyList(), anyList(), eq("auto"), eq(false));
     }
     
@@ -201,8 +201,8 @@ class LLMMCPConversationRunnerTest extends AbstractLLMMCPConversationRunnerTest 
         
         assertTrue(actual.getAssertionReport().isSuccess());
         assertThat(actual.getInteractionTrace().size(), is(3));
-        assertThat(actual.getInteractionTrace().get(0).getActionKind(), is(MCPInteractionActionNames.RESOURCE_LIST_KIND));
-        assertThat(actual.getInteractionTrace().get(0).getActionOrigin(), is(MCPInteractionTraceRecord.PROTOCOL_BRIDGE_ORIGIN));
+        assertThat(actual.getInteractionTrace().getFirst().getActionKind(), is(MCPInteractionActionNames.RESOURCE_LIST_KIND));
+        assertThat(actual.getInteractionTrace().getFirst().getActionOrigin(), is(MCPInteractionTraceRecord.PROTOCOL_BRIDGE_ORIGIN));
         assertThat(actual.getInteractionTrace().get(1).getActionKind(), is(MCPInteractionActionNames.RESOURCE_READ_KIND));
         assertThat(actual.getInteractionTrace().get(2).getTargetName(), is("database_gateway_execute_query"));
         assertThat(actual.getInteractionTrace().get(2).getActionOrigin(), is(MCPInteractionTraceRecord.MODEL_TOOL_CALL_ORIGIN));
@@ -235,7 +235,7 @@ class LLMMCPConversationRunnerTest extends AbstractLLMMCPConversationRunnerTest 
         when(getMCPInteractionClient().readResource("shardingsphere://features/mask/algorithms")).thenReturn(Map.of("algorithms", List.of(Map.of("type", "MD5"))));
         when(getMCPInteractionClient().call("database_gateway_plan_mask_rule", planArguments))
                 .thenReturn(Map.of("plan_id", "plan-1", "resources_to_read", List.of(Map.of("uri", workflowResourceUri))));
-        when(getMCPInteractionClient().readResource("shardingsphere://runtime")).thenReturn(Map.of("status", "available", "capability_fingerprint", "abc"));
+        when(getMCPInteractionClient().readResource("shardingsphere://runtime")).thenReturn(Map.of("status", "available"));
         when(getMCPInteractionClient().readResource(workflowResourceUri)).thenReturn(Map.of("plan_id", "plan-1", "status", "planned"));
         when(getMCPInteractionClient().call("database_gateway_apply_workflow", applyArguments)).thenReturn(Map.of("status", "awaiting-manual-execution", "response_mode", "manual_only"));
         when(getMCPInteractionClient().call("database_gateway_validate_workflow", validateArguments)).thenReturn(Map.of("status", "passed", "overall_status", "passed"));
@@ -289,14 +289,14 @@ class LLMMCPConversationRunnerTest extends AbstractLLMMCPConversationRunnerTest 
         
         assertTrue(actual.getAssertionReport().isSuccess());
         assertThat(actual.getInteractionTrace().size(), is(4));
-        assertThat(actual.getInteractionTrace().get(0).getActionKind(), is(MCPInteractionActionNames.PROMPT_LIST_KIND));
+        assertThat(actual.getInteractionTrace().getFirst().getActionKind(), is(MCPInteractionActionNames.PROMPT_LIST_KIND));
         assertThat(actual.getInteractionTrace().get(1).getActionKind(), is(MCPInteractionActionNames.PROMPT_GET_KIND));
         assertThat(actual.getInteractionTrace().get(2).getActionKind(), is(MCPInteractionActionNames.COMPLETION_KIND));
         verify(getLLMChatClient()).complete(anyList(), actualTools.capture(), eq("required"), eq(false));
         verify(getMCPInteractionClient()).listPrompts();
         verify(getMCPInteractionClient()).getPrompt(PROMPT_NAME, promptArguments);
         verify(getMCPInteractionClient()).complete(completionReference, "schema", "pub", completionContext);
-        assertThat(getToolName(actualTools.getValue().get(0)), is(MCPInteractionActionNames.LIST_PROMPTS));
+        assertThat(getToolName(actualTools.getValue().getFirst()), is(MCPInteractionActionNames.LIST_PROMPTS));
     }
     
     @Test
@@ -311,13 +311,13 @@ class LLMMCPConversationRunnerTest extends AbstractLLMMCPConversationRunnerTest 
         
         assertThat(actual.getAssertionReport().getFailureType(), is("missing_required_tool_coverage"));
         verify(getLLMChatClient()).complete(anyList(), actualTools.capture(), eq("required"), eq(false));
-        assertThat(getToolName(actualTools.getValue().get(0)), is("database_gateway_search_metadata"));
-        assertThat(getRequiredFields(actualTools.getValue().get(0)), is(List.of()));
-        assertThat(getPropertyType(actualTools.getValue().get(0), "database"), is("string"));
-        assertThat(getPropertyType(actualTools.getValue().get(0), "schema"), is("string"));
-        assertThat(getPropertyType(actualTools.getValue().get(0), "query"), is("string"));
-        assertThat(getPropertyType(actualTools.getValue().get(0), "object_types"), is("array"));
-        assertThat(getNestedPropertyType(actualTools.getValue().get(0), "object_types", "items"), is("string"));
+        assertThat(getToolName(actualTools.getValue().getFirst()), is("database_gateway_search_metadata"));
+        assertThat(getRequiredFields(actualTools.getValue().getFirst()), is(List.of()));
+        assertThat(getPropertyType(actualTools.getValue().getFirst(), "database"), is("string"));
+        assertThat(getPropertyType(actualTools.getValue().getFirst(), "schema"), is("string"));
+        assertThat(getPropertyType(actualTools.getValue().getFirst(), "query"), is("string"));
+        assertThat(getPropertyType(actualTools.getValue().getFirst(), "object_types"), is("array"));
+        assertThat(getNestedPropertyType(actualTools.getValue().getFirst(), "object_types", "items"), is("string"));
     }
     
     @Test
@@ -343,7 +343,7 @@ class LLMMCPConversationRunnerTest extends AbstractLLMMCPConversationRunnerTest 
         
         assertTrue(actual.getAssertionReport().isSuccess());
         verify(getLLMChatClient(), times(3)).complete(anyList(), actualTools.capture(), eq("required"), eq(false));
-        assertThat(getToolNames(actualTools.getAllValues().get(0)), is(List.of("database_gateway_search_metadata")));
+        assertThat(getToolNames(actualTools.getAllValues().getFirst()), is(List.of("database_gateway_search_metadata")));
         assertThat(getToolNames(actualTools.getAllValues().get(1)), is(List.of(MCPInteractionActionNames.READ_RESOURCE)));
         assertThat(getToolNames(actualTools.getAllValues().get(2)), is(List.of("database_gateway_execute_query")));
     }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/artifact/LLME2EArtifactBundle.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/artifact/LLME2EArtifactBundle.java
@@ -22,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionTraceRecord;
 
 import java.util.List;
-import java.util.Map;
 
 @RequiredArgsConstructor
 @Getter
@@ -37,8 +36,6 @@ public final class LLME2EArtifactBundle {
     private final String modelProvider;
     
     private final String modelName;
-    
-    private final Map<String, Object> capabilityFingerprints;
     
     private final String finalAnswerJson;
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/artifact/LLME2EArtifactWriter.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/artifact/LLME2EArtifactWriter.java
@@ -70,7 +70,6 @@ public final class LLME2EArtifactWriter {
                 "modelProvider", artifactBundle.getModelProvider(),
                 "modelName", artifactBundle.getModelName(),
                 "runtime", runtimeEvidence,
-                "capabilityFingerprints", artifactBundle.getCapabilityFingerprints(),
                 "failureType", artifactBundle.getAssertionReport().getFailureType());
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/artifact/LLME2EArtifactWriterTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/artifact/LLME2EArtifactWriterTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,14 +44,13 @@ class LLME2EArtifactWriterTest {
     @Test
     void assertWriteRedactsSecretsAndRecordsRunContext() throws IOException {
         LLME2EArtifactBundle artifactBundle = new LLME2EArtifactBundle("scenario-id", "system", "user",
-                "openai-compatible", MODEL_NAME, Map.of("descriptorCatalog", "abc123"),
-                "{\"api_key\":\"secret-value\"}", List.of("{\"token\":\"raw-secret\"}"), List.of(),
+                "openai-compatible", MODEL_NAME, "{\"api_key\":\"secret-value\"}", List.of("{\"token\":\"raw-secret\"}"), List.of(),
                 List.of("Authorization: Bearer runtime-secret", "MCP_LLM_API_KEY=runtime-secret"), LLME2EAssertionReport.failure("boom", "failed"));
         new LLME2EArtifactWriter().write(tempDir, artifactBundle, createScoreClosingEvidence());
         Map<String, Object> runContext = JsonUtils.fromJsonString(Files.readString(tempDir.resolve("run-context.json")), new TypeReference<>() {
         });
         assertThat(runContext.get("modelName"), is(MODEL_NAME));
-        assertThat(castToMap(runContext.get("capabilityFingerprints")).get("descriptorCatalog"), is("abc123"));
+        assertFalse(runContext.containsKey("capabilityFingerprints"));
         assertThat(castToMap(runContext.get("runtime")).get("runtimeMode"), is("docker"));
         assertTrue((boolean) castToMap(runContext.get("runtime")).get("dockerOwned"));
         assertThat(castToMap(runContext.get("runtime")).get("serverRuntime"), is("llama.cpp"));
@@ -65,7 +65,7 @@ class LLME2EArtifactWriterTest {
     @Test
     void assertWriteWithMissingScoreClosingEvidence() {
         LLME2EArtifactBundle artifactBundle = new LLME2EArtifactBundle("scenario-id", "system", "user",
-                "openai-compatible", MODEL_NAME, Map.of(), "{}", List.of(), List.of(), List.of(), LLME2EAssertionReport.failure("boom", "failed"));
+                "openai-compatible", MODEL_NAME, "{}", List.of(), List.of(), List.of(), LLME2EAssertionReport.failure("boom", "failed"));
         IllegalStateException actualException = assertThrows(IllegalStateException.class,
                 () -> new LLME2EArtifactWriter().write(tempDir, artifactBundle, Map.of("scoreClosing", true)));
         assertThat(actualException.getMessage(), is("Missing score-closing LLM runtime evidence field `runtimeMode`."));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/LLMUsabilitySuiteRunnerTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/LLMUsabilitySuiteRunnerTest.java
@@ -65,7 +65,7 @@ class LLMUsabilitySuiteRunnerTest {
         List<MCPInteractionTraceRecord> trace = List.of(new MCPInteractionTraceRecord(1, "tool_call", MCPInteractionTraceRecord.MODEL_TOOL_CALL_ORIGIN,
                 "database_gateway_execute_query", Map.of(), Map.of("result_kind", "result_set"), true, 0L));
         LLME2EArtifactBundle artifactBundle = new LLME2EArtifactBundle(scenario.getScenarioId(), scenario.getSystemPrompt(), scenario.getUserPrompt(), "provider", "model",
-                Map.of(), "{}", List.of("raw-output"), trace, List.of("runtime-log"), LLME2EAssertionReport.isSuccess("ok"));
+                "{}", List.of("raw-output"), trace, List.of("runtime-log"), LLME2EAssertionReport.isSuccess("ok"));
         return new LLMConversationExecutor.ConversationResult(artifactBundle, artifactDirectory);
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/assessment/LLMUsabilityMetricCalculatorTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/assessment/LLMUsabilityMetricCalculatorTest.java
@@ -273,11 +273,11 @@ class LLMUsabilityMetricCalculatorTest {
     }
     
     private LLME2EArtifactBundle createArtifactBundle(final List<MCPInteractionTraceRecord> interactionTrace) {
-        return new LLME2EArtifactBundle("scenario", "", "", "", "", Map.of(), "", List.of(), interactionTrace, List.of(), LLME2EAssertionReport.isSuccess("ok"));
+        return new LLME2EArtifactBundle("scenario", "", "", "", "", "", List.of(), interactionTrace, List.of(), LLME2EAssertionReport.isSuccess("ok"));
     }
     
     private LLME2EArtifactBundle createFailedArtifactBundle(final List<MCPInteractionTraceRecord> interactionTrace) {
-        return new LLME2EArtifactBundle("scenario", "", "", "", "", Map.of(), "", List.of(), interactionTrace, List.of(), LLME2EAssertionReport.failure("failed", "failed"));
+        return new LLME2EArtifactBundle("scenario", "", "", "", "", "", List.of(), interactionTrace, List.of(), LLME2EAssertionReport.failure("failed", "failed"));
     }
     
     private LLMUsabilityScenario createScenario() {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionMySQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionMySQLRuntimeE2ETest.java
@@ -292,8 +292,7 @@ abstract class AbstractProductionMySQLRuntimeE2ETest extends AbstractTransportPa
         assertTrue(capabilities.containsKey("next_action_contract"));
         assertTrue(capabilities.containsKey("common_flows"));
         assertTrue(capabilities.containsKey("security_hints"));
-        assertTrue(capabilities.containsKey("fingerprints"));
-        assertFalse(getMap(capabilities.get("fingerprints")).isEmpty());
+        assertFalse(capabilities.containsKey("fingerprints"));
         assertFalse(((List<?>) capabilities.get("common_flows")).isEmpty());
         Map<String, Object> modelFirstSummary = getMap(capabilities.get("model_first_summary"));
         assertThat(getMap(modelFirstSummary.get("official_discovery_methods")).get("tools"), is("tools/list"));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportBaselineContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportBaselineContractE2ETest.java
@@ -54,7 +54,7 @@ class HttpTransportBaselineContractE2ETest extends AbstractSharedHttpProgrammati
     }
     
     private Map<String, Object> createCapabilitiesContract(final Map<String, Object> payload) {
-        Map<String, Object> result = new LinkedHashMap<>(13, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(12, 1F);
         result.put("response_mode", payload.get("response_mode"));
         result.put("model_first_summary", payload.get("model_first_summary"));
         result.put("model_contract", payload.get("model_contract"));
@@ -63,7 +63,6 @@ class HttpTransportBaselineContractE2ETest extends AbstractSharedHttpProgrammati
         result.put("next_action_contract", payload.get("next_action_contract"));
         result.put("common_flows", payload.get("common_flows"));
         result.put("protocolAvailability", payload.get("protocolAvailability"));
-        result.put("fingerprints", payload.get("fingerprints"));
         result.put("resources", summarizeCapabilityResourceIdentities(castToMapList(payload.get("resources"))));
         result.put("resourceTemplates", summarizeCapabilityResourceTemplateIdentities(castToMapList(payload.get("resourceTemplates"))));
         result.put("tools", summarizeCapabilityTools(castToMapList(payload.get("tools"))));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportContractE2ETest.java
@@ -69,11 +69,7 @@ class HttpTransportContractE2ETest extends AbstractSharedHttpProgrammaticRuntime
         assertTrue(((List<?>) actualCapabilities.get("prompts")).stream().map(String::valueOf).anyMatch(each -> each.contains("inspect_metadata")));
         assertTrue(((List<?>) actualCapabilities.get("completionTargets")).stream().map(String::valueOf).anyMatch(each -> each.contains("inspect_metadata")));
         assertTrue(((List<?>) actualCapabilities.get("resourceNavigation")).stream().map(String::valueOf).anyMatch(each -> each.contains("database_gateway_apply_workflow")));
-        Map<String, Object> actualFingerprints = castToMap(actualCapabilities.get("fingerprints"));
-        assertFalse(String.valueOf(actualFingerprints.get("descriptorCatalog")).isEmpty());
-        assertFalse(String.valueOf(actualFingerprints.get("promptSet")).isEmpty());
-        assertFalse(String.valueOf(actualFingerprints.get("resourceNavigation")).isEmpty());
-        assertFalse(String.valueOf(actualFingerprints.get("modelFacingSchemas")).isEmpty());
+        assertFalse(actualCapabilities.containsKey("fingerprints"));
         Map<String, Object> actualProtocolAvailability = castToMap(actualCapabilities.get("protocolAvailability"));
         assertTrue((Boolean) actualProtocolAvailability.get("prompts"));
         assertTrue((Boolean) actualProtocolAvailability.get("completions"));

--- a/test/e2e/mcp/src/test/resources/baseline-contract/model-contract/capabilities.yaml
+++ b/test/e2e/mcp/src/test/resources/baseline-contract/model-contract/capabilities.yaml
@@ -171,9 +171,6 @@ common_flows:
   referenced_resources: ['shardingsphere://capabilities']
 protocolAvailability: {resources: true, resourceTemplates: true, tools: true, toolAnnotations: true,
   toolOutputSchemas: true, prompts: true, completions: true, resourceNavigation: true}
-fingerprints: {algorithm: sha256, descriptorCatalog: 28f6490a0c3745ae0c992aa89268fe6352d8a8c97c7276ac7123233c4456b1c1,
-  promptSet: 3232cdab7c69f8e627da044e3d85f2dd72a0d08102541a42f6b9d75c89b2557e, resourceNavigation: 241f02eb306c284cbb2535ee38390f8d962e0288d7ee34c8cf0ed363a44ab741,
-  modelFacingSchemas: 16a15a5912d4258496ce3faf866fad4f95e9c3f23682b23f8e1be2964d0a72ec}
 resources:
 - uri: shardingsphere://capabilities
   name: server-capability-catalog


### PR DESCRIPTION
Remove opaque fingerprint metadata from MCP capability and runtime payloads. Delete unused descriptor catalog hash helpers and stop LLM E2E artifacts from recording capability fingerprints.

Update MCP unit tests, E2E contract baselines, production runtime assertions.

For #35294.
