### PR TITLE
Update the Docker images used by optional modules for Clickhouse, MS SQL Server, Doris FE, Firebird, MySQL, Opengauss, PostgreSQL, and Presto

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/clickhouse/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/clickhouse/_index.cn.md
@@ -38,7 +38,7 @@ ShardingSphere 对 ClickHouse JDBC Driver 的支持位于可选模块中。
 ```yaml
 services:
   clickhouse-server:
-    image: clickhouse/clickhouse-server:25.12.1.649
+    image: clickhouse/clickhouse-server:26.6.1.1193
     environment:
       CLICKHOUSE_SKIP_USER_SETUP: "1"
     ports:

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/clickhouse/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/clickhouse/_index.en.md
@@ -38,7 +38,7 @@ Write a Docker Compose file to start ClickHouse.
 ```yaml
 services:
   clickhouse-server:
-    image: clickhouse/clickhouse-server:25.12.1.649
+    image: clickhouse/clickhouse-server:26.6.1.1193
     environment:
       CLICKHOUSE_SKIP_USER_SETUP: "1"
     ports:

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/doris-fe/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/doris-fe/_index.cn.md
@@ -37,7 +37,7 @@ ShardingSphere 对 Doris FE 的支持位于可选模块中。
 ```yaml
 services:
   doris:
-    image: dyrnq/doris:4.0.0
+    image: dyrnq/doris:4.1.2
     environment:
       RUN_MODE: standalone
       SKIP_CHECK_ULIMIT: true

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/doris-fe/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/doris-fe/_index.en.md
@@ -36,7 +36,7 @@ Write a Docker Compose file to start Doris FE and Doris BE.
 ```yaml
 services:
   doris:
-    image: dyrnq/doris:4.0.0
+    image: dyrnq/doris:4.1.2
     environment:
       RUN_MODE: standalone
       SKIP_CHECK_ULIMIT: true

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/firebird/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/firebird/_index.cn.md
@@ -37,7 +37,7 @@ ShardingSphere 对 Firebird JDBC Driver 的支持位于可选模块中。
 ```yaml
 services:
   firebird:
-    image: firebirdsql/firebird:5.0.3
+    image: firebirdsql/firebird:5.0.4-bookworm
     environment:
       FIREBIRD_ROOT_PASSWORD: masterkey
       FIREBIRD_USER: alice

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/firebird/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/firebird/_index.en.md
@@ -37,7 +37,7 @@ Write a Docker Compose file to start Firebird.
 ```yaml
 services:
   firebird:
-    image: firebirdsql/firebird:5.0.3
+    image: firebirdsql/firebird:5.0.4-bookworm
     environment:
       FIREBIRD_ROOT_PASSWORD: masterkey
       FIREBIRD_USER: alice

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/ms-sql-server/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/ms-sql-server/_index.cn.md
@@ -37,7 +37,7 @@ ShardingSphere 对 MS SQL Server 的支持位于可选模块中。
 ```yaml
 services:
   ms-sql-server:
-    image: mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04
+    image: mcr.microsoft.com/mssql/server:2025-CU6-ubuntu-24.04
     environment:
       ACCEPT_EULA: Y
       MSSQL_SA_PASSWORD: A_Str0ng_Required_Password

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/ms-sql-server/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/ms-sql-server/_index.en.md
@@ -37,7 +37,7 @@ Write a Docker Compose file to start MS SQL Server.
 ```yaml
 services:
   ms-sql-server:
-    image: mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04
+    image: mcr.microsoft.com/mssql/server:2025-CU6-ubuntu-24.04
     environment:
       ACCEPT_EULA: Y
       MSSQL_SA_PASSWORD: A_Str0ng_Required_Password

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/presto/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/presto/_index.cn.md
@@ -38,7 +38,7 @@ ShardingSphere 对 Presto JDBC Driver 的支持位于可选模块中。
 ```yaml
 services:
   presto:
-    image: prestodb/presto:0.296
+    image: prestodb/presto:0.298.1
     ports:
       - "8080:8080"
     volumes:

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/presto/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/presto/_index.en.md
@@ -39,7 +39,7 @@ In addition, this Iceberg Connector will start a Hive Metastore Server using a l
 ```yaml
 services:
   presto:
-    image: prestodb/presto:0.296
+    image: prestodb/presto:0.298.1
     ports:
       - "8080:8080"
     volumes:

