### PR TITLE
Update PowerShell and Rancher Desktop related CI config and doc

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -58,9 +58,7 @@ jobs:
         run: ./test/native/src/test/resources/test-native/sh/free-disk-space.sh
       - name: Setup Rancher Desktop without GUI on Windows Server
         if: matrix.os == 'windows-latest'
-        run: |
-          ./test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
-          "PATH=$env:PATH" >> $env:GITHUB_ENV
+        run: ./test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
       - uses: ./.github/workflows/resources/actions/setup-build-environment
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -81,9 +81,7 @@ jobs:
         run: ./test/native/src/test/resources/test-native/sh/free-disk-space.sh
       - name: Setup Rancher Desktop without GUI on Windows Server
         if: matrix.os == 'windows-latest'
-        run: |
-          ./test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
-          "PATH=$env:PATH" >> $env:GITHUB_ENV
+        run: ./test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
       - uses: ./.github/workflows/resources/actions/setup-build-environment
         with:
           java-version: '25.0.2'

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.cn.md
@@ -93,7 +93,6 @@ sudo systemctl restart docker.service
 ```shell
 winget install --id version-fox.vfox --source winget --exact
 if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
-# 此时需要打开新的 Powershell 7 终端
 vfox add java
 vfox install java@25.0.2-graalce
 vfox use --global java@25.0.2-graalce
@@ -121,12 +120,12 @@ wsl --install
 
 ```shell
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
-# 打开新的 PowerShell 7 终端
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
 
 @'
 {
   "min-api-version": "1.41",
+  "seccomp-profile": "/etc/rancher-desktop/seccomp.json",
   "features": {
     "containerd-snapshotter": true
   },
@@ -150,12 +149,12 @@ rdctl start --application.start-in-background --container-engine.name=moby --kub
 ```shell
 iex "& { $(irm https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1) } -Force"
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
-# 打开新的 PowerShell 7 终端
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
 
 @'
 {
   "min-api-version": "1.41",
+  "seccomp-profile": "/etc/rancher-desktop/seccomp.json",
   "features": {
     "containerd-snapshotter": true
   },

--- a/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/graalvm-native-image/development/_index.en.md
@@ -95,7 +95,6 @@ GraalVM CE can be installed using `version-fox/vfox` in Powershell 7 using the f
 ```shell
 winget install --id version-fox.vfox --source winget --exact
 if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
-# At this time, developer need to open a new Powershell 7 terminal
 vfox add java
 vfox install java@25.0.2-graalce
 vfox use --global java@25.0.2-graalce
@@ -126,12 +125,12 @@ and configure it to use the `dockerd(moby)` `Container Engine`.
 
 ```shell
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
-# Open a new PowerShell 7 terminal
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
 
 @'
 {
   "min-api-version": "1.41",
+  "seccomp-profile": "/etc/rancher-desktop/seccomp.json",
   "features": {
     "containerd-snapshotter": true
   },
@@ -155,12 +154,12 @@ You can execute the following command in PowerShell 7:
 ```shell
 iex "& { $(irm https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1) } -Force"
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
-# Open a new PowerShell 7 terminal
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
 
 @'
 {
   "min-api-version": "1.41",
+  "seccomp-profile": "/etc/rancher-desktop/seccomp.json",
   "features": {
     "containerd-snapshotter": true
   },

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -179,7 +179,6 @@ sudo systemctl restart docker.service
 ```shell
 winget install --id version-fox.vfox --source winget --exact
 if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
-# 此时需要打开新的 Powershell 7 终端
 vfox add java
 vfox install java@21.0.7-ms
 vfox use --global java@21.0.7-ms
@@ -200,12 +199,12 @@ wsl --install
 
 ```shell
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
-# 打开新的 PowerShell 7 终端
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
 
 @'
 {
   "min-api-version": "1.41",
+  "seccomp-profile": "/etc/rancher-desktop/seccomp.json",
   "features": {
     "containerd-snapshotter": true
   },

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -183,7 +183,6 @@ OpenJDK 21 can be installed using `version-fox/vfox` in Powershell 7 using the f
 ```shell
 winget install --id version-fox.vfox --source winget --exact
 if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
-# At this time, you need to open a new Powershell 7 terminal
 vfox add java
 vfox install java@21.0.7-ms
 vfox use --global java@21.0.7-ms
@@ -204,12 +203,12 @@ and configure `dockerd(moby)` to use the `Container Engine`.
 
 ```shell
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
-# Open a new PowerShell 7 terminal
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
 
 @'
 {
   "min-api-version": "1.41",
+  "seccomp-profile": "/etc/rancher-desktop/seccomp.json",
   "features": {
     "containerd-snapshotter": true
   },

--- a/test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
+++ b/test/native/src/test/resources/test-native/ps1/config-rdctl.ps1
@@ -20,7 +20,6 @@
 # This file is only used in the PowerShell 7 of ShardingSphere in GitHub Actions environment and should not be executed manually in a development environment.
 # Background information can be found at https://github.com/apache/shardingsphere/pull/35905 .
 iex "& { $(irm https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1) } -Force"
-winget install --id jazzdelightsme.WingetPathUpdater --source winget
 winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
 rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
 ./test/native/src/test/resources/test-native/ps1/wait-for-rancher-desktop-backend.ps1
@@ -28,6 +27,7 @@ rdctl start --application.start-in-background --container-engine.name=moby --kub
 @'
 {
   "min-api-version": "1.41",
+  "seccomp-profile": "/etc/rancher-desktop/seccomp.json",
   "features": {
     "containerd-snapshotter": true
   },

--- a/test/native/src/test/resources/testcontainers.properties
+++ b/test/native/src/test/resources/testcontainers.properties
@@ -16,4 +16,3 @@
 #
 
 pull.timeout = 240
-client.ping.timeout = 30


### PR DESCRIPTION
Fixes #38857 .

Changes proposed in this pull request:
  - Update PowerShell and Rancher Desktop related CI config and doc.
  - Starting with Rancher Desktop version `1.22.3`, the configuration `"seccomp-profile": "/etc/rancher-desktop/seccomp.json"` was added to `/etc/docker/daemon.json`. See https://github.com/rancher-sandbox/rancher-desktop/pull/10226 . I have verified this in a standalone Hyper-V instance using `rdctl shell cat /etc/docker/daemon.json`. We still need to customize the `/etc/docker/daemon.json` file because we need to set `log-driver` to `local` to avoid running out of space for the CI Runner. The Docker images downloaded by nativeTest are simply too numerous.
  - <img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/72137d05-1fac-4f26-bed6-e21320c510e8" />
  - Due to the merging of https://github.com/actions/runner-images/commit/9816650472a69082aeed485ff0578fff59817d7a , it is no longer necessary to use `winget install --id jazzdelightsme.WingetPathUpdater --source winget` or open a new terminal to update environment variables in PowerShell 7. This is related to the merging of the epic PR https://github.com/PowerShell/PowerShell/pull/25847, which will now automatically update and apply changes to environment variables in the current session.
  - Remove `client.ping.timeout = 30`, which was a previous misdiagnosis of the WSL internal structure.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
