### PR TITLE
Stabilize Ubuntu nativeTest CI under GraalVM Native Image

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
@@ -222,47 +222,6 @@ cd ./shardingsphere/
 
 ## 已知限制
 
-### `reachability-metadata.json` 限制
-
-受 https://github.com/apache/shardingsphere/issues/33206 影响，
-开发者执行 `./mvnw -PgenerateMetadata -T 1C -e clean test native:metadata-copy` 后，
-`infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json` 会生成不必要的包含绝对路径的 JSON 条目，
-
-对于 Ubuntu，类似如下，
-
-```json
-{
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader"
-      },
-      "glob": "home/runner/work/shardingsphere/shardingsphere/test/native/src/test/resources/test-native/yaml/proxy/databases/mysql/"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader"
-      },
-      "glob": "home/runner/work/shardingsphere/shardingsphere/test/native/src/test/resources/test-native/yaml/proxy/databases/mysql//global.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader"
-      },
-      "glob": "home/runner/work/shardingsphere/shardingsphere/test/native/src/test/resources/test-native/yaml/proxy/databases/postgresql/"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader"
-      },
-      "glob": "home/runner/work/shardingsphere/shardingsphere/test/native/src/test/resources/test-native/yaml/proxy/databases/postgresql//global.yaml"
-    }
-  ]
-}
-```
-
-需要为 ShardingSphere 提交 PR 的贡献者应始终手动删除这些包含绝对路径的 JSON 条目，并等待 https://github.com/oracle/graal/issues/8417 被解决。
-
 ### 单元测试库限制
 
 对于 `shardingsphere-test-native` 的 Maven Module，

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
@@ -229,48 +229,6 @@ developer should place it in the classpath of the `shardingsphere-test-native` s
 
 ## Known limitations
 
-### `reachability-metadata.json` limitations
-
-Affected by https://github.com/apache/shardingsphere/issues/33206,
-after developers execute `./mvnw -PgenerateMetadata -T 1C -e clean test native:metadata-copy`,
-`infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json` will generate unnecessary JSON entries containing absolute paths.
-
-For Ubuntu, it is similar to the following,
-
-```json
-{
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader"
-      },
-      "glob": "home/runner/work/shardingsphere/shardingsphere/test/native/src/test/resources/test-native/yaml/proxy/databases/mysql/"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader"
-      },
-      "glob": "home/runner/work/shardingsphere/shardingsphere/test/native/src/test/resources/test-native/yaml/proxy/databases/mysql//global.yaml"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader"
-      },
-      "glob": "home/runner/work/shardingsphere/shardingsphere/test/native/src/test/resources/test-native/yaml/proxy/databases/postgresql/"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader"
-      },
-      "glob": "home/runner/work/shardingsphere/shardingsphere/test/native/src/test/resources/test-native/yaml/proxy/databases/postgresql//global.yaml"
-    }
-  ]
-}
-```
-
-Contributors who need to submit PRs for ShardingSphere should always manually remove these JSON entries containing absolute paths
-and wait for https://github.com/oracle/graal/issues/8417 to be resolved.
-
 ### Unit test library limitations
 
 For the Maven Module of `shardingsphere-test-native`,

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -185,7 +185,7 @@ vfox install java@21.0.7-ms
 vfox use --global java@21.0.7-ms
 ```
 
-当 Windows 弹出窗口，要求允许类似 `C:\users\lingh\.version-fox\cache\java\v-21.0.7-ms\java-21.0.7-ms\bin\java.exe` 路径的应用通过 Windows 防火墙时，
+当 Windows 弹出窗口，要求允许类似 `C:\users\shard\.version-fox\cache\java\v-21.0.7-ms\java-21.0.7-ms\bin\java.exe` 路径的应用通过 Windows 防火墙时，
 应当批准。 
 背景参考 https://support.microsoft.com/en-us/windows/risks-of-allowing-apps-through-windows-firewall-654559af-3f54-3dcf-349f-71ccd90bcc5c 。
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -189,7 +189,7 @@ vfox install java@21.0.7-ms
 vfox use --global java@21.0.7-ms
 ```
 
-When Windows pops up a window asking you to allow an application with a path like `C:\users\lingh\.version-fox\cache\java\v-21.0.7-ms\java-21.0.7-ms\bin\java.exe` to pass through Windows Firewall,
+When Windows pops up a window asking you to allow an application with a path like `C:\users\shard\.version-fox\cache\java\v-21.0.7-ms\java-21.0.7-ms\bin\java.exe` to pass through Windows Firewall,
 you should approve it.
 Background reference https://support.microsoft.com/en-us/windows/risks-of-allowing-apps-through-windows-firewall-654559af-3f54-3dcf-349f-71ccd90bcc5c .
 

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
@@ -335,7 +335,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistService"
       },
       "type": "java.lang.Object"
     },