--- a/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
+++ b/infra/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere/generated-reachability-metadata/reachability-metadata.json
@@ -50,7 +50,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.io.FileDescriptor",
       "jniAccessible": true,
@@ -68,7 +68,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.io.IOException",
       "jniAccessible": true
@@ -118,6 +118,12 @@
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
+      },
+      "type": "java.io.Serializable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.io.Serializable"
     },
@@ -175,7 +181,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.lang.Class",
       "methods": [
@@ -247,7 +253,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.lang.Module",
       "methods": [
@@ -283,6 +289,12 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
       },
       "type": "java.lang.Object"
@@ -290,12 +302,6 @@
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
       },
       "type": "java.lang.Object"
     },
@@ -319,7 +325,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.lang.OutOfMemoryError",
       "jniAccessible": true
@@ -332,7 +338,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.lang.ProcessHandle",
       "methods": [
@@ -354,7 +360,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.lang.RuntimeException",
       "jniAccessible": true
@@ -385,12 +391,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.lang.String[]"
@@ -405,11 +405,16 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
-      "type": "java.lang.Thread"
+      "type": "java.lang.Thread",
+      "fields": [
+        {
+          "name": "threadLocalRandomProbe"
+        }
+      ]
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.lang.Thread",
       "methods": [
@@ -445,7 +450,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.net.InetSocketAddress",
       "jniAccessible": true,
@@ -461,7 +466,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.net.PortUnreachableException",
       "jniAccessible": true
@@ -471,21 +476,6 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.net.ServerSocket"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.net.Socket",
-      "methods": [
-        {
-          "name": "setOption",
-          "parameterTypes": [
-            "java.net.SocketOption",
-            "java.lang.Object"
-          ]
-        }
-      ]
     },
     {
       "condition": {
@@ -507,20 +497,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.net.UnixDomainSocketAddress",
-      "methods": [
-        {
-          "name": "of",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.net.UnixDomainSocketAddress",
@@ -535,7 +511,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.nio.Buffer",
       "jniAccessible": true,
@@ -560,7 +536,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.nio.ByteBuffer",
       "methods": [
@@ -581,13 +557,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.nio.DirectByteBuffer"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.nio.channels.ClosedChannelException",
       "jniAccessible": true,
@@ -600,7 +576,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "type": "java.nio.channels.FileChannel"
     },
@@ -609,20 +585,6 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.nio.charset.Charset"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.security.AccessController",
-      "methods": [
-        {
-          "name": "doPrivileged",
-          "parameterTypes": [
-            "java.security.PrivilegedExceptionAction"
-          ]
-        }
-      ]
     },
     {
       "condition": {
@@ -658,15 +620,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"
+        "typeReached": "org.apache.shardingsphere.infra.exception.external.sql.ShardingSphereSQLException"
       },
       "type": "java.sql.SQLException"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.database.connector.mysql.metadata.identifier.MySQLIdentifierCaseRuleProvider"
-      },
-      "type": "java.sql.Statement[]"
     },
     {
       "condition": {
@@ -682,13 +638,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabaseFactory"
-      },
-      "type": "java.sql.Statement[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilder"
       },
       "type": "java.sql.Statement[]"
     },
@@ -763,12 +713,6 @@
         "typeReached": "org.apache.shardingsphere.infra.expr.groovy.GroovyInlineExpressionParser"
       },
       "type": "java.util.Iterator"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "type": "java.util.List"
     },
     {
       "condition": {
@@ -1076,7 +1020,19 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfigurationBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfigurationCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"
       },
       "type": "org.apache.shardingsphere.broadcast.checker.BroadcastRuleConfigurationEmptyChecker"
     },
