### PR TITLE
Fix readwrite splitting swap pool config

### DIFF
--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/yaml/swapper/YamlProxyConfigurationSwapperTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/yaml/swapper/YamlProxyConfigurationSwapperTest.java
@@ -61,10 +61,10 @@ class YamlProxyConfigurationSwapperTest {
         assertThat(dataSource.getUsername(), is("sa"));
         assertThat(dataSource.getPassword(), is(""));
         assertThat(dataSource.getConnectionTimeout(), is(250L));
-        assertThat(dataSource.getIdleTimeout(), is(2L));
-        assertThat(dataSource.getMaxLifetime(), is(3L));
-        assertThat(dataSource.getMaximumPoolSize(), is(4));
-        assertThat(dataSource.getMinimumIdle(), is(5));
+        assertThat(dataSource.getIdleTimeout(), is(30000L));
+        assertThat(dataSource.getMaxLifetime(), is(600000L));
+        assertThat(dataSource.getMaximumPoolSize(), is(5));
+        assertThat(dataSource.getMinimumIdle(), is(4));
         assertTrue(dataSource.isReadOnly());
     }
     

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/yaml/swapper/YamlProxyDataSourceConfigurationSwapperTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/yaml/swapper/YamlProxyDataSourceConfigurationSwapperTest.java
@@ -56,10 +56,10 @@ class YamlProxyDataSourceConfigurationSwapperTest {
         PoolConfiguration actualPool = actualDataSourceConfig.getPool();
         assertNotNull(actualPool);
         assertThat(actualPool.getConnectionTimeoutMilliseconds(), is(250L));
-        assertThat(actualPool.getIdleTimeoutMilliseconds(), is(2L));
-        assertThat(actualPool.getMaxLifetimeMilliseconds(), is(3L));
-        assertThat(actualPool.getMaxPoolSize(), is(4));
-        assertThat(actualPool.getMinPoolSize(), is(5));
+        assertThat(actualPool.getIdleTimeoutMilliseconds(), is(30000L));
+        assertThat(actualPool.getMaxLifetimeMilliseconds(), is(600000L));
+        assertThat(actualPool.getMaxPoolSize(), is(5));
+        assertThat(actualPool.getMinPoolSize(), is(4));
         assertTrue(actualPool.getReadOnly());
     }
 }

--- a/proxy/backend/core/src/test/resources/conf/swap/database-readwrite-splitting.yaml
+++ b/proxy/backend/core/src/test/resources/conf/swap/database-readwrite-splitting.yaml
@@ -24,10 +24,10 @@ dataSources:
     username: sa
     password: ""
     connectionTimeoutMilliseconds: 250
-    idleTimeoutMilliseconds: 2
-    maxLifetimeMilliseconds: 3
-    maxPoolSize:  4
-    minPoolSize: 5
+    idleTimeoutMilliseconds: 30000
+    maxLifetimeMilliseconds: 600000
+    maxPoolSize: 5
+    minPoolSize: 4
     readOnly: true
 
 rules:


### PR DESCRIPTION
- Correct min and max pool size order in readwrite splitting swap fixture
- Use realistic idle timeout and max lifetime values
- Update YAML swapper assertions to match the corrected pool settings