@@ -429,12 +429,6 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.lang.Readable"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.manager.SystemSchemaManager"
-      },
-      "type": "java.lang.Record"
     },
     {
       "condition": {
@@ -546,6 +540,21 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "java.net.Socket",
+      "methods": [
+        {
+          "name": "setOption",
+          "parameterTypes": [
+            "java.net.SocketOption",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.net.Socket"
@@ -561,6 +570,20 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.net.URL"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "java.net.UnixDomainSocketAddress",
+      "methods": [
+        {
+          "name": "of",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
     },
     {
       "condition": {
@@ -648,6 +671,20 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "java.security.AccessController",
+      "methods": [
+        {
+          "name": "doPrivileged",
+          "parameterTypes": [
+            "java.security.PrivilegedExceptionAction"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.security.AccessController",
@@ -677,6 +714,17 @@
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
       },
       "type": "java.sql.Date"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"
+      },
+      "type": "java.sql.SQLException",
+      "fields": [
+        {
+          "name": "next"
+        }
+      ]
     },
     {
       "condition": {
@@ -731,6 +779,12 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.util.Iterator"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "java.util.List"
     },
     {
       "condition": {
@@ -1032,7 +1086,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.authority.distsql.parser.facade.AuthorityDistSQLParserFacade"
     },
@@ -1122,18 +1176,6 @@
       },
       "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration",
       "allDeclaredFields": true
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -1309,19 +1351,19 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.broadcast.distsql.parser.facade.BroadcastDistSQLParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.broadcast.rule.changed.BroadcastRuleChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.broadcast.rule.changed.BroadcastTableChangedProcessor"
     },
@@ -1503,7 +1545,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.data.pipeline.cdc.distsql.parser.facade.CDCDistSQLParserFacade"
     },
@@ -1945,7 +1987,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.data.pipeline.scenario.migration.distsql.parser.facade.MigrationDistSQLParserFacade"
     },
@@ -1957,7 +1999,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.clickhouse.jdbcurl.ClickHouseConnectionPropertiesParser"
     },
@@ -1969,7 +2011,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.firebird.jdbcurl.FirebirdConnectionPropertiesParser"
     },
@@ -1999,13 +2041,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.h2.checker.H2DatabasePrivilegeChecker"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.h2.jdbcurl.H2ConnectionPropertiesParser"
     },
@@ -2035,7 +2077,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.hive.jdbcurl.HiveConnectionPropertiesParser"
     },
@@ -2077,19 +2119,19 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.mysql.checker.MySQLDatabasePrivilegeChecker"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.mysql.jdbcurl.MySQLConnectionPropertiesParser"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.mysql.jdbcurl.MySQLDefaultQueryPropertiesProvider"
     },
@@ -2113,25 +2155,19 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.database.connector.mysql.metadata.identifier.MySQLIdentifierCaseRuleProvider"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
       },
       "type": "org.apache.shardingsphere.database.connector.mysql.type.MySQLDatabaseType"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.opengauss.checker.OpenGaussDatabasePrivilegeChecker"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.opengauss.jdbcurl.OpenGaussConnectionPropertiesParser"
     },
@@ -2155,19 +2191,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.database.connector.opengauss.metadata.identifier.OpenGaussIdentifierCaseRuleProvider"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
       },
       "type": "org.apache.shardingsphere.database.connector.opengauss.type.OpenGaussDatabaseType"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.oracle.jdbcurl.OracleConnectionPropertiesParser"
     },
@@ -2185,25 +2215,19 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.database.connector.oracle.metadata.identifier.OracleIdentifierCaseRuleProvider"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
       },
       "type": "org.apache.shardingsphere.database.connector.oracle.type.OracleDatabaseType"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.postgresql.checker.PostgreSQLDatabasePrivilegeChecker"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.postgresql.jdbcurl.PostgreSQLConnectionPropertiesParser"
     },
@@ -2227,19 +2251,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.database.connector.postgresql.metadata.identifier.PostgreSQLIdentifierCaseRuleProvider"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
       },
       "type": "org.apache.shardingsphere.database.connector.postgresql.type.PostgreSQLDatabaseType"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.presto.jdbcurl.PrestoConnectionPropertiesParser"
     },
@@ -2263,7 +2281,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.sql92.jdbcurl.SQL92ConnectionPropertiesParser"
     },
@@ -2275,7 +2293,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.database.connector.sql92.sqlserver.jdbcurl.SQLServerConnectionPropertiesParser"
     },
@@ -2495,6 +2513,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.database.DatabaseTypeEngine"
       },
       "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
@@ -2507,7 +2531,25 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabaseFactory"
+      },
+      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
+      },
+      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
+      },
+      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
       },
       "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
     },