@@ -1446,21 +1402,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.database.connector.clickhouse.jdbcurl.ClickHouseConnectionPropertiesParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.clickhouse.type.ClickHouseDatabaseType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.database.connector.firebird.jdbcurl.FirebirdConnectionPropertiesParser"
     },
     {
       "condition": {
@@ -1482,21 +1426,15 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.firebird.type.FirebirdDatabaseType"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
+        "typeReached": "org.apache.shardingsphere.transaction.xa.XAShardingSphereTransactionManager"
       },
       "type": "org.apache.shardingsphere.database.connector.h2.checker.H2DatabasePrivilegeChecker"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.database.connector.h2.jdbcurl.H2ConnectionPropertiesParser"
     },
     {
       "condition": {
@@ -1518,15 +1456,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.h2.type.H2DatabaseType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.database.connector.hive.jdbcurl.HiveConnectionPropertiesParser"
     },
     {
       "condition": {
@@ -1548,7 +1480,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.hive.type.HiveDatabaseType"
     },
@@ -1560,27 +1492,15 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.mariadb.type.MariaDBDatabaseType"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
+        "typeReached": "org.apache.shardingsphere.transaction.xa.XAShardingSphereTransactionManager"
       },
       "type": "org.apache.shardingsphere.database.connector.mysql.checker.MySQLDatabasePrivilegeChecker"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.database.connector.mysql.jdbcurl.MySQLConnectionPropertiesParser"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.database.connector.mysql.jdbcurl.MySQLDefaultQueryPropertiesProvider"
     },
     {
       "condition": {
@@ -1602,21 +1522,15 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.mysql.type.MySQLDatabaseType"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
+        "typeReached": "org.apache.shardingsphere.transaction.xa.XAShardingSphereTransactionManager"
       },
       "type": "org.apache.shardingsphere.database.connector.opengauss.checker.OpenGaussDatabasePrivilegeChecker"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.database.connector.opengauss.jdbcurl.OpenGaussConnectionPropertiesParser"
     },
     {
       "condition": {
@@ -1638,15 +1552,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.opengauss.type.OpenGaussDatabaseType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.database.connector.oracle.jdbcurl.OracleConnectionPropertiesParser"
     },
     {
       "condition": {
@@ -1662,21 +1570,15 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.oracle.type.OracleDatabaseType"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
+        "typeReached": "org.apache.shardingsphere.transaction.xa.XAShardingSphereTransactionManager"
       },
       "type": "org.apache.shardingsphere.database.connector.postgresql.checker.PostgreSQLDatabasePrivilegeChecker"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.database.connector.postgresql.jdbcurl.PostgreSQLConnectionPropertiesParser"
     },
     {
       "condition": {
@@ -1698,15 +1600,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.postgresql.type.PostgreSQLDatabaseType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.database.connector.presto.jdbcurl.PrestoConnectionPropertiesParser"
     },
     {
       "condition": {
@@ -1722,27 +1618,15 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.presto.type.PrestoDatabaseType"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.database.connector.sql92.jdbcurl.SQL92ConnectionPropertiesParser"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry"
       },
       "type": "org.apache.shardingsphere.database.connector.sql92.metadata.database.SQL92DatabaseMetaData"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.database.connector.sql92.sqlserver.jdbcurl.SQLServerConnectionPropertiesParser"
     },
     {
       "condition": {
@@ -1758,13 +1642,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.sql92.sqlserver.type.SQLServerDatabaseType"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "type": "org.apache.shardingsphere.database.connector.sql92.type.SQL92DatabaseType"
     },
@@ -1846,12 +1730,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.database.connector.mysql.metadata.identifier.MySQLIdentifierCaseRuleProvider"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.database.DatabaseTypeEngine"
       },
       "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
@@ -1864,13 +1742,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabaseFactory"
-      },
-      "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.manager.standalone.persist.service.StandaloneMetaDataManagerPersistService"
+        "typeReached": "org.apache.shardingsphere.infra.metadata.database.schema.builder.GenericSchemaBuilder"
       },
       "type": "org.apache.shardingsphere.driver.ShardingSphereDriver"
     },
@@ -1948,7 +1820,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
+        "typeReached": "org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"
       },
       "type": "org.apache.shardingsphere.encrypt.checker.config.EncryptRuleConfigurationEmptyChecker"
     },
@@ -2108,13 +1980,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.globalclock.yaml.config.YamlGlobalClockRuleConfigurationCustomizer"
     },
