### PR TITLE
Fix encrypt INSERT VALUES temporal literal handling

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -48,6 +48,7 @@
 1. SQL Parser: Support MariaDB cycleClause, groupConcatLimitClause, MEDIAN window function parse - [#38579](https://github.com/apache/shardingsphere/pull/38579)
 1. SQL Parser: Support mysql, doris insert & replace rows statement parse - [#38585](https://github.com/apache/shardingsphere/pull/38585)
 1. SQL Parser: Support Oracle model, pivot, XML and hierarchical query parsing and binding - [#38689](https://github.com/apache/shardingsphere/pull/38689)
+1. SQL Parser: Preserve temporal literal text and raw value for MySQL and Oracle date-time literal parsing - [#38886](https://github.com/apache/shardingsphere/pull/38886)
 1. SQL Binder: Support select order by index bind metadata - [#38386](https://github.com/apache/shardingsphere/pull/38386)
 1. SQL Binder: Support SQL bind when with temp table name is same with physical table - [#38411](https://github.com/apache/shardingsphere/pull/38411)
 1. JDBC: Support setMaxRows and getMaxRows method in jdbc when not execute SQL - [#38337](https://github.com/apache/shardingsphere/pull/38337)

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/pojo/EncryptInsertColumnToken.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/pojo/EncryptInsertColumnToken.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.enums.ParameterMarker
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.TemporalLiteralExpressionSegment;
 
 /**
  * Insert column token for encrypt.
@@ -48,6 +49,9 @@ public abstract class EncryptInsertColumnToken extends SQLToken {
         if (expressionSegment instanceof ParameterMarkerExpressionSegment) {
             ParameterMarkerExpressionSegment segment = (ParameterMarkerExpressionSegment) expressionSegment;
             return ParameterMarkerType.QUESTION == segment.getParameterMarkerType() ? "?" : "$" + (segment.getParameterMarkerIndex() + 1);
+        }
+        if (expressionSegment instanceof TemporalLiteralExpressionSegment) {
+            return expressionSegment.getText();
         }
         if (expressionSegment instanceof LiteralExpressionSegment) {
             Object literals = ((LiteralExpressionSegment) expressionSegment).getLiterals();

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/insert/EncryptInsertValuesTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/insert/EncryptInsertValuesTokenGeneratorTest.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.Co
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.InsertColumnsSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.TemporalLiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.InsertStatement;
@@ -84,6 +85,12 @@ class EncryptInsertValuesTokenGeneratorTest {
         assertThat(generator.generateSQLToken(createLiteralInsertStatementContext()).toString(), is("(1, 'Tom', 0, 'encryptValue', 'assistedEncryptValue', 'likeEncryptValue')"));
     }
     
+    @Test
+    void assertGenerateSQLTokenWithTemporalLiteralValue() {
+        generator.setPreviousSQLTokens(Collections.emptyList());
+        assertThat(generator.generateSQLToken(createTemporalLiteralInsertStatementContext()).toString(), is("(1, 'Tom', 0, 'encryptValue', 'assistedEncryptValue', 'likeEncryptValue')"));
+    }
+    
     private InsertStatementContext createLiteralInsertStatementContext() {
         ShardingSphereDatabase database = EncryptGeneratorFixtureBuilder.createDatabase();
         InsertColumnsSegment insertColumnsSegment = new InsertColumnsSegment(0, 0, Arrays.asList(
@@ -96,6 +103,26 @@ class EncryptInsertValuesTokenGeneratorTest {
         valueExpressions.add(new LiteralExpressionSegment(0, 0, "Tom"));
         valueExpressions.add(new LiteralExpressionSegment(0, 0, 0));
         valueExpressions.add(new LiteralExpressionSegment(0, 0, "123456"));
+        InsertStatement insertStatement = InsertStatement.builder().databaseType(DATABASE_TYPE)
+                .table(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_user"))))
+                .insertColumns(insertColumnsSegment).values(Collections.singletonList(new InsertValuesSegment(0, 0, valueExpressions))).build();
+        ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()),
+                new RuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()));
+        return new InsertStatementContext(insertStatement, metaData, "foo_db");
+    }
+    
+    private InsertStatementContext createTemporalLiteralInsertStatementContext() {
+        ShardingSphereDatabase database = EncryptGeneratorFixtureBuilder.createDatabase();
+        InsertColumnsSegment insertColumnsSegment = new InsertColumnsSegment(0, 0, Arrays.asList(
+                new ColumnSegment(0, 0, new IdentifierValue("id")),
+                new ColumnSegment(0, 0, new IdentifierValue("name")),
+                new ColumnSegment(0, 0, new IdentifierValue("status")),
+                new ColumnSegment(0, 0, new IdentifierValue("pwd"))));
+        List<ExpressionSegment> valueExpressions = new ArrayList<>(4);
+        valueExpressions.add(new LiteralExpressionSegment(0, 0, 1));
+        valueExpressions.add(new LiteralExpressionSegment(0, 0, "Tom"));
+        valueExpressions.add(new LiteralExpressionSegment(0, 0, 0));
+        valueExpressions.add(new TemporalLiteralExpressionSegment(0, 0, "2024-03-01", "DATE '2024-03-01'"));
         InsertStatement insertStatement = InsertStatement.builder().databaseType(DATABASE_TYPE)
                 .table(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_user"))))
                 .insertColumns(insertColumnsSegment).values(Collections.singletonList(new InsertValuesSegment(0, 0, valueExpressions))).build();

--- a/parser/sql/engine/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/engine/oracle/visitor/statement/OracleStatementVisitor.java
+++ b/parser/sql/engine/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/engine/oracle/visitor/statement/OracleStatementVisitor.java
@@ -357,7 +357,7 @@ public abstract class OracleStatementVisitor extends OracleStatementBaseVisitor<
     @Override
     public ASTNode visitDateTimeLiterals(final DateTimeLiteralsContext ctx) {
         if (null != ctx.LBE_()) {
-            return new DateTimeLiteralValue(ctx.identifier().getText(), ((StringLiteralValue) visit(ctx.stringLiterals())).getValue(), true);
+            return new DateTimeLiteralValue(ctx.identifier().getText(), ctx.stringLiterals().getText(), true);
         }
         String dateTimeType;
         if (null != ctx.DATE()) {
@@ -367,7 +367,7 @@ public abstract class OracleStatementVisitor extends OracleStatementBaseVisitor<
         } else {
             dateTimeType = ctx.TIMESTAMP().getText();
         }
-        return new DateTimeLiteralValue(dateTimeType, ((StringLiteralValue) visit(ctx.stringLiterals())).getValue(), false);
+        return new DateTimeLiteralValue(dateTimeType, ctx.stringLiterals().getText(), false);
     }
     
     @Override

--- a/parser/sql/engine/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/engine/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
+++ b/parser/sql/engine/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/engine/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
@@ -1008,8 +1008,8 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
         if (projection instanceof LiteralExpressionSegment) {
             LiteralExpressionSegment column = (LiteralExpressionSegment) projection;
             ExpressionProjectionSegment result = null == alias
-                    ? new ExpressionProjectionSegment(column.getStartIndex(), column.getStopIndex(), String.valueOf(column.getLiterals()), column)
-                    : new ExpressionProjectionSegment(column.getStartIndex(), ctx.alias().stop.getStopIndex(), String.valueOf(column.getLiterals()), column);
+                    ? new ExpressionProjectionSegment(column.getStartIndex(), column.getStopIndex(), column.getText(), column)
+                    : new ExpressionProjectionSegment(column.getStartIndex(), ctx.alias().stop.getStopIndex(), column.getText(), column);
             result.setAlias(alias);
             return result;
         }

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dml/expr/simple/TemporalLiteralExpressionSegment.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dml/expr/simple/TemporalLiteralExpressionSegment.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple;
+
+/**
+ * Temporal literal expression segment.
+ */
+public final class TemporalLiteralExpressionSegment extends LiteralExpressionSegment {
+    
+    private final String text;
+    
+    public TemporalLiteralExpressionSegment(final int startIndex, final int stopIndex, final Object literals, final String text) {
+        super(startIndex, stopIndex, literals);
+        this.text = text;
+    }
+    
+    @Override
+    public String getText() {
+        return text;
+    }
+}

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/util/SQLUtils.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/util/SQLUtils.java
@@ -26,10 +26,12 @@ import org.apache.shardingsphere.sql.parser.statement.core.enums.Paren;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.complex.CommonExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.TemporalLiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.JoinTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SubqueryTableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.literal.impl.BooleanLiteralValue;
+import org.apache.shardingsphere.sql.parser.statement.core.value.literal.impl.DateTimeLiteralValue;
 import org.apache.shardingsphere.sql.parser.statement.core.value.literal.impl.NullLiteralValue;
 import org.apache.shardingsphere.sql.parser.statement.core.value.literal.impl.NumberLiteralValue;
 import org.apache.shardingsphere.sql.parser.statement.core.value.literal.impl.OtherLiteralValue;
@@ -279,7 +281,10 @@ public final class SQLUtils {
             return new LiteralExpressionSegment(startIndex, stopIndex, null);
         }
         if (astNode instanceof TemporalLiteralValue) {
-            return new LiteralExpressionSegment(startIndex, stopIndex, ((TemporalLiteralValue) astNode).getValue());
+            return new TemporalLiteralExpressionSegment(startIndex, stopIndex, ((TemporalLiteralValue) astNode).getValue(), text);
+        }
+        if (astNode instanceof DateTimeLiteralValue) {
+            return new TemporalLiteralExpressionSegment(startIndex, stopIndex, ((DateTimeLiteralValue) astNode).getDateTimeValue(), text);
         }
         if (astNode instanceof OtherLiteralValue) {
             return new CommonExpressionSegment(startIndex, stopIndex, ((OtherLiteralValue) astNode).getValue());

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/value/literal/impl/DateTimeLiteralValue.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/value/literal/impl/DateTimeLiteralValue.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sql.parser.statement.core.value.literal.impl;
 
+import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.statement.core.value.literal.LiteralValue;
 
 /**
@@ -28,19 +29,29 @@ public final class DateTimeLiteralValue implements LiteralValue<String> {
     
     private final String dateTimeValue;
     
+    private final QuoteCharacter quoteCharacter;
+    
     private final boolean containsBrace;
     
     public DateTimeLiteralValue(final String dateTimeType, final String dateTimeValue, final boolean containsBrace) {
         this.dateTimeType = dateTimeType;
-        this.dateTimeValue = containsBrace ? dateTimeValue.substring(1, dateTimeValue.length() - 1) : dateTimeValue;
+        quoteCharacter = QuoteCharacter.getQuoteCharacter(dateTimeValue);
+        this.dateTimeValue = quoteCharacter.unwrap(dateTimeValue);
         this.containsBrace = containsBrace;
     }
     
     @Override
     public String getValue() {
-        if (containsBrace) {
-            return "{" + dateTimeType + " " + dateTimeValue + "}";
-        }
-        return dateTimeType + " " + dateTimeValue;
+        String quotedDateTimeValue = quoteCharacter.wrap(dateTimeValue);
+        return containsBrace ? "{" + dateTimeType + " " + quotedDateTimeValue + "}" : dateTimeType + " " + quotedDateTimeValue;
+    }
+    
+    /**
+     * Get date time value.
+     *
+     * @return date time value
+     */
+    public String getDateTimeValue() {
+        return dateTimeValue;
     }
 }

--- a/parser/sql/statement/core/src/test/java/org/apache/shardingsphere/sql/parser/statement/core/util/SQLUtilsTest.java
+++ b/parser/sql/statement/core/src/test/java/org/apache/shardingsphere/sql/parser/statement/core/util/SQLUtilsTest.java
@@ -17,6 +17,9 @@
 
 package org.apache.shardingsphere.sql.parser.statement.core.util;
 
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.TemporalLiteralExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.value.literal.impl.DateTimeLiteralValue;
+import org.apache.shardingsphere.sql.parser.statement.core.value.literal.impl.TemporalLiteralValue;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -93,6 +96,30 @@ class SQLUtilsTest {
     @Test
     void assertGetExactlyExpression() {
         assertThat(SQLUtils.getExactlyExpression("((a + b*c))"), is("((a+b*c))"));
+    }
+    
+    @Test
+    void assertCreateLiteralExpressionForTemporalLiteral() {
+        TemporalLiteralExpressionSegment actual = (TemporalLiteralExpressionSegment) SQLUtils.createLiteralExpression(
+                new TemporalLiteralValue("DATE", "'2024-03-01'"), 0, 16, "DATE '2024-03-01'");
+        assertThat(actual.getLiterals(), is("2024-03-01"));
+        assertThat(actual.getText(), is("DATE '2024-03-01'"));
+    }
+    
+    @Test
+    void assertCreateLiteralExpressionForDateTimeLiteral() {
+        TemporalLiteralExpressionSegment actual = (TemporalLiteralExpressionSegment) SQLUtils.createLiteralExpression(
+                new DateTimeLiteralValue("DATE", "'2024-03-01'", false), 0, 16, "DATE '2024-03-01'");
+        assertThat(actual.getLiterals(), is("2024-03-01"));
+        assertThat(actual.getText(), is("DATE '2024-03-01'"));
+    }
+    
+    @Test
+    void assertCreateLiteralExpressionForBraceDateTimeLiteral() {
+        TemporalLiteralExpressionSegment actual = (TemporalLiteralExpressionSegment) SQLUtils.createLiteralExpression(
+                new DateTimeLiteralValue("ts", "'2024-03-01 10:00:00'", true), 0, 25, "{ts '2024-03-01 10:00:00'}");
+        assertThat(actual.getLiterals(), is("2024-03-01 10:00:00"));
+        assertThat(actual.getText(), is("{ts '2024-03-01 10:00:00'}"));
     }
     
     @Test

--- a/parser/sql/statement/core/src/test/java/org/apache/shardingsphere/sql/parser/statement/core/value/literal/impl/DateTimeLiteralValueTest.java
+++ b/parser/sql/statement/core/src/test/java/org/apache/shardingsphere/sql/parser/statement/core/value/literal/impl/DateTimeLiteralValueTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.core.value.literal.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class DateTimeLiteralValueTest {
+    
+    @Test
+    void assertGetValue() {
+        assertThat(new DateTimeLiteralValue("DATE", "'2024-03-01'", false).getValue(), is("DATE '2024-03-01'"));
+    }
+    
+    @Test
+    void assertGetValueWithBrace() {
+        assertThat(new DateTimeLiteralValue("ts", "'2024-03-01 10:00:00'", true).getValue(), is("{ts '2024-03-01 10:00:00'}"));
+    }
+    
+    @Test
+    void assertGetDateTimeValue() {
+        assertThat(new DateTimeLiteralValue("ts", "'2024-03-01 10:00:00'", true).getDateTimeValue(), is("2024-03-01 10:00:00"));
+    }
+}

--- a/test/it/parser/src/main/resources/case/dml/insert.xml
+++ b/test/it/parser/src/main/resources/case/dml/insert.xml
@@ -2705,13 +2705,13 @@
         <values>
             <value>
                 <assignment-value>
-                    <common-expression text="TIMESTAMP'1999-12-01 10:00:00'" start-index="30" stop-index="59" />
+                    <literal-expression value="1999-12-01 10:00:00" start-index="30" stop-index="59" />
                 </assignment-value>
                 <assignment-value>
-                    <common-expression text="TIMESTAMP'1999-12-01 10:00:00'" start-index="62" stop-index="91" />
+                    <literal-expression value="1999-12-01 10:00:00" start-index="62" stop-index="91" />
                 </assignment-value>
                 <assignment-value>
-                    <common-expression text="TIMESTAMP'1999-12-01 10:00:00'" start-index="94" stop-index="123" />
+                    <literal-expression value="1999-12-01 10:00:00" start-index="94" stop-index="123" />
                 </assignment-value>
             </value>
         </values>

--- a/test/it/parser/src/main/resources/case/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-expression.xml
@@ -3221,7 +3221,7 @@
         <projections start-index="7" stop-index="32">
             <expression-projection text="{ts '2020-01-01 10:00:00'}" start-index="7" stop-index="32">
                 <expr>
-                    <common-expression text="{ts '2020-01-01 10:00:00'}" start-index="7" stop-index="32" />
+                    <literal-expression value="2020-01-01 10:00:00" start-index="7" stop-index="32" />
                 </expr>
             </expression-projection>
         </projections>

--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -575,7 +575,7 @@
                 <expr>
                     <function function-name="EXTRACT" text="EXTRACT(YEAR FROM TIMESTAMP '2001-02-16 20:38:40')" start-index="7" stop-index="56" literal-start-index="7" literal-stop-index="56">
                         <parameter>
-                            <common-expression text="TIMESTAMP '2001-02-16 20:38:40'" start-index="25" stop-index="55" literal-start-index="25" literal-stop-index="55" />
+                            <literal-expression value="2001-02-16 20:38:40" start-index="25" stop-index="55" literal-start-index="25" literal-stop-index="55" />
                         </parameter>
                         <literalText>EXTRACT(YEAR FROM TIMESTAMP '2001-02-16 20:38:40')</literalText>
                     </function>

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -14198,7 +14198,11 @@
 
     <select sql-case-id="select_datetime_lbe_literal_oracle">
         <projections start-index="7" stop-index="32">
-            <expression-projection text="{ts '2020-02-02 10:00:00'}" start-index="7" stop-index="32" />
+            <expression-projection text="{ts '2020-02-02 10:00:00'}" start-index="7" stop-index="32">
+                <expr>
+                    <literal-expression value="2020-02-02 10:00:00" start-index="7" stop-index="32" />
+                </expr>
+            </expression-projection>
         </projections>
         <from>
             <simple-table name="dual" start-index="39" stop-index="42" />

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/insert/insert-column.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/insert/insert-column.xml
@@ -47,6 +47,16 @@
         <output sql="INSERT INTO t_account_bak(account_id, `cipher_certificate_number`, `assisted_query_certificate_number`, `like_query_certificate_number`, `cipher_password`, `assisted_query_password`, `like_query_password`, `cipher_amount`, status) VALUES (1, 'encrypt_111X', 'assisted_query_111X', 'like_query_111X', 'encrypt_aaa', 'assisted_query_aaa', 'like_query_aaa', 'encrypt_1000', 'OK'), (2, 'encrypt_222X', 'assisted_query_222X', 'like_query_222X', 'encrypt_bbb', 'assisted_query_bbb', 'like_query_bbb', 'encrypt_2000', 'OK'), (3, 'encrypt_333X', 'assisted_query_333X', 'like_query_333X', 'encrypt_ccc', 'assisted_query_ccc', 'like_query_ccc', 'encrypt_3000', 'OK'), (4, 'encrypt_444X', 'assisted_query_444X', 'like_query_444X', 'encrypt_ddd', 'assisted_query_ddd', 'like_query_ddd', 'encrypt_4000', 'OK')" />
     </rewrite-assertion>
     
+    <rewrite-assertion id="insert_values_with_columns_with_plain_for_mysql_temporal_literal" db-types="MySQL">
+        <input sql="INSERT INTO t_account_bak(account_id, password, amount) VALUES (1, DATE '2024-03-01', 1000)" />
+        <output sql="INSERT INTO t_account_bak(account_id, `cipher_password`, `assisted_query_password`, `like_query_password`, `cipher_amount`) VALUES (1, 'encrypt_2024-03-01', 'assisted_query_2024-03-01', 'like_query_2024-03-01', 'encrypt_1000')" />
+    </rewrite-assertion>
+    
+    <rewrite-assertion id="insert_values_with_columns_with_plain_for_oracle_brace_datetime_literal" db-types="Oracle">
+        <input sql="INSERT INTO t_account_bak(account_id, password, amount) VALUES (1, {d '2024-03-01'}, 1000)" />
+        <output sql="INSERT INTO t_account_bak(account_id, &quot;cipher_password&quot;, &quot;assisted_query_password&quot;, &quot;like_query_password&quot;, &quot;cipher_amount&quot;) VALUES (1, 'encrypt_2024-03-01', 'assisted_query_2024-03-01', 'like_query_2024-03-01', 'encrypt_1000')" />
+    </rewrite-assertion>
+    
     <rewrite-assertion id="insert_values_without_columns_for_parameters" db-types="MySQL">
         <input sql="INSERT INTO t_account VALUES (?, ?, ?, ?), (2, '222X', 'bbb', 2000), (?, ?, ?, ?), (4, '444X', 'ddd', 4000)" parameters="1, 111X, aaa, 1000, 3, 333X, ccc, 3000" />
         <output sql="INSERT INTO t_account(`account_id`, `cipher_certificate_number`, `assisted_query_certificate_number`, `like_query_certificate_number`, `cipher_password`, `assisted_query_password`, `like_query_password`, `cipher_amount`) VALUES (?, ?, ?, ?, ?, ?, ?, ?), (2, 'encrypt_222X', 'assisted_query_222X', 'like_query_222X', 'encrypt_bbb', 'assisted_query_bbb', 'like_query_bbb', 'encrypt_2000'), (?, ?, ?, ?, ?, ?, ?, ?), (4, 'encrypt_444X', 'assisted_query_444X', 'like_query_444X', 'encrypt_ddd', 'assisted_query_ddd', 'like_query_ddd', 'encrypt_4000')" parameters="1, encrypt_111X, assisted_query_111X, like_query_111X, encrypt_aaa, assisted_query_aaa, like_query_aaa, encrypt_1000, 3, encrypt_333X, assisted_query_333X, like_query_333X, encrypt_ccc, assisted_query_ccc, like_query_ccc, encrypt_3000" />


### PR DESCRIPTION
## Summary
- Preserve SQL text for temporal literals parsed from INSERT VALUES.
- Treat DATE/TIME/TIMESTAMP literals as typed literal expressions so encrypt rewrite can use raw literal values while keeping temporal SQL syntax where needed.
- Preserve Oracle date-time literal quote metadata and align parser expected cases.

## Tests
- `./mvnw spotless:apply -Pcheck -T1C`
- `./mvnw -pl parser/sql/statement/core,features/encrypt/core -am -DskipITs -Dspotless.skip=true -Dtest=SQLUtilsTest,DateTimeLiteralValueTest,EncryptInsertValuesTokenGeneratorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl parser/sql/engine/dialect/oracle,parser/sql/statement/core -am -DskipITs -Dspotless.skip=true -Dmaven.test.skip=true install`
- `./mvnw -pl test/it/rewriter -am clean test -DskipITs -Dspotless.skip=true -Dtest=EncryptSQLRewriterIT -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw -pl test/it/parser -am clean test -DskipITs -Dspotless.skip=true -Dtest=org.apache.shardingsphere.test.it.sql.parser.oracle.InternalOracleParserIT -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw checkstyle:check -Pcheck -T1C`