@@ -2564,6 +2606,12 @@
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.resultset.ShardingSphereResultSet"
+      },
+      "type": "org.apache.shardingsphere.driver.jdbc.core.resultset.MySQLResultSetValueConverter"
     },
     {
       "condition": {
@@ -2741,19 +2789,19 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.encrypt.distsql.parser.facade.EncryptDistSQLParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.encrypt.rule.changed.EncryptTableChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.encrypt.rule.changed.EncryptorChangedProcessor"
     },
@@ -2853,7 +2901,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.globalclock.distsql.parser.facade.GlobalClockDistSQLParserFacade"
     },
@@ -2940,33 +2988,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -3140,6 +3164,24 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabaseFactory"
+      },
+      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
+      },
+      "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithm"
@@ -3231,6 +3273,24 @@
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
+      },
+      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabaseFactory"
+      },
+      "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabasesFactory"
       },
       "type": "org.apache.shardingsphere.infra.algorithm.keygen.uuid.UUIDKeyGenerateAlgorithm"
     },
@@ -3380,13 +3440,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.infra.binder.mysql.MySQLSQLStatementContextWarpProvider"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.infra.binder.mysql.bind.MySQLSQLBindEngine"
     },
@@ -3398,13 +3458,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.infra.binder.opengauss.OpenGaussSQLStatementContextWarpProvider"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.infra.binder.opengauss.bind.OpenGaussSQLBindEngine"
     },
@@ -3422,25 +3482,25 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.infra.binder.postgresql.PostgreSQLSQLStatementContextWarpProvider"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.infra.binder.postgresql.bind.PostgreSQLSQLBindEngine"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.infra.binder.sqlserver.SQLServerSQLStatementContextWarpProvider"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.infra.binder.sqlserver.bind.SQLServerSQLBindEngine"
     },
@@ -3928,18 +3988,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.instance.metadata.jdbc.JDBCInstanceMetaDataBuilder"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.instance.metadata.proxy.ProxyInstanceMetaDataBuilder"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
       },
       "type": "org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeData",
@@ -3970,18 +4018,6 @@
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
       },
       "type": "org.apache.shardingsphere.infra.instance.yaml.YamlComputeNodeDataCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.metadata.identifier.DefaultIdentifierCaseRuleProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.metadata.statistics.builder.dialect.PostgreSQLStatisticsAppender"
     },
     {
       "condition": {
@@ -4051,7 +4087,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.infra.util.yaml.YamlConfiguration"
     },
@@ -4060,12 +4096,6 @@
         "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlGlobalRuleConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.config.shortcut.YamlRuleConfigurationShortcuts"
     },
     {
       "condition": {
@@ -4085,18 +4115,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatisticsBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableRowDataPersistService"
-      },
-      "type": "org.apache.shardingsphere.infra.yaml.data.pojo.YamlRowStatisticsCustomizer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterMetaDataManagerPersistService"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
@@ -4110,7 +4128,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistService"
       },
       "type": "org.apache.shardingsphere.infra.yaml.schema.pojo.YamlShardingSphereTable",
       "methods": [
@@ -4476,19 +4494,19 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.mask.distsql.parser.facade.MaskDistSQLParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.mask.rule.changed.MaskAlgorithmChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.mask.rule.changed.MaskTableChangedProcessor"
     },
