### PR TITLE
Remove legacy MCP contract compatibility residue

### DIFF
--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPToolSpecificationFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPToolSpecificationFactoryTest.java
@@ -291,23 +291,6 @@ class MCPToolSpecificationFactoryTest extends AbstractMCPToolSpecificationFactor
     }
     
     @Test
-    void assertCreateToolSpecificationsRejectsRemovedToolNameAsProtocolError() {
-        try (MockedStatic<ToolDefinitionRegistry> mockedToolDefinitionRegistry = mockStatic(ToolDefinitionRegistry.class)) {
-            mockedToolDefinitionRegistry.when(ToolDefinitionRegistry::getSupportedToolDescriptors).thenReturn(List.of(createToolDescriptor("database_gateway_validate_proxy_connectivity")));
-            mockedToolDefinitionRegistry.when(() -> ToolDefinitionRegistry.getToolDefinition("database_gateway_validate_proxy_connectivity")).thenThrow(UnsupportedToolException.class);
-            MCPRuntimeContext runtimeContext = mock(MCPRuntimeContext.class, RETURNS_DEEP_STUBS);
-            when(runtimeContext.getSessionManager().getTransactionResourceManager().getRuntimeDatabases()).thenReturn(Collections.emptyMap());
-            SyncToolSpecification actualSpecification = new MCPToolSpecificationFactory(runtimeContext).createToolSpecifications().getFirst();
-            McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
-            when(exchange.sessionId()).thenReturn("session-id");
-            McpError actual = assertThrows(McpError.class,
-                    () -> actualSpecification.callHandler().apply(exchange, new CallToolRequest("database_gateway_validate_proxy_connectivity", Map.of())));
-            assertThat(actual.getJsonRpcError().code(), is(McpSchema.ErrorCodes.INVALID_PARAMS));
-            assertThat(actual.getJsonRpcError().message(), is("Unsupported tool `database_gateway_validate_proxy_connectivity`."));
-        }
-    }
-    
-    @Test
     void assertCreateToolSpecificationsRejectInvalidInputSchema() {
         MCPRuntimeContext runtimeContext = mock(MCPRuntimeContext.class, RETURNS_DEEP_STUBS);
         when(runtimeContext.getSessionManager().getTransactionResourceManager().getRuntimeDatabases()).thenReturn(Collections.emptyMap());

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/handler/core/CoreToolHandlers.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/handler/core/CoreToolHandlers.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.mcp.core.workflow.WorkflowRuntimeDefinitionRegi
 import org.apache.shardingsphere.mcp.core.tool.handler.execute.ExecuteQueryToolHandler;
 import org.apache.shardingsphere.mcp.core.tool.handler.execute.ExecuteUpdateToolHandler;
 import org.apache.shardingsphere.mcp.core.tool.handler.metadata.SearchMetadataToolHandler;
-import org.apache.shardingsphere.mcp.core.tool.handler.metadata.ValidateProxyConnectivityToolHandler;
+import org.apache.shardingsphere.mcp.core.tool.handler.metadata.ValidateRuntimeDatabaseToolHandler;
 import org.apache.shardingsphere.mcp.core.tool.handler.workflow.WorkflowExecutionToolHandler;
 import org.apache.shardingsphere.mcp.core.tool.handler.workflow.WorkflowValidationToolHandler;
 
@@ -41,7 +41,7 @@ final class CoreToolHandlers {
         WorkflowRuntimeDefinitionRegistry workflowRuntimeDefinitionRegistry = WorkflowRuntimeDefinitionRegistry.load();
         return List.of(
                 new SearchMetadataToolHandler(),
-                new ValidateProxyConnectivityToolHandler(),
+                new ValidateRuntimeDatabaseToolHandler(),
                 new ExecuteQueryToolHandler(),
                 new ExecuteUpdateToolHandler(),
                 new WorkflowExecutionToolHandler(workflowRuntimeDefinitionRegistry),

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/ValidateRuntimeDatabaseToolHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/ValidateRuntimeDatabaseToolHandler.java
@@ -24,8 +24,8 @@ import org.apache.shardingsphere.mcp.api.tool.MCPToolHandler;
 import org.apache.shardingsphere.mcp.core.protocol.error.MCPErrorConverter;
 import org.apache.shardingsphere.mcp.support.database.MCPDatabaseHandlerContext;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConnectionException;
-import org.apache.shardingsphere.mcp.support.database.tool.request.ProxyPreflightValidationRequest;
-import org.apache.shardingsphere.mcp.support.database.tool.service.ProxyPreflightValidationService;
+import org.apache.shardingsphere.mcp.support.database.tool.request.RuntimeDatabaseValidationRequest;
+import org.apache.shardingsphere.mcp.support.database.tool.service.RuntimeDatabaseValidationService;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
 
 import java.util.Map;
@@ -34,14 +34,14 @@ import java.util.Map;
  * Handler for runtime database validation tool.
  */
 @RequiredArgsConstructor
-public final class ValidateProxyConnectivityToolHandler implements MCPToolHandler<MCPDatabaseHandlerContext> {
+public final class ValidateRuntimeDatabaseToolHandler implements MCPToolHandler<MCPDatabaseHandlerContext> {
     
     public static final String TOOL_NAME = "database_gateway_validate_runtime_database";
     
-    private final ProxyPreflightValidationService validationService;
+    private final RuntimeDatabaseValidationService validationService;
     
-    public ValidateProxyConnectivityToolHandler() {
-        this(new ProxyPreflightValidationService());
+    public ValidateRuntimeDatabaseToolHandler() {
+        this(new RuntimeDatabaseValidationService());
     }
     
     @Override
@@ -56,7 +56,7 @@ public final class ValidateProxyConnectivityToolHandler implements MCPToolHandle
     
     @Override
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPToolCall toolCall) {
-        return validationService.validate(ProxyPreflightValidationRequest.from(toolCall.getArguments()), databaseContext::findRuntimeDatabaseConfiguration, this::createRecoveryPayload);
+        return validationService.validate(RuntimeDatabaseValidationRequest.from(toolCall.getArguments()), databaseContext::findRuntimeDatabaseConfiguration, this::createRecoveryPayload);
     }
     
     @SuppressWarnings("unchecked")

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/protocol/MCPErrorConverterTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/protocol/MCPErrorConverterTest.java
@@ -125,7 +125,6 @@ class MCPErrorConverterTest {
         Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("type"), is("tool_call"));
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_execute_update"));
-        assertFalse(actualRecovery.containsKey("requires_user_approval"));
     }
     
     @Test
@@ -143,7 +142,6 @@ class MCPErrorConverterTest {
         Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("type"), is("tool_call"));
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_apply_workflow"));
-        assertFalse(actualRecovery.containsKey("requires_user_approval"));
     }
     
     @Test
@@ -154,7 +152,6 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("category"), is("invalid_enum_value"));
         assertThat(actualRecovery.get("recovery_category"), is("invalid_enum"));
         assertThat(actualRecovery.get("allowed_values"), is(List.of("preview", "review-then-execute", "manual-only")));
-        assertFalse(actualRecovery.containsKey("suggested_next_tool"));
         assertThat(actualRecovery.get("suggested_arguments"), is(Map.of("execution_mode", "preview")));
         assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst()).get("tool_name"), is("database_gateway_apply_workflow"));
     }
@@ -189,7 +186,6 @@ class MCPErrorConverterTest {
         Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("type"), is("tool_call"));
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_search_metadata"));
-        assertFalse(actualRecovery.containsKey("requires_user_approval"));
     }
     
     @Test
@@ -235,7 +231,6 @@ class MCPErrorConverterTest {
         Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("type"), is("tool_call"));
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_search_metadata"));
-        assertFalse(actualRecovery.containsKey("requires_user_approval"));
     }
     
     @Test
@@ -284,11 +279,9 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("category"), is("unsafe_sql_attempted"));
         assertThat(actualRecovery.get("recovery_category"), is("unsafe_sql"));
         assertThat(actualRecovery.get("source_tool"), is("database_gateway_execute_query"));
-        assertFalse(actualRecovery.containsKey("suggested_next_tool"));
         assertThat(actualRecovery.get("normalized_sql"), is("UPDATE orders SET status = 'PAID'"));
         assertThat(actualRecovery.get("suggested_arguments"), is(suggestedArguments));
         assertThat(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst()).get("arguments"), is(suggestedArguments));
-        assertFalse(actualRecovery.containsKey("requires_user_approval"));
     }
     
     @Test
@@ -301,10 +294,8 @@ class MCPErrorConverterTest {
         Map<?, ?> actualRecovery = (Map<?, ?>) actual.get("recovery");
         assertThat(actualRecovery.get("category"), is("read_only_sql_sent_to_update_tool"));
         assertThat(actualRecovery.get("recovery_category"), is("unsupported_target"));
-        assertFalse(actualRecovery.containsKey("suggested_next_tool"));
         assertThat(actualRecovery.get("normalized_sql"), is("SELECT * FROM orders"));
         assertThat(actualRecovery.get("suggested_arguments"), is(suggestedArguments));
-        assertFalse(((Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst()).containsKey("requires_user_approval"));
     }
     
     @Test
@@ -320,7 +311,6 @@ class MCPErrorConverterTest {
         assertThat(((Map<?, ?>) actualNextActions.get(1)).get("tool_name"), is("database_gateway_search_metadata"));
         assertThat(((Map<?, ?>) actualNextActions.get(1)).get("arguments"), is(Map.of("object_types", List.of("database"))));
         assertThat(((Map<?, ?>) actualNextActions.get(1)).get("depends_on"), is(List.of(1)));
-        assertFalse(actualRecovery.containsKey("requires_user_approval"));
     }
     
     @Test
@@ -354,7 +344,6 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("category"), is("stale_workflow"));
         assertThat(actualRecovery.get("recovery_category"), is("stale_workflow"));
         assertThat(actualRecovery.get("plan_id"), is("plan-missing"));
-        assertFalse(actualRecovery.containsKey("suggested_next_tools"));
         assertThat(actualRecovery.get("completion_first"), is(Map.of("argument", "plan_id", "scope", "current MCP session")));
         assertThat(getFirstResourceToReadUri(actualRecovery), is("shardingsphere://capabilities"));
         Map<?, ?> actualCompletionAction = (Map<?, ?>) ((List<?>) actualRecovery.get("next_actions")).getFirst();
@@ -418,7 +407,6 @@ class MCPErrorConverterTest {
         assertThat(actualRecovery.get("recovery_category"), is("unavailable_runtime"));
         assertThat(actualRecovery.get("model_action"), is("Fix the MCP runtime database configuration outside MCP, then retry."));
         assertThat(getFirstResourceToReadUri(actualRecovery), is("shardingsphere://capabilities"));
-        assertFalse(actualRecovery.containsKey("requires_user_approval"));
         assertTrue((Boolean) actualRecovery.get("ask_user_when_uncertain"));
     }
     

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandlerTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.mcp.core.resource.handler.capability;
 
-import org.apache.shardingsphere.infra.util.json.JsonUtils;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
 import org.apache.shardingsphere.mcp.core.context.MCPRequestScope;
 import org.apache.shardingsphere.mcp.core.resource.ResourceTestDataFactory;
