### PR TITLE
Add database label for routed_sql_total metric and split routed_result_total metric

### DIFF
--- a/agent/plugins/metrics/core/src/main/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/RouteResultCountAdvice.java
+++ b/agent/plugins/metrics/core/src/main/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/RouteResultCountAdvice.java
@@ -24,27 +24,38 @@ import org.apache.shardingsphere.agent.plugin.metrics.core.collector.MetricsColl
 import org.apache.shardingsphere.agent.plugin.metrics.core.collector.type.CounterMetricsCollector;
 import org.apache.shardingsphere.agent.plugin.metrics.core.config.MetricCollectorType;
 import org.apache.shardingsphere.agent.plugin.metrics.core.config.MetricConfiguration;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.route.context.RouteUnit;
+import org.apache.shardingsphere.infra.session.query.QueryContext;
 
 import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * Route result count advice.
  */
 public final class RouteResultCountAdvice extends AbstractInstanceMethodAdvice {
     
-    private final MetricConfiguration routedResultConfig = new MetricConfiguration("routed_result_total",
-            MetricCollectorType.COUNTER, "Total count of routed result", Arrays.asList("object", "name"));
+    private final MetricConfiguration routedStorageUnitResultConfig = new MetricConfiguration("routed_storage_unit_total",
+            MetricCollectorType.COUNTER, "Total count of routed storage unit total", Arrays.asList("database", "name"));
+    
+    private final MetricConfiguration routedTableResultConfig = new MetricConfiguration("routed_table_total",
+            MetricCollectorType.COUNTER, "Total count of routed table total", Arrays.asList("database", "name"));
     
     @Override
     public void afterMethod(final TargetAdviceObject target, final TargetAdviceMethod method, final Object[] args, final Object result, final String pluginType) {
         if (null == result) {
             return;
         }
+        ShardingSphereDatabase database = (ShardingSphereDatabase) args[2];
         for (RouteUnit each : ((RouteContext) result).getRouteUnits()) {
-            MetricsCollectorRegistry.<CounterMetricsCollector>get(routedResultConfig, pluginType).inc("data_source", each.getDataSourceMapper().getActualName());
-            each.getTableMappers().forEach(table -> MetricsCollectorRegistry.<CounterMetricsCollector>get(routedResultConfig, pluginType).inc("table", table.getActualName()));
+            MetricsCollectorRegistry.<CounterMetricsCollector>get(routedStorageUnitResultConfig, pluginType).inc(database.getName(), each.getDataSourceMapper().getActualName());
+        }
+        QueryContext queryContext = (QueryContext) args[0];
+        Collection<String> tableNames = queryContext.getSqlStatementContext().getTablesContext().getTableNames();
+        for (String each : tableNames) {
+            MetricsCollectorRegistry.<CounterMetricsCollector>get(routedTableResultConfig, pluginType).inc(database.getName(), each);
         }
     }
 }