@@ -4527,12 +4545,6 @@
         "typeReached": "org.apache.shardingsphere.infra.util.eventbus.EventBusContext"
       },
       "type": "org.apache.shardingsphere.mode.deliver.DeliverEventSubscriber"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
     },
     {
       "condition": {
@@ -4623,12 +4635,6 @@
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.swapper.mode.YamlModeConfigurationSwapper"
       },
       "type": "org.apache.shardingsphere.mode.manager.cluster.yaml.ClusterYamlPersistRepositoryConfigurationSwapper"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
     },
     {
       "condition": {
@@ -4760,7 +4766,12 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
+      "fields": [
+        {
+          "name": "databaseName"
+        }
+      ]
     },
     {
       "condition": {
@@ -4826,13 +4837,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
     },
@@ -4905,7 +4916,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistService"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
       "fields": [
@@ -4936,17 +4947,6 @@
         "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.type.table.CreateTablePushDownMetaDataRefresher"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.searcher.NodePathSearcher"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.DatabaseMetaDataNodePath",
-      "fields": [
-        {
-          "name": "databaseName"
-        }
-      ]
     },
     {
       "condition": {
@@ -5233,6 +5233,18 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.DatabaseRuleDefinitionExecuteEngine"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.engine.database.type.CreateDatabaseRuleOperator"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.distsql.handler.executor.rdl.resource.RegisterStorageUnitExecutor"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
@@ -5241,7 +5253,15 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath",
+      "fields": [
+        {
+          "name": "database"
+        },
+        {
+          "name": "schemaName"
+        }
+      ]
     },
     {
       "condition": {
@@ -5277,13 +5297,19 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.factory.init.type.LocalConfigurationMetaDataContextsInitFactory"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.resource.StorageUnitManager"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleItemManager"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
     },
@@ -5309,7 +5335,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistService"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath",
       "fields": [
@@ -5349,20 +5375,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.searcher.NodePathSearcher"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath",
-      "fields": [
-        {
-          "name": "database"
-        },
-        {
-          "name": "schemaName"
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.repository.cluster.zookeeper.ZookeeperRepository"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.SchemaMetaDataNodePath"
@@ -5395,7 +5407,15 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.database.metadata.TableChangedHandler"
       },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
+      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath",
+      "fields": [
+        {
+          "name": "schema"
+        },
+        {
+          "name": "tableName"
+        }
+      ]
     },
     {
       "condition": {
@@ -5431,7 +5451,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistEnabledService"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.metadata.service.TableMetaDataPersistService"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath",
       "fields": [
@@ -5454,20 +5474,6 @@
         "typeReached": "org.apache.shardingsphere.mode.metadata.refresher.pushdown.type.table.CreateTablePushDownMetaDataRefresher"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.node.path.engine.searcher.NodePathSearcher"
-      },
-      "type": "org.apache.shardingsphere.mode.node.path.type.database.metadata.schema.TableMetaDataNodePath",
-      "fields": [
-        {
-          "name": "schema"
-        },
-        {
-          "name": "tableName"
-        }
-      ]
     },
     {
       "condition": {
@@ -6136,6 +6142,20 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.handler.global.node.compute.type.ComputeNodeOnlineHandler"
+      },
+      "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.OnlineNodePath",
+      "fields": [
+        {
+          "name": "instanceId"
+        },
+        {
+          "name": "instanceType"
+        }
+      ]
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.dispatch.listener.DataChangedEventListenerRegistry"
       },
       "type": "org.apache.shardingsphere.mode.node.path.type.global.node.compute.status.OnlineNodePath",
@@ -6415,7 +6435,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.parser.distsql.parser.facade.SQLParserDistSQLParserFacade"
     },
@@ -6494,33 +6514,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -6536,7 +6532,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.proxy.backend.firebird.handler.admin.FirebirdAdminExecutorCreator"
     },
@@ -6866,7 +6862,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.proxy.backend.mysql.handler.admin.MySQLAdminExecutorCreator"
     },
@@ -6902,7 +6898,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.proxy.backend.opengauss.handler.admin.OpenGaussAdminExecutorCreator"
     },
@@ -6920,7 +6916,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.PostgreSQLAdminExecutorCreator"
     },
@@ -7202,7 +7198,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.readwritesplitting.distsql.parser.facade.ReadwriteSplittingDistSQLParserFacade"
     },
@@ -7214,13 +7210,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.readwritesplitting.rule.changed.ReadwriteSplittingDataSourceChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.readwritesplitting.rule.changed.ReadwriteSplittingLoadBalancerChangedProcessor"
     },
@@ -7600,31 +7596,31 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.shadow.distsql.parser.facade.ShadowDistSQLParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.shadow.rule.changed.DefaultShadowAlgorithmNameChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.shadow.rule.changed.ShadowAlgorithmChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.shadow.rule.changed.ShadowDataSourceChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.shadow.rule.changed.ShadowTableChangedProcessor"
     },
@@ -8641,85 +8637,85 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.sharding.distsql.parser.facade.ShardingDistSQLParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.DefaultDatabaseShardingStrategyChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.DefaultKeyGenerateStrategyChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.DefaultShardingAuditorStrategyChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.DefaultShardingColumnChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.DefaultTableShardingStrategyChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.KeyGenerateStrategiesChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.KeyGeneratorChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.ShardingAlgorithmChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.ShardingAuditorChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.ShardingAutoTableChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.ShardingCacheChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.ShardingTableChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.rule.changed.ShardingTableReferenceChangedProcessor"
     },
@@ -8893,13 +8889,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigurationCustomizer"
     },
@@ -8997,13 +8993,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyRuleConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyRuleConfigurationCustomizer"
     },
@@ -9027,10 +9023,23 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
-      "allDeclaredFields": true,
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
+      },
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
       "methods": [
         {
           "name": "getComplex",
@@ -9052,7 +9061,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
       "methods": [
@@ -9096,13 +9105,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfigurationCustomizer"
     },
@@ -9298,19 +9307,19 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.single.distsql.parser.facade.SingleDistSQLParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.single.rule.changed.DefaultDataSourceChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "type": "org.apache.shardingsphere.single.rule.changed.SingleTableChangedProcessor"
     },
@@ -9348,13 +9357,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.clickhouse.parser.ClickHouseParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.clickhouse.visitor.statement.ClickHouseStatementVisitorFacade"
     },
@@ -9430,13 +9439,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.firebird.parser.FirebirdParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.firebird.visitor.statement.FirebirdStatementVisitorFacade"
     },
