### PR TITLE
Add proxy URL connect option for E2E containers

### DIFF
--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/adapter/impl/ShardingSphereProxyDockerContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/adapter/impl/ShardingSphereProxyDockerContainer.java
@@ -64,7 +64,7 @@ public final class ShardingSphereProxyDockerContainer extends DockerE2EContainer
         addEnv("TZ", "UTC");
         mapResources(config.getMountedResources());
         setWaitStrategy(new JdbcConnectCheckingWaitStrategy(() -> DriverManager.getConnection(
-                storageContainerConnectOption.getURL(getHost(), getMappedPort(3307), config.getProxyDataSourceName()), ProxyContainerConstants.USER, ProxyContainerConstants.PASSWORD)));
+                storageContainerConnectOption.getProxyURL(getHost(), getMappedPort(3307), config.getProxyDataSourceName()), ProxyContainerConstants.USER, ProxyContainerConstants.PASSWORD)));
         withStartupTimeout(Duration.of(120L, ChronoUnit.SECONDS));
     }
     
@@ -73,7 +73,7 @@ public final class ShardingSphereProxyDockerContainer extends DockerE2EContainer
         DataSource dataSource = targetDataSourceProvider.get();
         if (null == dataSource) {
             targetDataSourceProvider.set(StorageContainerUtils.generateDataSource(
-                    storageContainerConnectOption.getURL(getHost(), getMappedPort(3307), config.getProxyDataSourceName()), ProxyContainerConstants.USER, ProxyContainerConstants.PASSWORD, 2));
+                    storageContainerConnectOption.getProxyURL(getHost(), getMappedPort(3307), config.getProxyDataSourceName()), ProxyContainerConstants.USER, ProxyContainerConstants.PASSWORD, 2));
         }
         return targetDataSourceProvider.get();
     }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/storage/option/StorageContainerConnectOption.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/storage/option/StorageContainerConnectOption.java
@@ -48,4 +48,16 @@ public interface StorageContainerConnectOption {
      * @return URL
      */
     String getURL(String host, int port, String dataSourceName);
+    
+    /**
+     * Get proxy URL.
+     *
+     * @param host database host
+     * @param port database port
+     * @param dataSourceName data source name
+     * @return proxy URL
+     */
+    default String getProxyURL(final String host, final int port, final String dataSourceName) {
+        return getURL(host, port, dataSourceName);
+    }
 }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/storage/option/StorageContainerConnectOptionTest.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/storage/option/StorageContainerConnectOptionTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.env.container.storage.option;
+
+import org.apache.shardingsphere.test.e2e.env.container.storage.option.dialect.mysql.MySQLStorageContainerConnectOption;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class StorageContainerConnectOptionTest {
+    
+    @Test
+    void assertGetProxyURL() {
+        assertThat(new MySQLStorageContainerConnectOption().getProxyURL("127.0.0.1", 3307, "foo_ds"),
+                is("jdbc:mysql://127.0.0.1:3307/foo_ds?useSSL=true&requireSSL=true&enabledTLSProtocols=TLSv1.2,TLSv1.3&verifyServerCertificate=false"
+                        + "&useServerPrepStmts=true&useLocalSessionState=true&characterEncoding=utf-8&allowPublicKeyRetrieval=true&allowMultiQueries=true&rewriteBatchedStatements=true"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `StorageContainerConnectOption#getProxyURL` as a default seam for proxy connection URLs
- use the proxy URL seam when ShardingSphere Proxy Docker containers check readiness and create target data sources
- add a unit test for default proxy URL delegation

## Tests
- `./mvnw -pl test/e2e/env -DskipTests=false -Dtest=StorageContainerConnectOptionTest test`
- `./mvnw -Pcheck -pl test/e2e/env -DskipTests spotless:check checkstyle:check`
