### PR TITLE
Move index name length budget to dialect metadata

### DIFF
--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/DialectDatabaseMetaData.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/DialectDatabaseMetaData.java
@@ -123,7 +123,7 @@ public interface DialectDatabaseMetaData extends DatabaseTypedSPI {
      * @return index option
      */
     default DialectIndexOption getIndexOption() {
-        return new DialectIndexOption(false);
+        return new DialectIndexOption(false, Integer.MAX_VALUE);
     }
     
     /**

--- a/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/option/index/DialectIndexOption.java
+++ b/database/connector/core/src/main/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/option/index/DialectIndexOption.java
@@ -28,4 +28,6 @@ import lombok.RequiredArgsConstructor;
 public final class DialectIndexOption {
     
     private final boolean isSchemaUniquenessLevel;
+    
+    private final int indexNameMaxLength;
 }

--- a/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/DialectDatabaseMetaDataTest.java
+++ b/database/connector/core/src/test/java/org/apache/shardingsphere/database/connector/core/metadata/database/metadata/DialectDatabaseMetaDataTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.database.connector.core.metadata.database.meta
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.connection.DialectConnectionOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.datatype.DefaultDataTypeOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.index.DialectIndexOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.join.DialectJoinOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.pagination.DialectPaginationOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaOption;
@@ -69,7 +70,9 @@ class DialectDatabaseMetaDataTest {
     
     @Test
     void assertGetIndexOption() {
-        assertFalse(dialectDatabaseMetaData.getIndexOption().isSchemaUniquenessLevel());
+        DialectIndexOption actual = dialectDatabaseMetaData.getIndexOption();
+        assertFalse(actual.isSchemaUniquenessLevel());
+        assertThat(actual.getIndexNameMaxLength(), is(Integer.MAX_VALUE));
     }
     
     @Test

--- a/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
+++ b/database/connector/dialect/opengauss/src/main/java/org/apache/shardingsphere/database/connector/opengauss/metadata/database/OpenGaussDatabaseMetaData.java
@@ -42,6 +42,8 @@ import java.util.Optional;
  */
 public final class OpenGaussDatabaseMetaData implements DialectDatabaseMetaData {
     
+    private static final int INDEX_NAME_MAX_LENGTH = 63;
+    
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.QUOTE;
@@ -74,7 +76,7 @@ public final class OpenGaussDatabaseMetaData implements DialectDatabaseMetaData 
     
     @Override
     public DialectIndexOption getIndexOption() {
-        return new DialectIndexOption(true);
+        return new DialectIndexOption(true, INDEX_NAME_MAX_LENGTH);
     }
     
     @Override

--- a/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/database/OpenGaussDatabaseMetaDataTest.java
+++ b/database/connector/dialect/opengauss/src/test/java/org/apache/shardingsphere/database/connector/opengauss/metadata/database/OpenGaussDatabaseMetaDataTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.database.enums
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.IdentifierPatternType;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.index.DialectIndexOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.schema.DialectSchemaOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.table.DialectDriverQuerySystemCatalogOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
@@ -91,7 +92,9 @@ class OpenGaussDatabaseMetaDataTest {
     
     @Test
     void assertGetIndexOption() {
-        assertTrue(dialectDatabaseMetaData.getIndexOption().isSchemaUniquenessLevel());
+        DialectIndexOption actual = dialectDatabaseMetaData.getIndexOption();
+        assertTrue(actual.isSchemaUniquenessLevel());
+        assertThat(actual.getIndexNameMaxLength(), is(63));
     }
     
     @Test

--- a/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/OracleDatabaseMetaData.java
+++ b/database/connector/dialect/oracle/src/main/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/OracleDatabaseMetaData.java
@@ -43,6 +43,8 @@ import java.util.Optional;
  */
 public final class OracleDatabaseMetaData implements DialectDatabaseMetaData {
     
+    private static final int INDEX_NAME_MAX_LENGTH = 30;
+    
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.QUOTE;
@@ -70,7 +72,7 @@ public final class OracleDatabaseMetaData implements DialectDatabaseMetaData {
     
     @Override
     public DialectIndexOption getIndexOption() {
-        return new DialectIndexOption(true);
+        return new DialectIndexOption(true, INDEX_NAME_MAX_LENGTH);
     }
     
     @Override

--- a/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/OracleDatabaseMetaDataTest.java
+++ b/database/connector/dialect/oracle/src/test/java/org/apache/shardingsphere/database/connector/oracle/metadata/database/OracleDatabaseMetaDataTest.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.database.enums
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.IdentifierPatternType;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.altertable.DialectAlterTableOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.connection.DialectConnectionOption;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.index.DialectIndexOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.pagination.DialectPaginationOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
@@ -74,7 +75,9 @@ class OracleDatabaseMetaDataTest {
     
     @Test
     void assertGetIndexOption() {
-        assertTrue(dialectDatabaseMetaData.getIndexOption().isSchemaUniquenessLevel());
+        DialectIndexOption actual = dialectDatabaseMetaData.getIndexOption();
+        assertTrue(actual.isSchemaUniquenessLevel());
+        assertThat(actual.getIndexNameMaxLength(), is(30));
     }
     
     @Test

--- a/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/PostgreSQLDatabaseMetaData.java
+++ b/database/connector/dialect/postgresql/src/main/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/PostgreSQLDatabaseMetaData.java
@@ -39,6 +39,8 @@ import java.util.Collections;
  */
 public final class PostgreSQLDatabaseMetaData implements DialectDatabaseMetaData {
     
+    private static final int INDEX_NAME_MAX_LENGTH = 63;
+    
     @Override
     public QuoteCharacter getQuoteCharacter() {
         return QuoteCharacter.QUOTE;
@@ -66,7 +68,7 @@ public final class PostgreSQLDatabaseMetaData implements DialectDatabaseMetaData
     
     @Override
     public DialectIndexOption getIndexOption() {
-        return new DialectIndexOption(true);
+        return new DialectIndexOption(true, INDEX_NAME_MAX_LENGTH);
     }
     
     @Override

--- a/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/PostgreSQLDatabaseMetaDataTest.java
+++ b/database/connector/dialect/postgresql/src/test/java/org/apache/shardingsphere/database/connector/postgresql/metadata/database/PostgreSQLDatabaseMetaDataTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.database.enums
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.IdentifierPatternType;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.index.DialectIndexOption;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.transaction.DialectTransactionOption;
 import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
@@ -76,7 +77,9 @@ class PostgreSQLDatabaseMetaDataTest {
     
     @Test
     void assertGetIndexOption() {
-        assertTrue(dialectDatabaseMetaData.getIndexOption().isSchemaUniquenessLevel());
+        DialectIndexOption actual = dialectDatabaseMetaData.getIndexOption();
+        assertTrue(actual.isSchemaUniquenessLevel());
+        assertThat(actual.getIndexNameMaxLength(), is(63));
     }
     
     @Test

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/util/IndexMetaDataUtils.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/util/IndexMetaDataUtils.java
@@ -20,6 +20,8 @@ package org.apache.shardingsphere.infra.metadata.database.schema.util;
 import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
+import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -60,12 +62,6 @@ public final class IndexMetaDataUtils {
     private static final Pattern HASHED_INDEX_NAME_SUFFIX_PATTERN = Pattern.compile("_h[0-9a-z]{8}$");
     
     private static final Pattern TRUNCATED_INDEX_NAME_SUFFIX_PATTERN = Pattern.compile("_t[0-9a-z]{8}$");
-    
-    private static final int POSTGRESQL_INDEX_NAME_MAX_LENGTH = 63;
-    
-    private static final int OPENGAUSS_INDEX_NAME_MAX_LENGTH = 63;
-    
-    private static final int ORACLE_INDEX_NAME_MAX_LENGTH = 30;
     
     /**
      * Get logic index name.
@@ -278,19 +274,8 @@ public final class IndexMetaDataUtils {
     }
     
     private static int getIndexNameMaxLength(final DatabaseType databaseType) {
-        if (null == databaseType) {
-            return Integer.MAX_VALUE;
-        }
-        switch (databaseType.getType()) {
-            case "PostgreSQL":
-                return POSTGRESQL_INDEX_NAME_MAX_LENGTH;
-            case "openGauss":
-                return OPENGAUSS_INDEX_NAME_MAX_LENGTH;
-            case "Oracle":
-                return ORACLE_INDEX_NAME_MAX_LENGTH;
-            default:
-                return Integer.MAX_VALUE;
-        }
+        return null == databaseType ? Integer.MAX_VALUE
+                : DatabaseTypedSPILoader.findService(DialectDatabaseMetaData.class, databaseType).map(optional -> optional.getIndexOption().getIndexNameMaxLength()).orElse(Integer.MAX_VALUE);
     }
     
     private static int getLengthSafeGeneratedSuffixLength() {

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/IndexMetaDataUtilsTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/IndexMetaDataUtilsTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
@@ -44,6 +45,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class IndexMetaDataUtilsTest {
     
@@ -131,6 +133,16 @@ class IndexMetaDataUtilsTest {
         String actual = IndexMetaDataUtils.getActualIndexName(logicIndexName, "t_account_0", oracleDatabaseType);
         assertTrue(actual.matches(".*_h[0-9a-z]{8}$"));
         assertThat(actual.getBytes(StandardCharsets.UTF_8).length, is(30));
+    }
+    
+    @Test
+    void assertGetActualIndexNameKeepsLegacyFormatWithoutDialectMetaData() {
+        DatabaseType databaseType = mock(DatabaseType.class);
+        when(databaseType.getType()).thenReturn("UNKNOWN");
+        when(databaseType.getTrunkDatabaseType()).thenReturn(Optional.empty());
+        String logicIndexName = "very_long_named_index_boundary_case_for_sharding_length_safety_validation";
+        String actual = IndexMetaDataUtils.getActualIndexName(logicIndexName, "t_account_0", databaseType);
+        assertThat(actual, is("very_long_named_index_boundary_case_for_sharding_length_safety_validation_t_account_0"));
     }
     
     @Test


### PR DESCRIPTION
Add indexNameMaxLength to DialectIndexOption and configure the existing PostgreSQL, openGauss, and Oracle index name limits in their dialect metadata.

Update IndexMetaDataUtils to read the budget through DatabaseTypedSPILoader and fall back to unlimited length when no dialect metadata is available, preserving unknown database behavior.

Add coverage for default, dialect-specific, and no-SPI fallback behavior.

Revise #38449.