--- a/agent/plugins/metrics/core/src/main/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/SQLRouteCountAdvice.java
+++ b/agent/plugins/metrics/core/src/main/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/SQLRouteCountAdvice.java
@@ -25,9 +25,11 @@ import org.apache.shardingsphere.agent.plugin.metrics.core.collector.MetricsColl
 import org.apache.shardingsphere.agent.plugin.metrics.core.collector.type.CounterMetricsCollector;
 import org.apache.shardingsphere.agent.plugin.metrics.core.config.MetricCollectorType;
 import org.apache.shardingsphere.agent.plugin.metrics.core.config.MetricConfiguration;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.SQLStatement;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -37,13 +39,14 @@ import java.util.Optional;
 public final class SQLRouteCountAdvice extends AbstractInstanceMethodAdvice {
     
     private final MetricConfiguration config = new MetricConfiguration("routed_sql_total",
-            MetricCollectorType.COUNTER, "Total count of routed SQL", Collections.singletonList("type"), Collections.emptyMap());
+            MetricCollectorType.COUNTER, "Total count of routed SQL", Arrays.asList("database", "type"), Collections.emptyMap());
     
     @Override
     public void beforeMethod(final TargetAdviceObject target, final TargetAdviceMethod method, final Object[] args, final String pluginType) {
         QueryContext queryContext = (QueryContext) args[0];
+        ShardingSphereDatabase database = (ShardingSphereDatabase) args[2];
         SQLStatement sqlStatement = queryContext.getSqlStatementContext().getSqlStatement();
-        getSQLType(sqlStatement).ifPresent(optional -> MetricsCollectorRegistry.<CounterMetricsCollector>get(config, pluginType).inc(optional));
+        getSQLType(sqlStatement).ifPresent(optional -> MetricsCollectorRegistry.<CounterMetricsCollector>get(config, pluginType).inc(database.getName(), optional));
     }
     
     private Optional<String> getSQLType(final SQLStatement sqlStatement) {

--- a/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/RouteResultCountAdviceTest.java
+++ b/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/RouteResultCountAdviceTest.java
@@ -21,28 +21,48 @@ import org.apache.shardingsphere.agent.api.advice.TargetAdviceMethod;
 import org.apache.shardingsphere.agent.plugin.metrics.core.collector.MetricsCollectorRegistry;
 import org.apache.shardingsphere.agent.plugin.metrics.core.config.MetricCollectorType;
 import org.apache.shardingsphere.agent.plugin.metrics.core.config.MetricConfiguration;
-import org.apache.shardingsphere.agent.plugin.metrics.core.fixture.collector.MetricsCollectorFixture;
 import org.apache.shardingsphere.agent.plugin.metrics.core.fixture.TargetAdviceObjectFixture;
+import org.apache.shardingsphere.agent.plugin.metrics.core.fixture.collector.MetricsCollectorFixture;
+import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
+import org.apache.shardingsphere.infra.binder.context.statement.type.CommonSQLStatementContext;
+import org.apache.shardingsphere.infra.hint.HintValueContext;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.route.context.RouteMapper;
 import org.apache.shardingsphere.infra.route.context.RouteUnit;
+import org.apache.shardingsphere.infra.session.connection.ConnectionContext;
+import org.apache.shardingsphere.infra.session.query.QueryContext;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.TableNameSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.statement.type.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class RouteResultCountAdviceTest {
     
-    private final MetricConfiguration routedResultConfig = new MetricConfiguration("routed_result_total", MetricCollectorType.COUNTER, null, Arrays.asList("object", "name"));
+    private static final DatabaseType DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
+    
+    private final MetricConfiguration routedStorageUnitResultConfig = new MetricConfiguration("routed_storage_unit_total", MetricCollectorType.COUNTER, null, Arrays.asList("database", "name"));
+    
+    private final MetricConfiguration routedTableResultConfig = new MetricConfiguration("routed_table_total", MetricCollectorType.COUNTER, null, Arrays.asList("database", "name"));
     
     @AfterEach
     void reset() {
-        ((MetricsCollectorFixture) MetricsCollectorRegistry.get(routedResultConfig, "FIXTURE")).reset();
+        ((MetricsCollectorFixture) MetricsCollectorRegistry.get(routedStorageUnitResultConfig, "FIXTURE")).reset();
+        ((MetricsCollectorFixture) MetricsCollectorRegistry.get(routedTableResultConfig, "FIXTURE")).reset();
     }
     
     @Test
@@ -51,7 +71,30 @@ class RouteResultCountAdviceTest {
         RouteMapper dataSourceMapper = new RouteMapper("logic_db", "ds_0");
         RouteMapper tableMapper = new RouteMapper("t_order", "t_order_0");
         routeContext.getRouteUnits().add(new RouteUnit(dataSourceMapper, Collections.singleton(tableMapper)));
-        new RouteResultCountAdvice().afterMethod(new TargetAdviceObjectFixture(), mock(TargetAdviceMethod.class), new Object[]{}, routeContext, "FIXTURE");
-        assertThat(MetricsCollectorRegistry.get(routedResultConfig, "FIXTURE").toString(), is("data_source.ds_0=1, table.t_order_0=1"));
+        new RouteResultCountAdvice().afterMethod(new TargetAdviceObjectFixture(), mock(TargetAdviceMethod.class), new Object[]{createQueryContext(),
+                new ConnectionContext(Collections::emptySet), mockDatabase()}, routeContext, "FIXTURE");
+        assertThat(MetricsCollectorRegistry.get(routedStorageUnitResultConfig, "FIXTURE").toString(), is("foo_db.ds_0=1"));
+        assertThat(MetricsCollectorRegistry.get(routedTableResultConfig, "FIXTURE").toString(), is("foo_db.t_order=1"));
+    }
+    
+    private QueryContext createQueryContext() {
+        return new QueryContext(new CommonSQLStatementContext(SelectStatement.builder().databaseType(DATABASE_TYPE).build(), createTablesContext()), "",
+                Collections.emptyList(), new HintValueContext(), mockConnectionContext(), mock(ShardingSphereMetaData.class));
+    }
+    
+    private TablesContext createTablesContext() {
+        return new TablesContext(Collections.singleton(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")))));
+    }
+    
+    private ConnectionContext mockConnectionContext() {
+        ConnectionContext result = mock(ConnectionContext.class);
+        when(result.getCurrentDatabaseName()).thenReturn(Optional.of("foo_db"));
+        return result;
+    }
+    
+    private ShardingSphereDatabase mockDatabase() {
+        ShardingSphereDatabase result = mock(ShardingSphereDatabase.class);
+        when(result.getName()).thenReturn("foo_db");
+        return result;
     }
 }

--- a/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/SQLRouteCountAdviceTest.java
+++ b/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/SQLRouteCountAdviceTest.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.binder.context.statement.type.CommonSQLStatementContext;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.session.connection.ConnectionContext;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
@@ -40,6 +41,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -53,7 +55,7 @@ class SQLRouteCountAdviceTest {
     
     private static final DatabaseType DATABASE_TYPE = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
     
-    private final MetricConfiguration config = new MetricConfiguration("routed_sql_total", MetricCollectorType.COUNTER, null, Collections.singletonList("type"), Collections.emptyMap());
+    private final MetricConfiguration config = new MetricConfiguration("routed_sql_total", MetricCollectorType.COUNTER, null, Arrays.asList("database", "type"), Collections.emptyMap());
     
     private final SQLRouteCountAdvice advice = new SQLRouteCountAdvice();
     
@@ -65,8 +67,8 @@ class SQLRouteCountAdviceTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("routeContexts")
     void assertRoute(final String type, final QueryContext queryContext) {
-        advice.beforeMethod(new TargetAdviceObjectFixture(), mock(TargetAdviceMethod.class), new Object[]{queryContext, new ConnectionContext(Collections::emptySet)}, "FIXTURE");
-        assertThat(MetricsCollectorRegistry.get(config, "FIXTURE").toString(), is(String.format("%s=1", type)));
+        advice.beforeMethod(new TargetAdviceObjectFixture(), mock(TargetAdviceMethod.class), new Object[]{queryContext, new ConnectionContext(Collections::emptySet), mockDatabase()}, "FIXTURE");
+        assertThat(MetricsCollectorRegistry.get(config, "FIXTURE").toString(), is(String.format("foo_db.%s=1", type)));
     }
     
     private static Stream<Arguments> routeContexts() {
@@ -84,6 +86,12 @@ class SQLRouteCountAdviceTest {
     private static ConnectionContext mockConnectionContext() {
         ConnectionContext result = mock(ConnectionContext.class);
         when(result.getCurrentDatabaseName()).thenReturn(Optional.of("foo_db"));
+        return result;
+    }
+    
+    private ShardingSphereDatabase mockDatabase() {
+        ShardingSphereDatabase result = mock(ShardingSphereDatabase.class);
+        when(result.getName()).thenReturn("foo_db");
         return result;
     }
 }

--- a/agent/plugins/metrics/type/prometheus/src/main/resources/META-INF/conf/prometheus-advisors.yaml
+++ b/agent/plugins/metrics/type/prometheus/src/main/resources/META-INF/conf/prometheus-advisors.yaml
@@ -27,11 +27,13 @@ advisors:
     pointcuts:
       - name: route
         type: method
+        modifiers: public
   - target: org.apache.shardingsphere.infra.route.engine.SQLRouteEngine
     advice: org.apache.shardingsphere.agent.plugin.metrics.core.advice.RouteResultCountAdvice
     pointcuts:
       - name: route
         type: method
+        modifiers: public
   # Configure for proxy
   - target: org.apache.shardingsphere.proxy.frontend.command.CommandExecutorTask
     advice: org.apache.shardingsphere.agent.plugin.metrics.core.advice.proxy.ExecuteLatencyHistogramAdvice

--- a/docs/document/content/user-manual/shardingsphere-agent/metrics/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-agent/metrics/_index.cn.md
@@ -3,15 +3,16 @@ title = "Metrics"
 weight = 3
 +++
 
-| 指标名称                                 | 指标类型    | 指标描述                                                                                       |
-|:----------------------------------------|:----------|:----------------------------------------------------------------------------------------------|
-| build_info                              | GAUGE     | 构建信息                                                                                       |
-| parsed_sql_total                        | COUNTER   | 按类型（INSERT、UPDATE、DELETE、SELECT、DDL、DCL、DAL、TCL、RQL、RDL、RAL、RUL）分类的解析总数        |
-| routed_sql_total                        | COUNTER   | 按类型（INSERT、UPDATE、DELETE、SELECT）分类的路由总数                                             |
-| routed_result_total                     | COUNTER   | 路由结果总数(数据源路由结果、表路由结果)                                                            |
-| jdbc_state                              | GAUGE     | ShardingSphere-JDBC 状态信息。0 表示正常状态；1 表示熔断状态；2 锁定状态                              |
-| jdbc_meta_data_info                     | GAUGE     | ShardingSphere-JDBC 元数据信息                                                                  |
-| jdbc_statement_execute_total            | COUNTER   | 语句执行总数                                                                                    |
-| jdbc_statement_execute_errors_total     | COUNTER   | 语句执行错误总数                                                                                 |
-| jdbc_statement_execute_latency_millis   | HISTOGRAM | 语句执行耗时                                                                                    |
-| jdbc_transactions_total                 | COUNTER   | 事务总数，按 commit，rollback 分类                                                                |
+| 指标名称                                  | 指标类型    | 指标描述                                                                    |
+|:--------------------------------------|:----------|:------------------------------------------------------------------------|
+| build_info                            | GAUGE     | 构建信息                                                                    |
+| parsed_sql_total                      | COUNTER   | 按类型（INSERT、UPDATE、DELETE、SELECT、DDL、DCL、DAL、TCL、RQL、RDL、RAL、RUL）分类的解析总数 |
+| routed_sql_total                      | COUNTER   | 按数据库和 SQL 类型（INSERT、UPDATE、DELETE、SELECT）分类的路由总数                        |
+| routed_storage_unit_total             | COUNTER   | 数据库中存储单元路由结果总数                                                          |
+| routed_table_total                    | COUNTER   | 数据库中表路由结果总数                                                             |
+| jdbc_state                            | GAUGE     | ShardingSphere-JDBC 状态信息。0 表示正常状态；1 表示熔断状态；2 锁定状态                       |
+| jdbc_meta_data_info                   | GAUGE     | ShardingSphere-JDBC 元数据信息                                               |
+| jdbc_statement_execute_total          | COUNTER   | 语句执行总数                                                                  |
+| jdbc_statement_execute_errors_total   | COUNTER   | 语句执行错误总数                                                                |
+| jdbc_statement_execute_latency_millis | HISTOGRAM | 语句执行耗时                                                                  |
+| jdbc_transactions_total               | COUNTER   | 事务总数，按 commit，rollback 分类                                               |

--- a/docs/document/content/user-manual/shardingsphere-agent/metrics/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-agent/metrics/_index.en.md
@@ -7,8 +7,9 @@ weight = 3
 |:--------------------------------------|:----------|:-------------------------------------------------------------------------------------------------------|
 | build_info                            | GAUGE     | Build information                                                                                      |
 | parsed_sql_total                      | COUNTER   | Total count of parsed by type (INSERT, UPDATE, DELETE, SELECT, DDL, DCL, DAL, TCL, RQL, RDL, RAL, RUL) |
-| routed_sql_total                      | COUNTER   | Total count of routed by type (INSERT, UPDATE, DELETE, SELECT)                                         |
-| routed_result_total                   | COUNTER   | Total count of routed result (data source routed, table routed)                                        |
+| routed_sql_total                      | COUNTER   | Total count of routed by database and sql type (INSERT, UPDATE, DELETE, SELECT)                        |
+| routed_storage_unit_total             | COUNTER   | Total count of routed by storage unit of database                                                      |
+| routed_table_total                    | COUNTER   | Total count of routed by table of database                                                             |
 | jdbc_state                            | GAUGE     | Status information of ShardingSphere-JDBC. 0 is OK; 1 is CIRCUIT BREAK; 2 is LOCK                      |
 | jdbc_meta_data_info                   | GAUGE     | Meta data information of ShardingSphere-JDBC                                                           |
 | jdbc_statement_execute_total          | GAUGE     | Total number of statements executed                                                                    |

--- a/docs/document/content/user-manual/shardingsphere-proxy/observability/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/observability/_index.cn.md
@@ -121,8 +121,9 @@ cd apache-shardingsphere-${latest.release.version}-shardingsphere-proxy-bin
 |:-----------------------------|:----------|:--------------------------------------------------------------------------|
 | build_info                   | GAUGE     | 构建信息                                                                      |
 | parsed_sql_total             | COUNTER   | 按类型（INSERT、UPDATE、DELETE、SELECT、DDL、DCL、DAL、TCL、RQL、RDL、RAL、RUL）分类的解析总数   |
-| routed_sql_total             | COUNTER   | 按类型（INSERT、UPDATE、DELETE、SELECT）分类的路由总数                                   |
-| routed_result_total          | COUNTER   | 路由结果总数(数据源路由结果、表路由结果)                                                     |
+| routed_sql_total             | COUNTER   | 按数据库和 SQL 类型（INSERT、UPDATE、DELETE、SELECT）分类的路由总数                          |
+| routed_storage_unit_total    | COUNTER   | 数据库中存储单元路由结果总数                                                            |
+| routed_table_total           | COUNTER   | 数据库中表路由结果总数                                                               |
 | proxy_state                  | GAUGE     | ShardingSphere-Proxy 状态信息。0 表示正常状态；1 表示熔断状态；2 锁定状态                        |
 | proxy_meta_data_info         | GAUGE     | ShardingSphere-Proxy 元数据信息，database_count：逻辑库数量，storage_unit_count：存储节点数量 |
 | proxy_current_connections    | GAUGE     | ShardingSphere-Proxy 的当前连接数                                               |

--- a/docs/document/content/user-manual/shardingsphere-proxy/observability/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/observability/_index.en.md
@@ -122,8 +122,9 @@ After startup, you can find the plugin info in the log of ShardingSphere-Proxy, 
 |:-----------------------------|:----------|:------------------------------------------------------------------------------------------------------------------------------------------|
 | build_info                   | GAUGE     | Build information                                                                                                                         |
 | parsed_sql_total             | COUNTER   | Total count of parsed by type (INSERT, UPDATE, DELETE, SELECT, DDL, DCL, DAL, TCL, RQL, RDL, RAL, RUL)                                    |
-| routed_sql_total             | COUNTER   | Total count of routed by type (INSERT, UPDATE, DELETE, SELECT)                                                                            |
-| routed_result_total          | COUNTER   | Total count of routed result (data source routed, table routed)                                                                           |
+| routed_sql_total             | COUNTER   | Total count of routed by database and SQL type (INSERT, UPDATE, DELETE, SELECT)                                                           |
+| routed_storage_unit_total    | COUNTER   | Total count of routed by storage unit of database                                                                                         |
+| routed_table_total           | COUNTER   | Total count of routed by table of database                                                                                                |
 | proxy_state                  | GAUGE     | Status information of ShardingSphere-Proxy. 0 is OK; 1 is CIRCUIT BREAK; 2 is LOCK                                                        |
 | proxy_meta_data_info         | GAUGE     | Meta data information of ShardingSphere-Proxy. database_count is logic number of databases; storage_unit_count is number of storage units |
 | proxy_current_connections    | GAUGE     | Current connections of ShardingSphere-Proxy                                                                                               |

--- a/test/e2e/agent/plugins/metrics/prometheus/src/test/resources/cases/jdbc/routed_storage_unit_total.xml
+++ b/test/e2e/agent/plugins/metrics/prometheus/src/test/resources/cases/jdbc/routed_storage_unit_total.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<e2e-test-cases>
+    <test-case metric-name="routed_storage_unit_total" metric-type="counter">
+        <query-assertion metric="routed_storage_unit_total" query="routed_storage_unit_total{database='sharding_db', name='ds_0'}" />
+        <query-assertion metric="routed_storage_unit_total" query="routed_storage_unit_total{database='sharding_db', name='ds_1'}" />
+    </test-case>
+</e2e-test-cases>

--- a/test/e2e/agent/plugins/metrics/prometheus/src/test/resources/cases/jdbc/routed_table_total.xml
+++ b/test/e2e/agent/plugins/metrics/prometheus/src/test/resources/cases/jdbc/routed_table_total.xml
@@ -17,10 +17,7 @@
   -->
 
 <e2e-test-cases>
-    <test-case metric-name="routed_result_total" metric-type="counter">
-        <query-assertion metric="routed_result_total" query="routed_result_total{object='data_source', name='ds_0'}" />
-        <query-assertion metric="routed_result_total" query="routed_result_total{object='data_source', name='ds_1'}" />
-        <query-assertion metric="routed_result_total" query="routed_result_total{object='table', name='t_order_0'}" />
-        <query-assertion metric="routed_result_total" query="routed_result_total{object='table', name='t_order_1'}" />
+    <test-case metric-name="routed_table_total" metric-type="counter">
+        <query-assertion metric="routed_table_total" query="routed_table_total{database='sharding_db', name='t_order'}" />
     </test-case>
 </e2e-test-cases>

--- a/test/e2e/agent/plugins/metrics/prometheus/src/test/resources/cases/proxy/routed_storage_unit_total.xml
+++ b/test/e2e/agent/plugins/metrics/prometheus/src/test/resources/cases/proxy/routed_storage_unit_total.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<e2e-test-cases>
+    <test-case metric-name="routed_storage_unit_total" metric-type="counter">
+        <query-assertion metric="routed_storage_unit_total" query="routed_storage_unit_total{database='sharding_db', name='ds_0'}" />
+        <query-assertion metric="routed_storage_unit_total" query="routed_storage_unit_total{database='sharding_db', name='ds_1'}" />
+    </test-case>
+</e2e-test-cases>

--- a/test/e2e/agent/plugins/metrics/prometheus/src/test/resources/cases/proxy/routed_table_total.xml
+++ b/test/e2e/agent/plugins/metrics/prometheus/src/test/resources/cases/proxy/routed_table_total.xml
@@ -17,10 +17,7 @@
   -->
 
 <e2e-test-cases>
-    <test-case metric-name="routed_result_total" metric-type="counter">
-        <query-assertion metric="routed_result_total" query="routed_result_total{object='data_source', name='ds_0'}" />
-        <query-assertion metric="routed_result_total" query="routed_result_total{object='data_source', name='ds_1'}" />
-        <query-assertion metric="routed_result_total" query="routed_result_total{object='table', name='t_order_0'}" />
-        <query-assertion metric="routed_result_total" query="routed_result_total{object='table', name='t_order_1'}" />
+    <test-case metric-name="routed_table_total" metric-type="counter">
+        <query-assertion metric="routed_table_total" query="routed_table_total{database='sharding_db', name='t_order'}" />
     </test-case>
 </e2e-test-cases>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Add database label for routed_sql_total metric and split routed_result_total metric

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
