### PR TITLE
Fix metadata removal for quoted uppercase PostgreSQL tables

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchema.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchema.java
@@ -182,6 +182,12 @@ public final class ShardingSphereSchema {
      * @param tableName table name
      */
     public void removeTable(final String tableName) {
+        if (null != tableIndex.remove(tableName)) {
+            if (null != logicalTableIndex) {
+                logicalTableIndex.remove(tableName);
+            }
+            return;
+        }
         Optional<ShardingSphereTable> table = findTable(new IdentifierValue(tableName, QuoteCharacter.NONE));
         if (table.isPresent()) {
             tableIndex.remove(table.get().getName());
@@ -265,6 +271,9 @@ public final class ShardingSphereSchema {
      * @param viewName view name
      */
     public void removeView(final String viewName) {
+        if (null != viewIndex.remove(viewName)) {
+            return;
+        }
         ShardingSphereView view = getView(viewName);
         if (null == view) {
             return;

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchemaIdentifierTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchemaIdentifierTest.java
@@ -146,6 +146,15 @@ class ShardingSphereSchemaIdentifierTest {
     }
     
     @Test
+    void assertRemoveTableByActualName() {
+        ShardingSphereTable table = new ShardingSphereTable("Foo_Tbl", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        ShardingSphereSchema schema = new ShardingSphereSchema("foo_schema", postgreSQLDatabaseType, Collections.singleton(table), Collections.emptyList());
+        schema.refreshIdentifierContext(new DatabaseIdentifierContext(IdentifierCaseRuleSets.newLowerCaseRuleSet()));
+        schema.removeTable("Foo_Tbl");
+        assertTrue(schema.getAllTables().isEmpty());
+    }
+    
+    @Test
     void assertRemoveTablePrioritizesPhysicalTableIndexWhenBothIndexesCanMatch() {
         ShardingSphereTable lowerCaseTable = new ShardingSphereTable("foo_tbl", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         ShardingSphereTable upperCaseTable = new ShardingSphereTable("FOO_TBL", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
@@ -156,5 +165,14 @@ class ShardingSphereSchemaIdentifierTest {
         schema.refreshIdentifierContext(context);
         schema.removeTable("FOO_TBL");
         assertThat(schema.getTable("FOO_TBL"), is(lowerCaseTable));
+    }
+    
+    @Test
+    void assertRemoveViewByActualName() {
+        ShardingSphereView view = new ShardingSphereView("Foo_View", "SELECT 1");
+        ShardingSphereSchema schema = new ShardingSphereSchema("foo_schema", postgreSQLDatabaseType, Collections.emptyList(), Collections.singleton(view));
+        schema.refreshIdentifierContext(new DatabaseIdentifierContext(IdentifierCaseRuleSets.newLowerCaseRuleSet()));
+        schema.removeView("Foo_View");
+        assertTrue(schema.getAllViews().isEmpty());
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Fix metadata removal for quoted uppercase PostgreSQL tables

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
