### PR TITLE
Minor refacor in InsertValueContext

### DIFF
--- a/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/insert/values/InsertValueContext.java
+++ b/infra/binder/core/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/insert/values/InsertValueContext.java
@@ -101,11 +101,11 @@ public final class InsertValueContext {
     }
     
     private int getParameterIndex(final ParameterMarkerExpressionSegment paramMarkerExpression) {
-        int result = paramMarkerExpression.getParameterMarkerIndex() - parametersOffset;
-        if (result >= 0 && result < parameterMarkerExpressions.size()) {
+        int result = getParameterMarkerIndex(paramMarkerExpression.getParameterMarkerIndex());
+        if (result >= 0) {
             return result;
         }
-        result = getParameterMarkerIndex(paramMarkerExpression.getParameterMarkerIndex());
+        result = paramMarkerExpression.getParameterMarkerIndex() - parametersOffset;
         Preconditions.checkArgument(result >= 0, "Can not get parameter index.");
         return result;
     }

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/insert/values/InsertValueContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/insert/values/InsertValueContextTest.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.Expr
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ExpressionProjectionSegment;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.ParameterMarkerSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
 import org.mockito.internal.configuration.plugins.Plugins;
@@ -66,8 +65,7 @@ class InsertValueContextTest {
         ParameterMarkerExpressionSegment businessCodeParameterMarker = new ParameterMarkerExpressionSegment(0, 10, 2);
         ParameterMarkerExpressionSegment telephoneParameterMarker = new ParameterMarkerExpressionSegment(0, 10, 3);
         Collection<ExpressionSegment> assignments = Arrays.asList(merchantIdParameterMarker, businessCodeParameterMarker, telephoneParameterMarker);
-        List<ParameterMarkerSegment> parameterMarkerSegments = Arrays.asList(merchantIdParameterMarker, businessCodeParameterMarker, telephoneParameterMarker);
-        InsertValueContext insertValueContext = new InsertValueContext(assignments, Arrays.asList("merchant_id", "business_code", "telephone"), 0, parameterMarkerSegments);
+        InsertValueContext insertValueContext = new InsertValueContext(assignments, Arrays.asList("merchant_id", "business_code", "telephone"), 0);
         Optional<Object> literalValue = insertValueContext.getLiteralValue(1);
         assertTrue(literalValue.isPresent());
         assertThat(literalValue.get(), is("business_code"));

--- a/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/insert/values/InsertValueContextTest.java
+++ b/infra/binder/core/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/insert/values/InsertValueContextTest.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.Expr
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ExpressionProjectionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.ParameterMarkerSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
 import org.mockito.internal.configuration.plugins.Plugins;
@@ -57,6 +58,19 @@ class InsertValueContextTest {
         Optional<Object> valueFromInsertValueContext = insertValueContext.getLiteralValue(0);
         assertTrue(valueFromInsertValueContext.isPresent());
         assertThat(valueFromInsertValueContext.get(), is(parameterValue));
+    }
+    
+    @Test
+    void assertGetLiteralValueWithGlobalParameterMarkerIndex() {
+        ParameterMarkerExpressionSegment merchantIdParameterMarker = new ParameterMarkerExpressionSegment(0, 10, 1);
+        ParameterMarkerExpressionSegment businessCodeParameterMarker = new ParameterMarkerExpressionSegment(0, 10, 2);
+        ParameterMarkerExpressionSegment telephoneParameterMarker = new ParameterMarkerExpressionSegment(0, 10, 3);
+        Collection<ExpressionSegment> assignments = Arrays.asList(merchantIdParameterMarker, businessCodeParameterMarker, telephoneParameterMarker);
+        List<ParameterMarkerSegment> parameterMarkerSegments = Arrays.asList(merchantIdParameterMarker, businessCodeParameterMarker, telephoneParameterMarker);
+        InsertValueContext insertValueContext = new InsertValueContext(assignments, Arrays.asList("merchant_id", "business_code", "telephone"), 0, parameterMarkerSegments);
+        Optional<Object> literalValue = insertValueContext.getLiteralValue(1);
+        assertTrue(literalValue.isPresent());
+        assertThat(literalValue.get(), is("business_code"));
     }
     
     @Test


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Minor refacor in InsertValueContext

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