@@ -44,7 +43,6 @@ class ServerCapabilitiesHandlerTest {
         assertTrue(
                 ((Collection<?>) actual.get("supportedTools")).containsAll(List.of("database_gateway_search_metadata", "database_gateway_validate_runtime_database", "database_gateway_execute_query",
                         "database_gateway_execute_update", "database_gateway_apply_workflow", "database_gateway_validate_workflow")));
-        assertFalse(((Collection<?>) actual.get("supportedTools")).contains("database_gateway_validate_proxy_connectivity"));
         assertFalse(((List<?>) actual.get("resources")).isEmpty());
         assertFalse(((List<?>) actual.get("resourceTemplates")).isEmpty());
         assertFalse(((List<?>) actual.get("tools")).isEmpty());
@@ -59,7 +57,6 @@ class ServerCapabilitiesHandlerTest {
         assertNextActionContract(actual);
         assertCommonFlows(actual);
         assertSecurityHints(actual);
-        assertRemovedPayloadFieldsAbsent(actual);
         assertResourcePayloadContracts(actual);
         assertCoreToolSchemas(actual);
     }
@@ -154,7 +151,6 @@ class ServerCapabilitiesHandlerTest {
         assertThat(actual.get("argument_completion_method"), is("completion/complete"));
         assertThat(actual.get("catalog_fields"), is(List.of("supportedResources", "supportedTools", "resourceTemplates", "completionTargets", "resourceNavigation", "protocolAvailability")));
         assertThat(actual.get("payload_fields"), is("ShardingSphere-owned structured payload fields use snake_case."));
-        assertTrue(String.valueOf(actual.get("alias_rule")).contains("Do not assume"));
     }
     
     private void assertNextActionContract(final Map<String, Object> capabilities) {
@@ -212,13 +208,6 @@ class ServerCapabilitiesHandlerTest {
         assertTrue(String.valueOf(actualClientSafetyPolicy.get("abuse_guard")).contains("counted before dispatch"));
     }
     
-    private void assertRemovedPayloadFieldsAbsent(final Map<String, Object> capabilities) {
-        String actual = JsonUtils.toJsonString(capabilities);
-        for (String each : List.of("pending_questions", "parent_uri", "next_resource_uris", "read_resources_first", "empty_reason", "not_found_reason")) {
-            assertFalse(actual.contains(each));
-        }
-    }
-    
     private void assertResourcePayloadContracts(final Map<String, Object> capabilities) {
         Map<?, ?> capabilityCatalog = findResource(capabilities, "shardingsphere://capabilities");
         assertThat(getResourceMeta(capabilityCatalog).get(MCPShardingSphereMetadataKeys.RESOURCE_KIND), is("capability-catalog"));
@@ -274,28 +263,6 @@ class ServerCapabilitiesHandlerTest {
         Map<?, ?> inspectMetadataPrompt = findPrompt(capabilities, "inspect_metadata");
         Map<?, ?> schemaArgument = findPromptArgument(inspectMetadataPrompt, "schema");
         assertThat(((Map<?, ?>) schemaArgument.get("completion")).get("required_context_arguments"), is(List.of("database")));
-        assertNoRemovedPublicAliasFields(capabilities);
-    }
-    
-    private void assertNoRemovedPublicAliasFields(final Object value) {
-        if (value instanceof Map) {
-            assertNoRemovedPublicAliasFieldMap((Map<?, ?>) value);
-        } else if (value instanceof Collection) {
-            for (Object each : (Collection<?>) value) {
-                assertNoRemovedPublicAliasFields(each);
-            }
-        }
-    }
-    
-    private void assertNoRemovedPublicAliasFieldMap(final Map<?, ?> value) {
-        assertFalse(value.containsKey("recommended_next_tool"));
-        assertFalse(value.containsKey("suggested_next_tool"));
-        assertFalse(value.containsKey("suggested_next_tools"));
-        assertFalse(value.containsKey("recommended_recovery"));
-        assertFalse(value.containsKey("suggested_next_action"));
-        for (Object each : value.values()) {
-            assertNoRemovedPublicAliasFields(each);
-        }
     }
     
     private Map<?, ?> findResource(final Map<String, Object> capabilities, final String uriTemplate) {

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/ToolDefinitionRegistryTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/ToolDefinitionRegistryTest.java
@@ -87,11 +87,6 @@ class ToolDefinitionRegistryTest {
     }
     
     @Test
-    void assertGetToolDefinitionRejectsLegacyAlias() {
-        assertThrows(UnsupportedToolException.class, () -> ToolDefinitionRegistry.getToolDefinition("database_gateway_validate_proxy_connectivity"));
-    }
-    
-    @Test
     void assertDispatch() {
         MCPRuntimeContext runtimeContext = ResourceTestDataFactory.createRuntimeContext();
         runtimeContext.getSessionManager().createSession("session-1");
@@ -101,11 +96,6 @@ class ToolDefinitionRegistryTest {
             assertThat(toolDefinition.getDescriptor().getName(), is("database_gateway_search_metadata"));
             assertThat(((List<?>) actual.toPayload().get("items")).size(), is(1));
         }
-    }
-    
-    @Test
-    void assertDispatchRejectsLegacyAlias() {
-        assertThrows(UnsupportedToolException.class, () -> dispatch("database_gateway_validate_proxy_connectivity", Map.of("database", "missing_db")));
     }
     
     @Test

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/ExecuteUpdateToolHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/ExecuteUpdateToolHandlerTest.java
@@ -117,12 +117,9 @@ class ExecuteUpdateToolHandlerTest {
         assertThat(actual.toPayload().get("review_guidance"),
                 is("Review normalized_sql and side_effect_scope before execution. "
                         + "This preview is classification-only; it does not guarantee parsing, rule validation, algorithm initialization, affected rows, or runtime success."));
-        assertFalse(actual.toPayload().containsKey("suggested_next_tool"));
         assertThat(((Map<?, ?>) actual.toPayload().get("suggested_arguments")).get("execution_mode"), is("execute"));
-        assertFalse(((Map<?, ?>) actual.toPayload().get("suggested_arguments")).containsKey("approved_by_user"));
         assertThat(((Map<?, ?>) actual.toPayload().get("argument_provenance")).get("sql"), is("server_generated"));
         assertThat(((Map<?, ?>) actual.toPayload().get("argument_provenance")).get("execution_mode"), is("server_defaulted"));
-        assertFalse(((Map<?, ?>) actual.toPayload().get("argument_provenance")).containsKey("approved_by_user"));
         List<?> actualNextActions = (List<?>) actual.toPayload().get("next_actions");
         assertThat(actualNextActions.size(), is(1));
         assertThat(((Map<?, ?>) actualNextActions.getFirst()).get("type"), is("tool_call"));
@@ -131,11 +128,8 @@ class ExecuteUpdateToolHandlerTest {
         assertThat(((Map<?, ?>) actualNextActions.getFirst()).get("reason"),
                 is("Execute only after reviewing normalized_sql and side_effect_scope; preview did not validate runtime executability."));
         assertThat(((Map<?, ?>) ((Map<?, ?>) actualNextActions.getFirst()).get("arguments")).get("execution_mode"), is("execute"));
-        assertFalse(((Map<?, ?>) ((Map<?, ?>) actualNextActions.getFirst()).get("arguments")).containsKey("approved_by_user"));
-        assertFalse(((Map<?, ?>) actualNextActions.getFirst()).containsKey("requires_user_approval"));
         assertThat(((Map<?, ?>) ((List<?>) actual.toPayload().get("resources_to_read")).getFirst()).get("uri"), is("shardingsphere://databases/logic_db/capabilities"));
         assertFalse(actual.toPayload().containsKey("ask_user_when_uncertain"));
-        assertFalse(actual.toPayload().containsKey("recommended_next_call"));
         verifyNoInteractions(executionFacade);
     }
     

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/ValidateRuntimeDatabaseToolHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/ValidateRuntimeDatabaseToolHandlerTest.java
@@ -21,10 +21,10 @@ import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.support.database.MCPDatabaseHandlerContext;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
-import org.apache.shardingsphere.mcp.support.database.tool.request.ProxyPreflightValidationRequest;
-import org.apache.shardingsphere.mcp.support.database.tool.response.ProxyPreflightCheckResult;
-import org.apache.shardingsphere.mcp.support.database.tool.response.ProxyPreflightValidationResult;
-import org.apache.shardingsphere.mcp.support.database.tool.service.ProxyPreflightValidationService;
+import org.apache.shardingsphere.mcp.support.database.tool.request.RuntimeDatabaseValidationRequest;
+import org.apache.shardingsphere.mcp.support.database.tool.response.RuntimeDatabaseValidationCheckResult;
+import org.apache.shardingsphere.mcp.support.database.tool.response.RuntimeDatabaseValidationResult;
+import org.apache.shardingsphere.mcp.support.database.tool.service.RuntimeDatabaseValidationService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -40,27 +40,25 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class ValidateProxyConnectivityToolHandlerTest {
+class ValidateRuntimeDatabaseToolHandlerTest {
     
     @Test
     void assertGetToolName() {
-        assertThat(new ValidateProxyConnectivityToolHandler().getToolName(), is("database_gateway_validate_runtime_database"));
+        assertThat(new ValidateRuntimeDatabaseToolHandler().getToolName(), is("database_gateway_validate_runtime_database"));
     }
     
     @Test
     @SuppressWarnings("unchecked")
     void assertHandle() {
-        ProxyPreflightValidationService validationService = mock(ProxyPreflightValidationService.class);
+        RuntimeDatabaseValidationService validationService = mock(RuntimeDatabaseValidationService.class);
         when(validationService.validate(any(), any(), any()))
-                .thenReturn(ProxyPreflightValidationResult.ready("logic_db", List.of(ProxyPreflightCheckResult.passed("configuration", "Validated the request."))));
+                .thenReturn(RuntimeDatabaseValidationResult.ready("logic_db", List.of(RuntimeDatabaseValidationCheckResult.passed("configuration", "Validated the request."))));
         MCPDatabaseHandlerContext databaseContext = mock(MCPDatabaseHandlerContext.class);
         RuntimeDatabaseConfiguration runtimeDatabaseConfig = mock(RuntimeDatabaseConfiguration.class);
         when(databaseContext.findRuntimeDatabaseConfiguration("logic_db")).thenReturn(Optional.of(runtimeDatabaseConfig));
-        MCPResponse actual = new ValidateProxyConnectivityToolHandler(validationService).handle(databaseContext, new MCPToolCall("session-1", Map.of(
-                "jdbcUrl", "jdbc:mysql://127.0.0.1:3307/logic_db",
-                "database", "logic_db")));
+        MCPResponse actual = new ValidateRuntimeDatabaseToolHandler(validationService).handle(databaseContext, new MCPToolCall("session-1", Map.of("database", "logic_db")));
         assertThat(actual.toPayload().get("response_mode"), is("validation"));
-        ArgumentCaptor<ProxyPreflightValidationRequest> requestCaptor = ArgumentCaptor.forClass(ProxyPreflightValidationRequest.class);
+        ArgumentCaptor<RuntimeDatabaseValidationRequest> requestCaptor = ArgumentCaptor.forClass(RuntimeDatabaseValidationRequest.class);
         ArgumentCaptor<Function<String, Optional<RuntimeDatabaseConfiguration>>> resolverCaptor = ArgumentCaptor.forClass(Function.class);
         verify(validationService).validate(requestCaptor.capture(), resolverCaptor.capture(), any());
         assertThat(requestCaptor.getValue().getDatabase(), is("logic_db"));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowExecutionServiceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowExecutionServiceTest.java
@@ -74,11 +74,9 @@ class WorkflowExecutionServiceTest {
         assertThat(actualResponse.get("response_mode"), is("manual_only"));
         assertThat(actualResponse.get("plan_id"), is("plan-1"));
         assertThat(actualResponse.get("execution_mode"), is("manual-only"));
-        assertFalse(actualResponse.containsKey("recommended_next_tool"));
         List<?> actualNextActions = (List<?>) actualResponse.get("next_actions");
         assertThat(actualNextActions.size(), is(1));
         assertThat(((Map<?, ?>) actualNextActions.getFirst()).get("type"), is("ask_user"));
-        assertFalse(actualResponse.containsKey("requires_user_approval"));
         assertThat(((Map<?, ?>) actualResponse.get("manual_follow_up")).get("confirmation_field"), is("manual_artifacts_executed"));
         Map<?, ?> actualManualArtifactSummary = (Map<?, ?>) actualResponse.get("manual_artifact_summary");
         assertThat(actualManualArtifactSummary.get("ddl_artifact_count"), is(1));
@@ -244,7 +242,6 @@ class WorkflowExecutionServiceTest {
         assertThat(actualReviewFocus.get("artifact_categories"), is(List.of("add-column", "rule_distsql")));
         assertThat(actualReviewFocus.get("side_effect_scope"), is(List.of("physical-structure", "rule-metadata")));
         assertFalse((Boolean) actualReviewFocus.get("manual_only"));
-        assertFalse(actualReviewFocus.containsKey("requires_user_approval"));
         assertThat(actualReviewFocus.get("approval_field"), is("approved_steps"));
         assertThat(actualReviewFocus.get("approval_values"), is(List.of("ddl", "rule_distsql")));
         assertThat(actualResponse.get("review_summary"), is("Previewed 2 workflow artifacts with side-effect scope physical-structure, rule-metadata. Nothing has been applied."));
@@ -254,11 +251,8 @@ class WorkflowExecutionServiceTest {
         assertThat(actualNextAction.get("type"), is("ask_user"));
         assertThat(actualNextAction.get("required_inputs"), is(List.of("approved_steps")));
         assertFalse(actualNextAction.containsKey("depends_on"));
-        assertFalse(actualNextAction.containsKey("requires_user_approval"));
         assertThat(((Map<?, ?>) actualResponse.get("argument_provenance")).get("plan_id"), is("server_generated"));
         assertThat(((Map<?, ?>) actualResponse.get("argument_provenance")).get("execution_mode"), is("server_defaulted"));
-        assertFalse(((Map<?, ?>) actualResponse.get("argument_provenance")).containsKey("approved_by_user"));
-        assertFalse(actualResponse.containsKey("requires_user_approval"));
         assertThat(workflowSessionContext.getRequired("plan-1").getStatus(), is("previewed"));
         verify(executionFacade, never()).execute(any());
         verify(workflowApplySynchronizationHandler, never()).synchronize(any(), any(), any(), any(), any());
@@ -353,13 +347,10 @@ class WorkflowExecutionServiceTest {
         WorkflowExecutionService executionService = new WorkflowExecutionService();
         Map<String, Object> actualResponse = executionService.apply(workflowSessionContext, mock(MCPMetadataQueryFacade.class), mock(MCPFeatureQueryFacade.class),
                 mock(MCPFeatureExecutionFacade.class), MCPWorkflowApplySynchronizationHandler.NO_OP, "session-1", snapshot, List.of(), "preview");
-        assertFalse(actualResponse.containsKey("requires_user_approval"));
-        assertFalse(((Map<?, ?>) actualResponse.get("review_focus")).containsKey("requires_user_approval"));
         List<?> actualNextActions = (List<?>) actualResponse.get("next_actions");
         assertThat(actualNextActions.size(), is(1));
         Map<?, ?> actualNextAction = (Map<?, ?>) actualNextActions.getFirst();
         assertThat(((Map<?, ?>) actualNextAction.get("arguments")).get("execution_mode"), is("manual-only"));
-        assertFalse(actualNextAction.containsKey("requires_user_approval"));
     }
     
     @Test
@@ -378,7 +369,6 @@ class WorkflowExecutionServiceTest {
                 executionFacade, MCPWorkflowApplySynchronizationHandler.NO_OP, "session-1", snapshot, List.of("ddl", "index_ddl", "rule_distsql"), "review-then-execute");
         assertThat(actualResponse.get("status"), is("completed"));
         assertThat(actualResponse.get("response_mode"), is("executed"));
-        assertFalse(actualResponse.containsKey("recommended_next_tool"));
         assertThat(((List<?>) actualResponse.get("applied_artifacts")).size(), is(3));
         assertThat(((List<?>) actualResponse.get("executed_ddl")).size(), is(2));
         assertThat(((List<?>) actualResponse.get("executed_distsql")).size(), is(1));

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/descriptor/BroadcastToolDescriptorValidatorTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/descriptor/BroadcastToolDescriptorValidatorTest.java
@@ -65,7 +65,6 @@ class BroadcastToolDescriptorValidatorTest {
         assertFalse(properties.containsKey("column"));
         assertFalse(properties.containsKey("algorithm_type"));
         assertFalse(properties.containsKey("primary_algorithm_properties"));
-        assertFalse(properties.containsKey("user_overrides"));
     }
     
     @Test

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/descriptor/EncryptToolDescriptorValidatorTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/descriptor/EncryptToolDescriptorValidatorTest.java
@@ -178,7 +178,6 @@ class EncryptToolDescriptorValidatorTest {
     void assertInputSchemaDeclaresSecretReferenceObjects() {
         MCPToolDescriptor descriptor = MCPDescriptorCatalogIndex.getRequiredToolDescriptor(EncryptFeatureDefinition.PLAN_TOOL_NAME);
         Map<String, Object> properties = (Map<String, Object>) descriptor.getInputSchema().get("properties");
-        assertFalse(properties.containsKey("user_overrides"));
         assertTrue(String.valueOf(((Map<?, ?>) properties.get("primary_algorithm_properties")).get("description")).contains("protected placeholder objects"));
         assertTrue(String.valueOf(((Map<?, ?>) properties.get("assisted_query_algorithm_properties")).get("description")).contains("protected placeholder objects"));
         assertTrue(String.valueOf(((Map<?, ?>) properties.get("like_query_algorithm_properties")).get("description")).contains("protected placeholder objects"));

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/descriptor/MaskToolDescriptorValidatorTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/descriptor/MaskToolDescriptorValidatorTest.java
@@ -93,7 +93,6 @@ class MaskToolDescriptorValidatorTest {
     void assertStructuredIntentEvidenceIsMaskSpecific() {
         MCPToolDescriptor descriptor = MCPDescriptorCatalogIndex.getRequiredToolDescriptor(MaskFeatureDefinition.PLAN_TOOL_NAME);
         Map<String, Object> properties = (Map<String, Object>) descriptor.getInputSchema().get("properties");
-        assertFalse(properties.containsKey("user_overrides"));
         Map<String, Object> structuredIntentEvidence = (Map<String, Object>) properties.get("structured_intent_evidence");
         Map<String, Object> actualProperties = (Map<String, Object>) structuredIntentEvidence.get("properties");
         assertTrue(actualProperties.containsKey("field_semantics"));

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/handler/MaskToolHandlerTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/handler/MaskToolHandlerTest.java
@@ -101,8 +101,6 @@ class MaskToolHandlerTest {
         Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualPayload.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("type"), is("tool_call"));
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_apply_workflow"));
-        assertFalse(actualNextAction.containsKey("requires_user_approval"));
-        assertFalse(actualNextAction.containsKey("required_arguments"));
         assertThat(((Map<?, ?>) actualNextAction.get("arguments")).get("plan_id"), is("plan-1"));
         assertThat(((Map<?, ?>) actualNextAction.get("arguments")).get("execution_mode"), is("preview"));
     }

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/handler/PlanReadwriteSplittingStatusToolHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/handler/PlanReadwriteSplittingStatusToolHandler.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.tool.handler;
 
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
-import org.apache.shardingsphere.mcp.api.protocol.exception.MCPInvalidRequestException;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolHandler;
 import org.apache.shardingsphere.mcp.feature.readwritesplitting.ReadwriteSplittingFeatureDefinition;
@@ -65,9 +64,9 @@ public final class PlanReadwriteSplittingStatusToolHandler implements MCPToolHan
     
     @Override
     public MCPResponse handle(final MCPWorkflowHandlerContext workflowContext, final MCPToolCall toolCall) {
-        rejectOperationTypeAlias(toolCall.getArguments());
         ReadwriteSplittingStatusWorkflowRequest request = WorkflowRequestBinder.bindPlanningRequest(ReadwriteSplittingStatusWorkflowRequest::new, toolCall.getArguments(),
                 this::bindFeatureArguments, this::applyStructuredIntentEvidence);
+        request.setOperationType("");
         WorkflowContextSnapshot snapshot = planningService.plan(
                 workflowContext.getWorkflowSessionContext(), workflowContext.getDatabaseContext().getQueryFacade(), toolCall.getSessionId(), request);
         return new MCPMapResponse(createPlanResponse(snapshot));
@@ -161,12 +160,6 @@ public final class PlanReadwriteSplittingStatusToolHandler implements MCPToolHan
         applyStringField(structuredIntentEvidence, ReadwriteSplittingFeatureDefinition.RULE_FIELD, request::setRuleName);
         applyStringField(structuredIntentEvidence, ReadwriteSplittingFeatureDefinition.STORAGE_UNIT_FIELD, request::setStorageUnit);
         applyStringField(structuredIntentEvidence, ReadwriteSplittingFeatureDefinition.TARGET_STATUS_FIELD, request::setTargetStatus);
-    }
-    
-    private void rejectOperationTypeAlias(final Map<String, Object> arguments) {
-        if (arguments.containsKey(WorkflowFieldNames.OPERATION_TYPE)) {
-            throw new MCPInvalidRequestException("operation_type is not supported for readwrite-splitting status. Use target_status instead.");
-        }
     }
     
     private void applyStringField(final Map<String, Object> values, final String fieldName, final Consumer<String> consumer) {

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/descriptor/ReadwriteSplittingToolDescriptorValidatorTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/descriptor/ReadwriteSplittingToolDescriptorValidatorTest.java
@@ -77,7 +77,6 @@ class ReadwriteSplittingToolDescriptorValidatorTest {
         assertTrue(properties.containsKey(ReadwriteSplittingFeatureDefinition.READ_STORAGE_UNITS_FIELD));
         assertFalse(properties.containsKey("column"));
         assertFalse(properties.containsKey("primary_algorithm_properties"));
-        assertFalse(properties.containsKey("user_overrides"));
     }
     
     @Test
@@ -87,7 +86,6 @@ class ReadwriteSplittingToolDescriptorValidatorTest {
         Map<String, Object> properties = (Map<String, Object>) descriptor.getInputSchema().get("properties");
         assertTrue(properties.containsKey(ReadwriteSplittingFeatureDefinition.TARGET_STATUS_FIELD));
         assertFalse(properties.containsKey("operation_type"));
-        assertFalse(properties.containsKey("user_overrides"));
     }
     
     @Test

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/handler/ReadwriteSplittingToolHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/handler/ReadwriteSplittingToolHandlerTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.tool.handler;
 
-import org.apache.shardingsphere.mcp.api.protocol.exception.MCPInvalidRequestException;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.feature.readwritesplitting.ReadwriteSplittingFeatureDefinition;
@@ -47,7 +46,6 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -125,14 +123,6 @@ class ReadwriteSplittingToolHandlerTest {
         verify(planningService).plan(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
         assertThat(requestCaptor.getValue().getStorageUnit(), is("read_ds_0"));
         assertThat(requestCaptor.getValue().getTargetStatus(), is("disable"));
-    }
-    
-    @Test
-    void assertHandlePlanStatusRejectsOperationTypeAlias() {
-        MCPInvalidRequestException actual = assertThrows(MCPInvalidRequestException.class,
-                () -> new PlanReadwriteSplittingStatusToolHandler(mock(ReadwriteSplittingStatusWorkflowPlanningService.class)).handle(
-                        createWorkflowContextFixture().workflowContext, new MCPToolCall("session-1", Map.of("operation_type", "disable"))));
-        assertThat(actual.getMessage(), is("operation_type is not supported for readwrite-splitting status. Use target_status instead."));
     }
     
     private WorkflowContextSnapshot createRuleSnapshot() {

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/descriptor/ShadowToolDescriptorValidatorTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/descriptor/ShadowToolDescriptorValidatorTest.java
@@ -69,18 +69,6 @@ class ShadowToolDescriptorValidatorTest {
         assertTrue(properties.containsKey(ShadowFeatureDefinition.ALGORITHM_PROPERTIES_FIELD));
         assertFalse(properties.containsKey("column"));
         assertFalse(properties.containsKey("ddl_artifacts"));
-        assertFalse(properties.containsKey("user_overrides"));
-    }
-    
-    @Test
-    @SuppressWarnings("unchecked")
-    void assertPlanningInputSchemasDoNotExposeUserOverrides() {
-        for (String each : List.of(ShadowFeatureDefinition.PLAN_RULE_TOOL_NAME, ShadowFeatureDefinition.PLAN_DEFAULT_ALGORITHM_TOOL_NAME,
-                ShadowFeatureDefinition.PLAN_ALGORITHM_CLEANUP_TOOL_NAME)) {
-            MCPToolDescriptor descriptor = MCPDescriptorCatalogIndex.getRequiredToolDescriptor(each);
-            Map<String, Object> properties = (Map<String, Object>) descriptor.getInputSchema().get("properties");
-            assertFalse(properties.containsKey("user_overrides"));
-        }
     }
     
     @Test

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/descriptor/ShardingToolDescriptorValidatorTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/descriptor/ShardingToolDescriptorValidatorTest.java
@@ -86,7 +86,6 @@ class ShardingToolDescriptorValidatorTest {
         assertFalse(properties.containsKey("component_type"));
         assertFalse(properties.containsKey("default_strategy_type"));
         assertFalse(properties.containsKey("ddl_artifacts"));
-        assertFalse(properties.containsKey("user_overrides"));
     }
     
     @Test
@@ -111,7 +110,6 @@ class ShardingToolDescriptorValidatorTest {
             Map<String, Object> properties = (Map<String, Object>) MCPDescriptorCatalogIndex.getRequiredToolDescriptor(each).getInputSchema().get("properties");
             assertTrue(properties.containsKey("key_generator_type"));
             assertFalse(properties.containsKey("algorithm_type"));
-            assertFalse(properties.containsKey("user_overrides"));
         }
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/tool/request/RuntimeDatabaseValidationRequest.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/tool/request/RuntimeDatabaseValidationRequest.java
@@ -23,14 +23,14 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Proxy preflight validation request.
+ * Runtime database validation request.
  */
 @Getter
-public final class ProxyPreflightValidationRequest {
+public final class RuntimeDatabaseValidationRequest {
     
     private final String database;
     
-    public ProxyPreflightValidationRequest(final String database) {
+    public RuntimeDatabaseValidationRequest(final String database) {
         this.database = Objects.toString(database, "");
     }
     
@@ -40,8 +40,8 @@ public final class ProxyPreflightValidationRequest {
      * @param arguments tool arguments
      * @return request
      */
-    public static ProxyPreflightValidationRequest from(final Map<String, Object> arguments) {
-        return new ProxyPreflightValidationRequest(getRawString(arguments, "database"));
+    public static RuntimeDatabaseValidationRequest from(final Map<String, Object> arguments) {
+        return new RuntimeDatabaseValidationRequest(getRawString(arguments, "database"));
     }
     
     private static String getRawString(final Map<String, Object> arguments, final String fieldName) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/tool/response/RuntimeDatabaseValidationCheckResult.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/tool/response/RuntimeDatabaseValidationCheckResult.java
@@ -25,11 +25,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Proxy preflight check result.
+ * Runtime database validation check result.
  */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public final class ProxyPreflightCheckResult {
+public final class RuntimeDatabaseValidationCheckResult {
     
     private static final String STATUS_PASSED = "passed";
     
@@ -52,8 +52,8 @@ public final class ProxyPreflightCheckResult {
      * @param message check message
      * @return check result
      */
-    public static ProxyPreflightCheckResult passed(final String name, final String message) {
-        return new ProxyPreflightCheckResult(name, STATUS_PASSED, "ready", message);
+    public static RuntimeDatabaseValidationCheckResult passed(final String name, final String message) {
+        return new RuntimeDatabaseValidationCheckResult(name, STATUS_PASSED, "ready", message);
     }
     
     /**
@@ -64,8 +64,8 @@ public final class ProxyPreflightCheckResult {
      * @param message check message
      * @return check result
      */
-    public static ProxyPreflightCheckResult failed(final String name, final String category, final String message) {
-        return new ProxyPreflightCheckResult(name, STATUS_FAILED, category, message);
+    public static RuntimeDatabaseValidationCheckResult failed(final String name, final String category, final String message) {
+        return new RuntimeDatabaseValidationCheckResult(name, STATUS_FAILED, category, message);
     }
     
     /**
@@ -75,8 +75,8 @@ public final class ProxyPreflightCheckResult {
      * @param message check message
      * @return check result
      */
-    public static ProxyPreflightCheckResult skipped(final String name, final String message) {
-        return new ProxyPreflightCheckResult(name, STATUS_SKIPPED, "skipped", message);
+    public static RuntimeDatabaseValidationCheckResult skipped(final String name, final String message) {
+        return new RuntimeDatabaseValidationCheckResult(name, STATUS_SKIPPED, "skipped", message);
     }
     
     /**

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/tool/response/RuntimeDatabaseValidationResult.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/tool/response/RuntimeDatabaseValidationResult.java
@@ -31,17 +31,17 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Proxy preflight validation result.
+ * Runtime database validation result.
  */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public final class ProxyPreflightValidationResult implements MCPResponse {
+public final class RuntimeDatabaseValidationResult implements MCPResponse {
     
     private final String status;
     
     private final String database;
     
-    private final List<ProxyPreflightCheckResult> checks;
+    private final List<RuntimeDatabaseValidationCheckResult> checks;
     
     private final String category;
     
@@ -54,8 +54,8 @@ public final class ProxyPreflightValidationResult implements MCPResponse {
      * @param checks check results
      * @return validation result
      */
-    public static ProxyPreflightValidationResult ready(final String database, final List<ProxyPreflightCheckResult> checks) {
-        return new ProxyPreflightValidationResult("ready", Objects.toString(database, ""), checks, "ready", Map.of());
+    public static RuntimeDatabaseValidationResult ready(final String database, final List<RuntimeDatabaseValidationCheckResult> checks) {
+        return new RuntimeDatabaseValidationResult("ready", Objects.toString(database, ""), checks, "ready", Map.of());
     }
     
     /**
@@ -67,8 +67,8 @@ public final class ProxyPreflightValidationResult implements MCPResponse {
      * @param recovery recovery payload
      * @return validation result
      */
-    public static ProxyPreflightValidationResult failed(final String database, final List<ProxyPreflightCheckResult> checks, final String category, final Map<String, Object> recovery) {
-        return new ProxyPreflightValidationResult("failed", Objects.toString(database, ""), checks, category, null == recovery ? Map.of() : recovery);
+    public static RuntimeDatabaseValidationResult failed(final String database, final List<RuntimeDatabaseValidationCheckResult> checks, final String category, final Map<String, Object> recovery) {
+        return new RuntimeDatabaseValidationResult("failed", Objects.toString(database, ""), checks, category, null == recovery ? Map.of() : recovery);
     }
     
     @Override
@@ -85,7 +85,7 @@ public final class ProxyPreflightValidationResult implements MCPResponse {
     
     private List<Map<String, Object>> createChecksPayload() {
         List<Map<String, Object>> result = new LinkedList<>();
-        for (ProxyPreflightCheckResult each : checks) {
+        for (RuntimeDatabaseValidationCheckResult each : checks) {
             result.add(each.toPayload());
         }
         return result;

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/tool/service/RuntimeDatabaseValidationService.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/tool/service/RuntimeDatabaseValidationService.java
@@ -25,9 +25,9 @@ import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatab
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
 import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPDatabaseMetadata;
 import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPSchemaMetadata;
-import org.apache.shardingsphere.mcp.support.database.tool.request.ProxyPreflightValidationRequest;
-import org.apache.shardingsphere.mcp.support.database.tool.response.ProxyPreflightCheckResult;
-import org.apache.shardingsphere.mcp.support.database.tool.response.ProxyPreflightValidationResult;
+import org.apache.shardingsphere.mcp.support.database.tool.request.RuntimeDatabaseValidationRequest;
+import org.apache.shardingsphere.mcp.support.database.tool.response.RuntimeDatabaseValidationCheckResult;
+import org.apache.shardingsphere.mcp.support.database.tool.response.RuntimeDatabaseValidationResult;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -41,50 +41,50 @@ import java.util.Optional;
 import java.util.function.Function;
 
 /**
- * Proxy preflight validation service.
+ * Runtime database validation service.
  */
 @RequiredArgsConstructor
-public final class ProxyPreflightValidationService {
+public final class RuntimeDatabaseValidationService {
     
-    private static final String PRE_FLIGHT_BINDING_DATABASE = "__preflight_validation__";
+    private static final String VALIDATION_BINDING_DATABASE = "__preflight_validation__";
     
     private final MCPJdbcDatabaseProfileLoader profileLoader;
     
     private final MCPJdbcMetadataLoader metadataLoader;
     
-    public ProxyPreflightValidationService() {
+    public RuntimeDatabaseValidationService() {
         this(new MCPJdbcDatabaseProfileLoader(), new MCPJdbcMetadataLoader());
     }
     
     /**
-     * Validate proxy preflight request.
+     * Validate runtime database.
      *
      * @param request validation request
      * @param runtimeDatabaseResolver runtime database resolver
      * @param recoveryFactory runtime recovery factory
      * @return validation result
      */
-    public ProxyPreflightValidationResult validate(final ProxyPreflightValidationRequest request,
-                                                   final Function<String, Optional<RuntimeDatabaseConfiguration>> runtimeDatabaseResolver,
-                                                   final Function<RuntimeDatabaseConnectionException, Map<String, Object>> recoveryFactory) {
-        List<ProxyPreflightCheckResult> checks = new LinkedList<>();
+    public RuntimeDatabaseValidationResult validate(final RuntimeDatabaseValidationRequest request,
+                                                    final Function<String, Optional<RuntimeDatabaseConfiguration>> runtimeDatabaseResolver,
+                                                    final Function<RuntimeDatabaseConnectionException, Map<String, Object>> recoveryFactory) {
+        List<RuntimeDatabaseValidationCheckResult> checks = new LinkedList<>();
         String database = normalize(request.getDatabase());
         Optional<RuntimeDatabaseConfiguration> runtimeDatabaseConfig = findRuntimeDatabaseConfiguration(database, runtimeDatabaseResolver);
         if (runtimeDatabaseConfig.isEmpty()) {
             RuntimeDatabaseConnectionException ex = createMissingRuntimeDatabaseException(database);
-            checks.add(ProxyPreflightCheckResult.failed("configuration", ex.getCategory(), "The requested database is not configured for this MCP runtime."));
+            checks.add(RuntimeDatabaseValidationCheckResult.failed("configuration", ex.getCategory(), "The requested database is not configured for this MCP runtime."));
             appendSkippedChecks(checks, "jdbc_driver", "configuration validation did not finish");
             appendSkippedChecks(checks, "jdbc_connectivity", "configuration validation did not finish");
             appendSkippedChecks(checks, "metadata_read", "configuration validation did not finish");
             appendSkippedChecks(checks, "database_visibility", "configuration validation did not finish");
             return createFailureResult(database, checks, ex, recoveryFactory);
         }
-        checks.add(ProxyPreflightCheckResult.passed("configuration", "Resolved the configured runtime database."));
+        checks.add(RuntimeDatabaseValidationCheckResult.passed("configuration", "Resolved the configured runtime database."));
         RuntimeDatabaseProfile databaseProfile;
         try {
             databaseProfile = profileLoader.load(database, runtimeDatabaseConfig.get());
-            checks.add(ProxyPreflightCheckResult.passed("jdbc_driver", "Loaded the configured JDBC driver."));
-            checks.add(ProxyPreflightCheckResult.passed("jdbc_connectivity", "Opened a JDBC connection and validated the configured database type."));
+            checks.add(RuntimeDatabaseValidationCheckResult.passed("jdbc_driver", "Loaded the configured JDBC driver."));
+            checks.add(RuntimeDatabaseValidationCheckResult.passed("jdbc_connectivity", "Opened a JDBC connection and validated the configured database type."));
         } catch (final RuntimeDatabaseConnectionException ex) {
             appendProfileFailureChecks(checks, ex);
             appendSkippedChecks(checks, "metadata_read", "driver or connectivity validation failed");
@@ -94,20 +94,20 @@ public final class ProxyPreflightValidationService {
         MCPDatabaseMetadata databaseMetadata;
         try {
             databaseMetadata = metadataLoader.load(database, runtimeDatabaseConfig.get(), databaseProfile);
-            checks.add(ProxyPreflightCheckResult.passed("metadata_read", "Read metadata through the configured JDBC connection."));
+            checks.add(RuntimeDatabaseValidationCheckResult.passed("metadata_read", "Read metadata through the configured JDBC connection."));
         } catch (final RuntimeDatabaseConnectionException ex) {
-            checks.add(ProxyPreflightCheckResult.failed("metadata_read", ex.getCategory(), "Failed to read metadata through the configured JDBC connection."));
+            checks.add(RuntimeDatabaseValidationCheckResult.failed("metadata_read", ex.getCategory(), "Failed to read metadata through the configured JDBC connection."));
             appendSkippedChecks(checks, "database_visibility", "metadata validation failed");
             return createFailureResult(database, checks, ex, recoveryFactory);
         }
         try {
             validateDatabaseVisibility(database, runtimeDatabaseConfig.get(), databaseMetadata);
-            checks.add(ProxyPreflightCheckResult.passed("database_visibility", "Validated the requested database name against visible JDBC metadata and connection context."));
+            checks.add(RuntimeDatabaseValidationCheckResult.passed("database_visibility", "Validated the requested database name against visible JDBC metadata and connection context."));
         } catch (final RuntimeDatabaseConnectionException ex) {
-            checks.add(ProxyPreflightCheckResult.failed("database_visibility", ex.getCategory(), "The requested database name is not visible to the configured JDBC connection."));
+            checks.add(RuntimeDatabaseValidationCheckResult.failed("database_visibility", ex.getCategory(), "The requested database name is not visible to the configured JDBC connection."));
             return createFailureResult(database, checks, ex, recoveryFactory);
         }
-        return ProxyPreflightValidationResult.ready(database, checks);
+        return RuntimeDatabaseValidationResult.ready(database, checks);
     }
     
     private Optional<RuntimeDatabaseConfiguration> findRuntimeDatabaseConfiguration(final String database,
@@ -117,26 +117,26 @@ public final class ProxyPreflightValidationService {
     
     private RuntimeDatabaseConnectionException createMissingRuntimeDatabaseException(final String database) {
         return RuntimeDatabaseConnectionException.invalidConfiguration(resolveExceptionDatabaseName(database),
-                new IllegalStateException("Proxy preflight validation requires one configured runtime database."));
+                new IllegalStateException("Runtime database validation requires one configured runtime database."));
     }
     
-    private void appendProfileFailureChecks(final List<ProxyPreflightCheckResult> checks, final RuntimeDatabaseConnectionException ex) {
+    private void appendProfileFailureChecks(final List<RuntimeDatabaseValidationCheckResult> checks, final RuntimeDatabaseConnectionException ex) {
         if (RuntimeDatabaseConnectionException.CATEGORY_MISSING_JDBC_DRIVER.equals(ex.getCategory())) {
-            checks.add(ProxyPreflightCheckResult.failed("jdbc_driver", ex.getCategory(), "Failed to load the configured JDBC driver."));
+            checks.add(RuntimeDatabaseValidationCheckResult.failed("jdbc_driver", ex.getCategory(), "Failed to load the configured JDBC driver."));
             appendSkippedChecks(checks, "jdbc_connectivity", "driver loading failed");
             return;
         }
-        checks.add(ProxyPreflightCheckResult.passed("jdbc_driver", "Loaded the configured JDBC driver."));
-        checks.add(ProxyPreflightCheckResult.failed("jdbc_connectivity", ex.getCategory(), "Failed to open a JDBC connection or validate the configured database type."));
+        checks.add(RuntimeDatabaseValidationCheckResult.passed("jdbc_driver", "Loaded the configured JDBC driver."));
+        checks.add(RuntimeDatabaseValidationCheckResult.failed("jdbc_connectivity", ex.getCategory(), "Failed to open a JDBC connection or validate the configured database type."));
     }
     
-    private void appendSkippedChecks(final List<ProxyPreflightCheckResult> checks, final String name, final String reason) {
-        checks.add(ProxyPreflightCheckResult.skipped(name, String.format("Skipped because %s.", reason)));
+    private void appendSkippedChecks(final List<RuntimeDatabaseValidationCheckResult> checks, final String name, final String reason) {
+        checks.add(RuntimeDatabaseValidationCheckResult.skipped(name, String.format("Skipped because %s.", reason)));
     }
     
-    private ProxyPreflightValidationResult createFailureResult(final String database, final List<ProxyPreflightCheckResult> checks, final RuntimeDatabaseConnectionException cause,
-                                                               final Function<RuntimeDatabaseConnectionException, Map<String, Object>> recoveryFactory) {
-        return ProxyPreflightValidationResult.failed(database, checks, cause.getCategory(), recoveryFactory.apply(cause));
+    private RuntimeDatabaseValidationResult createFailureResult(final String database, final List<RuntimeDatabaseValidationCheckResult> checks, final RuntimeDatabaseConnectionException cause,
+                                                                final Function<RuntimeDatabaseConnectionException, Map<String, Object>> recoveryFactory) {
+        return RuntimeDatabaseValidationResult.failed(database, checks, cause.getCategory(), recoveryFactory.apply(cause));
     }
     
     private void validateDatabaseVisibility(final String database, final RuntimeDatabaseConfiguration runtimeDatabaseConfig, final MCPDatabaseMetadata databaseMetadata) {
@@ -197,7 +197,7 @@ public final class ProxyPreflightValidationService {
     }
     
     private String resolveExceptionDatabaseName(final String database) {
-        return database.isEmpty() ? PRE_FLIGHT_BINDING_DATABASE : database;
+        return database.isEmpty() ? VALIDATION_BINDING_DATABASE : database;
     }
     
     private String normalize(final String value) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidator.java
@@ -40,13 +40,6 @@ import java.util.regex.Pattern;
 
 final class MCPDescriptorCatalogValidator {
     
-    private static final Collection<String> BANNED_PUBLIC_ALIAS_FIELDS = List.of(
-            "recommended_next_tool", "suggested_next_tool", "suggested_next_tools", "recommended_recovery", "suggested_next_action");
-    
-    private static final Collection<String> BANNED_PUBLIC_INPUT_FIELDS = List.of("user_overrides");
-    
-    private static final Collection<String> BANNED_NEXT_ACTION_FIELDS = List.of("action_kind", "target_tool", "target_resource", "required_arguments");
-    
     private static final Collection<String> MODEL_CRITICAL_HINT_FIELDS = List.of(
             MCPPayloadFieldNames.NEXT_ACTIONS, MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.RESOURCE, MCPPayloadFieldNames.PARENT_RESOURCE,
             MCPPayloadFieldNames.NEXT_RESOURCES, "manual_artifact_summary", "manual_follow_up", "empty_state", "ambiguity_state", MCPPayloadFieldNames.RECOVERY, "recovery_guidance",
@@ -142,14 +135,6 @@ final class MCPDescriptorCatalogValidator {
                 () -> new IllegalStateException(String.format("Tool `%s` inputSchema must be an object.", descriptor.getName())));
         Object properties = inputSchema.get("properties");
         ShardingSpherePreconditions.checkState(properties instanceof Map, () -> new IllegalStateException(String.format("Tool `%s` inputSchema must declare properties.", descriptor.getName())));
-        validateNoBannedPublicInputFields(descriptor, (Map<?, ?>) properties);
-    }
-    
-    private static void validateNoBannedPublicInputFields(final MCPToolDescriptor descriptor, final Map<?, ?> properties) {
-        for (String each : BANNED_PUBLIC_INPUT_FIELDS) {
-            ShardingSpherePreconditions.checkState(!properties.containsKey(each),
-                    () -> new IllegalStateException(String.format("Tool `%s` inputSchema must use canonical fields instead of banned `%s`.", descriptor.getName(), each)));
-        }
     }
     
     private static void validateToolOutputSchema(final MCPToolDescriptor descriptor, final Collection<MCPToolDescriptorValidator> descriptorValidators) {
@@ -159,7 +144,6 @@ final class MCPDescriptorCatalogValidator {
         Object properties = outputSchema.get("properties");
         ShardingSpherePreconditions.checkState(properties instanceof Map && !((Map<?, ?>) properties).isEmpty(),
                 () -> new IllegalStateException(String.format("Tool `%s` outputSchema must declare properties.", descriptor.getName())));
-        validateNoBannedPublicAliasFields(descriptor, outputSchema);
         validateOutputExamples(descriptor, outputSchema);
         validateOutputExampleContractValues(descriptor, outputSchema);
         validateModelCriticalOutputHints(descriptor, (Map<?, ?>) properties);
@@ -220,25 +204,6 @@ final class MCPDescriptorCatalogValidator {
         }
     }
     
-    private static void validateNoBannedPublicAliasFields(final MCPToolDescriptor descriptor, final Object value) {
-        if (value instanceof Map) {
-            validateNoBannedPublicAliasFieldMap(descriptor, (Map<?, ?>) value);
-        } else if (value instanceof Collection) {
-            for (Object each : (Collection<?>) value) {
-                validateNoBannedPublicAliasFields(descriptor, each);
-            }
-        }
-    }
-    
-    private static void validateNoBannedPublicAliasFieldMap(final MCPToolDescriptor descriptor, final Map<?, ?> value) {
-        for (Entry<?, ?> entry : value.entrySet()) {
-            String key = String.valueOf(entry.getKey());
-            ShardingSpherePreconditions.checkState(!BANNED_PUBLIC_ALIAS_FIELDS.contains(key),
-                    () -> new IllegalStateException(String.format("Tool `%s` outputSchema must use canonical fields instead of banned `%s`.", descriptor.getName(), key)));
-            validateNoBannedPublicAliasFields(descriptor, entry.getValue());
-        }
-    }
-    
     private static void validateModelCriticalOutputHints(final MCPToolDescriptor descriptor, final Map<?, ?> properties) {
         for (Entry<?, ?> entry : properties.entrySet()) {
             String fieldName = String.valueOf(entry.getKey());
@@ -280,10 +245,6 @@ final class MCPDescriptorCatalogValidator {
         Object properties = ((Map<?, ?>) items).get("properties");
         ShardingSpherePreconditions.checkState(properties instanceof Map,
                 () -> new IllegalStateException(String.format("Tool `%s` next_actions items must declare properties.", descriptor.getName())));
-        for (String each : BANNED_NEXT_ACTION_FIELDS) {
-            ShardingSpherePreconditions.checkState(!((Map<?, ?>) properties).containsKey(each),
-                    () -> new IllegalStateException(String.format("Tool `%s` next_actions item must not declare banned `%s`.", descriptor.getName(), each)));
-        }
         for (String each : List.of("order", "type", "title")) {
             ShardingSpherePreconditions.checkState(((Map<?, ?>) properties).containsKey(each),
                     () -> new IllegalStateException(String.format("Tool `%s` next_actions item must declare `%s`.", descriptor.getName(), each)));

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidator.java
@@ -40,6 +40,14 @@ import java.util.regex.Pattern;
 
 final class MCPDescriptorCatalogValidator {
     
+    private static final Collection<String> REMOVED_MODEL_FACING_FIELDS = Set.of(
+            "target_tool", "target_resource", "required_arguments", "action_kind", "suggested_next_tool", "suggested_next_tools", "recommended_next_tool",
+            "recommended_recovery", "suggested_next_action", "approved_by_user", "requires_user_approval", "approval_required", "user_overrides");
+    
+    private static final Map<String, Collection<String>> NEXT_ACTION_ALLOWED_FIELDS = createNextActionAllowedFields();
+    
+    private static final Collection<String> NEXT_ACTION_SCHEMA_ALLOWED_FIELDS = createNextActionSchemaAllowedFields();
+    
     private static final Collection<String> MODEL_CRITICAL_HINT_FIELDS = List.of(
             MCPPayloadFieldNames.NEXT_ACTIONS, MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.RESOURCE, MCPPayloadFieldNames.PARENT_RESOURCE,
             MCPPayloadFieldNames.NEXT_RESOURCES, "manual_artifact_summary", "manual_follow_up", "empty_state", "ambiguity_state", MCPPayloadFieldNames.RECOVERY, "recovery_guidance",
@@ -55,6 +63,23 @@ final class MCPDescriptorCatalogValidator {
     private static final Pattern SINGLE_BRACE_PLACEHOLDER_PATTERN = Pattern.compile("(?<!\\{)\\{\\s*([a-zA-Z0-9_.-]+)\\s*}(?!})");
     
     private MCPDescriptorCatalogValidator() {
+    }
+    
+    private static Map<String, Collection<String>> createNextActionAllowedFields() {
+        return Map.of(
+                "resource_read", Set.of("order", "type", "title", "resource_uri", "reason", "depends_on"),
+                "tool_call", Set.of("order", "type", "title", "tool_name", "arguments", "reason", "depends_on"),
+                "completion", Set.of("order", "type", "title", "ref", "argument", "context", "missing_context_arguments", "resume_ref", "resume_arguments", "reason", "depends_on"),
+                "ask_user", Set.of("order", "type", "title", "question", "required_inputs", "reason", "depends_on"),
+                "terminal", Set.of("order", "type", "title", "reason", "depends_on"));
+    }
+    
+    private static Collection<String> createNextActionSchemaAllowedFields() {
+        Set<String> result = new HashSet<>();
+        for (Collection<String> each : NEXT_ACTION_ALLOWED_FIELDS.values()) {
+            result.addAll(each);
+        }
+        return result;
     }
     
     static void validate(final MCPDescriptorCatalog catalog) {
@@ -135,6 +160,7 @@ final class MCPDescriptorCatalogValidator {
                 () -> new IllegalStateException(String.format("Tool `%s` inputSchema must be an object.", descriptor.getName())));
         Object properties = inputSchema.get("properties");
         ShardingSpherePreconditions.checkState(properties instanceof Map, () -> new IllegalStateException(String.format("Tool `%s` inputSchema must declare properties.", descriptor.getName())));
+        validateNoRemovedModelFacingFields(descriptor, inputSchema);
     }
     
     private static void validateToolOutputSchema(final MCPToolDescriptor descriptor, final Collection<MCPToolDescriptorValidator> descriptorValidators) {
@@ -144,6 +170,7 @@ final class MCPDescriptorCatalogValidator {
         Object properties = outputSchema.get("properties");
         ShardingSpherePreconditions.checkState(properties instanceof Map && !((Map<?, ?>) properties).isEmpty(),
                 () -> new IllegalStateException(String.format("Tool `%s` outputSchema must declare properties.", descriptor.getName())));
+        validateNoRemovedModelFacingFields(descriptor, outputSchema);
         validateOutputExamples(descriptor, outputSchema);
         validateOutputExampleContractValues(descriptor, outputSchema);
         validateModelCriticalOutputHints(descriptor, (Map<?, ?>) properties);
@@ -202,6 +229,67 @@ final class MCPDescriptorCatalogValidator {
         for (Object each : value.values()) {
             validateExampleContractValue(descriptor, each);
         }
+        Object nextActions = value.get(MCPPayloadFieldNames.NEXT_ACTIONS);
+        if (null != nextActions) {
+            validateConcreteNextActions(descriptor, nextActions);
+        }
+    }
+    
+    private static void validateNoRemovedModelFacingFields(final MCPToolDescriptor descriptor, final Object value) {
+        if (value instanceof Map) {
+            validateNoRemovedModelFacingFieldMap(descriptor, (Map<?, ?>) value);
+        } else if (value instanceof Collection) {
+            for (Object each : (Collection<?>) value) {
+                validateNoRemovedModelFacingFields(descriptor, each);
+            }
+        }
+    }
+    
+    private static void validateNoRemovedModelFacingFieldMap(final MCPToolDescriptor descriptor, final Map<?, ?> value) {
+        for (Entry<?, ?> entry : value.entrySet()) {
+            String key = String.valueOf(entry.getKey());
+            validateNoRemovedModelFacingField(descriptor, key);
+            if ("required".equals(key)) {
+                validateNoRemovedModelFacingRequiredFields(descriptor, entry.getValue());
+            }
+            validateNoRemovedModelFacingFields(descriptor, entry.getValue());
+        }
+    }
+    
+    private static void validateNoRemovedModelFacingRequiredFields(final MCPToolDescriptor descriptor, final Object value) {
+        if (!(value instanceof Collection)) {
+            return;
+        }
+        for (Object each : (Collection<?>) value) {
+            validateNoRemovedModelFacingField(descriptor, String.valueOf(each));
+        }
+    }
+    
+    private static void validateNoRemovedModelFacingField(final MCPToolDescriptor descriptor, final String fieldName) {
+        ShardingSpherePreconditions.checkState(!REMOVED_MODEL_FACING_FIELDS.contains(fieldName),
+                () -> new IllegalStateException(String.format("Tool `%s` model-facing contract must use canonical fields instead of removed `%s`.", descriptor.getName(), fieldName)));
+    }
+    
+    private static void validateConcreteNextActions(final MCPToolDescriptor descriptor, final Object value) {
+        ShardingSpherePreconditions.checkState(value instanceof Collection,
+                () -> new IllegalStateException(String.format("Tool `%s` next_actions example must be an array.", descriptor.getName())));
+        for (Object each : (Collection<?>) value) {
+            ShardingSpherePreconditions.checkState(each instanceof Map,
+                    () -> new IllegalStateException(String.format("Tool `%s` next_actions example item must be an object.", descriptor.getName())));
+            validateConcreteNextAction(descriptor, (Map<?, ?>) each);
+        }
+    }
+    
+    private static void validateConcreteNextAction(final MCPToolDescriptor descriptor, final Map<?, ?> action) {
+        String type = String.valueOf(action.get("type"));
+        Collection<String> allowedFields = NEXT_ACTION_ALLOWED_FIELDS.get(type);
+        ShardingSpherePreconditions.checkState(null != allowedFields,
+                () -> new IllegalStateException(String.format("Tool `%s` next_actions example uses unknown type `%s`.", descriptor.getName(), type)));
+        for (Object each : action.keySet()) {
+            String fieldName = String.valueOf(each);
+            ShardingSpherePreconditions.checkState(allowedFields.contains(fieldName),
+                    () -> new IllegalStateException(String.format("Tool `%s` next_actions example `%s` contains unsupported field `%s`.", descriptor.getName(), type, fieldName)));
+        }
     }
     
     private static void validateModelCriticalOutputHints(final MCPToolDescriptor descriptor, final Map<?, ?> properties) {
@@ -253,6 +341,11 @@ final class MCPDescriptorCatalogValidator {
                     () -> new IllegalStateException(String.format("Tool `%s` next_actions item field `%s` must be an object.", descriptor.getName(), each)));
             Object description = ((Map<?, ?>) field).get("description");
             checkDescription(null == description ? "" : description.toString(), String.format("Tool next_actions item field `%s.%s` description", descriptor.getName(), each));
+        }
+        for (Object each : ((Map<?, ?>) properties).keySet()) {
+            String fieldName = String.valueOf(each);
+            ShardingSpherePreconditions.checkState(NEXT_ACTION_SCHEMA_ALLOWED_FIELDS.contains(fieldName),
+                    () -> new IllegalStateException(String.format("Tool `%s` next_actions item contains unsupported field `%s`.", descriptor.getName(), fieldName)));
         }
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPModelFirstContractPayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPModelFirstContractPayloadBuilder.java
@@ -98,14 +98,12 @@ final class MCPModelFirstContractPayloadBuilder {
     }
     
     Map<String, Object> createFieldNamingContract() {
-        Map<String, Object> result = new LinkedHashMap<>(6, 1F);
+        Map<String, Object> result = new LinkedHashMap<>(5, 1F);
         result.put("official_discovery_methods", List.of("tools/list", "resources/list", "resources/templates/list", "prompts/list"));
         result.put("argument_completion_method", ARGUMENT_COMPLETION_METHOD);
         result.put("catalog_fields", List.of("supportedResources", "supportedTools", "resourceTemplates", "completionTargets", "resourceNavigation", "protocolAvailability"));
         result.put("payload_fields", "ShardingSphere-owned structured payload fields use snake_case.");
         result.put("descriptor_fields", "Descriptor-derived MCP schema fields keep the protocol or JSON Schema field names required by MCP clients.");
-        result.put("alias_rule", "Do not assume camelCase and snake_case variants are aliases unless the same descriptor explicitly documents both.");
-        result.put("cleanup_rule", "Prefer one canonical ShardingSphere payload field over parallel compatibility aliases.");
         return result;
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/WorkflowFieldNames.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/WorkflowFieldNames.java
@@ -68,8 +68,6 @@ public final class WorkflowFieldNames {
     
     public static final String TABLE = "table";
     
-    public static final String USER_OVERRIDES = "user_overrides";
-    
     private WorkflowFieldNames() {
     }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowRequestBinder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowRequestBinder.java
@@ -51,7 +51,6 @@ public final class WorkflowRequestBinder {
         T result = requestSupplier.get();
         bindCommonPlanningFields(result, workflowPlanningArguments);
         applyObjectMap(arguments.get(WorkflowFieldNames.STRUCTURED_INTENT_EVIDENCE), WorkflowFieldNames.STRUCTURED_INTENT_EVIDENCE, actualValue -> structuredIntentBinder.accept(result, actualValue));
-        rejectUserOverrides(arguments);
         featureArgumentBinder.accept(result, workflowPlanningArguments);
         return result;
     }
@@ -86,12 +85,6 @@ public final class WorkflowRequestBinder {
         Map<String, Object> actualValue = getObjectMap(rawValue, name);
         if (!actualValue.isEmpty()) {
             consumer.accept(actualValue);
-        }
-    }
-    
-    private static void rejectUserOverrides(final Map<String, Object> arguments) {
-        if (arguments.containsKey(WorkflowFieldNames.USER_OVERRIDES)) {
-            throw new MCPInvalidRequestException("user_overrides is not supported. Use top-level workflow arguments instead.");
         }
     }
     

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/tool/request/RuntimeDatabaseValidationRequestTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/tool/request/RuntimeDatabaseValidationRequestTest.java
@@ -24,19 +24,17 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-class ProxyPreflightValidationRequestTest {
+class RuntimeDatabaseValidationRequestTest {
     
     @Test
     void assertFromPreservesDatabaseArgument() {
-        ProxyPreflightValidationRequest actual = ProxyPreflightValidationRequest.from(Map.of(
-                "jdbcUrl", " jdbc:mysql://127.0.0.1:3307/logic_db ",
-                "database", " logic_db "));
+        RuntimeDatabaseValidationRequest actual = RuntimeDatabaseValidationRequest.from(Map.of("database", " logic_db "));
         assertThat(actual.getDatabase(), is(" logic_db "));
     }
     
     @Test
     void assertFromDefaultsMissingDatabase() {
-        ProxyPreflightValidationRequest actual = ProxyPreflightValidationRequest.from(Map.of());
+        RuntimeDatabaseValidationRequest actual = RuntimeDatabaseValidationRequest.from(Map.of());
         assertThat(actual.getDatabase(), is(""));
     }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/tool/response/RuntimeDatabaseValidationCheckResultTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/tool/response/RuntimeDatabaseValidationCheckResultTest.java
@@ -24,11 +24,11 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-class ProxyPreflightCheckResultTest {
+class RuntimeDatabaseValidationCheckResultTest {
     
     @Test
     void assertPassed() {
-        ProxyPreflightCheckResult actual = ProxyPreflightCheckResult.passed("jdbc_connectivity", "Opened a JDBC connection.");
+        RuntimeDatabaseValidationCheckResult actual = RuntimeDatabaseValidationCheckResult.passed("jdbc_connectivity", "Opened a JDBC connection.");
         assertThat(actual.getName(), is("jdbc_connectivity"));
         assertThat(actual.getStatus(), is("passed"));
         assertThat(actual.getCategory(), is("ready"));
@@ -37,7 +37,7 @@ class ProxyPreflightCheckResultTest {
     
     @Test
     void assertFailed() {
-        ProxyPreflightCheckResult actual = ProxyPreflightCheckResult.failed("jdbc_driver", "missing_jdbc_driver", "Failed to load the configured JDBC driver.");
+        RuntimeDatabaseValidationCheckResult actual = RuntimeDatabaseValidationCheckResult.failed("jdbc_driver", "missing_jdbc_driver", "Failed to load the configured JDBC driver.");
         assertThat(actual.getName(), is("jdbc_driver"));
         assertThat(actual.getStatus(), is("failed"));
         assertThat(actual.getCategory(), is("missing_jdbc_driver"));
@@ -46,7 +46,7 @@ class ProxyPreflightCheckResultTest {
     
     @Test
     void assertSkipped() {
-        ProxyPreflightCheckResult actual = ProxyPreflightCheckResult.skipped("database_visibility", "Skipped because no database was provided.");
+        RuntimeDatabaseValidationCheckResult actual = RuntimeDatabaseValidationCheckResult.skipped("database_visibility", "Skipped because no database was provided.");
         assertThat(actual.getName(), is("database_visibility"));
         assertThat(actual.getStatus(), is("skipped"));
         assertThat(actual.getCategory(), is("skipped"));
@@ -55,7 +55,7 @@ class ProxyPreflightCheckResultTest {
     
     @Test
     void assertToPayload() {
-        Map<String, Object> actual = ProxyPreflightCheckResult.failed("metadata_read", "connection_failed", "Failed to read metadata.").toPayload();
+        Map<String, Object> actual = RuntimeDatabaseValidationCheckResult.failed("metadata_read", "connection_failed", "Failed to read metadata.").toPayload();
         assertThat(actual, is(Map.of(
                 "name", "metadata_read",
                 "status", "failed",

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/tool/response/RuntimeDatabaseValidationResultTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/tool/response/RuntimeDatabaseValidationResultTest.java
@@ -25,11 +25,11 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-class ProxyPreflightValidationResultTest {
+class RuntimeDatabaseValidationResultTest {
     
     @Test
     void assertReady() {
-        ProxyPreflightValidationResult actual = ProxyPreflightValidationResult.ready("logic_db", List.of(ProxyPreflightCheckResult.passed("configuration", "Validated the request.")));
+        RuntimeDatabaseValidationResult actual = RuntimeDatabaseValidationResult.ready("logic_db", List.of(RuntimeDatabaseValidationCheckResult.passed("configuration", "Validated the request.")));
         assertThat(actual.getStatus(), is("ready"));
         assertThat(actual.getDatabase(), is("logic_db"));
         assertThat(actual.getCategory(), is("ready"));
@@ -39,8 +39,8 @@ class ProxyPreflightValidationResultTest {
     @Test
     void assertFailed() {
         Map<String, Object> recovery = Map.of("category", "connection_failed");
-        ProxyPreflightValidationResult actual = ProxyPreflightValidationResult.failed("logic_db",
-                List.of(ProxyPreflightCheckResult.failed("jdbc_connectivity", "connection_failed", "Failed to open a JDBC connection.")), "connection_failed", recovery);
+        RuntimeDatabaseValidationResult actual = RuntimeDatabaseValidationResult.failed("logic_db",
+                List.of(RuntimeDatabaseValidationCheckResult.failed("jdbc_connectivity", "connection_failed", "Failed to open a JDBC connection.")), "connection_failed", recovery);
         assertThat(actual.getStatus(), is("failed"));
         assertThat(actual.getDatabase(), is("logic_db"));
         assertThat(actual.getCategory(), is("connection_failed"));
@@ -49,8 +49,8 @@ class ProxyPreflightValidationResultTest {
     
     @Test
     void assertToPayload() {
-        Map<String, Object> actual = ProxyPreflightValidationResult.failed("logic_db",
-                List.of(ProxyPreflightCheckResult.failed("metadata_read", "connection_failed", "Failed to read metadata.")),
+        Map<String, Object> actual = RuntimeDatabaseValidationResult.failed("logic_db",
+                List.of(RuntimeDatabaseValidationCheckResult.failed("metadata_read", "connection_failed", "Failed to read metadata.")),
                 "connection_failed", Map.of("category", "connection_failed")).toPayload();
         assertThat(actual.get("response_mode"), is("validation"));
         assertThat(actual.get("status"), is("failed"));

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/tool/service/RuntimeDatabaseValidationServiceTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/tool/service/RuntimeDatabaseValidationServiceTest.java
@@ -24,8 +24,8 @@ import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatab
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseProfile;
 import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPDatabaseMetadata;
 import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPSchemaMetadata;
-import org.apache.shardingsphere.mcp.support.database.tool.request.ProxyPreflightValidationRequest;
-import org.apache.shardingsphere.mcp.support.database.tool.response.ProxyPreflightValidationResult;
+import org.apache.shardingsphere.mcp.support.database.tool.request.RuntimeDatabaseValidationRequest;
+import org.apache.shardingsphere.mcp.support.database.tool.response.RuntimeDatabaseValidationResult;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -56,16 +56,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-class ProxyPreflightValidationServiceTest {
+class RuntimeDatabaseValidationServiceTest {
     
     @Test
     void assertValidateWithMissingDatabase() {
         MCPJdbcDatabaseProfileLoader profileLoader = mock(MCPJdbcDatabaseProfileLoader.class);
         MCPJdbcMetadataLoader metadataLoader = mock(MCPJdbcMetadataLoader.class);
-        ProxyPreflightValidationResult actual = new ProxyPreflightValidationService(profileLoader, metadataLoader)
-                .validate(new ProxyPreflightValidationRequest(""),
+        RuntimeDatabaseValidationResult actual = new RuntimeDatabaseValidationService(profileLoader, metadataLoader)
+                .validate(new RuntimeDatabaseValidationRequest(""),
                         ignored -> Optional.empty(),
-                        ProxyPreflightValidationServiceTest::createRecoveryPayload);
+                        RuntimeDatabaseValidationServiceTest::createRecoveryPayload);
         Map<String, Object> actualPayload = actual.toPayload();
         assertThat(actualPayload.get("status"), is("failed"));
         assertThat(actualPayload.get("category"), is("invalid_configuration"));
@@ -79,10 +79,10 @@ class ProxyPreflightValidationServiceTest {
     void assertValidateWithUnknownDatabase() {
         MCPJdbcDatabaseProfileLoader profileLoader = mock(MCPJdbcDatabaseProfileLoader.class);
         MCPJdbcMetadataLoader metadataLoader = mock(MCPJdbcMetadataLoader.class);
-        ProxyPreflightValidationResult actual = new ProxyPreflightValidationService(profileLoader, metadataLoader)
-                .validate(new ProxyPreflightValidationRequest("logic_db"),
+        RuntimeDatabaseValidationResult actual = new RuntimeDatabaseValidationService(profileLoader, metadataLoader)
+                .validate(new RuntimeDatabaseValidationRequest("logic_db"),
                         ignored -> Optional.empty(),
-                        ProxyPreflightValidationServiceTest::createRecoveryPayload);
+                        RuntimeDatabaseValidationServiceTest::createRecoveryPayload);
         Map<String, Object> actualPayload = actual.toPayload();
         assertThat(actualPayload.get("status"), is("failed"));
         assertThat(actualPayload.get("category"), is("invalid_configuration"));
@@ -97,10 +97,10 @@ class ProxyPreflightValidationServiceTest {
         RuntimeDatabaseConfiguration runtimeDatabaseConfig = createRuntimeDatabaseConfiguration();
         when(profileLoader.load(any(), any(RuntimeDatabaseConfiguration.class))).thenReturn(createProfile());
         when(metadataLoader.load(any(), any(RuntimeDatabaseConfiguration.class), any(RuntimeDatabaseProfile.class))).thenReturn(createMetadata("logic_db"));
-        ProxyPreflightValidationService service = new ProxyPreflightValidationService(profileLoader, metadataLoader);
-        ProxyPreflightValidationResult actual = service.validate(new ProxyPreflightValidationRequest("logic_db"),
+        RuntimeDatabaseValidationService service = new RuntimeDatabaseValidationService(profileLoader, metadataLoader);
+        RuntimeDatabaseValidationResult actual = service.validate(new RuntimeDatabaseValidationRequest("logic_db"),
                 ignored -> Optional.of(runtimeDatabaseConfig),
-                ProxyPreflightValidationServiceTest::createRecoveryPayload);
+                RuntimeDatabaseValidationServiceTest::createRecoveryPayload);
         Map<String, Object> actualPayload = actual.toPayload();
         assertThat(actualPayload.get("status"), is("ready"));
         ArgumentCaptor<RuntimeDatabaseConfiguration> configurationCaptor = ArgumentCaptor.forClass(RuntimeDatabaseConfiguration.class);
@@ -115,10 +115,10 @@ class ProxyPreflightValidationServiceTest {
         RuntimeDatabaseConfiguration runtimeDatabaseConfig = createRuntimeDatabaseConfiguration();
         when(profileLoader.load(any(), any(RuntimeDatabaseConfiguration.class))).thenReturn(createProfile());
         when(metadataLoader.load(any(), any(RuntimeDatabaseConfiguration.class), any(RuntimeDatabaseProfile.class))).thenReturn(createMetadata("logic_db"));
-        ProxyPreflightValidationResult actual = new ProxyPreflightValidationService(profileLoader, metadataLoader)
-                .validate(new ProxyPreflightValidationRequest("logic_db"),
+        RuntimeDatabaseValidationResult actual = new RuntimeDatabaseValidationService(profileLoader, metadataLoader)
+                .validate(new RuntimeDatabaseValidationRequest("logic_db"),
                         ignored -> Optional.of(runtimeDatabaseConfig),
-                        ProxyPreflightValidationServiceTest::createRecoveryPayload);
+                        RuntimeDatabaseValidationServiceTest::createRecoveryPayload);
         Map<String, Object> actualPayload = actual.toPayload();
         assertThat(actualPayload.get("status"), is("ready"));
         assertThat(((Map<?, ?>) ((List<?>) actualPayload.get("checks")).get(4)).get("status"), is("passed"));
@@ -131,10 +131,10 @@ class ProxyPreflightValidationServiceTest {
         RuntimeDatabaseConfiguration runtimeDatabaseConfig = new RuntimeDatabaseConfiguration("MySQL", InvisibleDatabaseDriver.JDBC_URL, "demo", "", InvisibleDatabaseDriver.class.getName());
         when(profileLoader.load(any(), any(RuntimeDatabaseConfiguration.class))).thenReturn(createProfile());
         when(metadataLoader.load(any(), any(RuntimeDatabaseConfiguration.class), any(RuntimeDatabaseProfile.class))).thenReturn(createMetadata("public"));
-        ProxyPreflightValidationResult actual = new ProxyPreflightValidationService(profileLoader, metadataLoader)
-                .validate(new ProxyPreflightValidationRequest("logic_db"),
+        RuntimeDatabaseValidationResult actual = new RuntimeDatabaseValidationService(profileLoader, metadataLoader)
+                .validate(new RuntimeDatabaseValidationRequest("logic_db"),
                         ignored -> Optional.of(runtimeDatabaseConfig),
-                        ProxyPreflightValidationServiceTest::createRecoveryPayload);
+                        RuntimeDatabaseValidationServiceTest::createRecoveryPayload);
         Map<String, Object> actualPayload = actual.toPayload();
         assertThat(actualPayload.get("status"), is("failed"));
         assertThat(actualPayload.get("category"), is(RuntimeDatabaseConnectionException.CATEGORY_DATABASE_NOT_VISIBLE));
@@ -150,10 +150,10 @@ class ProxyPreflightValidationServiceTest {
         when(profileLoader.load(any(), any(RuntimeDatabaseConfiguration.class))).thenReturn(createProfile());
         when(metadataLoader.load(any(), any(RuntimeDatabaseConfiguration.class), any(RuntimeDatabaseProfile.class)))
                 .thenThrow(RuntimeDatabaseConnectionException.connectionFailed("logic_db", new SQLException("Broken connection")));
-        ProxyPreflightValidationResult actual = new ProxyPreflightValidationService(profileLoader, metadataLoader)
-                .validate(new ProxyPreflightValidationRequest("logic_db"),
+        RuntimeDatabaseValidationResult actual = new RuntimeDatabaseValidationService(profileLoader, metadataLoader)
+                .validate(new RuntimeDatabaseValidationRequest("logic_db"),
                         ignored -> Optional.of(runtimeDatabaseConfig),
-                        ProxyPreflightValidationServiceTest::createRecoveryPayload);
+                        RuntimeDatabaseValidationServiceTest::createRecoveryPayload);
         Map<String, Object> actualPayload = actual.toPayload();
         assertThat(actualPayload.get("status"), is("failed"));
         assertThat(actualPayload.get("category"), is(RuntimeDatabaseConnectionException.CATEGORY_CONNECTION_FAILED));
@@ -169,10 +169,10 @@ class ProxyPreflightValidationServiceTest {
         MCPJdbcMetadataLoader metadataLoader = mock(MCPJdbcMetadataLoader.class);
         RuntimeDatabaseConfiguration runtimeDatabaseConfig = createRuntimeDatabaseConfiguration();
         when(profileLoader.load(any(), any(RuntimeDatabaseConfiguration.class))).thenThrow(cause);
-        ProxyPreflightValidationResult actual = new ProxyPreflightValidationService(profileLoader, metadataLoader)
-                .validate(new ProxyPreflightValidationRequest("logic_db"),
+        RuntimeDatabaseValidationResult actual = new RuntimeDatabaseValidationService(profileLoader, metadataLoader)
+                .validate(new RuntimeDatabaseValidationRequest("logic_db"),
                         ignored -> Optional.of(runtimeDatabaseConfig),
-                        ProxyPreflightValidationServiceTest::createRecoveryPayload);
+                        RuntimeDatabaseValidationServiceTest::createRecoveryPayload);
         Map<String, Object> actualPayload = actual.toPayload();
         List<?> checks = (List<?>) actualPayload.get("checks");
         assertThat(actualPayload.get("status"), is("failed"));
@@ -216,7 +216,7 @@ class ProxyPreflightValidationServiceTest {
     
     private static final class InvisibleDatabaseDriver implements Driver {
         
-        private static final String JDBC_URL = "jdbc:preflight:invisible";
+        private static final String JDBC_URL = "jdbc:runtime-validation:invisible";
         
         private static final InvisibleDatabaseDriver INSTANCE = new InvisibleDatabaseDriver();
         

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogLoaderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogLoaderTest.java
@@ -51,7 +51,6 @@ class MCPDescriptorCatalogLoaderTest {
         assertPublicToolAnnotations(actual);
         assertPlanningToolAnnotations(actual);
         assertResourceDescriptor(actual);
-        assertNoBannedPublicAliasFields(actual);
         assertNoResponseFormatOptions(actual);
         assertNoToolExecutionPayload(actual);
     }
@@ -61,7 +60,6 @@ class MCPDescriptorCatalogLoaderTest {
         MCPDescriptorCatalog catalog = MCPDescriptorCatalogLoader.load();
         MCPToolDescriptor actual = findTool(catalog, "database_gateway_apply_workflow");
         assertThat(findInputProperty(actual, "execution_mode").get("enum"), is(List.of("preview", "review-then-execute", "manual-only")));
-        assertFalse(hasInputProperty(actual, "approved_by_user"));
     }
     
     @Test
@@ -140,11 +138,6 @@ class MCPDescriptorCatalogLoaderTest {
         return (Map<?, ?>) ((Map<?, ?>) properties).get(fieldName);
     }
     
-    private boolean hasInputProperty(final MCPToolDescriptor toolDescriptor, final String fieldName) {
-        Object properties = toolDescriptor.getInputSchema().get("properties");
-        return ((Map<?, ?>) properties).containsKey(fieldName);
-    }
-    
     private void assertResourceDescriptor(final MCPDescriptorCatalog catalog) {
         ShardingSphereMCPResourceMetadata metadata = findShardingSphereResourceMetadata(catalog, "shardingsphere://workflows/{plan_id}");
         assertThat(metadata.getResourceKind(), is("detail"));
@@ -154,12 +147,6 @@ class MCPDescriptorCatalogLoaderTest {
         assertThat(actual.getMeta().get(MCPShardingSphereMetadataKeys.RESOURCE_KIND), is("detail"));
         assertThat(actual.getMeta().get(MCPShardingSphereMetadataKeys.RELATED_TOOLS), is(List.of("database_gateway_validate_workflow", "database_gateway_apply_workflow")));
         assertThat(findShardingSphereResourceMetadata(catalog, "shardingsphere://workflow/test-resource").getResourceKind(), is("detail"));
-    }
-    
-    private void assertNoBannedPublicAliasFields(final MCPDescriptorCatalog catalog) {
-        for (MCPToolDescriptor each : catalog.getToolDescriptors()) {
-            assertFalse(containsBannedPublicAliasField(each.getOutputSchema()));
-        }
     }
     
     private void assertNoResponseFormatOptions(final MCPDescriptorCatalog catalog) {
@@ -174,33 +161,6 @@ class MCPDescriptorCatalogLoaderTest {
         for (Object each : (List<?>) payload.get("tools")) {
             assertFalse(((Map<?, ?>) each).containsKey("execution"));
         }
-    }
-    
-    private boolean containsBannedPublicAliasField(final Object value) {
-        if (value instanceof Map) {
-            return containsBannedPublicAliasFieldMap((Map<?, ?>) value);
-        }
-        if (value instanceof Iterable) {
-            for (Object each : (Iterable<?>) value) {
-                if (containsBannedPublicAliasField(each)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-    
-    private boolean containsBannedPublicAliasFieldMap(final Map<?, ?> value) {
-        if (value.containsKey("recommended_next_tool") || value.containsKey("suggested_next_tool") || value.containsKey("suggested_next_tools")
-                || value.containsKey("recommended_recovery") || value.containsKey("suggested_next_action")) {
-            return true;
-        }
-        for (Object each : value.values()) {
-            if (containsBannedPublicAliasField(each)) {
-                return true;
-            }
-        }
-        return false;
     }
     
     private boolean containsResponseFormatOption(final Object value) {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidatorTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidatorTest.java
@@ -51,6 +51,50 @@ class MCPDescriptorCatalogValidatorTest {
     }
     
     @Test
+    void assertValidateRejectsRemovedModelFacingOutputField() {
+        assertValidationError(createCatalog(List.of(), List.of(createToolDescriptor(
+                "database_gateway_test_tool", new MCPToolAnnotations("Test Tool", true, false, true, true),
+                createOutputSchema(Map.of("recommended_next_tool", Map.of("type", "string", "description", "Removed alias.")))))),
+                "Tool `database_gateway_test_tool` model-facing contract must use canonical fields instead of removed `recommended_next_tool`.");
+    }
+    
+    @Test
+    void assertValidateRejectsRemovedModelFacingInputField() {
+        assertValidationError(createCatalog(List.of(), List.of(new MCPToolDescriptor(
+                "database_gateway_test_tool", "Test Tool", "Run a test tool.",
+                createInputSchema(Map.of("query", Map.of("type", "string", "description", "Query."),
+                        "user_overrides", Map.of("type", "object", "description", "Removed duplicate input."))),
+                createOutputSchema(), new MCPToolAnnotations("Test Tool", true, false, true, true), Map.of()))),
+                "Tool `database_gateway_test_tool` model-facing contract must use canonical fields instead of removed `user_overrides`.");
+    }
+    
+    @Test
+    void assertValidateRejectsRemovedModelFacingRequiredInputField() {
+        assertValidationError(createCatalog(List.of(), List.of(new MCPToolDescriptor(
+                "database_gateway_test_tool", "Test Tool", "Run a test tool.",
+                createInputSchema(Map.of("query", Map.of("type", "string", "description", "Query.")), List.of("query", "required_arguments")),
+                createOutputSchema(), new MCPToolAnnotations("Test Tool", true, false, true, true), Map.of()))),
+                "Tool `database_gateway_test_tool` model-facing contract must use canonical fields instead of removed `required_arguments`.");
+    }
+    
+    @Test
+    void assertValidateRejectsUnsupportedNextActionSchemaField() {
+        assertValidationError(createCatalog(List.of(), List.of(createToolDescriptor(
+                "database_gateway_test_tool", new MCPToolAnnotations("Test Tool", true, false, true, true),
+                createOutputSchema(Map.of("next_actions", createNextActionsSchema("extra_context")))))),
+                "Tool `database_gateway_test_tool` next_actions item contains unsupported field `extra_context`.");
+    }
+    
+    @Test
+    void assertValidateRejectsUnsupportedNextActionExampleField() {
+        assertValidationError(createCatalog(List.of(), List.of(createToolDescriptor(
+                "database_gateway_test_tool", new MCPToolAnnotations("Test Tool", true, false, true, true),
+                createOutputSchema(Map.of("next_actions", createNextActionsSchema()), List.of(Map.of("next_actions", List.of(
+                        Map.of("order", 1, "type", "tool_call", "title", "Retry", "tool_name", "database_gateway_test_tool", "arguments", Map.of(), "extra_context", "bad")))))))),
+                "Tool `database_gateway_test_tool` next_actions example `tool_call` contains unsupported field `extra_context`.");
+    }
+    
+    @Test
     void assertValidateRejectsFeatureOwnedToolDescriptor() {
         assertValidationError(createCatalog(List.of(), List.of(createToolDescriptor(
                 "database_gateway_extension_test_tool", new MCPToolAnnotations("Extension Tool", true, false, true, true), createOutputSchema()))),
@@ -154,7 +198,11 @@ class MCPDescriptorCatalogValidatorTest {
     }
     
     private Map<String, Object> createInputSchema(final Map<String, Object> properties) {
-        return Map.of("type", "object", "properties", properties, "required", List.of("query"), "additionalProperties", false);
+        return createInputSchema(properties, List.of("query"));
+    }
+    
+    private Map<String, Object> createInputSchema(final Map<String, Object> properties, final List<String> requiredFields) {
+        return Map.of("type", "object", "properties", properties, "required", requiredFields, "additionalProperties", false);
     }
     
     private Map<String, Object> createOutputSchema() {
@@ -163,5 +211,26 @@ class MCPDescriptorCatalogValidatorTest {
     
     private Map<String, Object> createOutputSchema(final Map<String, Object> properties) {
         return Map.of("type", "object", "properties", properties, "examples", List.of(Map.of("status", "ok")));
+    }
+    
+    private Map<String, Object> createOutputSchema(final Map<String, Object> properties, final List<Map<String, Object>> examples) {
+        return Map.of("type", "object", "properties", properties, "examples", examples);
+    }
+    
+    private Map<String, Object> createNextActionsSchema() {
+        return createNextActionsSchema("");
+    }
+    
+    private Map<String, Object> createNextActionsSchema(final String additionalFieldName) {
+        Map<String, Object> actionProperties = new LinkedHashMap<>();
+        actionProperties.put("order", Map.of("type", "integer", "description", "1-based action order."));
+        actionProperties.put("type", Map.of("type", "string", "description", "Canonical action type."));
+        actionProperties.put("title", Map.of("type", "string", "description", "Action title."));
+        actionProperties.put("tool_name", Map.of("type", "string", "description", "Canonical tool name."));
+        actionProperties.put("arguments", Map.of("type", "object", "description", "Canonical tool arguments."));
+        if (!additionalFieldName.isEmpty()) {
+            actionProperties.put(additionalFieldName, Map.of("type", "string", "description", "Unsupported field."));
+        }
+        return Map.of("type", "array", "description", "Structured follow-up actions.", "items", Map.of("type", "object", "properties", actionProperties));
     }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidatorTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidatorTest.java
@@ -51,24 +51,6 @@ class MCPDescriptorCatalogValidatorTest {
     }
     
     @Test
-    void assertValidateRejectsPublicAliasOutputField() {
-        assertValidationError(createCatalog(List.of(), List.of(createToolDescriptor(
-                "database_gateway_test_tool", new MCPToolAnnotations("Test Tool", true, false, true, true),
-                createOutputSchema(Map.of("recommended_next_tool", Map.of("type", "string", "description", "Removed alias.")))))),
-                "Tool `database_gateway_test_tool` outputSchema must use canonical fields instead of banned `recommended_next_tool`.");
-    }
-    
-    @Test
-    void assertValidateRejectsPublicUserOverridesInputField() {
-        assertValidationError(createCatalog(List.of(), List.of(new MCPToolDescriptor(
-                "database_gateway_test_tool", "Test Tool", "Run a test tool.",
-                createInputSchema(Map.of("query", Map.of("type", "string", "description", "Query."),
-                        "user_overrides", Map.of("type", "object", "description", "Removed duplicate input."))),
-                createOutputSchema(), new MCPToolAnnotations("Test Tool", true, false, true, true), Map.of()))),
-                "Tool `database_gateway_test_tool` inputSchema must use canonical fields instead of banned `user_overrides`.");
-    }
-    
-    @Test
     void assertValidateRejectsFeatureOwnedToolDescriptor() {
         assertValidationError(createCatalog(List.of(), List.of(createToolDescriptor(
                 "database_gateway_extension_test_tool", new MCPToolAnnotations("Extension Tool", true, false, true, true), createOutputSchema()))),

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPModelFirstContractPayloadBuilderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPModelFirstContractPayloadBuilderTest.java
@@ -69,12 +69,9 @@ class MCPModelFirstContractPayloadBuilderTest {
         assertThat(actual.size(), is(5));
         Map<?, ?> actualToolCall = findByType(actual, "tool_call");
         assertTrue(((Collection<?>) actualToolCall.get("required_fields")).contains("tool_name"));
-        assertFalse(((Collection<?>) actualToolCall.get("required_fields")).contains("requires_user_approval"));
         Map<?, ?> actualCompletion = findByType(actual, "completion");
         assertTrue(((Collection<?>) actualCompletion.get("required_fields")).contains("ref"));
         assertTrue(((Collection<?>) actualCompletion.get("required_fields")).contains("argument"));
-        assertFalse(((Collection<?>) actualCompletion.get("required_fields")).contains("reference_type"));
-        assertFalse(((Collection<?>) actualCompletion.get("required_fields")).contains("argument_name"));
         assertTrue(((Collection<?>) actualCompletion.get("optional_fields")).contains("resume_ref"));
         assertTrue(((Collection<?>) actualCompletion.get("optional_fields")).contains("resume_arguments"));
     }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/protocol/MCPNextActionUtilsTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/protocol/MCPNextActionUtilsTest.java
@@ -37,8 +37,6 @@ class MCPNextActionUtilsTest {
         assertThat(actual.get("title"), is("Read resource"));
         assertThat(actual.get("resource_uri"), is("shardingsphere://capabilities"));
         assertThat(actual.get("reason"), is("Read capabilities."));
-        assertFalse(actual.containsKey("requires_user_approval"));
-        assertNoRemovedAliases(actual);
     }
     
     @Test
@@ -49,8 +47,6 @@ class MCPNextActionUtilsTest {
         assertThat(actual.get("title"), is("Call database_gateway_search_metadata"));
         assertThat(actual.get("tool_name"), is("database_gateway_search_metadata"));
         assertThat(actual.get("arguments"), is(Map.of("query", "orders")));
-        assertFalse(actual.containsKey("requires_user_approval"));
-        assertNoRemovedAliases(actual);
     }
     
     @Test
@@ -60,8 +56,6 @@ class MCPNextActionUtilsTest {
         assertThat(actual.get("title"), is("Retry database_gateway_execute_update"));
         assertThat(actual.get("tool_name"), is("database_gateway_execute_update"));
         assertThat(actual.get("arguments"), is(Map.of("execution_mode", "preview")));
-        assertFalse(actual.containsKey("requires_user_approval"));
-        assertNoRemovedAliases(actual);
     }
     
     @Test
@@ -81,8 +75,6 @@ class MCPNextActionUtilsTest {
         assertThat(actual.get("missing_context_arguments"), is(List.of("table")));
         assertThat(actual.get("resume_ref"), is(Map.of("type", "tool", "name", "database_gateway_search_metadata")));
         assertThat(actual.get("resume_arguments"), is(Map.of("query", "orders")));
-        assertFalse(actual.containsKey("requires_user_approval"));
-        assertNoRemovedAliases(actual);
     }
     
     @Test
@@ -101,7 +93,6 @@ class MCPNextActionUtilsTest {
         assertFalse(actual.containsKey("context"));
         assertFalse(actual.containsKey("resume_ref"));
         assertFalse(actual.containsKey("resume_arguments"));
-        assertNoRemovedAliases(actual);
     }
     
     @Test
@@ -111,8 +102,6 @@ class MCPNextActionUtilsTest {
         assertThat(actual.get("title"), is("Ask user"));
         assertThat(actual.get("question"), is("Choose execution mode."));
         assertThat(actual.get("required_inputs"), is(List.of("execution_mode")));
-        assertFalse(actual.containsKey("requires_user_approval"));
-        assertNoRemovedAliases(actual);
     }
     
     @Test
@@ -121,8 +110,6 @@ class MCPNextActionUtilsTest {
         assertThat(actual.get("type"), is("terminal"));
         assertThat(actual.get("title"), is("Stop"));
         assertThat(actual.get("reason"), is("Done."));
-        assertFalse(actual.containsKey("requires_user_approval"));
-        assertNoRemovedAliases(actual);
     }
     
     @Test
@@ -140,20 +127,5 @@ class MCPNextActionUtilsTest {
         Map<String, Object> actual = MCPNextActionUtils.dependsOn(action, 1);
         assertThat(actual.get("depends_on"), is(List.of(1)));
         assertFalse(action.containsKey("depends_on"));
-    }
-    
-    private void assertNoRemovedAliases(final Map<String, Object> action) {
-        assertFalse(action.containsKey("target_tool"));
-        assertFalse(action.containsKey("target_resource"));
-        assertFalse(action.containsKey("required_arguments"));
-        assertFalse(action.containsKey("action_kind"));
-        assertFalse(action.containsKey("reference_type"));
-        assertFalse(action.containsKey("reference"));
-        assertFalse(action.containsKey("argument_name"));
-        assertFalse(action.containsKey("argument_value"));
-        assertFalse(action.containsKey("argument_prefix"));
-        assertFalse(action.containsKey("context_arguments"));
-        assertFalse(action.containsKey("resume_target_type"));
-        assertFalse(action.containsKey("resume_target"));
     }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanPayloadBuilderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanPayloadBuilderTest.java
@@ -86,7 +86,6 @@ class WorkflowPlanPayloadBuilderTest {
         assertThat(actualReviewFocus.get("artifact_categories"), is(List.of("algorithm_properties")));
         assertThat(actualReviewFocus.get("side_effect_scope"), is(List.of()));
         assertFalse((Boolean) actualReviewFocus.get("manual_only"));
-        assertFalse(actualReviewFocus.containsKey("requires_user_approval"));
         assertThat(actualReviewFocus.get("next_review_action"), is("answer_clarification_questions"));
         List<?> actualClarificationQuestions = (List<?>) actual.get("clarification_questions");
         assertThat(((Map<?, ?>) actualClarificationQuestions.getFirst()).get("input_type"), is("boolean"));
@@ -94,8 +93,6 @@ class WorkflowPlanPayloadBuilderTest {
         assertThat(((Map<?, ?>) actualClarificationQuestions.getFirst()).get("display_message"), is("Do you need LIKE query?"));
         assertThat(((Map<?, ?>) actualClarificationQuestions.get(1)).get("input_type"), is("secret"));
         assertTrue((Boolean) ((Map<?, ?>) actualClarificationQuestions.get(1)).get("secret"));
-        assertFalse(actual.containsKey("recommended_next_tool"));
-        assertFalse(actual.containsKey("requires_user_approval"));
         assertThat(((Map<?, ?>) actual.get("proxy_topology_hint")).get("expected_runtime_view"), is("proxy_rule_distsql"));
         assertTrue(extractResourceUris((List<?>) actual.get("resources_to_read")).contains("shardingsphere://features/encrypt/algorithms"));
         assertThat(((Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst()).get("type"), is("ask_user"));
@@ -169,15 +166,11 @@ class WorkflowPlanPayloadBuilderTest {
         assertTrue(actualResourceUris.contains("shardingsphere://features/mask/databases/logic_db/tables/orders/rules"));
         assertFalse(actualResourceUris.contains("shardingsphere://databases/logic_db/schemas/public/tables/orders/columns"));
         assertFalse(actualResourceUris.contains("shardingsphere://databases/logic_db/schemas/public/tables/orders/indexes"));
-        assertFalse(actual.containsKey("recommended_next_tool"));
-        assertFalse(actual.containsKey("requires_user_approval"));
         Map<?, ?> actualReviewFocus = (Map<?, ?>) actual.get("review_focus");
-        assertFalse(actualReviewFocus.containsKey("requires_user_approval"));
         assertThat(actualReviewFocus.get("next_review_action"), is("call_database_gateway_apply_workflow_preview"));
         Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_apply_workflow"));
         assertThat(((Map<?, ?>) actualNextAction.get("arguments")).get("execution_mode"), is("preview"));
-        assertFalse(actualNextAction.containsKey("requires_user_approval"));
     }
     
     @Test
@@ -325,12 +318,10 @@ class WorkflowPlanPayloadBuilderTest {
         Map<String, Object> actual = WorkflowPlanPayloadBuilder.build(snapshot);
         Map<?, ?> actualReviewFocus = (Map<?, ?>) actual.get("review_focus");
         assertTrue((Boolean) actualReviewFocus.get("manual_only"));
-        assertFalse(actualReviewFocus.containsKey("requires_user_approval"));
         assertThat(((Map<?, ?>) actual.get("argument_provenance")).get("execution_mode"), is("inferred_from_intent"));
         Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_apply_workflow"));
         assertThat(((Map<?, ?>) actualNextAction.get("arguments")).get("execution_mode"), is("preview"));
-        assertFalse(actualNextAction.containsKey("requires_user_approval"));
     }
     
     @Test
@@ -346,7 +337,6 @@ class WorkflowPlanPayloadBuilderTest {
         Map<String, Object> actual = WorkflowPlanPayloadBuilder.build(snapshot);
         Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
         assertThat(actual.get("response_mode"), is("terminal"));
-        assertFalse(actual.containsKey("recommended_next_tool"));
         assertThat(actualNextAction.get("type"), is("tool_call"));
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_plan_encrypt_rule"));
     }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowRequestBinderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowRequestBinderTest.java
@@ -80,15 +80,6 @@ class WorkflowRequestBinderTest {
     }
     
     @Test
-    void assertBindPlanningRequestRejectsUserOverrides() {
-        MCPInvalidRequestException actual = assertThrows(MCPInvalidRequestException.class,
-                () -> WorkflowRequestBinder.bindPlanningRequest(Map.of("user_overrides", Map.of("algorithm_type", "MD5")),
-                        (request, workflowPlanningArguments) -> request.setAlgorithmType(workflowPlanningArguments.getStringArgument("algorithm_type")),
-                        (request, structuredIntentEvidence) -> request.setFieldSemantics(String.valueOf(structuredIntentEvidence.get("field_semantics")))));
-        assertThat(actual.getMessage(), is("user_overrides is not supported. Use top-level workflow arguments instead."));
-    }
-    
-    @Test
     void assertBindPlanningRequestRejectsInvalidStructuredIntentEvidence() {
         MCPInvalidRequestException actual = assertThrows(MCPInvalidRequestException.class, () -> WorkflowRequestBinder.bindPlanningRequest(Map.of(
                 "database", "logic_db",

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowValidationSupportTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowValidationSupportTest.java
@@ -61,7 +61,6 @@ class WorkflowValidationSupportTest {
         assertThat(actualResult.get("status"), is("failed"));
         assertThat(actualResult.get("plan_id"), is("plan-1"));
         assertThat(actualResult.get("recovery_guidance"), is("Continue the workflow from the same session that created the plan."));
-        assertFalse(actualResult.containsKey("requires_user_approval"));
         assertThat(((Map<?, ?>) ((List<?>) actualResult.get("issues")).get(0)).get("code"), is(WorkflowIssueCode.SESSION_OWNERSHIP_MISMATCH));
     }
     
@@ -230,11 +229,8 @@ class WorkflowValidationSupportTest {
         assertThat(actualResult.get("status"), is("validated"));
         assertThat(actualResult.get("plan_id"), is("plan-1"));
         assertThat(actualResult.get("recovery_guidance"), is(""));
-        assertFalse(actualResult.containsKey("recommended_recovery"));
-        assertFalse(actualResult.containsKey("recommended_next_tool"));
         List<?> actualNextActions = (List<?>) actualResult.get("next_actions");
         assertThat(((Map<?, ?>) actualNextActions.get(0)).get("type"), is("terminal"));
-        assertFalse(((Map<?, ?>) actualNextActions.get(0)).containsKey("requires_user_approval"));
         assertThat(workflowSessionContext.getRequired("plan-1").getStatus(), is("validated"));
         assertThat(workflowSessionContext.getRequired("plan-1").getInteractionPlan().getCurrentStep(), is("validated"));
     }
@@ -269,7 +265,6 @@ class WorkflowValidationSupportTest {
         workflowSessionContext.save(snapshot);
         Map<String, Object> actualResult = validationSupport.finalizeValidation(workflowSessionContext, snapshot, validationReport);
         List<?> actualNextActions = (List<?>) actualResult.get("next_actions");
-        assertFalse(actualResult.containsKey("recommended_next_tool"));
         assertThat(((Map<?, ?>) actualNextActions.get(0)).get("tool_name"), is("database_gateway_plan_encrypt_rule"));
     }
     
@@ -286,10 +281,8 @@ class WorkflowValidationSupportTest {
         Map<String, Object> actualResult = validationSupport.finalizeValidation(workflowSessionContext, snapshot, validationReport);
         Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualResult.get("next_actions")).get(0);
         assertThat(actualResult.get("recovery_guidance"), is("Manual-only artifacts are exported but not executed by MCP. Execute them manually, then run database_gateway_validate_workflow again."));
-        assertFalse(actualResult.containsKey("requires_user_approval"));
         assertThat(actualNextAction.get("type"), is("ask_user"));
         assertThat(actualNextAction.get("required_inputs"), is(List.of("manual_artifacts_executed")));
-        assertFalse(actualNextAction.containsKey("requires_user_approval"));
         assertFalse(actualNextAction.containsKey("tool_name"));
     }
     
@@ -302,7 +295,6 @@ class WorkflowValidationSupportTest {
         assertThat(actualMismatch.get("actual"), is("actual"));
         assertThat(actualMismatch.get("impact"), is("impact"));
         assertThat(actualMismatch.get("remediation"), is("fix it"));
-        assertFalse(actualMismatch.containsKey("suggested_next_action"));
     }
     
     private WorkflowContextSnapshot createSnapshot() {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPActionExecutorTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPActionExecutorTest.java
@@ -95,12 +95,6 @@ class LLMMCPActionExecutorTest {
     }
     
     @Test
-    void assertExecuteSafelyRejectsLegacyCompletionArguments() {
-        assertThrows(IllegalArgumentException.class, () -> new LLMMCPActionExecutor(new FakeMCPInteractionClient()).executeSafely(
-                MCPInteractionActionNames.COMPLETE, Map.of("reference_type", "resource", "resource_uri", "shardingsphere://databases", "argument_name", "uri")));
-    }
-    
-    @Test
     void assertExecuteSafelyRejectsUnsupportedCompletionReferenceType() {
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class, () -> new LLMMCPActionExecutor(new FakeMCPInteractionClient()).executeSafely(
                 MCPInteractionActionNames.COMPLETE, Map.of("ref", Map.of("type", "REF/PROMPT", "name", "inspect_metadata"), "argument", Map.of("name", "schema"))));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunnerNextActionTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunnerNextActionTest.java
@@ -98,22 +98,6 @@ class LLMMCPConversationRunnerNextActionTest extends AbstractLLMMCPConversationR
     }
     
     @Test
-    void assertRunRejectsLegacyCompletionArguments() throws IOException, InterruptedException {
-        LLME2EScenario actualScenario = createScenario(List.of(MCPInteractionActionNames.COMPLETE, "database_gateway_execute_query"));
-        LLMMCPConversationRunner actualRunner = createRunner(3);
-        Map<String, Object> completionReference = Map.of("type", "ref/prompt", "name", PROMPT_NAME);
-        when(getLLMChatClient().complete(anyList(), anyList(), eq("required"), eq(false))).thenReturn(
-                createToolCallCompletion("tool-1", MCPInteractionActionNames.COMPLETE, Map.of("reference", completionReference, "argument_name", "schema"), "completion-response"));
-        
-        LLME2EArtifactBundle actual = actualRunner.run(actualScenario);
-        
-        assertFalse(actual.getAssertionReport().isSuccess());
-        assertThat(actual.getAssertionReport().getFailureType(), is("invalid_tool_arguments"));
-        assertThat(actual.getInteractionTrace().size(), is(1));
-        verify(getMCPInteractionClient(), never()).complete(completionReference, "schema", "", Map.of());
-    }
-    
-    @Test
     void assertRunPromptsImmediateCompletionNextAction() throws IOException, InterruptedException {
         LLME2EScenario actualScenario = createScenario(List.of(MCPInteractionActionNames.GET_PROMPT, MCPInteractionActionNames.COMPLETE, "database_gateway_execute_query"));
         LLMMCPConversationRunner actualRunner = createRunner(5);

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/scenario/LLMStructuredAnswer.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/scenario/LLMStructuredAnswer.java
@@ -90,9 +90,6 @@ public final class LLMStructuredAnswer {
     
     private static List<String> createInteractionSequence(final Map<String, Object> payload) {
         List<String> result = new LinkedList<>();
-        if (payload.containsKey("toolSequence")) {
-            throw new IllegalArgumentException("toolSequence is not supported. Use interactionSequence.");
-        }
         Object rawInteractionSequence = payload.get("interactionSequence");
         if (null == rawInteractionSequence) {
             return result;

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/scenario/LLMStructuredAnswerTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/scenario/LLMStructuredAnswerTest.java
@@ -53,13 +53,6 @@ class LLMStructuredAnswerTest {
     }
     
     @Test
-    void assertFromJsonRejectsLegacyToolSequence() {
-        assertThrows(IllegalArgumentException.class, () -> LLMStructuredAnswer.fromJson("""
-                {"database":"logic_db","schema":"public","table":"orders","query":"SELECT 1","totalOrders":"2","toolSequence":["database_gateway_execute_query"]}
-                """));
-    }
-    
-    @Test
     void assertFromJsonRejectsObjectInteractionSequenceEntries() {
         assertThrows(IllegalArgumentException.class, () -> LLMStructuredAnswer.fromJson("""
                 {"database":"logic_db","schema":"public","table":"orders","query":"SELECT 1","totalOrders":"2","interactionSequence":[{"tool":"database_gateway_execute_query"}]}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/LLMUsabilitySuiteRunner.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/LLMUsabilitySuiteRunner.java
@@ -209,8 +209,6 @@ final class LLMUsabilitySuiteRunner {
             assertFalse(each.getActionOrigin().isBlank(), () -> "Trace action origin is blank in " + evaluatedScenario.scenario().getScenarioId());
             assertTrue(KNOWN_ACTION_ORIGINS.contains(each.getActionOrigin()), () -> "Unknown trace action origin in " + evaluatedScenario.scenario().getScenarioId());
             assertFalse(each.getTargetName().isBlank(), () -> "Trace target name is blank in " + evaluatedScenario.scenario().getScenarioId());
-            MCPModelContractAssertions.assertNoBannedPublicFields(each.getArguments());
-            MCPModelContractAssertions.assertNoBannedPublicFields(each.getStructuredContent());
             MCPModelContractAssertions.assertCanonicalNextActionLists(each.getStructuredContent());
         }
     }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionMySQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionMySQLRuntimeE2ETest.java
@@ -332,7 +332,6 @@ abstract class AbstractProductionMySQLRuntimeE2ETest extends AbstractTransportPa
         assertFalse((Boolean) actual.get("would_execute"));
         List<Map<String, Object>> nextActions = getMapList(actual.get("next_actions"));
         assertThat(nextActions.stream().map(each -> String.valueOf(each.get("type"))).toList(), is(List.of("tool_call")));
-        assertFalse(nextActions.getFirst().containsKey("requires_user_approval"));
     }
     
     protected void assertAiNativeSqlResult(final MCPInteractionClient interactionClient) throws IOException, InterruptedException {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyFeatureWorkflowContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyFeatureWorkflowContractE2ETest.java
@@ -149,7 +149,6 @@ class HttpProductionProxyFeatureWorkflowContractE2ETest extends AbstractProducti
     }
     
     private void assertModelFacingPayloadContract(final Map<String, Object> payload) {
-        MCPModelContractAssertions.assertNoBannedPublicFields(payload);
         MCPModelContractAssertions.assertCanonicalNextActionLists(payload);
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/FeatureWorkflowContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/FeatureWorkflowContractE2ETest.java
@@ -114,7 +114,6 @@ class FeatureWorkflowContractE2ETest extends AbstractSharedHttpProgrammaticRunti
     }
     
     private void assertModelFacingPayloadContract(final Map<String, Object> payload) {
-        MCPModelContractAssertions.assertNoBannedPublicFields(payload);
         MCPModelContractAssertions.assertCanonicalNextActionLists(payload);
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportApprovalSafetyE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportApprovalSafetyE2ETest.java
@@ -110,7 +110,6 @@ class HttpTransportApprovalSafetyE2ETest extends AbstractSharedHttpProgrammaticR
     }
     
     private void assertModelFacingPayloadContract(final Map<String, Object> payload) {
-        MCPModelContractAssertions.assertNoBannedPublicFields(payload);
         MCPModelContractAssertions.assertCanonicalNextActionLists(payload);
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportContractE2ETest.java
@@ -263,7 +263,6 @@ class HttpTransportContractE2ETest extends AbstractSharedHttpProgrammaticRuntime
     }
     
     private void assertModelFacingPayloadContract(final Map<String, Object> payload) {
-        MCPModelContractAssertions.assertNoBannedPublicFields(payload);
         MCPModelContractAssertions.assertCanonicalNextActionLists(payload);
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportRecoveryE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportRecoveryE2ETest.java
@@ -160,7 +160,6 @@ class HttpTransportRecoveryE2ETest extends AbstractSharedHttpProgrammaticRuntime
     }
     
     private void assertModelFacingPayloadContract(final Map<String, Object> payload) {
-        MCPModelContractAssertions.assertNoBannedPublicFields(payload);
         MCPModelContractAssertions.assertCanonicalNextActionLists(payload);
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPModelContractAssertions.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPModelContractAssertions.java
@@ -21,17 +21,12 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Assertions for model-facing MCP contracts.
  */
 public final class MCPModelContractAssertions {
-    
-    private static final Set<String> BANNED_PUBLIC_FIELDS = Set.of(
-            "target_tool", "target_resource", "required_arguments", "action_kind", "suggested_next_tool", "suggested_next_tools", "recommended_next_tool",
-            "recommended_recovery", "suggested_next_action", "approved_by_user", "requires_user_approval", "approval_required");
     
     private static final Map<String, Set<String>> NEXT_ACTION_REQUIRED_FIELDS = Map.of(
             "resource_read", Set.of("order", "type", "title", "resource_uri"),
@@ -41,21 +36,6 @@ public final class MCPModelContractAssertions {
             "terminal", Set.of("order", "type", "title"));
     
     private MCPModelContractAssertions() {
-    }
-    
-    /**
-     * Assert that no banned public fields are present recursively.
-     *
-     * @param value model-facing payload value
-     */
-    public static void assertNoBannedPublicFields(final Object value) {
-        if (value instanceof Map) {
-            assertNoBannedPublicFieldMap((Map<?, ?>) value);
-        } else if (value instanceof Collection) {
-            for (Object each : (Collection<?>) value) {
-                assertNoBannedPublicFields(each);
-            }
-        }
     }
     
     /**
@@ -70,15 +50,6 @@ public final class MCPModelContractAssertions {
             for (Object each : (Collection<?>) value) {
                 assertCanonicalNextActionLists(each);
             }
-        }
-    }
-    
-    private static void assertNoBannedPublicFieldMap(final Map<?, ?> value) {
-        for (Object each : value.keySet()) {
-            assertFalse(BANNED_PUBLIC_FIELDS.contains(String.valueOf(each)), () -> "Banned model-facing field returned: " + each);
-        }
-        for (Object each : value.values()) {
-            assertNoBannedPublicFields(each);
         }
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPModelContractAssertions.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPModelContractAssertions.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -28,12 +29,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public final class MCPModelContractAssertions {
     
+    private static final Set<String> REMOVED_MODEL_FACING_FIELDS = Set.of(
+            "target_tool", "target_resource", "required_arguments", "action_kind", "suggested_next_tool", "suggested_next_tools", "recommended_next_tool",
+            "recommended_recovery", "suggested_next_action", "approved_by_user", "requires_user_approval", "approval_required", "user_overrides");
+    
     private static final Map<String, Set<String>> NEXT_ACTION_REQUIRED_FIELDS = Map.of(
             "resource_read", Set.of("order", "type", "title", "resource_uri"),
             "tool_call", Set.of("order", "type", "title", "tool_name", "arguments"),
             "completion", Set.of("order", "type", "title", "ref", "argument"),
             "ask_user", Set.of("order", "type", "title", "question"),
             "terminal", Set.of("order", "type", "title"));
+    
+    private static final Map<String, Set<String>> NEXT_ACTION_ALLOWED_FIELDS = Map.of(
+            "resource_read", Set.of("order", "type", "title", "resource_uri", "reason", "depends_on"),
+            "tool_call", Set.of("order", "type", "title", "tool_name", "arguments", "reason", "depends_on"),
+            "completion", Set.of("order", "type", "title", "ref", "argument", "context", "missing_context_arguments", "resume_ref", "resume_arguments", "reason", "depends_on"),
+            "ask_user", Set.of("order", "type", "title", "question", "required_inputs", "reason", "depends_on"),
+            "terminal", Set.of("order", "type", "title", "reason", "depends_on"));
     
     private MCPModelContractAssertions() {
     }
@@ -54,11 +66,18 @@ public final class MCPModelContractAssertions {
     }
     
     private static void assertCanonicalNextActionListMap(final Map<?, ?> value) {
+        assertNoRemovedModelFacingFields(value);
         if (value.containsKey("next_actions") && !isNextActionsSchema(value.get("next_actions"))) {
             assertNextActions(value.get("next_actions"));
         }
         for (Object each : value.values()) {
             assertCanonicalNextActionLists(each);
+        }
+    }
+    
+    private static void assertNoRemovedModelFacingFields(final Map<?, ?> value) {
+        for (Object each : value.keySet()) {
+            assertFalse(REMOVED_MODEL_FACING_FIELDS.contains(String.valueOf(each)), () -> "Removed model-facing field returned: " + each);
         }
     }
     
@@ -79,6 +98,9 @@ public final class MCPModelContractAssertions {
         assertTrue(NEXT_ACTION_REQUIRED_FIELDS.containsKey(type), () -> "Unknown next_actions type: " + type);
         for (String each : NEXT_ACTION_REQUIRED_FIELDS.get(type)) {
             assertTrue(action.containsKey(each), () -> String.format("next_actions `%s` must contain `%s`.", type, each));
+        }
+        for (Object each : action.keySet()) {
+            assertTrue(NEXT_ACTION_ALLOWED_FIELDS.get(type).contains(String.valueOf(each)), () -> String.format("next_actions `%s` contains unsupported field `%s`.", type, each));
         }
     }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPModelContractAssertionsTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPModelContractAssertionsTest.java
@@ -28,17 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class MCPModelContractAssertionsTest {
     
     @Test
-    void assertNoBannedPublicFields() {
-        assertDoesNotThrow(() -> MCPModelContractAssertions.assertNoBannedPublicFields(Map.of("next_actions", List.of(Map.of("type", "terminal")))));
-    }
-    
-    @Test
-    void assertNoBannedPublicFieldsWithNestedBannedField() {
-        assertThrows(AssertionError.class, () -> MCPModelContractAssertions.assertNoBannedPublicFields(
-                Map.of("recovery", List.of(Map.of("requires_user_approval", true)))));
-    }
-    
-    @Test
     void assertCanonicalNextActionLists() {
         assertDoesNotThrow(() -> MCPModelContractAssertions.assertCanonicalNextActionLists(Map.of("next_actions", List.of(
                 Map.of("order", 1, "type", "tool_call", "title", "Retry", "tool_name", "database_gateway_execute_update", "arguments", Map.of())))));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPModelContractAssertionsTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPModelContractAssertionsTest.java
@@ -55,4 +55,18 @@ class MCPModelContractAssertionsTest {
         assertThrows(AssertionError.class, () -> MCPModelContractAssertions.assertCanonicalNextActionLists(
                 Map.of("next_actions", List.of(Map.of("order", 1, "type", "tool_call", "title", "Retry", "tool_name", "database_gateway_execute_update")))));
     }
+    
+    @Test
+    void assertCanonicalNextActionListsWithRemovedField() {
+        assertThrows(AssertionError.class, () -> MCPModelContractAssertions.assertCanonicalNextActionLists(
+                Map.of("next_actions", List.of(Map.of(
+                        "order", 1, "type", "tool_call", "title", "Retry", "tool_name", "database_gateway_execute_update", "arguments", Map.of(), "target_tool", "legacy")))));
+    }
+    
+    @Test
+    void assertCanonicalNextActionListsWithUnsupportedField() {
+        assertThrows(AssertionError.class, () -> MCPModelContractAssertions.assertCanonicalNextActionLists(
+                Map.of("next_actions", List.of(Map.of(
+                        "order", 1, "type", "tool_call", "title", "Retry", "tool_name", "database_gateway_execute_update", "arguments", Map.of(), "extra_context", "bad")))));
+    }
 }

--- a/test/e2e/mcp/src/test/resources/baseline-contract/model-contract/capabilities.yaml
+++ b/test/e2e/mcp/src/test/resources/baseline-contract/model-contract/capabilities.yaml
@@ -100,10 +100,6 @@ field_naming_contract:
   payload_fields: ShardingSphere-owned structured payload fields use snake_case.
   descriptor_fields: Descriptor-derived MCP schema fields keep the protocol or JSON
     Schema field names required by MCP clients.
-  alias_rule: Do not assume camelCase and snake_case variants are aliases unless the
-    same descriptor explicitly documents both.
-  cleanup_rule: Prefer one canonical ShardingSphere payload field over parallel compatibility
-    aliases.
 next_action_contract:
 - type: resource_read
   required_fields: [order, type, title, resource_uri]


### PR DESCRIPTION
Rename runtime database validation internals away from the old proxy connectivity/preflight class names, remove stale legacy field and alias guards, and keep the model-facing MCP surface on canonical next_actions, target_status, and runtime database validation contracts.

Also update MCP model contract baselines and focused tests so they verify the current public contract instead of preserving removed compatibility fields.

For #35294