@@ -2280,33 +2152,9 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.binder.mysql.MySQLSQLStatementContextWarpProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.binder.mysql.bind.MySQLSQLBindEngine"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.binder.context.segment.select.projection.extractor.ProjectionIdentifierExtractEngine"
       },
       "type": "org.apache.shardingsphere.infra.binder.opengauss.OpenGaussProjectionIdentifierExtractor"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.binder.opengauss.OpenGaussSQLStatementContextWarpProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.binder.opengauss.bind.OpenGaussSQLBindEngine"
     },
     {
       "condition": {
@@ -2319,30 +2167,6 @@
         "typeReached": "org.apache.shardingsphere.infra.binder.context.segment.select.projection.extractor.ProjectionIdentifierExtractEngine"
       },
       "type": "org.apache.shardingsphere.infra.binder.postgresql.PostgreSQLProjectionIdentifierExtractor"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.binder.postgresql.PostgreSQLSQLStatementContextWarpProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.binder.postgresql.bind.PostgreSQLSQLBindEngine"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.binder.sqlserver.SQLServerSQLStatementContextWarpProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.infra.binder.sqlserver.bind.SQLServerSQLBindEngine"
     },
     {
       "condition": {
@@ -2506,31 +2330,25 @@
     },
     {
       "condition": {
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+      },
+      "type": "org.apache.shardingsphere.infra.util.yaml.YamlConfiguration"
+    },
+    {
+      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.manager.cluster.persist.service.ClusterComputeNodePersistService"
       },
       "type": "org.apache.shardingsphere.infra.util.yaml.YamlConfiguration"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.infra.util.yaml.YamlConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
-      },
-      "type": "org.apache.shardingsphere.infra.util.yaml.YamlConfiguration"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlGlobalRuleConfiguration"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration"
     },
@@ -2772,7 +2590,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
+        "typeReached": "org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"
       },
       "type": "org.apache.shardingsphere.mask.checker.MaskRuleConfigurationEmptyChecker"
     },
@@ -3535,13 +3353,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfigurationCustomizer"
     },
@@ -3883,7 +3701,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
+        "typeReached": "org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"
       },
       "type": "org.apache.shardingsphere.readwritesplitting.checker.ReadwriteSplittingRuleConfigurationEmptyChecker"
     },
@@ -4095,7 +3913,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
+        "typeReached": "org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"
       },
       "type": "org.apache.shardingsphere.shadow.checker.ShadowRuleConfigurationEmptyChecker"
     },
@@ -4525,7 +4343,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
+        "typeReached": "org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"
       },
       "type": "org.apache.shardingsphere.sharding.checker.config.ShardingRuleConfigurationEmptyChecker"
     },
@@ -4993,18 +4811,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.mode.node.rule.tuple.YamlRuleNodeTupleSwapperEngine"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyRuleConfiguration",
@@ -5033,15 +4839,27 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
+        "typeReached": "org.apache.shardingsphere.mode.manager.cluster.ClusterContextManagerBuilder"
       },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyRuleConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.keygen.YamlKeyGenerateStrategyRuleConfigurationCustomizer"
+      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
+      "methods": [
+        {
+          "name": "getComplex",
+          "parameterTypes": []
+        },
+        {
+          "name": "getHint",
+          "parameterTypes": []
+        },
+        {
+          "name": "getNone",
+          "parameterTypes": []
+        },
+        {
+          "name": "getStandard",
+          "parameterTypes": []
+        }
+      ]
     },
     {
       "condition": {
@@ -5069,55 +4887,19 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfiguration",
-      "methods": [
-        {
-          "name": "getComplex",
-          "parameterTypes": []
-        },
-        {
-          "name": "getHint",
-          "parameterTypes": []
-        },
-        {
-          "name": "getNone",
-          "parameterTypes": []
-        },
-        {
-          "name": "getStandard",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfigurationBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "type": "org.apache.shardingsphere.sharding.yaml.config.strategy.sharding.YamlShardingStrategyConfigurationCustomizer"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.util.yaml.constructor.ShardingSphereYamlConstructor"
       },
       "type": "org.apache.shardingsphere.sharding.yaml.engine.construct.NoneShardingStrategyConfigurationYamlConstruct"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
+        "typeReached": "org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"
       },
       "type": "org.apache.shardingsphere.single.checker.config.SingleRuleConfigurationEmptyChecker"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
       },
       "type": "org.apache.shardingsphere.single.decorator.SingleRuleConfigurationDecorator"
     },
