### PR TITLE
Compute the Snowflake epoch in UTC instead of the system timezone

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -31,6 +31,7 @@
 1. Sharding: Fix generated actual index names exceeding database identifier length limits while preserving legacy generated index name compatibility - [#38449](https://github.com/apache/shardingsphere/pull/38449)
 1. Sharding: Fix AUTO_INTERVAL sharding failure under JVM default locales that use comma decimal separators - [#38806](https://github.com/apache/shardingsphere/pull/38806)
 1. DistSQL: Fix case-sensitive storage unit matching in `SHOW RULES USED STORAGE UNIT` - [#38848](https://github.com/apache/shardingsphere/pull/38848)
+1. Sharding: Compute the Snowflake key generator epoch in UTC instead of the JVM default timezone - [#38932](https://github.com/apache/shardingsphere/pull/38932)
 
 ### Enhancements
 

--- a/infra/algorithm/type/key-generator/type/snowflake/pom.xml
+++ b/infra/algorithm/type/key-generator/type/snowflake/pom.xml
@@ -33,7 +33,7 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-
+    
     <build>
         <plugins>
             <plugin>

--- a/infra/algorithm/type/key-generator/type/snowflake/pom.xml
+++ b/infra/algorithm/type/key-generator/type/snowflake/pom.xml
@@ -33,4 +33,15 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${argLine} -Duser.timezone=Asia/Shanghai</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/infra/algorithm/type/key-generator/type/snowflake/pom.xml
+++ b/infra/algorithm/type/key-generator/type/snowflake/pom.xml
@@ -26,6 +26,10 @@
     <artifactId>shardingsphere-infra-algorithm-key-generator-snowflake</artifactId>
     <name>${project.artifactId}</name>
     
+    <properties>
+        <argLine>-Duser.timezone=Asia/Shanghai</argLine>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
@@ -33,15 +37,4 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-    
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>${argLine} -Duser.timezone=Asia/Shanghai</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/infra/algorithm/type/key-generator/type/snowflake/src/main/java/org/apache/shardingsphere/infra/algorithm/keygen/snowflake/SnowflakeKeyGenerateAlgorithm.java
+++ b/infra/algorithm/type/key-generator/type/snowflake/src/main/java/org/apache/shardingsphere/infra/algorithm/keygen/snowflake/SnowflakeKeyGenerateAlgorithm.java
@@ -28,9 +28,8 @@ import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstanceContext;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstanceContextAware;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Properties;
@@ -91,7 +90,7 @@ public final class SnowflakeKeyGenerateAlgorithm implements KeyGenerateAlgorithm
     private int maxTolerateTimeDifferenceMillis;
     
     static {
-        EPOCH = LocalDateTime.of(2016, 11, 1, 0, 0, 0).toInstant(ZoneId.systemDefault().getRules().getOffset(Instant.now())).toEpochMilli();
+        EPOCH = LocalDateTime.of(2016, 11, 1, 0, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
     }
     
     @Override

--- a/infra/algorithm/type/key-generator/type/snowflake/src/test/java/org/apache/shardingsphere/infra/algorithm/keygen/snowflake/SnowflakeKeyGenerateAlgorithmTest.java
+++ b/infra/algorithm/type/key-generator/type/snowflake/src/test/java/org/apache/shardingsphere/infra/algorithm/keygen/snowflake/SnowflakeKeyGenerateAlgorithmTest.java
@@ -52,6 +52,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
 class SnowflakeKeyGenerateAlgorithmTest {
     
     private static final long DEFAULT_SEQUENCE_BITS = 12L;
@@ -59,6 +62,14 @@ class SnowflakeKeyGenerateAlgorithmTest {
     private static final int DEFAULT_KEY_AMOUNT = 10;
     
     private static final ComputeNodeInstanceContext INSTANCE;
+    
+    @Test
+    void assertEpochShouldBeTimezoneIndependent() {
+        // The EPOCH is supposed to represent 2016-11-01 00:00:00 UTC.
+        // It MUST equal the UTC-based value regardless of system timezone.
+        long expectedUtcEpoch = LocalDateTime.of(2016, 11, 1, 0, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        assertThat(SnowflakeKeyGenerateAlgorithm.EPOCH, is(expectedUtcEpoch));
+    }
     
     static {
         ComputeNodeInstanceContext computeNodeInstanceContext = mock(ComputeNodeInstanceContext.class);


### PR DESCRIPTION
The static `EPOCH` for `2016-11-01 00:00:00` is converted to epoch millis using the JVM's **default timezone** offset (`ZoneId.systemDefault()...getOffset(Instant.now())`). The Snowflake key timestamps therefore shift with the server's timezone, which can cause duplicate or mis-ordered keys across deployments in different zones. Use `ZoneOffset.UTC` so the epoch is timezone-independent.

Added a test (run under `-Duser.timezone=Asia/Shanghai`) asserting the epoch equals the UTC-based value.

## Verifying this change

The added `SnowflakeKeyGenerateAlgorithmTest#assertEpochShouldBeTimezoneIndependent` fails before this change and passes after. The bug only manifests when the system timezone is not UTC, so the test is run in a non-UTC zone:

Before the fix:

```
$ TZ=America/New_York mvn test -Dtest=SnowflakeKeyGenerateAlgorithmTest -pl infra/algorithm/type/key-generator/type/snowflake
[INFO] Running org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithmTest
[ERROR] Tests run: 12, Failures: 1, Errors: 0, Skipped: 0 <<< FAILURE!
[ERROR]   SnowflakeKeyGenerateAlgorithmTest.assertEpochShouldBeTimezoneIndependent
[INFO] BUILD FAILURE
```

After the fix:

```
$ TZ=America/New_York mvn test -Dtest=SnowflakeKeyGenerateAlgorithmTest -pl infra/algorithm/type/key-generator/type/snowflake
[INFO] Running org.apache.shardingsphere.infra.algorithm.keygen.snowflake.SnowflakeKeyGenerateAlgorithmTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

