### PR TITLE
Fix metadata refresh for quoted uppercase PostgreSQL tables

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/manager/GenericSchemaManager.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/manager/GenericSchemaManager.java
@@ -24,7 +24,9 @@ import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSp
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -60,8 +62,13 @@ public final class GenericSchemaManager {
      * @return to be added tables
      */
     public static Collection<ShardingSphereTable> getToBeAddedTables(final ShardingSphereSchema reloadSchema, final ShardingSphereSchema currentSchema) {
-        return reloadSchema.getAllTables().stream().filter(each -> !currentSchema.containsTable(each.getName())
-                || !each.toString().equals(currentSchema.getTable(each.getName()).toString())).collect(Collectors.toList());
+        Map<String, ShardingSphereTable> currentTables = createTableMap(currentSchema.getAllTables());
+        return reloadSchema.getAllTables().stream().filter(each -> isNotExistingOrChanged(each, currentTables)).collect(Collectors.toList());
+    }
+    
+    private static boolean isNotExistingOrChanged(final ShardingSphereTable reloadTable, final Map<String, ShardingSphereTable> currentTables) {
+        ShardingSphereTable currentTable = currentTables.get(reloadTable.getName());
+        return null == currentTable || !reloadTable.toString().equals(currentTable.toString());
     }
     
     /**
@@ -90,7 +97,12 @@ public final class GenericSchemaManager {
      * @return to be dropped table
      */
     public static Collection<ShardingSphereTable> getToBeDroppedTables(final ShardingSphereSchema reloadSchema, final ShardingSphereSchema currentSchema) {
-        return currentSchema.getAllTables().stream().filter(each -> !reloadSchema.containsTable(each.getName())).collect(Collectors.toList());
+        Map<String, ShardingSphereTable> reloadTables = createTableMap(reloadSchema.getAllTables());
+        return currentSchema.getAllTables().stream().filter(each -> !reloadTables.containsKey(each.getName())).collect(Collectors.toList());
+    }
+    
+    private static Map<String, ShardingSphereTable> createTableMap(final Collection<ShardingSphereTable> tables) {
+        return tables.stream().collect(Collectors.toMap(ShardingSphereTable::getName, each -> each, (oldValue, currentValue) -> currentValue, () -> new LinkedHashMap<>(tables.size(), 1F)));
     }
     
     /**

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/manager/GenericSchemaManagerTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/manager/GenericSchemaManagerTest.java
@@ -18,10 +18,12 @@
 package org.apache.shardingsphere.infra.metadata.database.schema.manager;
 
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.TableType;
+import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCaseRuleSets;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
+import org.apache.shardingsphere.infra.metadata.identifier.DatabaseIdentifierContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -111,6 +113,12 @@ class GenericSchemaManagerTest {
     }
     
     @Test
+    void assertGetToBeDroppedTablesWithActualName() {
+        assertTrue(GenericSchemaManager.getToBeDroppedTables(
+                createLowerCaseSchema("foo_schema", createTable("Foo_Tbl", TableType.TABLE)), createLowerCaseSchema("foo_schema", createTable("Foo_Tbl", TableType.TABLE))).isEmpty());
+    }
+    
+    @Test
     void assertGetToBeDroppedSchemaNames() {
         ShardingSphereDatabase currentDatabase = mock(ShardingSphereDatabase.class);
         when(currentDatabase.getAllSchemas()).thenReturn(Stream.of(createSchema("foo_schema"), createSchema("bar_schema")).collect(Collectors.toList()));
@@ -126,11 +134,20 @@ class GenericSchemaManagerTest {
                 Arguments.of("same table definition already exists",
                         createSchema("foo_schema", createTable("foo_tbl", TableType.TABLE)), createSchema("foo_schema", createTable("foo_tbl", TableType.TABLE)), Collections.emptySet()),
                 Arguments.of("same table name but different definition",
-                        createSchema("foo_schema", createTable("foo_tbl", TableType.TABLE)), createSchema("foo_schema", createTable("foo_tbl", TableType.VIEW)), Collections.singleton("foo_tbl")));
+                        createSchema("foo_schema", createTable("foo_tbl", TableType.TABLE)), createSchema("foo_schema", createTable("foo_tbl", TableType.VIEW)), Collections.singleton("foo_tbl")),
+                Arguments.of("same actual table name already exists",
+                        createLowerCaseSchema("foo_schema", createTable("Foo_Tbl", TableType.TABLE)),
+                        createLowerCaseSchema("foo_schema", createTable("Foo_Tbl", TableType.TABLE)), Collections.emptySet()));
     }
     
     private static ShardingSphereSchema createSchema(final String name, final ShardingSphereTable... tables) {
         return new ShardingSphereSchema(name, mock(DatabaseType.class), Stream.of(tables).collect(Collectors.toList()), Collections.emptyList());
+    }
+    
+    private static ShardingSphereSchema createLowerCaseSchema(final String name, final ShardingSphereTable... tables) {
+        ShardingSphereSchema result = createSchema(name, tables);
+        result.refreshIdentifierContext(new DatabaseIdentifierContext(IdentifierCaseRuleSets.newLowerCaseRuleSet()));
+        return result;
     }
     
     private static ShardingSphereTable createTable(final String name, final TableType type) {


### PR DESCRIPTION

Changes proposed in this pull request:
  - Fix metadata refresh for quoted uppercase PostgreSQL tables

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