@@ -5239,18 +5021,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.clickhouse.parser.ClickHouseParserFacade"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.clickhouse.visitor.statement.ClickHouseStatementVisitorFacade"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.sql.parser.engine.core.database.cache.ParseTreeCacheBuilder"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.core.database.cache.ParseTreeCacheLoader"
@@ -5282,18 +5052,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.firebird.parser.FirebirdParserFacade"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.firebird.visitor.statement.FirebirdStatementVisitorFacade"
     },
     {
       "condition": {
@@ -5350,18 +5108,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.hive.parser.HiveParserFacade"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.hive.visitor.statement.HiveStatementVisitorFacade"
     },
     {
       "condition": {
@@ -5432,18 +5178,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.mysql.parser.MySQLParserFacade"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.mysql.visitor.statement.MySQLStatementVisitorFacade"
     },
     {
       "condition": {
@@ -5559,18 +5293,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.opengauss.parser.OpenGaussParserFacade"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.opengauss.visitor.statement.OpenGaussStatementVisitorFacade"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.opengauss.visitor.statement.type.OpenGaussDDLStatementVisitor",
@@ -5599,19 +5321,21 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.oracle.parser.OracleParserFacade"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.oracle.visitor.statement.OracleStatementVisitorFacade"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"
+      },
+      "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.parser.PostgreSQLLexer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.antlr.v4.runtime.CharStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.parser.PostgreSQLLexer",
       "methods": [
@@ -5653,7 +5377,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
+        "typeReached": "org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.parser.PostgreSQLParser",
       "methods": [
@@ -5669,13 +5393,15 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
       },
-      "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.parser.PostgreSQLParserFacade"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.visitor.statement.PostgreSQLStatementVisitorFacade"
+      "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.parser.PostgreSQLParser",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.antlr.v4.runtime.TokenStream"
+          ]
+        }
+      ]
     },
     {
       "condition": {
@@ -5708,6 +5434,20 @@
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"
+      },
+      "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.visitor.statement.type.PostgreSQLDMLStatementVisitor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.apache.shardingsphere.database.connector.core.type.DatabaseType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.shardingsphere.infra.parser.cache.SQLStatementCacheLoader"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.postgresql.visitor.statement.type.PostgreSQLDMLStatementVisitor",
       "methods": [
@@ -5763,18 +5503,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.presto.parser.PrestoParserFacade"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.presto.visitor.statement.PrestoStatementVisitorFacade"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatement"
       },
       "type": "org.apache.shardingsphere.sql.parser.engine.presto.visitor.statement.type.PrestoDDLStatementVisitor",
@@ -5786,18 +5514,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.sql92.parser.SQL92ParserFacade"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.sql92.visitor.statement.SQL92StatementVisitorFacade"
     },
     {
       "condition": {
@@ -5826,18 +5542,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.sqlserver.parser.SQLServerParserFacade"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "type": "org.apache.shardingsphere.sql.parser.engine.sqlserver.visitor.statement.SQLServerStatementVisitorFacade"
     },
     {
       "condition": {
@@ -6003,13 +5707,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.sqlfederation.yaml.config.YamlSQLFederationRuleConfigurationCustomizer"
     },
@@ -6075,13 +5779,13 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.sqltranslator.yaml.config.YamlSQLTranslatorRuleConfigurationCustomizer"
     },
@@ -6261,25 +5965,15 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationBeanInfo"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.initializer.BootstrapInitializer"
+        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
       },
       "type": "org.apache.shardingsphere.transaction.yaml.config.YamlTransactionRuleConfigurationCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"
-      },
-      "type": {
-        "proxy": [
-          "java.sql.Connection"
-        ]
-      }
     }
   ],
   "resources": [
@@ -6315,7 +6009,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.ShardingSphereProxy"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "glob": "META-INF/native/libnetty_transport_native_epoll_x86_64.so"
     },
@@ -6573,27 +6267,15 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
+        "typeReached": "org.apache.shardingsphere.transaction.xa.XAShardingSphereTransactionManager"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.checker.DialectDatabasePrivilegeChecker"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.jdbcurl.DialectDefaultQueryPropertiesProvider"
     },
     {
       "condition": {
         "typeReached": "org.apache.shardingsphere.infra.database.DatabaseTypeEngine"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.jdbcurl.DialectJdbcUrlFetcher"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.jdbcurl.parser.ConnectionPropertiesParser"
     },
     {
       "condition": {
@@ -6615,7 +6297,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.props.TypedPropertyValue"
+        "typeReached": "org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.database.connector.core.type.DatabaseType"
     },
@@ -6651,37 +6333,19 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.Portal"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.infra.algorithm.keygen.spi.KeyGenerateAlgorithm"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extended.parse.PostgreSQLComParseExecutor"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.infra.binder.context.DialectCommonSQLStatementContextWarpProvider"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.infra.binder.context.segment.select.projection.extractor.ProjectionIdentifierExtractEngine"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.infra.binder.context.segment.select.projection.extractor.DialectProjectionIdentifierExtractor"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.infra.binder.engine.DialectSQLBindEngine"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.metadata.manager.rule.DatabaseRuleConfigurationManager"
+        "typeReached": "org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.infra.config.rule.checker.DatabaseRuleConfigurationEmptyChecker"
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase"
+        "typeReached": "org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistFacade"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.infra.config.rule.decorator.RuleConfigurationDecorator"
     },
@@ -6849,18 +6513,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.sql.parser.spi.DialectSQLParserFacade"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple.PostgreSQLComQueryExecutor"
-      },
-      "glob": "META-INF/services/org.apache.shardingsphere.sql.parser.spi.SQLStatementVisitorFacade"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.SQLFederationConnectionConfigBuilderFactory"
       },
       "glob": "META-INF/services/org.apache.shardingsphere.sqlfederation.compiler.context.connection.config.DialectSQLFederationConnectionConfigBuilder"