@@ -9498,13 +9507,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.hive.parser.HiveParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.hive.visitor.statement.HiveStatementVisitorFacade"
     },
@@ -9580,13 +9589,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.mysql.parser.MySQLParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.mysql.visitor.statement.MySQLStatementVisitorFacade"
     },
@@ -9704,13 +9713,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.opengauss.parser.OpenGaussParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.opengauss.visitor.statement.OpenGaussStatementVisitorFacade"
     },
@@ -9744,13 +9753,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.oracle.parser.OracleParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.oracle.visitor.statement.OracleStatementVisitorFacade"
     },
@@ -9812,13 +9821,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.parser.PostgreSQLParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.visitor.statement.PostgreSQLStatementVisitorFacade"
     },
@@ -9908,13 +9917,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.presto.parser.PrestoParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.presto.visitor.statement.PrestoStatementVisitorFacade"
     },
@@ -9934,13 +9943,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.sql92.parser.SQL92ParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.sql92.visitor.statement.SQL92StatementVisitorFacade"
     },
@@ -9974,13 +9983,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.sqlserver.parser.SQLServerParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.sqlserver.visitor.statement.SQLServerStatementVisitorFacade"
     },
@@ -10281,7 +10290,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.sqlfederation.distsql.parser.facade.SQLFederationDistSQLParserFacade"
     },
@@ -10293,21 +10302,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.mysql.MySQLSQLFederationFunctionRegister"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
       },
       "type": "org.apache.shardingsphere.sqlfederation.opengauss.OpenGaussSQLFederationConnectionConfigBuilder"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.opengauss.OpenGaussSQLFederationFunctionRegister"
     },
     {
       "condition": {
@@ -10320,12 +10317,6 @@
         "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
       },
       "type": "org.apache.shardingsphere.sqlfederation.postgresql.PostgreSQLSQLFederationConnectionConfigBuilder"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.postgresql.PostgreSQLSQLFederationFunctionRegister"
     },
     {
       "condition": {
@@ -10412,33 +10403,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -10512,7 +10479,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.sqltranslator.distsql.parser.facade.SQLTranslatorDistSQLParserFacade"
     },
@@ -10595,33 +10562,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -10941,7 +10884,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "type": "org.apache.shardingsphere.transaction.distsql.parser.facade.TransactionDistSQLParserFacade"
     },
@@ -10968,6 +10911,48 @@
           "parameterTypes": []
         }
       ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
+      },
+      "type": "org.apache.shardingsphere.transaction.xa.jta.connection.dialect.FirebirdXAConnectionWrapper"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
+      },
+      "type": "org.apache.shardingsphere.transaction.xa.jta.connection.dialect.H2XAConnectionWrapper"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
+      },
+      "type": "org.apache.shardingsphere.transaction.xa.jta.connection.dialect.MariaDBXAConnectionWrapper"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
+      },
+      "type": "org.apache.shardingsphere.transaction.xa.jta.connection.dialect.MySQLXAConnectionWrapper"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
+      },
+      "type": "org.apache.shardingsphere.transaction.xa.jta.connection.dialect.OpenGaussXAConnectionWrapper"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
+      },
+      "type": "org.apache.shardingsphere.transaction.xa.jta.connection.dialect.OracleXAConnectionWrapper"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
+      },
+      "type": "org.apache.shardingsphere.transaction.xa.jta.connection.dialect.PostgreSQLXAConnectionWrapper"
     },
     {
       "condition": {
@@ -11060,33 +11045,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
       },
       "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.StandaloneContextManagerBuilder"
-      },
-      "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationCustomizer"
     },
     {
       "condition": {
@@ -11096,7 +11057,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"
       },
       "type": {
         "proxy": [
@@ -11396,13 +11357,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.datasource.pool.props.validator.DataSourcePoolPropertiesValidator"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.checker.DialectDatabasePrivilegeChecker"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.jdbcurl.DialectDefaultQueryPropertiesProvider"
     },
@@ -11414,7 +11375,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.jdbcurl.parser.ConnectionPropertiesParser"
     },
@@ -11438,49 +11399,49 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleProvider"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.type.DatabaseType"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.distsql.handler.engine.update.AdvancedDistSQLUpdateExecutor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.distsql.handler.engine.update.DistSQLUpdateExecutor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.distsql.handler.engine.update.rdl.rule.spi.database.DatabaseRuleDefinitionExecutor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.distsql.parser.engine.spi.DistSQLParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.resultset.ShardingSphereResultSet"
+      },
+      "glob": "META-INF/services/org.apache.shardingsphere.driver.jdbc.core.resultset.DialectResultSetValueConverter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.infra.algorithm.keygen.spi.KeyGenerateAlgorithm"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.infra.binder.context.DialectCommonSQLStatementContextWarpProvider"
     },
@@ -11492,7 +11453,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.infra.binder.engine.DialectSQLBindEngine"
     },
