### PR TITLE
Avoid NPE in DatabaseMetaDataManager.dropSchema by capturing the schema first

### DIFF
--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/manager/database/DatabaseMetaDataManager.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/manager/database/DatabaseMetaDataManager.java
@@ -99,8 +99,9 @@ public final class DatabaseMetaDataManager {
         if (!database.containsSchema(schemaName)) {
             return;
         }
+        ShardingSphereSchema schema = database.getSchema(schemaName);
         database.dropSchema(schemaName);
-        if (database.getSchema(schemaName).getAllTables().stream().anyMatch(each -> TableRefreshUtils.isSingleTable(each.getName(), database))) {
+        if (schema.getAllTables().stream().anyMatch(each -> TableRefreshUtils.isSingleTable(each.getName(), database))) {
             database.reloadRules();
         }
         metaData.getGlobalRuleMetaData().getRules().forEach(each -> ((GlobalRule) each).refresh(metaData.getAllDatabases(), GlobalRuleChangedType.SCHEMA_CHANGED));

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/database/DatabaseMetaDataManagerTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/database/DatabaseMetaDataManagerTest.java
@@ -151,7 +151,7 @@ class DatabaseMetaDataManagerTest {
         when(metaDataContexts.getMetaData().getDatabase("foo_db")).thenReturn(realDatabase);
         assertDoesNotThrow(() -> databaseMetaDataManager.dropSchema("foo_db", "foo_schema"));
     }
-
+    
     @Test
     void assertDropSchemaWithSingleTableRefreshRules() {
         ShardingSphereSchema schema = mock(ShardingSphereSchema.class);

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/database/DatabaseMetaDataManagerTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/database/DatabaseMetaDataManagerTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mock;
 
 import java.sql.Types;
 import java.util.Collections;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -146,12 +147,11 @@ class DatabaseMetaDataManagerTest {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
         ShardingSphereSchema schema = new ShardingSphereSchema("foo_schema", databaseType);
         ShardingSphereDatabase realDatabase = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class),
-                new RuleMetaData(Collections.emptyList()), Collections.singleton(schema), new ConfigurationProperties(new java.util.Properties()));
+                new RuleMetaData(Collections.emptyList()), Collections.singleton(schema), new ConfigurationProperties(new Properties()));
         when(metaDataContexts.getMetaData().getDatabase("foo_db")).thenReturn(realDatabase);
-        // Should not throw NPE; the schema tables should be checked BEFORE dropSchema, not after
         assertDoesNotThrow(() -> databaseMetaDataManager.dropSchema("foo_db", "foo_schema"));
     }
-    
+
     @Test
     void assertDropSchemaWithSingleTableRefreshRules() {
         ShardingSphereSchema schema = mock(ShardingSphereSchema.class);

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/database/DatabaseMetaDataManagerTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/manager/database/DatabaseMetaDataManagerTest.java
@@ -19,11 +19,13 @@ package org.apache.shardingsphere.mode.metadata.manager.database;
 
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereView;
+import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.infra.rule.attribute.datanode.MutableDataNodeRuleAttribute;
 import org.apache.shardingsphere.infra.rule.scope.GlobalRule;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
@@ -43,6 +45,7 @@ import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -136,6 +139,17 @@ class DatabaseMetaDataManagerTest {
         when(metaDataContexts.getMetaData().getDatabase("foo_db").getSchema("foo_schema").getAllTables()).thenReturn(Collections.emptyList());
         databaseMetaDataManager.dropSchema("foo_db", "foo_schema");
         verify(metaDataContexts.getMetaData().getDatabase("foo_db")).dropSchema("foo_schema");
+    }
+    
+    @Test
+    void assertDropExistedSchemaShouldNotNPEAfterSchemaDropped() {
+        DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
+        ShardingSphereSchema schema = new ShardingSphereSchema("foo_schema", databaseType);
+        ShardingSphereDatabase realDatabase = new ShardingSphereDatabase("foo_db", databaseType, mock(ResourceMetaData.class),
+                new RuleMetaData(Collections.emptyList()), Collections.singleton(schema), new ConfigurationProperties(new java.util.Properties()));
+        when(metaDataContexts.getMetaData().getDatabase("foo_db")).thenReturn(realDatabase);
+        // Should not throw NPE; the schema tables should be checked BEFORE dropSchema, not after
+        assertDoesNotThrow(() -> databaseMetaDataManager.dropSchema("foo_db", "foo_schema"));
     }
     
     @Test


### PR DESCRIPTION
`DatabaseMetaDataManager.dropSchema` reads `database.getSchema(schemaName).getAllTables()` **after** calling `database.dropSchema(schemaName)`. The schema is already gone at that point, so `getSchema(...)` returns `null` and `getAllTables()` throws a `NullPointerException`.

Capture the schema reference before dropping it. Added a test asserting `dropSchema` does not throw after the schema is removed.

## Verifying this change

The added `DatabaseMetaDataManagerTest#assertDropExistedSchemaShouldNotNPEAfterSchemaDropped` fails before this change and passes after:

Before the fix:

```
$ mvn test -Dtest=DatabaseMetaDataManagerTest -pl mode/core
[INFO] Running org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManagerTest
[ERROR] Tests run: 20, Failures: 1, Errors: 0, Skipped: 0 <<< FAILURE!
org.opentest4j.AssertionFailedError: Unexpected exception thrown: java.lang.NullPointerException: Cannot invoke "...ShardingSphereSchema.getAllTables()" because the return value of "...ShardingSphereDatabase.getSchema(String)" is null
	at org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManager.dropSchema(DatabaseMetaDataManager.java:103)
	at org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManagerTest.assertDropExistedSchemaShouldNotNPEAfterSchemaDropped(DatabaseMetaDataManagerTest.java:152)
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=DatabaseMetaDataManagerTest -pl mode/core
[INFO] Running org.apache.shardingsphere.mode.metadata.manager.database.DatabaseMetaDataManagerTest
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

