### PR TITLE
Close DDL E2E table metadata result set

### DIFF
--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/sql/it/sql/ddl/DDLE2EIT.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/sql/it/sql/ddl/DDLE2EIT.java
@@ -320,7 +320,9 @@ class DDLE2EIT implements SQLE2EIT {
     }
     
     private boolean containsTable(final Connection connection, final String tableName) throws SQLException {
-        return connection.getMetaData().getTables(null, null, tableName, new String[]{"TABLE", "VIEW"}).next();
+        try (ResultSet resultSet = connection.getMetaData().getTables(null, null, tableName, new String[]{"TABLE", "VIEW"})) {
+            return resultSet.next();
+        }
     }
     
     @SuppressWarnings("CollectionWithoutInitialCapacity")


### PR DESCRIPTION
### Motivation

`DDLE2EIT` waits for DDL table or view metadata by polling `DatabaseMetaData#getTables(...)`.

`getTables(...)` returns a `ResultSet` that should be closed by the caller. The current `containsTable(...)` implementation directly calls `next()` on that `ResultSet`, so repeated metadata polling can keep database-side resources open longer than necessary.

### Changes

- Close the `ResultSet` returned by `DatabaseMetaData#getTables(...)` in `DDLE2EIT#containsTable(...)` with try-with-resources.
- Keep the existing table-existence semantics unchanged.

### Verification

- `./mvnw -pl test/e2e/sql -am -DskipITs -Dspotless.skip=true -DskipTests test-compile`
- `./mvnw spotless:apply -Pcheck -T1C`
- `./mvnw checkstyle:check -Pcheck -T1C`
