### PR TITLE
Skip the retry sleep when the timeout is already exceeded

### DIFF
--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/retry/RetryExecutor.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/retry/RetryExecutor.java
@@ -53,6 +53,9 @@ public final class RetryExecutor {
     
     @SneakyThrows(InterruptedException.class)
     private boolean isTimeout() {
+        if (timeoutMillis >= 0L && elapsedMillis >= timeoutMillis) {
+            return true;
+        }
         Thread.sleep(intervalMillis);
         if (timeoutMillis < 0L) {
             return false;

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/retry/RetryExecutorTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/retry/RetryExecutorTest.java
@@ -23,6 +23,8 @@ import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import java.time.Duration;
 
 class RetryExecutorTest {
     
@@ -47,5 +49,12 @@ class RetryExecutorTest {
                 return ++currentCount > 10;
             }
         }, null));
+    }
+    
+    @Test
+    void assertExecuteZeroTimeoutShouldNotSleep() {
+        assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
+            assertFalse(new RetryExecutor(0L, 5000L).execute(value -> false, null));
+        });
     }
 }


### PR DESCRIPTION
`RetryExecutor.isTimeout()` calls `Thread.sleep(intervalMillis)` *before* checking whether the timeout has already elapsed, so an already-exceeded timeout still incurs a full interval delay (e.g. `new RetryExecutor(0L, 5000L).execute(...)` sleeps 5s before returning). Return immediately when the elapsed time has reached the timeout, before sleeping.

Added a test asserting a zero timeout returns promptly instead of sleeping.

## Verifying this change

The added `RetryExecutorTest#assertExecuteZeroTimeoutShouldNotSleep` fails before this change and passes after:

Before the fix:

```
$ mvn test -Dtest=RetryExecutorTest -pl mode/core
[INFO] Running org.apache.shardingsphere.mode.retry.RetryExecutorTest
[ERROR] Tests run: 4, Failures: 1, Errors: 0, Skipped: 0 <<< FAILURE!
[ERROR]   RetryExecutorTest.assertExecuteZeroTimeoutShouldNotSleep:56
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=RetryExecutorTest -pl mode/core
[INFO] Running org.apache.shardingsphere.mode.retry.RetryExecutorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