@@ -11546,18 +11507,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.infra.instance.metadata.InstanceMetaDataBuilder"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.infra.metadata.statistics.builder.DialectStatisticsAppender"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.backend.postgresql.handler.admin.factory.PostgreSQLSelectAdminExecutorFactory"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.infra.metadata.statistics.collector.DialectDatabaseStatisticsCollector"
@@ -11582,12 +11531,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.util.yaml.YamlEngine"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.infra.util.yaml.shortcuts.ShardingSphereYamlShortcuts"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.yaml.config.swapper.mode.YamlModeConfigurationSwapper"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.infra.yaml.config.swapper.mode.YamlPersistRepositoryConfigurationSwapper"
@@ -11597,12 +11540,6 @@
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.mode.deliver.DeliverEventSubscriber"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.mode.manager.builder.ContextManagerBuilder"
     },
     {
       "condition": {
@@ -11636,19 +11573,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.mode.repository.standalone.StandalonePersistRepository"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.mode.spi.rule.RuleItemConfigurationChangedProcessor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.proxy.backend.connector.AdvancedProxySQLExecutor"
     },
@@ -11660,7 +11591,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandlerFactory"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.proxy.backend.handler.admin.executor.DatabaseAdminExecutorCreator"
     },
@@ -11702,13 +11633,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.sql.parser.spi.DialectSQLParserFacade"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.command.query.text.query.MySQLComQueryPacketExecutor"
+        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.sql.parser.spi.SQLStatementVisitorFacade"
     },
@@ -11720,21 +11651,27 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.sqlfederation.compiler.sql.function.DialectSQLFederationFunctionRegister"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.sqltranslator.rule.SQLTranslatorRule"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.sqltranslator.spi.SQLTranslator"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine"
       },
-      "glob": "META-INF/services/org.apache.shardingsphere.timeservice.spi.TimestampService"
+      "glob": "META-INF/services/org.apache.shardingsphere.transaction.spi.ShardingSphereDistributedTransactionManager"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource"
+      },
+      "glob": "META-INF/services/org.apache.shardingsphere.transaction.xa.jta.connection.XAConnectionWrapper"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.xa.XAShardingSphereTransactionManager"
+      },
+      "glob": "META-INF/services/org.apache.shardingsphere.transaction.xa.spi.XATransactionManagerProvider"
     },
     {
       "condition": {
@@ -11744,7 +11681,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "glob": "META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider"
     },
@@ -11752,7 +11689,25 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
+      "glob": "META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
       "glob": "META-INF/services/org.testcontainers.core.CreateContainerCmdModifier"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
+      },
+      "glob": "META-INF/services/org.testcontainers.core.CreateContainerCmdModifier"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "glob": "client-v2-version.properties"
     },
     {
       "condition": {
@@ -11771,6 +11726,18 @@
         "typeReached": "org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"
       },
       "glob": "com/atomikos/icatch/provider/imp/transactions.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "glob": "com/clickhouse/client/internal/org/apache/hc/client5/version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "glob": "container-license-acceptance.txt"
     },
     {
       "condition": {
@@ -11819,6 +11786,12 @@
         "typeReached": "org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"
       },
       "glob": "org/h2/util/data.zip"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "glob": "org/postgresql/driverconfig.properties"
     },
     {
       "condition": {
@@ -13100,6 +13073,18 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "glob": "test-native/sql/clickhouse-init.sql"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "glob": "test-native/sql/seata-script-client-at-postgresql.sql"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "glob": "test-native/sql/seata-script-client-at-postgresql.sql"
@@ -13244,13 +13229,34 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.mysql.authentication.MySQLAuthenticationEngine"
+        "typeReached": "org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"
       },
-      "module": "jdk.jfr",
-      "glob": "jdk/jfr/internal/types/metadata.bin"
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_zh.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_zh_Hans.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_zh_Hans_CN.properties"
     }
   ],