@@ -6897,7 +6549,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
+        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "glob": "META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider"
     },
@@ -6905,25 +6557,7 @@
       "condition": {
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
-      "glob": "META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
       "glob": "META-INF/services/org.testcontainers.core.CreateContainerCmdModifier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
-      },
-      "glob": "META-INF/services/org.testcontainers.core.CreateContainerCmdModifier"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "client-v2-version.properties"
     },
     {
       "condition": {
@@ -6942,18 +6576,6 @@
         "typeReached": "org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"
       },
       "glob": "com/atomikos/icatch/provider/imp/transactions.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "com/clickhouse/client/internal/org/apache/hc/client5/version.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "container-license-acceptance.txt"
     },
     {
       "condition": {
@@ -6996,18 +6618,6 @@
         "typeReached": "org.apache.shardingsphere.driver.jdbc.core.statement.StatementManager"
       },
       "glob": "org/firebirdsql/jaybird_error_sqlstates.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.mode.repository.standalone.jdbc.JDBCRepository"
-      },
-      "glob": "org/h2/util/data.zip"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "org/postgresql/driverconfig.properties"
     },
     {
       "condition": {
@@ -8289,18 +7899,6 @@
     },
     {
       "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "test-native/sql/clickhouse-init.sql"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource"
-      },
-      "glob": "test-native/sql/seata-script-client-at-postgresql.sql"
-    },
-    {
-      "condition": {
         "typeReached": "org.apache.shardingsphere.transaction.base.seata.at.SeataATShardingSphereTransactionManager"
       },
       "glob": "test-native/sql/seata-script-client-at-postgresql.sql"
@@ -8442,33 +8040,6 @@
         "typeReached": "org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"
       },
       "glob": "transactions.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"
