### PR TITLE
Remove pseudo MCP LLM server runtime configuration

### DIFF
--- a/.github/workflows/e2e-mcp.yml
+++ b/.github/workflows/e2e-mcp.yml
@@ -108,7 +108,6 @@ jobs:
             echo "target_platform=${target_platform}"
             echo "server_image=$(load_property 'mcp.llm.server-image')"
             echo "base_server_image=${base_server_image}"
-            echo "server_runtime=$(load_property 'mcp.llm.server-runtime')"
             echo "model_repository=$(load_property 'mcp.llm.model-repository')"
             echo "model_quantization=$(load_property 'mcp.llm.model-quantization')"
             echo "model_reference=$(load_property 'mcp.llm.model')"
@@ -125,7 +124,6 @@ jobs:
             -f test/e2e/mcp/src/test/resources/docker/llm-runtime/Dockerfile \
             -t "${{ steps.mcp-e2e-properties.outputs.server_image }}" \
             --build-arg "BASE_IMAGE=${{ steps.mcp-e2e-properties.outputs.base_server_image }}" \
-            --build-arg "SERVER_RUNTIME=${{ steps.mcp-e2e-properties.outputs.server_runtime }}" \
             --build-arg "MODEL_REPOSITORY=${{ steps.mcp-e2e-properties.outputs.model_repository }}" \
             --build-arg "MODEL_QUANTIZATION=${{ steps.mcp-e2e-properties.outputs.model_quantization }}" \
             --build-arg "MODEL_REFERENCE=${{ steps.mcp-e2e-properties.outputs.model_reference }}" \

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/config/LLME2EConfiguration.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/config/LLME2EConfiguration.java
@@ -48,8 +48,6 @@ public final class LLME2EConfiguration {
     
     private static final String DEFAULT_API_KEY = "mcp-llm-score";
     
-    private static final String DEFAULT_SERVER_RUNTIME = "llama.cpp";
-    
     private static final String DEFAULT_SERVER_IMAGE = "apache/shardingsphere-mcp-llm-runtime:local";
     
     private final String baseUrl;
@@ -71,8 +69,6 @@ public final class LLME2EConfiguration {
     private final String runId;
     
     private final RuntimeMode runtimeMode;
-    
-    private final String serverRuntime;
     
     private final String serverImage;
     
@@ -102,7 +98,6 @@ public final class LLME2EConfiguration {
                 Paths.get(readString(props, "mcp.llm.artifact-root", "target/llm-e2e")),
                 readString(props, "mcp.llm.run-id", createDefaultRunId()),
                 runtimeMode,
-                readString(props, "mcp.llm.server-runtime", DEFAULT_SERVER_RUNTIME),
                 readString(props, "mcp.llm.server-image", DEFAULT_SERVER_IMAGE),
                 readString(props, "mcp.llm.base-server-image", ""),
                 readString(props, "mcp.llm.base-server-image-digest", ""),
@@ -130,7 +125,7 @@ public final class LLME2EConfiguration {
      */
     public LLME2EConfiguration withBaseUrl(final String baseUrl) {
         return new LLME2EConfiguration(normalizeBaseUrl(baseUrl), modelProvider, modelName, apiKey, readyTimeoutSeconds, requestTimeoutSeconds, maxTurns, artifactRoot, runId,
-                runtimeMode, serverRuntime, serverImage, baseServerImage, baseServerImageDigest, modelMetadata);
+                runtimeMode, serverImage, baseServerImage, baseServerImageDigest, modelMetadata);
     }
     
     /**
@@ -142,7 +137,7 @@ public final class LLME2EConfiguration {
      */
     public LLME2EConfiguration withModelEndpoint(final String baseUrl, final String apiKey) {
         return new LLME2EConfiguration(normalizeBaseUrl(baseUrl), modelProvider, modelName, apiKey, readyTimeoutSeconds, requestTimeoutSeconds, maxTurns, artifactRoot, runId,
-                runtimeMode, serverRuntime, serverImage, baseServerImage, baseServerImageDigest, modelMetadata);
+                runtimeMode, serverImage, baseServerImage, baseServerImageDigest, modelMetadata);
     }
     
     /**
@@ -154,7 +149,7 @@ public final class LLME2EConfiguration {
      */
     public LLME2EConfiguration withReadinessTimeouts(final int readyTimeoutSeconds, final int requestTimeoutSeconds) {
         return new LLME2EConfiguration(baseUrl, modelProvider, modelName, apiKey, readyTimeoutSeconds, requestTimeoutSeconds, maxTurns, artifactRoot, runId, runtimeMode,
-                serverRuntime, serverImage, baseServerImage, baseServerImageDigest, modelMetadata);
+                serverImage, baseServerImage, baseServerImageDigest, modelMetadata);
     }
     
     /**

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/config/LLME2EConfigurationTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/config/LLME2EConfigurationTest.java
@@ -53,8 +53,6 @@ class LLME2EConfigurationTest {
     
     private String originalBaseServerImageDigest;
     
-    private String originalServerRuntime;
-    
     private String originalModelRepository;
     
     private String originalModelFileName;
@@ -74,7 +72,6 @@ class LLME2EConfigurationTest {
         originalServerImage = System.getProperty("mcp.llm.server-image");
         originalBaseServerImage = System.getProperty("mcp.llm.base-server-image");
         originalBaseServerImageDigest = System.getProperty("mcp.llm.base-server-image-digest");
-        originalServerRuntime = System.getProperty("mcp.llm.server-runtime");
         originalModelRepository = System.getProperty("mcp.llm.model-repository");
         originalModelFileName = System.getProperty("mcp.llm.model-file-name");
         originalModelQuantization = System.getProperty("mcp.llm.model-quantization");
@@ -86,7 +83,6 @@ class LLME2EConfigurationTest {
         System.clearProperty("mcp.llm.server-image");
         System.clearProperty("mcp.llm.base-server-image");
         System.clearProperty("mcp.llm.base-server-image-digest");
-        System.clearProperty("mcp.llm.server-runtime");
         System.clearProperty("mcp.llm.model-repository");
         System.clearProperty("mcp.llm.model-file-name");
         System.clearProperty("mcp.llm.model-quantization");
@@ -103,7 +99,6 @@ class LLME2EConfigurationTest {
         restoreProperty("mcp.llm.server-image", originalServerImage);
         restoreProperty("mcp.llm.base-server-image", originalBaseServerImage);
         restoreProperty("mcp.llm.base-server-image-digest", originalBaseServerImageDigest);
-        restoreProperty("mcp.llm.server-runtime", originalServerRuntime);
         restoreProperty("mcp.llm.model-repository", originalModelRepository);
         restoreProperty("mcp.llm.model-file-name", originalModelFileName);
         restoreProperty("mcp.llm.model-quantization", originalModelQuantization);
@@ -121,7 +116,6 @@ class LLME2EConfigurationTest {
         String expectedModelReference = expectedProps.getProperty("mcp.llm.model");
         assertThat(actual.getModelName(), is(expectedModelReference));
         assertThat(actual.getApiKey(), is("mcp-llm-score"));
-        assertThat(actual.getServerRuntime(), is(expectedProps.getProperty("mcp.llm.server-runtime")));
         assertThat(actual.getServerImage(), is("apache/shardingsphere-mcp-llm-runtime:local"));
         assertThat(actual.getBaseServerImage(), is("ghcr.io/ggml-org/llama.cpp:server-b9191"));
         assertThat(actual.getBaseServerImageDigest(), is(expectedProps.getProperty("mcp.llm.base-server-image-digest")));
@@ -167,14 +161,12 @@ class LLME2EConfigurationTest {
         System.setProperty("mcp.llm.server-image", "test/mcp-llm-runtime:test");
         System.setProperty("mcp.llm.base-server-image", "test/llama.cpp:test");
         System.setProperty("mcp.llm.base-server-image-digest", "test-base-server-image-digest");
-        System.setProperty("mcp.llm.server-runtime", "test-runtime");
         System.setProperty("mcp.llm.model-repository", "ggml-org/Qwen3-1.7B-GGUF");
         System.setProperty("mcp.llm.model-file-name", "Qwen3-1.7B-Q4_K_M.gguf");
         System.setProperty("mcp.llm.model-quantization", "Q4_K_M");
         System.setProperty("mcp.llm.model-revision", "daeb8e2d528a760970442092f6bf1e55c3b659eb");
         System.setProperty("mcp.llm.model-sha256", "configured-model-sha256");
         LLME2EConfiguration actual = LLME2EConfiguration.load();
-        assertThat(actual.getServerRuntime(), is("test-runtime"));
         assertThat(actual.getServerImage(), is("test/mcp-llm-runtime:test"));
         assertThat(actual.getBaseServerImage(), is("test/llama.cpp:test"));
         assertThat(actual.getBaseServerImageDigest(), is("test-base-server-image-digest"));
@@ -241,7 +233,7 @@ class LLME2EConfigurationTest {
     
     private LLME2EConfiguration createConfiguration(final RuntimeMode runtimeMode, final Path artifactRoot) {
         return new LLME2EConfiguration("http://127.0.0.1:8080/v1", "openai-compatible", "ggml-org/Qwen3-1.7B-GGUF:Q4_K_M", "mcp-llm-score", 600, 240, 10,
-                artifactRoot, "run-id", runtimeMode, "llama.cpp", "apache/shardingsphere-mcp-llm-runtime:local", "ghcr.io/ggml-org/llama.cpp:server-b9191", "",
+                artifactRoot, "run-id", runtimeMode, "apache/shardingsphere-mcp-llm-runtime:local", "ghcr.io/ggml-org/llama.cpp:server-b9191", "",
                 new LLME2EConfiguration.ModelMetadata("ggml-org/Qwen3-1.7B-GGUF", "Qwen3-1.7B-Q4_K_M.gguf", "Q4_K_M", "daeb8e2d528a760970442092f6bf1e55c3b659eb",
                         "configured-model-sha256"));
     }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/client/LLMChatModelClientTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/client/LLMChatModelClientTest.java
@@ -162,7 +162,7 @@ class LLMChatModelClientTest {
     
     private LLME2EConfiguration createConfiguration(final String baseUrl, final int readyTimeoutSeconds) {
         return new LLME2EConfiguration(baseUrl, "openai-compatible", REQUIRED_MODEL, "mcp-llm-score", readyTimeoutSeconds, 30, 10,
-                Path.of("target/llm-e2e"), "run-id", RuntimeMode.DOCKER, "llama.cpp", "apache/shardingsphere-mcp-llm-runtime:local", "ghcr.io/ggml-org/llama.cpp:server-b9191",
+                Path.of("target/llm-e2e"), "run-id", RuntimeMode.DOCKER, "apache/shardingsphere-mcp-llm-runtime:local", "ghcr.io/ggml-org/llama.cpp:server-b9191",
                 "test-base-server-image-digest", MODEL_METADATA);
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/fixture/LLMRuntimeSupport.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/fixture/LLMRuntimeSupport.java
@@ -195,7 +195,7 @@ public final class LLMRuntimeSupport {
             result.put("runtimeMode", config.getRuntimeMode().getValue());
             result.put("dockerOwned", true);
             result.put("provider", config.getModelProvider());
-            result.put("serverRuntime", config.getServerRuntime());
+            result.put("serverRuntime", "llama.cpp");
             result.put("serverImage", config.getServerImage());
             result.put("serverImageId", serverImageId);
             result.put("baseServerImage", config.getBaseServerImage());
@@ -225,7 +225,6 @@ public final class LLMRuntimeSupport {
                     && configuration.getRuntimeMode() == config.getRuntimeMode()
                     && configuration.getModelName().equals(config.getModelName())
                     && configuration.getApiKey().equals(config.getApiKey())
-                    && configuration.getServerRuntime().equals(config.getServerRuntime())
                     && configuration.getServerImage().equals(config.getServerImage())
                     && configuration.getBaseServerImage().equals(config.getBaseServerImage())
                     && configuration.getBaseServerImageDigest().equals(config.getBaseServerImageDigest())

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/fixture/LLMRuntimeSupportTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/fixture/LLMRuntimeSupportTest.java
@@ -85,7 +85,7 @@ class LLMRuntimeSupportTest {
     @Test
     void assertPrepareWithUnsupportedProvider() {
         LLME2EConfiguration config = new LLME2EConfiguration("http://127.0.0.1:8080/v1", "openai", REQUIRED_MODEL, "mcp-llm-score", 600, 240, 10,
-                Path.of("target/llm-e2e"), "run-id", RuntimeMode.DOCKER, "llama.cpp", "apache/shardingsphere-mcp-llm-runtime:local", "ghcr.io/ggml-org/llama.cpp:server-b9191",
+                Path.of("target/llm-e2e"), "run-id", RuntimeMode.DOCKER, "apache/shardingsphere-mcp-llm-runtime:local", "ghcr.io/ggml-org/llama.cpp:server-b9191",
                 "test-base-server-image-digest", MODEL_METADATA);
         IllegalStateException actualException = assertThrows(IllegalStateException.class, () -> LLMRuntimeSupport.prepare(config));
         assertThat(actualException.getMessage(), is("MCP LLM E2E requires provider openai-compatible."));
@@ -93,7 +93,7 @@ class LLMRuntimeSupportTest {
     
     private LLME2EConfiguration createConfiguration(final RuntimeMode runtimeMode, final String modelName, final String baseUrl) {
         return new LLME2EConfiguration(baseUrl, "openai-compatible", modelName, "mcp-llm-score", 2, 2, 10, Path.of("target/llm-e2e"), "run-id",
-                runtimeMode, "llama.cpp", "apache/shardingsphere-mcp-llm-runtime:local", "ghcr.io/ggml-org/llama.cpp:server-b9191", "test-base-server-image-digest", MODEL_METADATA);
+                runtimeMode, "apache/shardingsphere-mcp-llm-runtime:local", "ghcr.io/ggml-org/llama.cpp:server-b9191", "test-base-server-image-digest", MODEL_METADATA);
     }
     
     private HttpServer startModelServer(final String modelName) throws IOException {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/LLMUsabilitySuiteRunnerTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/LLMUsabilitySuiteRunnerTest.java
@@ -86,6 +86,6 @@ class LLMUsabilitySuiteRunnerTest {
     
     private LLME2EConfiguration createConfiguration() {
         return new LLME2EConfiguration("http://127.0.0.1:8080/v1", "provider", "model", "api-key", 1, 1, 1, tempDir, "run-id", RuntimeMode.EXTERNAL_DEBUG,
-                "runtime", "server-image", "base-image", "", new LLME2EConfiguration.ModelMetadata("repository", "model.gguf", "Q4", "revision", "sha256"));
+                "server-image", "base-image", "", new LLME2EConfiguration.ModelMetadata("repository", "model.gguf", "Q4", "revision", "sha256"));
     }
 }

--- a/test/e2e/mcp/src/test/resources/docker/llm-runtime/Dockerfile
+++ b/test/e2e/mcp/src/test/resources/docker/llm-runtime/Dockerfile
@@ -17,7 +17,6 @@
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
-ARG SERVER_RUNTIME
 ARG MODEL_REPOSITORY
 ARG MODEL_QUANTIZATION
 ARG MODEL_REFERENCE
@@ -28,7 +27,7 @@ ARG MODEL_SHA256
 LABEL org.opencontainers.image.title="Apache ShardingSphere MCP LLM E2E Runtime"
 LABEL org.opencontainers.image.description="Prepackaged model server for MCP LLM E2E score evidence"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
-LABEL org.apache.shardingsphere.mcp.llm.server-runtime="${SERVER_RUNTIME}"
+LABEL org.apache.shardingsphere.mcp.llm.runtime="llama.cpp"
 LABEL org.apache.shardingsphere.mcp.llm.model-repository="${MODEL_REPOSITORY}"
 LABEL org.apache.shardingsphere.mcp.llm.model-quantization="${MODEL_QUANTIZATION}"
 LABEL org.apache.shardingsphere.mcp.llm.model-reference="${MODEL_REFERENCE}"

--- a/test/e2e/mcp/src/test/resources/docker/llm-runtime/build-local.sh
+++ b/test/e2e/mcp/src/test/resources/docker/llm-runtime/build-local.sh
@@ -100,7 +100,6 @@ if [ -z "${TARGET_PLATFORM}" ]; then
 fi
 BASE_IMAGE="${MCP_LLM_BASE_SERVER_IMAGE:-$(read_required_property "mcp.llm.base-server-image")}"
 BASE_DIGEST="${MCP_LLM_BASE_SERVER_IMAGE_DIGEST:-$(read_optional_property "mcp.llm.base-server-image-digest")}"
-SERVER_RUNTIME="${MCP_LLM_SERVER_RUNTIME:-$(read_required_property "mcp.llm.server-runtime")}"
 MODEL_REPOSITORY="${MCP_LLM_MODEL_REPOSITORY:-$(read_required_property "mcp.llm.model-repository")}"
 MODEL_QUANTIZATION="${MCP_LLM_MODEL_QUANTIZATION:-$(read_required_property "mcp.llm.model-quantization")}"
 MODEL_REFERENCE="${MCP_LLM_MODEL:-$(read_required_property "mcp.llm.model")}"
@@ -121,7 +120,6 @@ esac
 if [ "--dry-run" = "${MODE}" ] || [ "--print" = "${MODE}" ]; then
   echo "target_platform=${TARGET_PLATFORM}"
   echo "base_image=${BASE_IMAGE}"
-  echo "server_runtime=${SERVER_RUNTIME}"
   echo "model_repository=${MODEL_REPOSITORY}"
   echo "model_quantization=${MODEL_QUANTIZATION}"
   echo "model_reference=${MODEL_REFERENCE}"
@@ -142,7 +140,6 @@ fi
 docker build \
   --platform "${TARGET_PLATFORM}" \
   --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
-  --build-arg "SERVER_RUNTIME=${SERVER_RUNTIME}" \
   --build-arg "MODEL_REPOSITORY=${MODEL_REPOSITORY}" \
   --build-arg "MODEL_QUANTIZATION=${MODEL_QUANTIZATION}" \
   --build-arg "MODEL_REFERENCE=${MODEL_REFERENCE}" \

--- a/test/e2e/mcp/src/test/resources/env/e2e-env.properties
+++ b/test/e2e/mcp/src/test/resources/env/e2e-env.properties
@@ -35,7 +35,6 @@ mcp.llm.request-timeout-seconds=240
 mcp.llm.max-turns=10
 mcp.llm.artifact-root=target/llm-e2e
 mcp.llm.run-id=
-mcp.llm.server-runtime=llama.cpp
 mcp.llm.server-image=apache/shardingsphere-mcp-llm-runtime:local
 mcp.llm.target-platform=
 mcp.llm.base-server-image=ghcr.io/ggml-org/llama.cpp:server-b9191


### PR DESCRIPTION
Remove the configurable mcp.llm.server-runtime property because the LLM E2E Docker runtime is fixed to llama.cpp.

Also drop the related Docker build argument and workflow input, keep llama.cpp as explicit runtime evidence, and update affected tests accordingly.

For #35294.