### PR TITLE
Fix temporal literal rendering in insert values

### DIFF
--- a/infra/rewrite/core/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/generic/InsertValue.java
+++ b/infra/rewrite/core/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/generic/InsertValue.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.enums.ParameterMarker
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.TemporalLiteralExpressionSegment;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -115,6 +116,9 @@ public class InsertValue {
         if (expressionSegment instanceof ParameterMarkerExpressionSegment) {
             ParameterMarkerExpressionSegment segment = (ParameterMarkerExpressionSegment) expressionSegment;
             return ParameterMarkerType.QUESTION == segment.getParameterMarkerType() ? "?" : "$" + (segment.getParameterMarkerIndex() + 1);
+        }
+        if (expressionSegment instanceof TemporalLiteralExpressionSegment) {
+            return expressionSegment.getText();
         }
         if (expressionSegment instanceof LiteralExpressionSegment) {
             Object literals = ((LiteralExpressionSegment) expressionSegment).getLiterals();

--- a/infra/rewrite/core/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/generic/InsertValueTest.java
+++ b/infra/rewrite/core/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/token/common/pojo/generic/InsertValueTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.Type
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.complex.ComplexExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.TemporalLiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
 
@@ -77,6 +78,16 @@ class InsertValueTest {
         InsertValue insertValue = new InsertValue(expressionSegments);
         String actualToString = insertValue.toString();
         String expectedToString = "(SYSDATE)";
+        assertThat(actualToString, is(expectedToString));
+    }
+    
+    @Test
+    void assertTemporalLiteralToString() {
+        List<ExpressionSegment> expressionSegments = new ArrayList<>(1);
+        expressionSegments.add(new TemporalLiteralExpressionSegment(0, 16, "2017-08-08", "DATE '2017-08-08'"));
+        InsertValue insertValue = new InsertValue(expressionSegments);
+        String actualToString = insertValue.toString();
+        String expectedToString = "(DATE '2017-08-08')";
         assertThat(actualToString, is(expectedToString));
     }
 }


### PR DESCRIPTION
### Motivation

`TemporalLiteralExpressionSegment` keeps the raw literal value for consumers while preserving the original SQL literal text, such as `DATE '2017-08-08'`, through `getText()`.

`InsertValue` renders insert value expressions back to SQL. Since `TemporalLiteralExpressionSegment` extends `LiteralExpressionSegment`, it could otherwise fall through the generic literal formatter and render a date literal as a plain string literal.

### Changes

- Return `TemporalLiteralExpressionSegment#getText()` before generic literal formatting in `InsertValue`.
- Add a focused unit test for preserving `DATE '2017-08-08'` in insert values.

### Verification

- `./mvnw -pl infra/rewrite/core -am -DskipITs -Dspotless.skip=true -Dtest=InsertValueTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw spotless:apply -Pcheck -T1C`
- `./mvnw checkstyle:check -Pcheck -T1C`