-      },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_zh.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"
-      },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_zh_Hans.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.shardingsphere.transaction.xa.atomikos.manager.AtomikosTransactionManagerProvider"
-      },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_zh_Hans_CN.properties"
-    },
-    {
-      "bundle": "com.microsoft.sqlserver.jdbc.SQLServerResource"
-    },
-    {
-      "bundle": "sun.util.logging.resources.logging"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <clickhouse-jdbc.version>0.9.8</clickhouse-jdbc.version>
         <hive-jdbc.version>4.0.1</hive-jdbc.version>
         <hive-server2-jdbc-driver-thin.version>1.8.2</hive-server2-jdbc-driver-thin.version>
-        <presto.version>0.296</presto.version>
+        <presto.version>0.298.1</presto.version>
         <jaybird.version>5.0.10.java8</jaybird.version>
         
         <hikari-cp.version>4.0.3</hikari-cp.version>

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/DorisFETest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/DorisFETest.java
@@ -49,7 +49,7 @@ class DorisFETest {
     
     @SuppressWarnings("resource")
     @Container
-    private final GenericContainer<?> container = new GenericContainer<>("dyrnq/doris:4.0.0")
+    private final GenericContainer<?> container = new GenericContainer<>("dyrnq/doris:4.1.2")
             .withEnv("RUN_MODE", "standalone")
             .withEnv("SKIP_CHECK_ULIMIT", "true")
             .withExposedPorts(9030);

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/MySQLTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/MySQLTest.java
@@ -55,7 +55,7 @@ class MySQLTest {
     
     @SuppressWarnings("resource")
     @Container
-    private final GenericContainer<?> container = new GenericContainer<>("mysql:9.5.0-oraclelinux9")
+    private final GenericContainer<?> container = new GenericContainer<>("mysql:9.7.1-oraclelinux9")
             .withEnv("MYSQL_ROOT_PASSWORD", password)
             .withExposedPorts(3306);
     

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/OpenGaussTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/OpenGaussTest.java
@@ -50,7 +50,7 @@ class OpenGaussTest {
     
     @SuppressWarnings("resource")
     @Container
-    private final GenericContainer<?> container = new GenericContainer<>("opengauss/opengauss-server:7.0.0-RC1")
+    private final GenericContainer<?> container = new GenericContainer<>("opengauss/opengauss-server:7.0.0-RC3.B025-openEuler22.03")
             .withEnv("GS_PASSWORD", password)
             .withExposedPorts(5432);
     

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/PrestoTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/PrestoTest.java
@@ -57,7 +57,7 @@ class PrestoTest {
     private String baseJdbcUrl;
     
     @Container
-    private final GenericContainer<?> container = new GenericContainer<>("prestodb/presto:0.296")
+    private final GenericContainer<?> container = new GenericContainer<>("prestodb/presto:0.298.1")
             .withExposedPorts(8080)
             .withCopyFileToContainer(
                     MountableFile.forHostPath(Paths.get("src/test/resources/test-native/properties/presto-iceberg.properties").toAbsolutePath()),

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/hive/SystemSchemasTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/jdbc/databases/hive/SystemSchemasTest.java
@@ -55,7 +55,7 @@ class SystemSchemasTest {
     
     @Container
     @AutoClose
-    private final GenericContainer<?> postgres = new GenericContainer<>("postgres:18.1-trixie")
+    private final GenericContainer<?> postgres = new GenericContainer<>("postgres:18.4-trixie")
             .withEnv("POSTGRES_PASSWORD", "example")
             .withNetwork(network)
             .withNetworkAliases("some-postgres");

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/databases/MySQLTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/databases/MySQLTest.java
@@ -46,7 +46,7 @@ import java.util.Properties;
 class MySQLTest {
     
     @Container
-    private final GenericContainer<?> mysqlContainer = new GenericContainer<>("mysql:9.5.0-oraclelinux9")
+    private final GenericContainer<?> mysqlContainer = new GenericContainer<>("mysql:9.7.1-oraclelinux9")
             .withEnv("MYSQL_ROOT_PASSWORD", "yourStrongPassword123!")
             .withExposedPorts(3306);
     

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/databases/PostgresTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/databases/PostgresTest.java
@@ -46,7 +46,7 @@ import java.time.Duration;
 class PostgresTest {
     
     @Container
-    private final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:18.1-trixie");
+    private final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:18.4-trixie");
     
     private ProxyTestingServer proxyTestingServer;
     

--- a/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/transactions/base/SeataTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/test/natived/proxy/transactions/base/SeataTest.java
@@ -57,7 +57,7 @@ class SeataTest {
             .waitingFor(Wait.forHttp("/health").forPort(8091).forStatusCode(HttpStatus.SC_OK).forResponsePredicate("\"ok\""::equals));
     
     @Container
-    private final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:18.1-trixie")
+    private final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:18.4-trixie")
             .withCopyFileToContainer(
                     MountableFile.forHostPath(Paths.get("src/test/resources/test-native/sh/postgres.sh").toAbsolutePath()),
                     "/docker-entrypoint-initdb.d/postgres.sh");

--- a/test/native/src/test/resources/container-license-acceptance.txt
+++ b/test/native/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04
+mcr.microsoft.com/mssql/server:2025-CU6-ubuntu-24.04

--- a/test/native/src/test/resources/test-native/yaml/jdbc/databases/clickhouse.yaml
+++ b/test/native/src/test/resources/test-native/yaml/jdbc/databases/clickhouse.yaml
@@ -19,15 +19,15 @@ dataSources:
   ds_0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:clickhouse:25.12.1.649:///demo_ds_0?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql
+    jdbcUrl: jdbc:tc:clickhouse:26.6.1.1193:///demo_ds_0?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:clickhouse:25.12.1.649:///demo_ds_1?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql
+    jdbcUrl: jdbc:tc:clickhouse:26.6.1.1193:///demo_ds_1?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql
   ds_2:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:clickhouse:25.12.1.649:///demo_ds_2?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql
+    jdbcUrl: jdbc:tc:clickhouse:26.6.1.1193:///demo_ds_2?TC_INITSCRIPT=test-native/sql/clickhouse-init.sql
 
 rules:
   - !SHARDING

--- a/test/native/src/test/resources/test-native/yaml/jdbc/databases/firebird.yaml
+++ b/test/native/src/test/resources/test-native/yaml/jdbc/databases/firebird.yaml
@@ -19,15 +19,15 @@ dataSources:
   ds_0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:firebird:5.0.3:///demo_ds_0
+    jdbcUrl: jdbc:tc:firebird:5.0.4-bookworm:///demo_ds_0
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:firebird:5.0.3:///demo_ds_1
+    jdbcUrl: jdbc:tc:firebird:5.0.4-bookworm:///demo_ds_1
   ds_2:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:firebird:5.0.3:///demo_ds_2
+    jdbcUrl: jdbc:tc:firebird:5.0.4-bookworm:///demo_ds_2
 rules:
 - !SHARDING
   tables:

--- a/test/native/src/test/resources/test-native/yaml/jdbc/databases/postgresql.yaml
+++ b/test/native/src/test/resources/test-native/yaml/jdbc/databases/postgresql.yaml
@@ -19,15 +19,15 @@ dataSources:
   ds_0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:18.1-trixie:///demo_ds_0
+    jdbcUrl: jdbc:tc:postgresql:18.4-trixie:///demo_ds_0
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:18.1-trixie:///demo_ds_1
+    jdbcUrl: jdbc:tc:postgresql:18.4-trixie:///demo_ds_1
   ds_2:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:18.1-trixie:///demo_ds_2
+    jdbcUrl: jdbc:tc:postgresql:18.4-trixie:///demo_ds_2
 
 rules:
 - !SHARDING

--- a/test/native/src/test/resources/test-native/yaml/jdbc/databases/sqlserver.yaml
+++ b/test/native/src/test/resources/test-native/yaml/jdbc/databases/sqlserver.yaml
@@ -19,15 +19,15 @@ dataSources:
   ds_0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:sqlserver:2025-RTM-ubuntu-22.04://test-native-databases-mssqlserver;databaseName=demo_ds_0
+    jdbcUrl: jdbc:tc:sqlserver:2025-CU6-ubuntu-24.04://test-native-databases-mssqlserver;databaseName=demo_ds_0
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:sqlserver:2025-RTM-ubuntu-22.04://test-native-databases-mssqlserver;databaseName=demo_ds_1
+    jdbcUrl: jdbc:tc:sqlserver:2025-CU6-ubuntu-24.04://test-native-databases-mssqlserver;databaseName=demo_ds_1
   ds_2:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:sqlserver:2025-RTM-ubuntu-22.04://test-native-databases-mssqlserver;databaseName=demo_ds_2
+    jdbcUrl: jdbc:tc:sqlserver:2025-CU6-ubuntu-24.04://test-native-databases-mssqlserver;databaseName=demo_ds_2
 
 rules:
 - !SHARDING

--- a/test/native/src/test/resources/test-native/yaml/jdbc/transactions/base/seata.yaml
+++ b/test/native/src/test/resources/test-native/yaml/jdbc/transactions/base/seata.yaml
@@ -19,15 +19,15 @@ dataSources:
   ds_0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:18.1-trixie:///demo_ds_0?TC_INITSCRIPT=test-native/sql/seata-script-client-at-postgresql.sql
+    jdbcUrl: jdbc:tc:postgresql:18.4-trixie:///demo_ds_0?TC_INITSCRIPT=test-native/sql/seata-script-client-at-postgresql.sql
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:18.1-trixie:///demo_ds_1?TC_INITSCRIPT=test-native/sql/seata-script-client-at-postgresql.sql
+    jdbcUrl: jdbc:tc:postgresql:18.4-trixie:///demo_ds_1?TC_INITSCRIPT=test-native/sql/seata-script-client-at-postgresql.sql
   ds_2:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
     driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
-    jdbcUrl: jdbc:tc:postgresql:18.1-trixie:///demo_ds_2?TC_INITSCRIPT=test-native/sql/seata-script-client-at-postgresql.sql
+    jdbcUrl: jdbc:tc:postgresql:18.4-trixie:///demo_ds_2?TC_INITSCRIPT=test-native/sql/seata-script-client-at-postgresql.sql
 
 rules:
 - !SHARDING


### PR DESCRIPTION
For #38933 .

Changes proposed in this pull request:
  - Update the Docker images used by optional modules for Clickhouse, MS SQL Server, Doris FE, Firebird, MySQL, Opengauss, PostgreSQL, and Presto.
  - This is part of https://github.com/apache/shardingsphere/issues/38933 , which first requires upgrading the database version used by nativeTest.
  - To align with the Presto Docker image version, bump the Presto JDBC driver `com.facebook.presto:presto-jdbc` used for testing.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
