### PR TITLE
Refactor revision candidate naming

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/metadata/reviser/index/EncryptIndexReviser.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/metadata/reviser/index/EncryptIndexReviser.java
@@ -38,7 +38,7 @@ public final class EncryptIndexReviser implements IndexReviser<EncryptRule> {
     
     @Override
     public Optional<IndexMetaData> revise(final String tableName, final IndexMetaData originalMetaData, final Collection<TableMetaData> originalTableMetaDataList,
-                                          final Collection<TableMetaData> indexNameRecoveryCandidateTableMetaDataList, final EncryptRule rule) {
+                                          final Collection<TableMetaData> indexNameRecoveryCandidateTables, final EncryptRule rule) {
         if (originalMetaData.getColumns().isEmpty()) {
             return Optional.empty();
         }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/metadata/reviser/index/ShardingIndexReviser.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/metadata/reviser/index/ShardingIndexReviser.java
@@ -42,12 +42,12 @@ public final class ShardingIndexReviser implements IndexReviser<ShardingRule> {
     
     @Override
     public Optional<IndexMetaData> revise(final String tableName, final IndexMetaData originalMetaData, final Collection<TableMetaData> originalTableMetaDataList,
-                                          final Collection<TableMetaData> indexNameRecoveryCandidateTableMetaDataList, final ShardingRule rule) {
+                                          final Collection<TableMetaData> indexNameRecoveryCandidateTables, final ShardingRule rule) {
         if (shardingTable.getActualDataNodes().isEmpty()) {
             return Optional.empty();
         }
         String logicIndexName = IndexMetaDataUtils.findGeneratedLogicIndexName(originalMetaData.getName(), tableName,
-                findCandidateLogicIndexNames(originalMetaData, originalTableMetaDataList, indexNameRecoveryCandidateTableMetaDataList)).orElse(originalMetaData.getName());
+                findCandidateLogicIndexNames(originalMetaData, originalTableMetaDataList, indexNameRecoveryCandidateTables)).orElse(originalMetaData.getName());
         IndexMetaData result = new IndexMetaData(
                 logicIndexName, originalMetaData.getColumns());
         result.setUnique(originalMetaData.isUnique());
@@ -55,7 +55,7 @@ public final class ShardingIndexReviser implements IndexReviser<ShardingRule> {
     }
     
     private Collection<String> findCandidateLogicIndexNames(final IndexMetaData originalMetaData, final Collection<TableMetaData> originalTableMetaDataList,
-                                                            final Collection<TableMetaData> indexNameRecoveryCandidateTableMetaDataList) {
+                                                            final Collection<TableMetaData> indexNameRecoveryCandidateTables) {
         Collection<String> result = new LinkedHashSet<>();
         result.add(getGeneratedAnonymousIndexName(originalMetaData));
         for (TableMetaData eachTable : originalTableMetaDataList) {
@@ -63,7 +63,7 @@ public final class ShardingIndexReviser implements IndexReviser<ShardingRule> {
                 result.addAll(findCandidateLogicIndexNames(eachTable));
             }
         }
-        for (TableMetaData each : indexNameRecoveryCandidateTableMetaDataList) {
+        for (TableMetaData each : indexNameRecoveryCandidateTables) {
             if (isLogicTable(each.getName())) {
                 result.addAll(findCandidateLogicIndexNamesFromRevisionCandidate(each));
             }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseFactory.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseFactory.java
@@ -83,7 +83,7 @@ public final class ShardingSphereDatabaseFactory {
      */
     public static ShardingSphereDatabase create(final String name, final DatabaseType protocolType, final DatabaseConfiguration databaseConfig,
                                                 final ConfigurationProperties props, final ComputeNodeInstanceContext computeNodeInstanceContext) throws SQLException {
-        return createWithSchemaMetaDataRevisionCandidates(name, protocolType, databaseConfig, props, computeNodeInstanceContext, Collections.emptyList());
+        return createWithRevisionCandidateSchemas(name, protocolType, databaseConfig, props, computeNodeInstanceContext, Collections.emptyList());
     }
     
     /**
@@ -121,26 +121,26 @@ public final class ShardingSphereDatabaseFactory {
     }
     
     /**
-     * Create database with schema meta data revision candidate schemas.
+     * Create database with revision candidate schemas.
      *
      * @param name database name
      * @param protocolType database protocol type
      * @param databaseConfig database configuration
      * @param props configuration properties
      * @param computeNodeInstanceContext compute node instance context
-     * @param schemaMetaDataRevisionCandidateSchemas schema meta data revision candidate schemas
+     * @param revisionCandidateSchemas revision candidate schemas
      * @return created database
      * @throws SQLException SQL exception
      */
-    public static ShardingSphereDatabase createWithSchemaMetaDataRevisionCandidates(final String name, final DatabaseType protocolType, final DatabaseConfiguration databaseConfig,
-                                                                                    final ConfigurationProperties props, final ComputeNodeInstanceContext computeNodeInstanceContext,
-                                                                                    final Collection<ShardingSphereSchema> schemaMetaDataRevisionCandidateSchemas) throws SQLException {
+    public static ShardingSphereDatabase createWithRevisionCandidateSchemas(final String name, final DatabaseType protocolType, final DatabaseConfiguration databaseConfig,
+                                                                            final ConfigurationProperties props, final ComputeNodeInstanceContext computeNodeInstanceContext,
+                                                                            final Collection<ShardingSphereSchema> revisionCandidateSchemas) throws SQLException {
         ResourceMetaData resourceMetaData = new ResourceMetaData(databaseConfig.getDataSources(), databaseConfig.getStorageUnits());
         DatabaseIdentifierContext identifierContext = DatabaseIdentifierContextFactory.create(protocolType, resourceMetaData, props);
         Collection<ShardingSphereRule> databaseRules = DatabaseRulesBuilder.build(name, protocolType, databaseConfig, computeNodeInstanceContext, resourceMetaData);
         Map<String, ShardingSphereSchema> schemas = new ConcurrentHashMap<>(GenericSchemaBuilder.build(protocolType,
                 new GenericSchemaBuilderMaterial(resourceMetaData.getStorageUnits(), databaseRules, props, new DatabaseTypeRegistry(protocolType).getDefaultSchemaName(name),
-                        identifierContext, schemaMetaDataRevisionCandidateSchemas)));
+                        identifierContext, revisionCandidateSchemas)));
         SystemSchemaBuilder.build(name, protocolType, props).forEach(schemas::putIfAbsent);
         return new ShardingSphereDatabase(name, protocolType, resourceMetaData, new RuleMetaData(databaseRules), schemas.values(), props);
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilderMaterial.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilderMaterial.java
@@ -46,7 +46,7 @@ public final class GenericSchemaBuilderMaterial {
     
     private final DatabaseIdentifierContext identifierContext;
     
-    private final Collection<ShardingSphereSchema> schemaMetaDataRevisionCandidateSchemas;
+    private final Collection<ShardingSphereSchema> revisionCandidateSchemas;
     
     public GenericSchemaBuilderMaterial(final Map<String, StorageUnit> storageUnits, final Collection<ShardingSphereRule> rules, final ConfigurationProperties props,
                                         final String defaultSchemaName, final DatabaseIdentifierContext identifierContext) {

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/MetaDataReviseEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/MetaDataReviseEngine.java
@@ -65,7 +65,7 @@ public final class MetaDataReviseEngine {
         Map<String, ShardingSphereSchema> result = new HashMap<>(schemaMetaDataMap.size(), 1F);
         for (Entry<String, SchemaMetaData> entry : schemaMetaDataMap.entrySet()) {
             SchemaMetaData schemaMetaData = new SchemaMetaDataReviseEngine(
-                    rules, material.getProps(), material.getSchemaMetaDataRevisionCandidateSchemas()).revise(entry.getValue());
+                    rules, material.getProps(), material.getRevisionCandidateSchemas()).revise(entry.getValue());
             result.put(entry.getKey(), new ShardingSphereSchema(entry.getKey(), protocolType, convertToTables(schemaMetaData.getTables()), new LinkedList<>()));
         }
         return result;

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/index/IndexReviseEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/index/IndexReviseEngine.java
@@ -45,16 +45,16 @@ public final class IndexReviseEngine<T extends ShardingSphereRule> {
      * @param tableName table name
      * @param originalMetaDataList original index meta data list
      * @param originalTableMetaDataList original table meta data list
-     * @param schemaMetaDataRevisionCandidateTableMetaDataList schema meta data revision candidate table meta data list
+     * @param indexNameRecoveryCandidateTables index name recovery candidate tables
      * @return revised index meta data
      */
     public Collection<IndexMetaData> revise(final String tableName, final Collection<IndexMetaData> originalMetaDataList,
                                             final Collection<TableMetaData> originalTableMetaDataList,
-                                            final Collection<TableMetaData> schemaMetaDataRevisionCandidateTableMetaDataList) {
+                                            final Collection<TableMetaData> indexNameRecoveryCandidateTables) {
         Optional<? extends IndexReviser<T>> reviser = reviseEntry.getIndexReviser(rule, tableName);
         return reviser.isPresent()
                 ? originalMetaDataList.stream()
-                        .map(each -> reviser.get().revise(tableName, each, originalTableMetaDataList, schemaMetaDataRevisionCandidateTableMetaDataList, rule))
+                        .map(each -> reviser.get().revise(tableName, each, originalTableMetaDataList, indexNameRecoveryCandidateTables, rule))
                         .filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList())
                 : originalMetaDataList;
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/index/IndexReviser.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/index/IndexReviser.java
@@ -37,10 +37,10 @@ public interface IndexReviser<T extends ShardingSphereRule> {
      * @param tableName table name
      * @param originalMetaData original index meta data
      * @param originalTableMetaDataList original table meta data list
-     * @param indexNameRecoveryCandidateTableMetaDataList index name recovery candidate table meta data list
+     * @param indexNameRecoveryCandidateTables index name recovery candidate tables
      * @param rule rule
      * @return revised index meta data
      */
     Optional<IndexMetaData> revise(String tableName, IndexMetaData originalMetaData,
-                                   Collection<TableMetaData> originalTableMetaDataList, Collection<TableMetaData> indexNameRecoveryCandidateTableMetaDataList, T rule);
+                                   Collection<TableMetaData> originalTableMetaDataList, Collection<TableMetaData> indexNameRecoveryCandidateTables, T rule);
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/table/TableMetaDataReviseEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/table/TableMetaDataReviseEngine.java
@@ -67,16 +67,16 @@ public final class TableMetaDataReviseEngine<T extends ShardingSphereRule> {
      *
      * @param originalMetaData original table meta data
      * @param originalMetaDataList original table meta data list
-     * @param schemaMetaDataRevisionCandidateTableMetaDataList schema meta data revision candidate table meta data list
+     * @param indexNameRecoveryCandidateTables index name recovery candidate tables
      * @return revised table meta data
      */
     public TableMetaData revise(final TableMetaData originalMetaData, final Collection<TableMetaData> originalMetaDataList,
-                                final Collection<TableMetaData> schemaMetaDataRevisionCandidateTableMetaDataList) {
+                                final Collection<TableMetaData> indexNameRecoveryCandidateTables) {
         Optional<? extends TableNameReviser<T>> tableNameReviser = reviseEntry.getTableNameReviser();
         String revisedTableName = tableNameReviser.map(optional -> optional.revise(originalMetaData.getName(), rule)).orElse(originalMetaData.getName());
         return new TableMetaData(revisedTableName, new ColumnReviseEngine<>(rule, reviseEntry).revise(originalMetaData.getName(), originalMetaData.getColumns()),
                 new IndexReviseEngine<>(rule, reviseEntry).revise(originalMetaData.getName(), originalMetaData.getIndexes(), originalMetaDataList,
-                        schemaMetaDataRevisionCandidateTableMetaDataList),
+                        indexNameRecoveryCandidateTables),
                 new ConstraintReviseEngine<>(rule, reviseEntry).revise(originalMetaData.getName(), originalMetaData.getConstraints()), originalMetaData.getType());
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseFactoryTest.java
@@ -105,7 +105,7 @@ class ShardingSphereDatabaseFactoryTest {
     }
     
     @Test
-    void assertCreateWithDatabaseConfigurationAndSchemaMetaDataRevisionCandidates() throws SQLException {
+    void assertCreateWithDatabaseConfigurationAndRevisionCandidateSchemas() throws SQLException {
         DatabaseType protocolType = mock(DatabaseType.class);
         ShardingSphereSchema candidateSchema = new ShardingSphereSchema("candidate_schema", protocolType);
         try (
@@ -117,10 +117,10 @@ class ShardingSphereDatabaseFactoryTest {
             mockedRulesBuilder.when(() -> DatabaseRulesBuilder.build(eq("foo_db"), eq(protocolType), eq(databaseConfig), eq(computeNodeInstanceContext), any(ResourceMetaData.class)))
                     .thenReturn(Collections.singleton(mock(ShardingSphereRule.class)));
             mockedGenericSchemaBuilder.when(() -> GenericSchemaBuilder.build(eq(protocolType),
-                    argThat(material -> material.getSchemaMetaDataRevisionCandidateSchemas().contains(candidateSchema))))
+                    argThat(material -> material.getRevisionCandidateSchemas().contains(candidateSchema))))
                     .thenReturn(Collections.singletonMap("foo_schema", new ShardingSphereSchema("foo_schema", protocolType)));
             mockedSystemSchemaBuilder.when(() -> SystemSchemaBuilder.build("foo_db", protocolType, props)).thenReturn(Collections.emptyMap());
-            ShardingSphereDatabase actual = ShardingSphereDatabaseFactory.createWithSchemaMetaDataRevisionCandidates(
+            ShardingSphereDatabase actual = ShardingSphereDatabaseFactory.createWithRevisionCandidateSchemas(
                     "foo_db", protocolType, databaseConfig, props, computeNodeInstanceContext, Collections.singleton(candidateSchema));
             assertTrue(actual.containsSchema("foo_schema"));
         }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/index/IndexReviseEngineTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/index/IndexReviseEngineTest.java
@@ -86,7 +86,7 @@ class IndexReviseEngineTest {
     }
     
     @Test
-    void assertReviseWithSchemaMetaDataRevisionCandidateTableMetaDataList() {
+    void assertReviseWithIndexNameRecoveryCandidateTables() {
         IndexReviser reviser = mock(IndexReviser.class);
         Collection<IndexMetaData> originalIndexes = Arrays.asList(new IndexMetaData("idx_0"), new IndexMetaData("idx_1"));
         Collection<TableMetaData> originalTables = Collections.singleton(new TableMetaData("foo_tbl", Collections.emptyList(), originalIndexes, Collections.emptyList()));

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/factory/MetaDataContextsFactory.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/factory/MetaDataContextsFactory.java
@@ -172,7 +172,7 @@ public final class MetaDataContextsFactory {
                                                                   final MetaDataContexts originalMetaDataContext) throws SQLException {
         ConfigurationProperties props = originalMetaDataContext.getMetaData().getProps();
         DatabaseType protocolType = DatabaseTypeEngine.getProtocolType(databaseConfig, props);
-        return ShardingSphereDatabaseFactory.createWithSchemaMetaDataRevisionCandidates(databaseName, protocolType, databaseConfig, props, instanceContext,
+        return ShardingSphereDatabaseFactory.createWithRevisionCandidateSchemas(databaseName, protocolType, databaseConfig, props, instanceContext,
                 originalMetaDataContext.getMetaData().getDatabase(databaseName).getAllSchemas());
     }
     

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/CreateTablePushDownMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/CreateTablePushDownMetaDataRefresher.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.mode.persist.service.MetaDataManagerPersistServ
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.constraint.ConstraintDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.table.CreateTableStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 
 import java.sql.SQLException;
 import java.util.Collection;
@@ -47,7 +48,7 @@ public final class CreateTablePushDownMetaDataRefresher implements PushDownMetaD
     public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService, final ShardingSphereDatabase database, final String logicDataSourceName,
                         final String schemaName, final DatabaseType databaseType, final CreateTableStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
         ShardingSphereTable loadedTable = metaDataLoader.loadCreatedTable(database, logicDataSourceName, schemaName, sqlStatement.getTable().getTableName().getIdentifier(), props,
-                createSchemaMetaDataRevisionCandidateSchemas(database, schemaName, sqlStatement, props));
+                createRevisionCandidateSchemas(database, schemaName, sqlStatement, props));
         metaDataManagerPersistService.createTable(database, schemaName, loadedTable);
     }
     
@@ -56,9 +57,9 @@ public final class CreateTablePushDownMetaDataRefresher implements PushDownMetaD
         return CreateTableStatement.class;
     }
     
-    private Collection<ShardingSphereSchema> createSchemaMetaDataRevisionCandidateSchemas(final ShardingSphereDatabase database, final String schemaName,
-                                                                                          final CreateTableStatement sqlStatement, final ConfigurationProperties props) {
-        Collection<ShardingSphereIndex> indexes = createIndexMetaDataRevisionCandidates(sqlStatement);
+    private Collection<ShardingSphereSchema> createRevisionCandidateSchemas(final ShardingSphereDatabase database, final String schemaName,
+                                                                            final CreateTableStatement sqlStatement, final ConfigurationProperties props) {
+        Collection<ShardingSphereIndex> indexes = createRevisionCandidateIndexes(sqlStatement);
         if (indexes.isEmpty()) {
             return database.getAllSchemas();
         }
@@ -69,12 +70,12 @@ public final class CreateTablePushDownMetaDataRefresher implements PushDownMetaD
         return result;
     }
     
-    private Collection<ShardingSphereIndex> createIndexMetaDataRevisionCandidates(final CreateTableStatement sqlStatement) {
+    private Collection<ShardingSphereIndex> createRevisionCandidateIndexes(final CreateTableStatement sqlStatement) {
         Collection<ShardingSphereIndex> result = new LinkedList<>();
         for (ConstraintDefinitionSegment each : sqlStatement.getConstraintDefinitions()) {
             each.getIndexName().ifPresent(optional -> result.add(new ShardingSphereIndex(
                     optional.getIndexName().getIdentifier().getValue(), each.getIndexColumns().stream()
-                            .map(ColumnSegment::getIdentifier).map(optionalColumn -> optionalColumn.getValue()).collect(Collectors.toList()),
+                            .map(ColumnSegment::getIdentifier).map(IdentifierValue::getValue).collect(Collectors.toList()),
                     each.isUniqueKey() || optional.isUniqueKey())));
         }
         return result;

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/TableMetaDataRefresherLoader.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/TableMetaDataRefresherLoader.java
@@ -64,14 +64,14 @@ public final class TableMetaDataRefresherLoader {
      * @param schemaName schema name
      * @param tableIdentifierValue table identifier value
      * @param props configuration properties
-     * @param schemaMetaDataRevisionCandidateSchemas schema meta data revision candidate schemas
+     * @param revisionCandidateSchemas revision candidate schemas
      * @return loaded table meta data
      * @throws SQLException SQL exception
      */
     public ShardingSphereTable loadCreatedTable(final ShardingSphereDatabase database, final String logicDataSourceName, final String schemaName,
                                                 final IdentifierValue tableIdentifierValue, final ConfigurationProperties props,
-                                                final Collection<ShardingSphereSchema> schemaMetaDataRevisionCandidateSchemas) throws SQLException {
-        return loadTable(database, logicDataSourceName, schemaName, tableIdentifierValue, props, false, schemaMetaDataRevisionCandidateSchemas);
+                                                final Collection<ShardingSphereSchema> revisionCandidateSchemas) throws SQLException {
+        return loadTable(database, logicDataSourceName, schemaName, tableIdentifierValue, props, false, revisionCandidateSchemas);
     }
     
     /**
@@ -92,7 +92,7 @@ public final class TableMetaDataRefresherLoader {
     
     private ShardingSphereTable loadTable(final ShardingSphereDatabase database, final String logicDataSourceName, final String schemaName,
                                           final IdentifierValue tableIdentifierValue, final ConfigurationProperties props, final boolean fallbackWhenMissing,
-                                          final Collection<ShardingSphereSchema> schemaMetaDataRevisionCandidateSchemas) throws SQLException {
+                                          final Collection<ShardingSphereSchema> revisionCandidateSchemas) throws SQLException {
         String candidateTableName = TableRefreshUtils.getTableLoadCandidateName(database, tableIdentifierValue, props);
         RuleMetaData ruleMetaData = new RuleMetaData(new LinkedList<>(database.getRuleMetaData().getRules()));
         boolean singleTable = TableRefreshUtils.isSingleTable(candidateTableName, database);
@@ -100,7 +100,7 @@ public final class TableMetaDataRefresherLoader {
             ruleMetaData.getAttributes(MutableDataNodeRuleAttribute.class).forEach(each -> each.put(logicDataSourceName, schemaName, candidateTableName));
         }
         GenericSchemaBuilderMaterial material = new GenericSchemaBuilderMaterial(database.getResourceMetaData().getStorageUnits(), ruleMetaData.getRules(), props, schemaName,
-                database.getIdentifierContext(), schemaMetaDataRevisionCandidateSchemas);
+                database.getIdentifierContext(), revisionCandidateSchemas);
         Map<String, ShardingSphereSchema> schemas = GenericSchemaBuilder.build(Collections.singletonList(candidateTableName), database.getProtocolType(), material);
         ShardingSphereTable result = Optional.ofNullable(schemas.get(schemaName)).map(optional -> optional.getTable(candidateTableName))
                 .orElseGet(() -> fallbackWhenMissing ? new ShardingSphereTable(candidateTableName, Collections.emptyList(), Collections.emptyList(), Collections.emptyList()) : null);

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/factory/MetaDataContextsFactoryTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/factory/MetaDataContextsFactoryTest.java
@@ -109,7 +109,7 @@ class MetaDataContextsFactoryTest {
         when(ShardingSphereDatabaseFactory.create(anyString(), any(DatabaseType.class), any(DatabaseConfiguration.class),
                 any(ConfigurationProperties.class), any(ComputeNodeInstanceContext.class), anyCollection()))
                 .thenAnswer(invocation -> createDatabaseFromConfiguration(invocation.getArgument(0), invocation.getArgument(1), invocation.getArgument(2), invocation.getArgument(5)));
-        when(ShardingSphereDatabaseFactory.createWithSchemaMetaDataRevisionCandidates(anyString(), any(DatabaseType.class), any(DatabaseConfiguration.class),
+        when(ShardingSphereDatabaseFactory.createWithRevisionCandidateSchemas(anyString(), any(DatabaseType.class), any(DatabaseConfiguration.class),
                 any(ConfigurationProperties.class), any(ComputeNodeInstanceContext.class), anyCollection()))
                 .thenAnswer(invocation -> createDatabaseFromConfiguration(invocation.getArgument(0), invocation.getArgument(1), invocation.getArgument(2), invocation.getArgument(5)));
         when(GlobalRulesBuilder.buildRules(anyCollection(), anyCollection(), any(ConfigurationProperties.class))).thenReturn(Collections.singleton(new MockedRule()));

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/CreateTablePushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/CreateTablePushDownMetaDataRefresherTest.java
@@ -96,7 +96,6 @@ class CreateTablePushDownMetaDataRefresherTest {
         assertThat(persistService.getCreatedTable().getName(), is("Foo_Tbl"));
     }
     
-    @SuppressWarnings("rawtypes")
     @Test
     void assertRefreshCreatedShardingTableRestoresTruncatedNamedIndexFromCreateTableStatementCandidate() throws SQLException {
         String logicTableName = "tbl";
@@ -118,7 +117,7 @@ class CreateTablePushDownMetaDataRefresherTest {
         Map<ShardingSphereRule, MetaDataReviseEntry<?>> reviseEntries = Collections.singletonMap(rule, new CreateTableCandidateMetaDataReviseEntry());
         PushDownMetaDataManagerPersistServiceFixture persistService = new PushDownMetaDataManagerPersistServiceFixture();
         try (MockedStatic<OrderedSPILoader> mockedLoader = mockStatic(OrderedSPILoader.class, CALLS_REAL_METHODS)) {
-            mockedLoader.when(() -> OrderedSPILoader.getServices(eq(MetaDataReviseEntry.class), anyCollection())).thenReturn((Map) reviseEntries);
+            mockedLoader.when(() -> OrderedSPILoader.getServices(eq(MetaDataReviseEntry.class), anyCollection())).thenReturn(reviseEntries);
             new CreateTablePushDownMetaDataRefresher().refresh(persistService, createDatabase(dataSource, new RuleMetaData(Collections.singleton(rule))), LOGIC_DATA_SOURCE_NAME, SCHEMA_NAME,
                     databaseType, createCreateTableStatement(logicTableName, logicIndexName), createPropertiesWithCheckMetaDataEnabled());
         }
@@ -296,8 +295,8 @@ class CreateTablePushDownMetaDataRefresherTest {
         
         @Override
         public Optional<IndexMetaData> revise(final String tableName, final IndexMetaData originalMetaData, final Collection<TableMetaData> originalTableMetaDataList,
-                                              final Collection<TableMetaData> indexNameRecoveryCandidateTableMetaDataList, final CreateTableCandidateRule rule) {
-            Collection<String> candidateIndexNames = indexNameRecoveryCandidateTableMetaDataList.stream()
+                                              final Collection<TableMetaData> indexNameRecoveryCandidateTables, final CreateTableCandidateRule rule) {
+            Collection<String> candidateIndexNames = indexNameRecoveryCandidateTables.stream()
                     .filter(each -> rule.logicTableName.equalsIgnoreCase(each.getName())).flatMap(each -> each.getIndexes().stream()).map(IndexMetaData::getName).collect(Collectors.toSet());
             IndexMetaData result = new IndexMetaData(IndexMetaDataUtils.findGeneratedLogicIndexName(
                     originalMetaData.getName(), tableName, candidateIndexNames).orElse(originalMetaData.getName()), originalMetaData.getColumns());


### PR DESCRIPTION
Shorten schema metadata revision candidate naming across the metadata revision path. Rename the factory entry point and related material, loader, engine, and test identifiers to use revision candidate schemas and index name recovery candidate tables consistently.

This keeps the existing metadata revision behavior unchanged while removing repeated schema/table metadata wording from internal names.

Revise #38449