-  "bundles": [],
+  "bundles": [
+    {
+      "name": "com.microsoft.sqlserver.jdbc.SQLServerResource",
+      "locales": [
+        "zh-CN"
+      ]
+    }
+  ],
   "jni": [
     {
       "condition": {

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/util/ProxyTestingServer.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/util/ProxyTestingServer.java
@@ -19,13 +19,21 @@ package org.apache.shardingsphere.test.natived.commons.util;
 
 import lombok.Getter;
 import org.apache.curator.test.InstanceSpec;
-import org.apache.shardingsphere.proxy.Bootstrap;
-import org.awaitility.Awaitility;
+import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.proxy.arguments.BootstrapArguments;
+import org.apache.shardingsphere.proxy.backend.config.ProxyConfigurationLoader;
+import org.apache.shardingsphere.proxy.backend.config.YamlProxyConfiguration;
+import org.apache.shardingsphere.proxy.frontend.CDCServer;
+import org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy;
+import org.apache.shardingsphere.proxy.frontend.ssl.ProxySSLContext;
+import org.apache.shardingsphere.proxy.initializer.BootstrapInitializer;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
 import java.sql.SQLException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * This class is designed to start ShardingSphere Proxy directly in the current process,
@@ -39,30 +47,48 @@ public final class ProxyTestingServer {
     @Getter
     private final int proxyPort;
     
-    private final CompletableFuture<Void> completableFuture;
+    private final ShardingSphereProxy proxy;
     
     /**
-     * Call this method to start the Server side of ShardingSphere Proxy in a separate thread.
+     * Call this method to start the Server side of ShardingSphere Proxy.
      *
      * @param configAbsolutePath The absolute path to the directory where {@code global.yaml} is located.
+     * @see org.apache.shardingsphere.proxy.Bootstrap
      */
     public ProxyTestingServer(final String configAbsolutePath) {
         proxyPort = InstanceSpec.getRandomPort();
-        completableFuture = CompletableFuture.runAsync(() -> {
-            try {
-                Bootstrap.main(new String[]{String.valueOf(proxyPort), configAbsolutePath, "0.0.0.0"});
-            } catch (final IOException | SQLException ex) {
-                throw new RuntimeException(ex);
+        String[] args = new String[]{String.valueOf(proxyPort), configAbsolutePath, "0.0.0.0"};
+        try {
+            BootstrapArguments bootstrapArgs = new BootstrapArguments(args);
+            YamlProxyConfiguration yamlConfig = ProxyConfigurationLoader.load(bootstrapArgs.getConfigurationPath());
+            int port = bootstrapArgs.getPort().orElseThrow(() -> new IllegalStateException("Check `org.apache.curator.test.InstanceSpec#getRandomPort`."));
+            List<String> addresses = bootstrapArgs.getAddresses();
+            checkPort(addresses, port);
+            new BootstrapInitializer().init(yamlConfig, port);
+            Optional.ofNullable((Integer) yamlConfig.getServerConfiguration().getProps().get(ConfigurationPropertyKey.CDC_SERVER_PORT.getKey()))
+                    .ifPresent(optional -> new Thread(new CDCServer(addresses, optional)).start());
+            ProxySSLContext.init();
+            proxy = new ShardingSphereProxy();
+            bootstrapArgs.getSocketPath().ifPresent(proxy::start);
+            proxy.startInternal(port, addresses);
+        } catch (final SQLException | IOException | InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+    
+    private void checkPort(final List<String> addresses, final int port) throws IOException {
+        for (String each : addresses) {
+            try (ServerSocket socket = new ServerSocket()) {
+                socket.bind(new InetSocketAddress(each, port));
             }
-        });
+        }
     }
     
     /**
-     * Force close ShardingSphere Proxy.
+     * Close ShardingSphere Proxy.
      *
      */
     public void close() {
-        completableFuture.cancel(false);
-        Awaitility.await().atMost(1L, TimeUnit.MINUTES).until(completableFuture::isDone);
+        proxy.close();
     }
 }

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/util/ResourceUtils.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/commons/util/ResourceUtils.java
@@ -46,6 +46,7 @@ public class ResourceUtils {
     public static void closeJdbcDataSource(final DataSource dataSource) throws SQLException {
         try (Connection connection = dataSource.getConnection()) {
             ContextManager contextManager = connection.unwrap(ShardingSphereConnection.class).getContextManager();
+            close(dataSource);
             contextManager.getStorageUnits(DefaultDatabase.LOGIC_NAME).values().stream().map(StorageUnit::getDataSource).forEach(ResourceUtils::close);
             contextManager.close();
         }
@@ -62,6 +63,7 @@ public class ResourceUtils {
     public static void closeJdbcDataSource(final DataSource dataSource, final String logicDataBaseName) throws SQLException {
         try (Connection connection = dataSource.getConnection()) {
             ContextManager contextManager = connection.unwrap(ShardingSphereConnection.class).getContextManager();
+            close(dataSource);
             contextManager.getStorageUnits(logicDataBaseName).values().stream().map(StorageUnit::getDataSource).forEach(ResourceUtils::close);
             contextManager.close();
         }

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/modes/cluster/ZookeeperTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/modes/cluster/ZookeeperTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledInNativeImage;
 
 import javax.sql.DataSource;
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -49,27 +50,36 @@ class ZookeeperTest {
     
     private TestShardingService testShardingService;
     
+    private TestingServer testingServer;
+    
     @BeforeEach
-    void beforeEach() {
+    void beforeEach() throws Exception {
         assertNull(System.getProperty(systemPropKeyPrefix + "server-lists"));
+        testingServer = new TestingServer();
     }
     
     @AfterEach
-    void afterEach() throws SQLException {
-        ResourceUtils.closeJdbcDataSource(logicDataSource);
+    void afterEach() throws SQLException, IOException {
         System.clearProperty(systemPropKeyPrefix + "server-lists");
+        try {
+            if (null != logicDataSource) {
+                ResourceUtils.closeJdbcDataSource(logicDataSource);
+            }
+        } finally {
+            if (null != testingServer) {
+                testingServer.close();
+            }
+        }
     }
     
     @Test
     void assertShardingInLocalTransactions() throws Exception {
-        try (TestingServer testingServer = new TestingServer()) {
-            String connectString = testingServer.getConnectString();
-            logicDataSource = createDataSource(connectString);
-            testShardingService = new TestShardingService(logicDataSource);
-            initEnvironment();
-            testShardingService.processSuccess();
-            testShardingService.cleanEnvironment();
-        }
+        String connectString = testingServer.getConnectString();
+        logicDataSource = createDataSource(connectString);
+        testShardingService = new TestShardingService(logicDataSource);
+        initEnvironment();
+        testShardingService.processSuccess();
+        testShardingService.cleanEnvironment();
     }
     
     /**

--- a/test/native/src/test/resources/testcontainers.properties
+++ b/test/native/src/test/resources/testcontainers.properties
@@ -16,3 +16,4 @@
 #
 
 pull.timeout = 240
+client.ping.timeout = 30


### PR DESCRIPTION
For #38857 .

Changes proposed in this pull request:
  - Stabilize Ubuntu nativeTest CI under GraalVM Native Image. 
  - The current PR does not involve CI on Windows Server 2025. However, changing `client.ping.timeout` from `10` to `30` can help reduce CI failure rates on Windows Server 2025.
  - Update the documentation to remove the inappropriate reference to my personal folder `lingh`.
  - Refactor `org.apache.shardingsphere.test.natived.commons.util.ProxyTestingServer` to use fix from https://github.com/apache/shardingsphere/pull/38665 . Also fixes https://github.com/apache/shardingsphere/issues/33206 .
  - Fixes a bug where `org.apache.shardingsphere.test.natived.jdbc.modes.cluster.ZookeeperTest` would still make requests to the ZooKeeper server via the ContextManager after the ZooKeeper server was shut down. This was actually an effect of a recent change introduced in the ShardingSphere master branch, which now attempts to access the ZooKeeper server when the ContextManager is shut down.
  - Refactor `org.apache.shardingsphere.test.natived.commons.util.ResourceUtils` to avoid the following warning log. This is likely related to a recent commit on the master branch.
```bash
[INFO] Running org.apache.shardingsphere.test.natived.jdbc.databases.hive.ZookeeperServiceDiscoveryTest
[WARN ] 2026-06-20 17:01:45.584 [HikariPool-39 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:01:46.273 [HikariPool-35 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:01:46.710 [HikariPool-39 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:01:48.632 [HikariPool-39 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:01:48.884 [HikariPool-35 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:01:50.434 [HikariPool-39 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:01:51.152 [HikariPool-35 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:01:51.245 [HikariPool-39 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:01:52.396 [HikariPool-35 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:01:52.924 [HikariPool-35 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:01:54.712 [HikariPool-35 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:01:56.129 [HikariPool-39 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:02:01.100 [HikariPool-39 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:02:01.677 [HikariPool-39 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:02:06.121 [HikariPool-35 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:02:08.922 [HikariPool-35 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:02:11.498 [HikariPool-35 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:02:11.818 [HikariPool-35 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:02:15.649 [HikariPool-39 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:02:23.747 [HikariPool-39 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:02:50.188 [HikariPool-43 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:03:02.504 [HikariPool-43 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:03:02.817 [HikariPool-43 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:03:14.676 [HikariPool-43 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:03:16.473 [HikariPool-43 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:03:16.530 [HikariPool-43 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:03:18.242 [HikariPool-43 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:03:20.948 [HikariPool-43 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:03:22.932 [HikariPool-43 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[WARN ] 2026-06-20 17:03:23.316 [HikariPool-43 connection closer] o.a.s.d.j.c.c.ShardingSphereConnection - Rollback transaction failed on connection close
java.lang.NullPointerException: Cannot invoke "org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine.getTransactionManager(org.apache.shardingsphere.transaction.api.TransactionType)" because the return value of "org.apache.shardingsphere.transaction.rule.TransactionRule.getResource()" is null
	at org.apache.shardingsphere.transaction.ConnectionTransaction.<init>(ConnectionTransaction.java:49)
	at org.apache.shardingsphere.driver.jdbc.core.connection.DriverDatabaseConnectionManager.getConnectionTransaction(DriverDatabaseConnectionManager.java:91)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.rollbackTransaction(ShardingSphereConnection.java:316)
	at org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection.close(ShardingSphereConnection.java:303)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:143)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:451)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 315.4 s -- in org.apache.shardingsphere.test.natived.jdbc.databases.hive.ZookeeperServiceDiscoveryTest
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
