### PR TITLE
Fix MCP generated DistSQL quoting and algorithm validation

### DIFF
--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastRuleDistSQLPlanningService.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastRuleDistSQLPlanningService.java
@@ -50,6 +50,6 @@ public final class BroadcastRuleDistSQLPlanningService {
     
     private String formatTableNames(final List<String> tableNames) {
         return tableNames.stream().peek(each -> WorkflowSQLUtils.checkSupportedIdentifier("table", each))
-                .map(WorkflowSQLUtils::formatDistSQLIdentifier).collect(Collectors.joining(", "));
+                .map(WorkflowSQLUtils::formatGeneratedRuleDistSQLIdentifier).collect(Collectors.joining(", "));
     }
 }

--- a/mcp/features/broadcast/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-broadcast.yaml
+++ b/mcp/features/broadcast/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-broadcast.yaml
@@ -334,7 +334,7 @@ tools:
           distsql_artifacts:
             - operation_type: create
               artifact_type: rule_distsql
-              sql: CREATE BROADCAST TABLE RULE t_order
+              sql: CREATE BROADCAST TABLE RULE `t_order`
           next_actions:
             - order: 1
               type: tool_call

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/handler/BroadcastToolHandlerTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/handler/BroadcastToolHandlerTest.java
@@ -97,7 +97,7 @@ class BroadcastToolHandlerTest {
         clarifiedIntent.setOperationType("create");
         result.setClarifiedIntent(clarifiedIntent);
         result.setInteractionPlan(InteractionPlan.create("plan-1", request, "Broadcast workflow plan.", List.of("review"), List.of("rules")));
-        result.getRuleArtifacts().add(new RuleArtifact("create", "CREATE BROADCAST TABLE RULE t_order"));
+        result.getRuleArtifacts().add(new RuleArtifact("create", "CREATE BROADCAST TABLE RULE `t_order`"));
         return result;
     }
     

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastRuleDistSQLPlanningServiceTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastRuleDistSQLPlanningServiceTest.java
@@ -35,7 +35,7 @@ class BroadcastRuleDistSQLPlanningServiceTest {
     void assertPlanCreateRule() {
         RuleArtifact actual = service.planCreateRule(List.of("t_order", "order"));
         assertThat(actual.getOperationType(), is("create"));
-        assertThat(actual.getSql(), is("CREATE BROADCAST TABLE RULE t_order, `order`"));
+        assertThat(actual.getSql(), is("CREATE BROADCAST TABLE RULE `t_order`, `order`"));
     }
     
     @Test
@@ -48,7 +48,7 @@ class BroadcastRuleDistSQLPlanningServiceTest {
     void assertPlanDropRule() {
         RuleArtifact actual = service.planDropRule(List.of("t_order"));
         assertThat(actual.getOperationType(), is("drop"));
-        assertThat(actual.getSql(), is("DROP BROADCAST TABLE RULE t_order"));
+        assertThat(actual.getSql(), is("DROP BROADCAST TABLE RULE `t_order`"));
     }
     
     @Test

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowPlanningServiceTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowPlanningServiceTest.java
@@ -44,7 +44,7 @@ class BroadcastWorkflowPlanningServiceTest {
         WorkflowContextSnapshot actual = createService().plan(new TestWorkflowSessionContext(), queryFacade, "session-1", createRequest("create", "t_order,t_order_item"));
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
         assertThat(actual.getWorkflowKind().getValue(), is("broadcast.rule"));
-        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE BROADCAST TABLE RULE t_order, t_order_item"));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE BROADCAST TABLE RULE `t_order`, `t_order_item`"));
         assertFalse(actual.getDdlArtifacts().iterator().hasNext());
         assertFalse(actual.getIndexPlans().iterator().hasNext());
     }
@@ -54,7 +54,7 @@ class BroadcastWorkflowPlanningServiceTest {
         MCPFeatureQueryFacade queryFacade = mockQueryFacade(List.of(Map.of("broadcast_table", "t_order")));
         WorkflowContextSnapshot actual = createService().plan(new TestWorkflowSessionContext(), queryFacade, "session-1", createRequest("drop", "t_order"));
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
-        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("DROP BROADCAST TABLE RULE t_order"));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("DROP BROADCAST TABLE RULE `t_order`"));
     }
     
     @Test

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptRuleDistSQLPlanningService.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptRuleDistSQLPlanningService.java
@@ -69,11 +69,11 @@ public final class EncryptRuleDistSQLPlanningService {
     }
     
     private String createDropRuleSql(final String tableName) {
-        return String.format("DROP ENCRYPT RULE %s", WorkflowSQLUtils.formatDistSQLIdentifier(tableName));
+        return String.format("DROP ENCRYPT RULE %s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(tableName));
     }
     
     private String createEncryptRuleSql(final String prefix, final String tableName, final List<String> columnSegments) {
-        return String.format("%s %s (%sCOLUMNS(%s%s%s))", prefix, WorkflowSQLUtils.formatDistSQLIdentifier(tableName), System.lineSeparator(), System.lineSeparator(),
+        return String.format("%s %s (%sCOLUMNS(%s%s%s))", prefix, WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(tableName), System.lineSeparator(), System.lineSeparator(),
                 String.join(", " + System.lineSeparator(), columnSegments), System.lineSeparator());
     }
     
@@ -113,13 +113,13 @@ public final class EncryptRuleDistSQLPlanningService {
     
     private String createTargetEncryptColumnSegment(final EncryptWorkflowRequest request) {
         StringBuilder result = new StringBuilder();
-        result.append(String.format("(NAME=%s, CIPHER=%s", WorkflowSQLUtils.formatDistSQLIdentifier(request.getColumn()),
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getOptions().getCipherColumnName())));
+        result.append(String.format("(NAME=%s, CIPHER=%s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getColumn()),
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getOptions().getCipherColumnName())));
         if (Boolean.TRUE.equals(request.getOptions().getRequiresEqualityFilter())) {
-            result.append(String.format(", ASSISTED_QUERY_COLUMN=%s", WorkflowSQLUtils.formatDistSQLIdentifier(request.getOptions().getAssistedQueryColumnName())));
+            result.append(String.format(", ASSISTED_QUERY_COLUMN=%s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getOptions().getAssistedQueryColumnName())));
         }
         if (Boolean.TRUE.equals(request.getOptions().getRequiresLikeQuery())) {
-            result.append(String.format(", LIKE_QUERY_COLUMN=%s", WorkflowSQLUtils.formatDistSQLIdentifier(request.getOptions().getLikeQueryColumnName())));
+            result.append(String.format(", LIKE_QUERY_COLUMN=%s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getOptions().getLikeQueryColumnName())));
         }
         result.append(String.format(", ENCRYPT_ALGORITHM(%s)", WorkflowSQLUtils.createAlgorithmFragment(request.getAlgorithmType(), request.getPrimaryAlgorithmProperties())));
         if (Boolean.TRUE.equals(request.getOptions().getRequiresEqualityFilter())) {
@@ -143,13 +143,13 @@ public final class EncryptRuleDistSQLPlanningService {
         WorkflowSQLUtils.checkSupportedIdentifier("cipher_column", cipherColumn);
         WorkflowSQLUtils.checkSupportedIdentifier("assisted_query_column", assistedQueryColumn);
         WorkflowSQLUtils.checkSupportedIdentifier("like_query_column", likeQueryColumn);
-        StringBuilder result = new StringBuilder(String.format("(NAME=%s, CIPHER=%s", WorkflowSQLUtils.formatDistSQLIdentifier(logicColumn),
-                WorkflowSQLUtils.formatDistSQLIdentifier(cipherColumn)));
+        StringBuilder result = new StringBuilder(String.format("(NAME=%s, CIPHER=%s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(logicColumn),
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(cipherColumn)));
         if (!assistedQueryColumn.isEmpty()) {
-            result.append(String.format(", ASSISTED_QUERY_COLUMN=%s", WorkflowSQLUtils.formatDistSQLIdentifier(assistedQueryColumn)));
+            result.append(String.format(", ASSISTED_QUERY_COLUMN=%s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(assistedQueryColumn)));
         }
         if (!likeQueryColumn.isEmpty()) {
-            result.append(String.format(", LIKE_QUERY_COLUMN=%s", WorkflowSQLUtils.formatDistSQLIdentifier(likeQueryColumn)));
+            result.append(String.format(", LIKE_QUERY_COLUMN=%s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(likeQueryColumn)));
         }
         result.append(String.format(", ENCRYPT_ALGORITHM(%s)",
                 WorkflowSQLUtils.createAlgorithmFragment(WorkflowRuleValueUtils.getRuleValue(rule, "encryptor_type"), WorkflowSQLUtils.createPropertyMap(rule.get("encryptor_props")))));

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowValidationService.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowValidationService.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.mcp.feature.encrypt.tool.service;
 import org.apache.shardingsphere.mcp.feature.encrypt.EncryptFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.encrypt.tool.model.EncryptWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.encrypt.tool.model.EncryptWorkflowState;
+import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureExecutionFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
@@ -31,6 +32,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssue;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowAlgorithmUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactMaskUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactBundle.ExecutableWorkflowArtifact;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowLifecycleUtils;
@@ -84,7 +86,7 @@ public final class EncryptWorkflowValidationService implements MCPWorkflowRuntim
         List<Map<String, Object>> result = new LinkedList<>();
         for (ExecutableWorkflowArtifact each : artifacts) {
             if (each.ruleDistSql()) {
-                addRuleDistSQLIssues(result, each.sql(), each.displaySql());
+                addRuleDistSQLIssues(result, snapshot, each.sql(), each.displaySql());
             }
         }
         return result;
@@ -96,7 +98,7 @@ public final class EncryptWorkflowValidationService implements MCPWorkflowRuntim
         workflowSynchronizationSupport.synchronize(() -> createValidationReport(snapshot, queryFacade));
     }
     
-    private void addRuleDistSQLIssues(final List<Map<String, Object>> issues, final String sql, final String displaySql) {
+    private void addRuleDistSQLIssues(final List<Map<String, Object>> issues, final WorkflowContextSnapshot snapshot, final String sql, final String displaySql) {
         if (!isEncryptRuleDistSQL(sql)) {
             return;
         }
@@ -109,6 +111,27 @@ public final class EncryptWorkflowValidationService implements MCPWorkflowRuntim
         String actualSQL = sql.toLowerCase(Locale.ENGLISH);
         if (actualSQL.contains("encrypt_algorithm") && actualSQL.contains("'aes-key-value'") && !actualSQL.contains("'digest-algorithm-name'")) {
             issues.add(createValidationIssue("Generated AES encrypt DistSQL is missing `digest-algorithm-name`.", displaySql));
+        }
+        addAlgorithmIssues(issues, getWorkflowRequest(snapshot), displaySql);
+    }
+    
+    private void addAlgorithmIssues(final List<Map<String, Object>> issues, final EncryptWorkflowRequest request, final String displaySql) {
+        addEncryptAlgorithmIssue(issues, "encrypt", request.getAlgorithmType(), request.getPrimaryAlgorithmProperties(), displaySql);
+        if (Boolean.TRUE.equals(request.getOptions().getRequiresEqualityFilter())) {
+            addEncryptAlgorithmIssue(issues, "assisted query", request.getOptions().getAssistedQueryAlgorithmType(), request.getOptions().getAssistedQueryAlgorithmProperties(), displaySql);
+        }
+        if (Boolean.TRUE.equals(request.getOptions().getRequiresLikeQuery())) {
+            addEncryptAlgorithmIssue(issues, "like query", request.getOptions().getLikeQueryAlgorithmType(), request.getOptions().getLikeQueryAlgorithmProperties(), displaySql);
+        }
+    }
+    
+    private void addEncryptAlgorithmIssue(final List<Map<String, Object>> issues, final String role, final String algorithmType, final Map<String, String> properties, final String displaySql) {
+        if (algorithmType.isEmpty()) {
+            return;
+        }
+        if (!WorkflowAlgorithmUtils.isAlgorithmServiceAvailable(EncryptAlgorithm.class, algorithmType, properties)) {
+            issues.add(createValidationIssue(String.format("Generated encrypt DistSQL references %s algorithm `%s`, but it cannot be loaded or initialized by EncryptAlgorithm SPI.",
+                    role, algorithmType), displaySql));
         }
     }
     

--- a/mcp/features/encrypt/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-encrypt.yaml
+++ b/mcp/features/encrypt/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-encrypt.yaml
@@ -451,7 +451,7 @@ tools:
             - artifact_id: create-encrypt-rule
               artifact_type: rule_dist_sql
               sql: >-
-                CREATE ENCRYPT RULE orders (COLUMNS((NAME=status, CIPHER=status_cipher,
+                CREATE ENCRYPT RULE `orders` (COLUMNS((NAME=`status`, CIPHER=`status_cipher`,
                 ENCRYPT_ALGORITHM(TYPE(NAME='aes', PROPERTIES('aes-key-value'='******', 'digest-algorithm-name'='SHA-1'))))))
           masked_property_preview:
             primary:

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/handler/EncryptToolHandlerTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/handler/EncryptToolHandlerTest.java
@@ -179,7 +179,7 @@ class EncryptToolHandlerTest {
         WorkflowContextSnapshot result = createSnapshot("plan-1", "planned");
         result.setRequest(request);
         result.getPropertyRequirements().add(new AlgorithmPropertyRequirement("primary", "aes-key-value", true, true, "key", ""));
-        result.getRuleArtifacts().add(new RuleArtifact("create", "CREATE ENCRYPT RULE orders (PROPERTIES('aes-key-value'='123456'))"));
+        result.getRuleArtifacts().add(new RuleArtifact("create", "CREATE ENCRYPT RULE `orders` (PROPERTIES('aes-key-value'='123456'))"));
         result.setInteractionPlan(createInteractionPlan());
         return result;
     }

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptRuleDistSQLPlanningServiceTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptRuleDistSQLPlanningServiceTest.java
@@ -40,11 +40,11 @@ class EncryptRuleDistSQLPlanningServiceTest {
         List<RuleArtifact> actual = service.planEncryptRule(request, List.of(), "MySQL");
         assertThat(actual.size(), is(1));
         assertThat(actual.getFirst().getOperationType(), is("create"));
-        assertTrue(actual.getFirst().getSql().startsWith("CREATE ENCRYPT RULE orders"));
-        assertTrue(actual.getFirst().getSql().contains("NAME=phone"));
-        assertTrue(actual.getFirst().getSql().contains("CIPHER=phone_cipher"));
-        assertTrue(actual.getFirst().getSql().contains("ASSISTED_QUERY_COLUMN=phone_assisted_query"));
-        assertTrue(actual.getFirst().getSql().contains("LIKE_QUERY_COLUMN=phone_like_query"));
+        assertTrue(actual.getFirst().getSql().startsWith("CREATE ENCRYPT RULE `orders`"));
+        assertTrue(actual.getFirst().getSql().contains("NAME=`phone`"));
+        assertTrue(actual.getFirst().getSql().contains("CIPHER=`phone_cipher`"));
+        assertTrue(actual.getFirst().getSql().contains("ASSISTED_QUERY_COLUMN=`phone_assisted_query`"));
+        assertTrue(actual.getFirst().getSql().contains("LIKE_QUERY_COLUMN=`phone_like_query`"));
     }
     
     @Test
@@ -55,10 +55,10 @@ class EncryptRuleDistSQLPlanningServiceTest {
                 Map.of("logic_column", "email", "cipher_column", "email_cipher", "encryptor_type", "AES", "encryptor_props", "aes-key-value=old")), "MySQL");
         assertThat(actual.size(), is(1));
         assertThat(actual.getFirst().getOperationType(), is("alter"));
-        assertTrue(actual.getFirst().getSql().startsWith("ALTER ENCRYPT RULE orders"));
-        assertTrue(actual.getFirst().getSql().contains("NAME=email"));
-        assertTrue(actual.getFirst().getSql().contains("NAME=phone"));
-        assertTrue(actual.getFirst().getSql().contains("CIPHER=phone_cipher"));
+        assertTrue(actual.getFirst().getSql().startsWith("ALTER ENCRYPT RULE `orders`"));
+        assertTrue(actual.getFirst().getSql().contains("NAME=`email`"));
+        assertTrue(actual.getFirst().getSql().contains("NAME=`phone`"));
+        assertTrue(actual.getFirst().getSql().contains("CIPHER=`phone_cipher`"));
     }
     
     @Test
@@ -88,7 +88,7 @@ class EncryptRuleDistSQLPlanningServiceTest {
         request.setTable("key");
         List<RuleArtifact> actual = service.planEncryptRule(request, List.of(), "MySQL");
         assertTrue(actual.getFirst().getSql().startsWith("CREATE ENCRYPT RULE `key`"));
-        assertTrue(actual.getFirst().getSql().contains("NAME=phone"));
+        assertTrue(actual.getFirst().getSql().contains("NAME=`phone`"));
     }
     
     @Test
@@ -98,9 +98,9 @@ class EncryptRuleDistSQLPlanningServiceTest {
         request.setColumn("name");
         request.getOptions().setCipherColumnName("name_cipher");
         List<RuleArtifact> actual = service.planEncryptRule(request, List.of(), "MySQL");
-        assertTrue(actual.getFirst().getSql().startsWith("CREATE ENCRYPT RULE t_user"));
+        assertTrue(actual.getFirst().getSql().startsWith("CREATE ENCRYPT RULE `t_user`"));
         assertTrue(actual.getFirst().getSql().contains("NAME=`name`"));
-        assertTrue(actual.getFirst().getSql().contains("CIPHER=name_cipher"));
+        assertTrue(actual.getFirst().getSql().contains("CIPHER=`name_cipher`"));
         assertTrue(actual.getFirst().getSql().contains("TYPE(NAME='aes'"));
     }
     
@@ -131,7 +131,7 @@ class EncryptRuleDistSQLPlanningServiceTest {
         List<RuleArtifact> actual = service.planEncryptDropRule(request, List.of(Map.of("logic_column", "phone", "cipher_column", "phone_cipher")), "MySQL");
         assertThat(actual.size(), is(1));
         assertThat(actual.getFirst().getOperationType(), is("drop"));
-        assertThat(actual.getFirst().getSql(), is("DROP ENCRYPT RULE orders"));
+        assertThat(actual.getFirst().getSql(), is("DROP ENCRYPT RULE `orders`"));
     }
     
     @Test
@@ -143,9 +143,9 @@ class EncryptRuleDistSQLPlanningServiceTest {
                 Map.of("logic_column", "email", "cipher_column", "email_cipher", "encryptor_type", "AES", "encryptor_props", "aes-key-value=old")), "MySQL");
         assertThat(actual.size(), is(1));
         assertThat(actual.getFirst().getOperationType(), is("drop"));
-        assertTrue(actual.getFirst().getSql().startsWith("ALTER ENCRYPT RULE orders"));
-        assertTrue(actual.getFirst().getSql().contains("NAME=email"));
-        assertTrue(actual.getFirst().getSql().contains("CIPHER=email_cipher"));
+        assertTrue(actual.getFirst().getSql().startsWith("ALTER ENCRYPT RULE `orders`"));
+        assertTrue(actual.getFirst().getSql().contains("NAME=`email`"));
+        assertTrue(actual.getFirst().getSql().contains("CIPHER=`email_cipher`"));
     }
     
     @Test
@@ -156,9 +156,9 @@ class EncryptRuleDistSQLPlanningServiceTest {
                 Map.of("logic_column", "Phone", "cipher_column", "Phone_cipher"),
                 Map.of("logic_column", "phone", "cipher_column", "phone_cipher", "encryptor_type", "AES", "encryptor_props", "aes-key-value=old")), "PostgreSQL");
         assertThat(actual.size(), is(1));
-        assertTrue(actual.getFirst().getSql().startsWith("ALTER ENCRYPT RULE orders"));
-        assertTrue(actual.getFirst().getSql().contains("NAME=phone"));
-        assertTrue(actual.getFirst().getSql().contains("CIPHER=phone_cipher"));
+        assertTrue(actual.getFirst().getSql().startsWith("ALTER ENCRYPT RULE `orders`"));
+        assertTrue(actual.getFirst().getSql().contains("NAME=`phone`"));
+        assertTrue(actual.getFirst().getSql().contains("CIPHER=`phone_cipher`"));
     }
     
     @Test
@@ -168,7 +168,7 @@ class EncryptRuleDistSQLPlanningServiceTest {
         List<RuleArtifact> actual = service.planEncryptDropRule(request, List.of(Map.of("logic_column", "phone", "cipher_column", "phone_cipher")), "PostgreSQL");
         assertThat(actual.size(), is(1));
         assertThat(actual.getFirst().getOperationType(), is("drop"));
-        assertThat(actual.getFirst().getSql(), is("DROP ENCRYPT RULE orders"));
+        assertThat(actual.getFirst().getSql(), is("DROP ENCRYPT RULE `orders`"));
     }
     
     @Test
@@ -178,7 +178,7 @@ class EncryptRuleDistSQLPlanningServiceTest {
         List<RuleArtifact> actual = service.planEncryptDropRule(request, List.of(Map.of("logic_column", "phone", "cipher_column", "phone_cipher")), "MySQL");
         assertThat(actual.size(), is(1));
         assertThat(actual.getFirst().getOperationType(), is("drop"));
-        assertThat(actual.getFirst().getSql(), is("DROP ENCRYPT RULE orders"));
+        assertThat(actual.getFirst().getSql(), is("DROP ENCRYPT RULE `orders`"));
     }
     
     private EncryptWorkflowRequest createRequest(final String operationType, final boolean equalityFilter, final boolean likeQuery) {

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowPlanningServiceTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowPlanningServiceTest.java
@@ -107,7 +107,7 @@ class EncryptWorkflowPlanningServiceTest {
         EncryptRuleInspectionService ruleInspectionService = mock(EncryptRuleInspectionService.class);
         when(ruleInspectionService.queryEncryptRules(any(), any(), any())).thenReturn(List.of(Map.of("logic_column", "phone")));
         EncryptRuleDistSQLPlanningService ruleDistSQLPlanningService = mock(EncryptRuleDistSQLPlanningService.class);
-        when(ruleDistSQLPlanningService.planEncryptDropRule(any(), any(), any())).thenReturn(List.of(new RuleArtifact("drop", "DROP ENCRYPT RULE orders")));
+        when(ruleDistSQLPlanningService.planEncryptDropRule(any(), any(), any())).thenReturn(List.of(new RuleArtifact("drop", "DROP ENCRYPT RULE `orders`")));
         WorkflowContextSnapshot actual = createService(ruleInspectionService, mock(EncryptAlgorithmRecommendationService.class),
                 mock(EncryptAlgorithmPropertyTemplateService.class), ruleDistSQLPlanningService)
                 .plan(new TestWorkflowSessionContext(), createMetadataQueryFacade(), mock(MCPFeatureQueryFacade.class), "session-1", createRequest("drop"));
@@ -216,9 +216,9 @@ class EncryptWorkflowPlanningServiceTest {
                 new EncryptRuleDistSQLPlanningService()).plan(new TestWorkflowSessionContext(), createMetadataQueryFacade(), mock(MCPFeatureQueryFacade.class), "session-1", request);
         String actualSQL = actual.getRuleArtifacts().getFirst().getSql();
         assertThat(actual.getStatus(), is("planned"));
-        assertTrue(actualSQL.startsWith("CREATE ENCRYPT RULE t_user"));
+        assertTrue(actualSQL.startsWith("CREATE ENCRYPT RULE `t_user`"));
         assertTrue(actualSQL.contains("NAME=`name`"));
-        assertTrue(actualSQL.contains("CIPHER=name_cipher"));
+        assertTrue(actualSQL.contains("CIPHER=`name_cipher`"));
         assertTrue(actualSQL.contains("TYPE(NAME='aes'"));
         assertTrue(actualSQL.contains("'digest-algorithm-name'='SHA-1'"));
     }

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowValidationServiceTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptWorkflowValidationServiceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.encrypt.tool.service;
 
+import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mcp.feature.encrypt.EncryptFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.encrypt.TestWorkflowSessionContext;
 import org.apache.shardingsphere.mcp.feature.encrypt.tool.model.EncryptWorkflowRequest;
@@ -33,9 +35,11 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactBundle.ExecutableWorkflowArtifact;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactPayloadUtils;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSQLUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationException;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationSupport;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.internal.configuration.plugins.Plugins;
 
 import java.lang.reflect.Field;
@@ -49,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -108,6 +113,27 @@ class EncryptWorkflowValidationServiceTest {
         List<Map<String, Object>> actual = new EncryptWorkflowValidationService().validate(new WorkflowContextSnapshot(),
                 List.of(createRuleDistSQLArtifact(sql, sql.replace("123456", "******"))));
         assertTrue(actual.isEmpty());
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsRejectsUnavailableEncryptAlgorithm() {
+        EncryptWorkflowRequest request = new EncryptWorkflowRequest();
+        request.setAlgorithmType("AES");
+        request.getPrimaryAlgorithmProperties().put("aes-key-value", "raw-secret");
+        request.getPrimaryAlgorithmProperties().put("digest-algorithm-name", "SHA-1");
+        WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
+        snapshot.setRequest(request);
+        String sql = "CREATE ENCRYPT RULE `t_user` (COLUMNS((NAME=`phone`, CIPHER=`phone_cipher`, "
+                + "ENCRYPT_ALGORITHM(TYPE(NAME='aes', PROPERTIES('aes-key-value'='******', 'digest-algorithm-name'='SHA-1'))))))";
+        try (MockedStatic<TypedSPILoader> ignored = mockStatic(TypedSPILoader.class)) {
+            ignored.when(() -> TypedSPILoader.checkService(EncryptAlgorithm.class, "AES", WorkflowSQLUtils.createProperties(request.getPrimaryAlgorithmProperties())))
+                    .thenThrow(new IllegalArgumentException("raw-secret"));
+            List<Map<String, Object>> actual = new EncryptWorkflowValidationService().validate(snapshot, List.of(createRuleDistSQLArtifact(sql, sql)));
+            assertThat(actual.size(), is(1));
+            assertThat(actual.getFirst().get("message"), is("Generated encrypt DistSQL references encrypt algorithm `AES`, "
+                    + "but it cannot be loaded or initialized by EncryptAlgorithm SPI."));
+            assertFalse(String.valueOf(actual).contains("raw-secret"));
+        }
     }
     
     @Test

--- a/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskRuleDistSQLPlanningService.java
+++ b/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskRuleDistSQLPlanningService.java
@@ -47,7 +47,7 @@ public final class MaskRuleDistSQLPlanningService {
      */
     public RuleArtifact planMaskDropRule(final WorkflowRequest request) {
         validateMaskIdentifiers(request);
-        return new RuleArtifact("drop", String.format("DROP MASK RULE %s", WorkflowSQLUtils.formatDistSQLIdentifier(request.getTable())));
+        return new RuleArtifact("drop", String.format("DROP MASK RULE %s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getTable())));
     }
     
     private void validateMaskIdentifiers(final WorkflowRequest request) {
@@ -56,13 +56,13 @@ public final class MaskRuleDistSQLPlanningService {
     }
     
     private String createTargetMaskColumnSegment(final WorkflowRequest request) {
-        return String.format("(NAME=%s, %s)", WorkflowSQLUtils.formatDistSQLIdentifier(request.getColumn()),
+        return String.format("(NAME=%s, %s)", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getColumn()),
                 WorkflowSQLUtils.createAlgorithmFragment(request.getAlgorithmType(), request.getPrimaryAlgorithmProperties()));
     }
     
     private String createMaskRuleSql(final String prefix, final String tableName, final List<String> columnSegments) {
         WorkflowSQLUtils.checkSupportedIdentifier("table", tableName);
-        return String.format("%s %s (%sCOLUMNS(%s%s%s))", prefix, WorkflowSQLUtils.formatDistSQLIdentifier(tableName), System.lineSeparator(), System.lineSeparator(),
+        return String.format("%s %s (%sCOLUMNS(%s%s%s))", prefix, WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(tableName), System.lineSeparator(), System.lineSeparator(),
                 String.join(", " + System.lineSeparator(), columnSegments), System.lineSeparator());
     }
 }

--- a/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowValidationService.java
+++ b/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowValidationService.java
@@ -17,35 +17,43 @@
 
 package org.apache.shardingsphere.mcp.feature.mask.tool.service;
 
+import org.apache.shardingsphere.mask.spi.MaskAlgorithm;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureExecutionFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
-import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowRuntimeHandler;
+import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.RuleWorkflowFeatureData;
 import org.apache.shardingsphere.mcp.support.workflow.model.ValidationReport;
 import org.apache.shardingsphere.mcp.support.workflow.model.ValidationSection;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssue;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowAlgorithmUtils;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactMaskUtils;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactBundle.ExecutableWorkflowArtifact;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowLifecycleUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowRuleValueUtils;
-import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSecretReferenceUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSQLUtils;
-import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactMaskUtils;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSecretReferenceUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationSupport;
-import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowValidationSupport;
+import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowApplyArtifactValidator;
+import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowRuntimeHandler;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
 /**
  * Mask workflow validation service.
  */
-public final class MaskWorkflowValidationService implements MCPWorkflowRuntimeHandler {
+public final class MaskWorkflowValidationService implements MCPWorkflowRuntimeHandler, MCPWorkflowApplyArtifactValidator {
     
     private final WorkflowValidationSupport validationSupport = new WorkflowValidationSupport();
     
@@ -72,9 +80,44 @@ public final class MaskWorkflowValidationService implements MCPWorkflowRuntimeHa
     }
     
     @Override
+    public List<Map<String, Object>> validate(final WorkflowContextSnapshot snapshot, final Collection<ExecutableWorkflowArtifact> artifacts) {
+        List<Map<String, Object>> result = new LinkedList<>();
+        for (ExecutableWorkflowArtifact each : artifacts) {
+            if (each.ruleDistSql()) {
+                addRuleDistSQLIssues(result, snapshot, each.sql(), each.displaySql());
+            }
+        }
+        return result;
+    }
+    
+    @Override
     public void synchronize(final WorkflowContextSnapshot snapshot, final MCPMetadataQueryFacade metadataQueryFacade,
                             final MCPFeatureQueryFacade queryFacade, final MCPFeatureExecutionFacade executionFacade, final String sessionId) {
         workflowSynchronizationSupport.synchronize(() -> createValidationReport(snapshot, queryFacade));
+    }
+    
+    private void addRuleDistSQLIssues(final List<Map<String, Object>> issues, final WorkflowContextSnapshot snapshot, final String sql, final String displaySql) {
+        if (!isMaskRuleDistSQL(sql)) {
+            return;
+        }
+        WorkflowRequest request = null == snapshot.getRequest() ? new WorkflowRequest() : snapshot.getRequest();
+        if (request.getAlgorithmType().isEmpty()) {
+            return;
+        }
+        if (!WorkflowAlgorithmUtils.isAlgorithmServiceAvailable(MaskAlgorithm.class, request.getAlgorithmType(), request.getPrimaryAlgorithmProperties())) {
+            issues.add(createValidationIssue(String.format("Generated mask DistSQL references algorithm `%s`, but it cannot be loaded or initialized by MaskAlgorithm SPI.",
+                    request.getAlgorithmType()), displaySql));
+        }
+    }
+    
+    private boolean isMaskRuleDistSQL(final String sql) {
+        String actualSQL = sql.trim().toUpperCase(Locale.ENGLISH);
+        return actualSQL.startsWith("CREATE MASK RULE") || actualSQL.startsWith("ALTER MASK RULE");
+    }
+    
+    private Map<String, Object> createValidationIssue(final String message, final String sql) {
+        return new WorkflowIssue(WorkflowIssueCode.SQL_EXECUTABILITY_FAILED, "error", WorkflowLifecycle.STEP_REVIEW,
+                message, "Regenerate the workflow artifact through the feature planner before approval.", true, Map.of("sql", sql)).toMap();
     }
     
     private ValidationReport createValidationReport(final WorkflowContextSnapshot snapshot, final MCPFeatureQueryFacade queryFacade) {

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/handler/MaskToolHandlerTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/handler/MaskToolHandlerTest.java
@@ -145,7 +145,7 @@ class MaskToolHandlerTest {
         WorkflowContextSnapshot result = createSnapshot("plan-1", "planned");
         result.setRequest(request);
         result.getPropertyRequirements().add(new AlgorithmPropertyRequirement("primary", "first-n", true, false, "from", ""));
-        result.getRuleArtifacts().add(new RuleArtifact("create", "CREATE MASK RULE orders (TYPE(NAME='keep_first_n_last_m'))"));
+        result.getRuleArtifacts().add(new RuleArtifact("create", "CREATE MASK RULE `orders` (TYPE(NAME='keep_first_n_last_m'))"));
         result.setInteractionPlan(createInteractionPlan());
         return result;
     }

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskRuleDistSQLPlanningServiceTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskRuleDistSQLPlanningServiceTest.java
@@ -35,7 +35,7 @@ class MaskRuleDistSQLPlanningServiceTest {
     void assertPlanMaskRuleWithCreate() {
         RuleArtifact actual = service.planMaskRule(createRequest("create"));
         assertThat(actual.getOperationType(), is("create"));
-        assertTrue(actual.getSql().startsWith("CREATE MASK RULE orders"));
+        assertTrue(actual.getSql().startsWith("CREATE MASK RULE `orders`"));
         assertTrue(actual.getSql().contains("TYPE(NAME='mask_from_x_to_y'"));
     }
     
@@ -65,7 +65,7 @@ class MaskRuleDistSQLPlanningServiceTest {
         request.setTable("key");
         RuleArtifact actual = service.planMaskRule(request);
         assertTrue(actual.getSql().startsWith("CREATE MASK RULE `key`"));
-        assertTrue(actual.getSql().contains("NAME=phone"));
+        assertTrue(actual.getSql().contains("NAME=`phone`"));
     }
     
     @Test
@@ -89,7 +89,7 @@ class MaskRuleDistSQLPlanningServiceTest {
     void assertPlanMaskDropRuleWithoutRemainingColumns() {
         RuleArtifact actual = service.planMaskDropRule(createRequest("drop"));
         assertThat(actual.getOperationType(), is("drop"));
-        assertThat(actual.getSql(), is("DROP MASK RULE orders"));
+        assertThat(actual.getSql(), is("DROP MASK RULE `orders`"));
     }
     
     private WorkflowRequest createRequest(final String operationType) {

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowPlanningServiceTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowPlanningServiceTest.java
@@ -138,7 +138,7 @@ class MaskWorkflowPlanningServiceTest {
         MaskRuleInspectionService ruleInspectionService = mock(MaskRuleInspectionService.class);
         when(ruleInspectionService.queryMaskRules(any(), any(), any())).thenReturn(List.of(Map.of("column", "phone")));
         MaskRuleDistSQLPlanningService ruleDistSQLPlanningService = mock(MaskRuleDistSQLPlanningService.class);
-        when(ruleDistSQLPlanningService.planMaskDropRule(any())).thenReturn(new RuleArtifact("drop", "DROP MASK RULE orders"));
+        when(ruleDistSQLPlanningService.planMaskDropRule(any())).thenReturn(new RuleArtifact("drop", "DROP MASK RULE `orders`"));
         WorkflowContextSnapshot actual = createService(ruleInspectionService, mock(MaskAlgorithmRecommendationService.class),
                 mock(MaskAlgorithmPropertyTemplateService.class), ruleDistSQLPlanningService)
                 .plan(new TestWorkflowSessionContext(), createMetadataQueryFacade(), mock(MCPFeatureQueryFacade.class), "session-1", createRequest("drop"));

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowValidationServiceTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/tool/service/MaskWorkflowValidationServiceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.mask.tool.service;
 
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.apache.shardingsphere.mask.spi.MaskAlgorithm;
 import org.apache.shardingsphere.mcp.feature.mask.MaskFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.mask.TestWorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureExecutionFacade;
@@ -30,9 +32,12 @@ import org.apache.shardingsphere.mcp.support.workflow.model.SecretReferenceValue
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactBundle.ExecutableWorkflowArtifact;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSQLUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationException;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationSupport;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.internal.configuration.plugins.Plugins;
 
 import java.lang.reflect.Field;
@@ -43,8 +48,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -84,6 +91,33 @@ class MaskWorkflowValidationServiceTest {
         assertFalse(actual.containsKey("sql_executability_validation"));
         verifyNoInteractions(metadataQueryFacade);
         verifyNoInteractions(executionFacade);
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsRejectsUnavailableMaskAlgorithm() {
+        WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
+        WorkflowRequest request = new WorkflowRequest();
+        request.setAlgorithmType("MASK_FROM_X_TO_Y");
+        request.getPrimaryAlgorithmProperties().put("replace-char", "raw-secret");
+        snapshot.setRequest(request);
+        String sql = "CREATE MASK RULE `orders` (COLUMNS((NAME=`phone`, TYPE(NAME='mask_from_x_to_y', PROPERTIES('replace-char'='******')))))";
+        try (MockedStatic<TypedSPILoader> mockedStatic = mockStatic(TypedSPILoader.class)) {
+            mockedStatic.when(() -> TypedSPILoader.checkService(MaskAlgorithm.class, "MASK_FROM_X_TO_Y",
+                    WorkflowSQLUtils.createProperties(request.getPrimaryAlgorithmProperties()))).thenThrow(new IllegalArgumentException("raw-secret"));
+            List<Map<String, Object>> actual = new MaskWorkflowValidationService().validate(snapshot, List.of(createRuleDistSQLArtifact(sql)));
+            assertThat(actual.size(), is(1));
+            assertThat(actual.getFirst().get("code"), is(WorkflowIssueCode.SQL_EXECUTABILITY_FAILED));
+            assertFalse(String.valueOf(actual).contains("raw-secret"));
+        }
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsIgnoresDropMaskRule() {
+        WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
+        WorkflowRequest request = new WorkflowRequest();
+        request.setAlgorithmType("MASK_FROM_X_TO_Y");
+        snapshot.setRequest(request);
+        assertTrue(new MaskWorkflowValidationService().validate(snapshot, List.of(createRuleDistSQLArtifact("DROP MASK RULE `orders`"))).isEmpty());
     }
     
     @Test
@@ -254,5 +288,9 @@ class MaskWorkflowValidationServiceTest {
         clarifiedIntent.setOperationType(operationType);
         result.setClarifiedIntent(clarifiedIntent);
         return result;
+    }
+    
+    private ExecutableWorkflowArtifact createRuleDistSQLArtifact(final String sql) {
+        return new ExecutableWorkflowArtifact("review-rule-sql", "rule_dist_sql", sql, sql, true);
     }
 }

--- a/mcp/features/readwrite-splitting/pom.xml
+++ b/mcp/features/readwrite-splitting/pom.xml
@@ -37,5 +37,10 @@
             <artifactId>shardingsphere-readwrite-splitting-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-algorithm-load-balancer-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingRuleDistSQLPlanningService.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingRuleDistSQLPlanningService.java
@@ -56,14 +56,14 @@ public final class ReadwriteSplittingRuleDistSQLPlanningService {
      * @return rule artifact
      */
     public RuleArtifact planDropRule(final String ruleName) {
-        return new RuleArtifact("drop", String.format("DROP READWRITE_SPLITTING RULE %s", WorkflowSQLUtils.formatDistSQLIdentifier(ruleName)));
+        return new RuleArtifact("drop", String.format("DROP READWRITE_SPLITTING RULE %s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(ruleName)));
     }
     
     private String createRuleDefinition(final ReadwriteSplittingRuleWorkflowRequest request) {
         return String.format("%s (WRITE_STORAGE_UNIT=%s, READ_STORAGE_UNITS(%s), TRANSACTIONAL_READ_QUERY_STRATEGY='%s'%s)",
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getRuleName()),
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getWriteStorageUnit()),
-                request.getReadStorageUnits().stream().map(WorkflowSQLUtils::formatDistSQLIdentifier).collect(Collectors.joining(", ")),
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getRuleName()),
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getWriteStorageUnit()),
+                request.getReadStorageUnits().stream().map(WorkflowSQLUtils::formatGeneratedRuleDistSQLIdentifier).collect(Collectors.joining(", ")),
                 WorkflowSQLUtils.escapeLiteral(request.getTransactionalReadQueryStrategy().toUpperCase(Locale.ENGLISH)),
                 createLoadBalancerFragment(request));
     }

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingRuleWorkflowValidationService.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingRuleWorkflowValidationService.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.tool.service;
 
+import org.apache.shardingsphere.infra.algorithm.loadbalancer.spi.LoadBalanceAlgorithm;
 import org.apache.shardingsphere.mcp.feature.readwritesplitting.tool.model.ReadwriteSplittingRuleWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureExecutionFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
@@ -25,23 +26,30 @@ import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.ValidationReport;
 import org.apache.shardingsphere.mcp.support.workflow.model.ValidationSection;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssue;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowAlgorithmUtils;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactBundle.ExecutableWorkflowArtifact;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowLifecycleUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowRuleValueUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSQLUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationSupport;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowValidationSupport;
+import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowApplyArtifactValidator;
 import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowRuntimeHandler;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
  * Readwrite-splitting rule workflow validation service.
  */
-public final class ReadwriteSplittingRuleWorkflowValidationService implements MCPWorkflowRuntimeHandler {
+public final class ReadwriteSplittingRuleWorkflowValidationService implements MCPWorkflowRuntimeHandler, MCPWorkflowApplyArtifactValidator {
     
     private final WorkflowValidationSupport validationSupport = new WorkflowValidationSupport();
     
@@ -52,12 +60,6 @@ public final class ReadwriteSplittingRuleWorkflowValidationService implements MC
     public ReadwriteSplittingRuleWorkflowValidationService() {
         inspectionService = new ReadwriteSplittingInspectionService();
         workflowSynchronizationSupport = new WorkflowSynchronizationSupport();
-    }
-    
-    ReadwriteSplittingRuleWorkflowValidationService(final ReadwriteSplittingInspectionService inspectionService,
-                                                    final WorkflowSynchronizationSupport workflowSynchronizationSupport) {
-        this.inspectionService = inspectionService;
-        this.workflowSynchronizationSupport = workflowSynchronizationSupport;
     }
     
     @Override
@@ -74,9 +76,69 @@ public final class ReadwriteSplittingRuleWorkflowValidationService implements MC
     }
     
     @Override
+    public List<Map<String, Object>> validate(final WorkflowContextSnapshot snapshot, final Collection<ExecutableWorkflowArtifact> artifacts) {
+        List<Map<String, Object>> result = new LinkedList<>();
+        for (ExecutableWorkflowArtifact each : artifacts) {
+            if (each.ruleDistSql()) {
+                addRuleDistSQLIssues(result, snapshot, each.sql(), each.displaySql());
+            }
+        }
+        return result;
+    }
+    
+    @Override
     public void synchronize(final WorkflowContextSnapshot snapshot, final MCPMetadataQueryFacade metadataQueryFacade,
                             final MCPFeatureQueryFacade queryFacade, final MCPFeatureExecutionFacade executionFacade, final String sessionId) {
         workflowSynchronizationSupport.synchronize(() -> createValidationReport(snapshot, queryFacade));
+    }
+    
+    private void addRuleDistSQLIssues(final List<Map<String, Object>> issues, final WorkflowContextSnapshot snapshot, final String sql, final String displaySql) {
+        if (!isReadwriteSplittingRuleDistSQL(sql) || !(snapshot.getRequest() instanceof ReadwriteSplittingRuleWorkflowRequest)) {
+            return;
+        }
+        ReadwriteSplittingRuleWorkflowRequest request = (ReadwriteSplittingRuleWorkflowRequest) snapshot.getRequest();
+        addLoadBalancerIssue(issues, request, displaySql);
+        addWeightIssues(issues, request, displaySql);
+    }
+    
+    private boolean isReadwriteSplittingRuleDistSQL(final String sql) {
+        String actualSQL = sql.trim().toUpperCase(Locale.ENGLISH);
+        return actualSQL.startsWith("CREATE READWRITE_SPLITTING RULE") || actualSQL.startsWith("ALTER READWRITE_SPLITTING RULE");
+    }
+    
+    private void addLoadBalancerIssue(final List<Map<String, Object>> issues, final ReadwriteSplittingRuleWorkflowRequest request, final String displaySql) {
+        if (request.getLoadBalancerType().isEmpty()) {
+            return;
+        }
+        if (!WorkflowAlgorithmUtils.isAlgorithmServiceAvailable(LoadBalanceAlgorithm.class, request.getLoadBalancerType(), request.getLoadBalancerProperties())) {
+            issues.add(createValidationIssue(String.format("Generated readwrite-splitting DistSQL references load balancer algorithm `%s`, "
+                    + "but it cannot be loaded or initialized by LoadBalanceAlgorithm SPI.", request.getLoadBalancerType()), displaySql));
+        }
+    }
+    
+    private void addWeightIssues(final List<Map<String, Object>> issues, final ReadwriteSplittingRuleWorkflowRequest request, final String displaySql) {
+        if (!"WEIGHT".equalsIgnoreCase(request.getLoadBalancerType())) {
+            return;
+        }
+        if (request.getLoadBalancerProperties().isEmpty()) {
+            issues.add(createValidationIssue("Generated readwrite-splitting DistSQL uses WEIGHT load balancer without weight properties.", displaySql));
+            return;
+        }
+        for (String each : request.getLoadBalancerProperties().keySet()) {
+            if (!request.getReadStorageUnits().contains(each)) {
+                issues.add(createValidationIssue(String.format("Generated readwrite-splitting DistSQL defines weight for unknown read storage unit `%s`.", each), displaySql));
+            }
+        }
+        for (String each : request.getReadStorageUnits()) {
+            if (!request.getLoadBalancerProperties().containsKey(each)) {
+                issues.add(createValidationIssue(String.format("Generated readwrite-splitting DistSQL is missing weight for read storage unit `%s`.", each), displaySql));
+            }
+        }
+    }
+    
+    private Map<String, Object> createValidationIssue(final String message, final String sql) {
+        return new WorkflowIssue(WorkflowIssueCode.SQL_EXECUTABILITY_FAILED, "error", WorkflowLifecycle.STEP_REVIEW,
+                message, "Regenerate the workflow artifact through the feature planner before approval.", true, Map.of("sql", sql)).toMap();
     }
     
     private ValidationReport createValidationReport(final WorkflowContextSnapshot snapshot, final MCPFeatureQueryFacade queryFacade) {

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingStatusDistSQLPlanningService.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingStatusDistSQLPlanningService.java
@@ -42,8 +42,8 @@ public final class ReadwriteSplittingStatusDistSQLPlanningService {
             throw new MCPInvalidRequestException("target_status is required for readwrite-splitting status.");
         }
         return new RuleArtifact(operation.toLowerCase(Locale.ENGLISH), String.format("ALTER READWRITE_SPLITTING RULE %s %s %s FROM %s",
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getRuleName()), operation,
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getStorageUnit()), WorkflowSQLUtils.formatDistSQLIdentifier(request.getDatabase())));
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getRuleName()), operation,
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getStorageUnit()), WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getDatabase())));
     }
     
     /**

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingStatusWorkflowValidationService.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingStatusWorkflowValidationService.java
@@ -55,14 +55,6 @@ public final class ReadwriteSplittingStatusWorkflowValidationService implements 
         workflowSynchronizationSupport = new WorkflowSynchronizationSupport();
     }
     
-    ReadwriteSplittingStatusWorkflowValidationService(final ReadwriteSplittingInspectionService inspectionService,
-                                                      final ReadwriteSplittingStatusDistSQLPlanningService distSQLPlanningService,
-                                                      final WorkflowSynchronizationSupport workflowSynchronizationSupport) {
-        this.inspectionService = inspectionService;
-        this.distSQLPlanningService = distSQLPlanningService;
-        this.workflowSynchronizationSupport = workflowSynchronizationSupport;
-    }
-    
     @Override
     public Map<String, Object> validate(final WorkflowSessionContext workflowSessionContext, final MCPMetadataQueryFacade metadataQueryFacade,
                                         final MCPFeatureQueryFacade queryFacade, final MCPFeatureExecutionFacade executionFacade, final String sessionId,

--- a/mcp/features/readwrite-splitting/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-readwrite-splitting.yaml
+++ b/mcp/features/readwrite-splitting/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-readwrite-splitting.yaml
@@ -510,7 +510,7 @@ tools:
           distsql_artifacts:
             - operation_type: create
               artifact_type: rule_distsql
-              sql: CREATE READWRITE_SPLITTING RULE readwrite_ds (WRITE_STORAGE_UNIT=ds_write, READ_STORAGE_UNITS(ds_read_0), TRANSACTIONAL_READ_QUERY_STRATEGY='DYNAMIC')
+              sql: CREATE READWRITE_SPLITTING RULE `readwrite_ds` (WRITE_STORAGE_UNIT=`ds_write`, READ_STORAGE_UNITS(`ds_read_0`), TRANSACTIONAL_READ_QUERY_STRATEGY='DYNAMIC')
           next_actions:
             - order: 1
               type: tool_call
@@ -624,7 +624,7 @@ tools:
           distsql_artifacts:
             - target_status: enable
               artifact_type: rule_distsql
-              sql: ALTER READWRITE_SPLITTING RULE readwrite_ds ENABLE ds_read_0 FROM logic_db
+              sql: ALTER READWRITE_SPLITTING RULE `readwrite_ds` ENABLE `ds_read_0` FROM `logic_db`
           next_actions:
             - order: 1
               type: tool_call

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/handler/ReadwriteSplittingToolHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/handler/ReadwriteSplittingToolHandlerTest.java
@@ -131,7 +131,7 @@ class ReadwriteSplittingToolHandlerTest {
         request.setRuleName("readwrite_ds");
         WorkflowContextSnapshot result = createSnapshot(request, ReadwriteSplittingFeatureDefinition.RULE_WORKFLOW_KIND.getValue());
         result.getRuleArtifacts().add(new RuleArtifact("create",
-                "CREATE READWRITE_SPLITTING RULE readwrite_ds (WRITE_STORAGE_UNIT=write_ds, READ_STORAGE_UNITS(read_ds_0), TRANSACTIONAL_READ_QUERY_STRATEGY='DYNAMIC')"));
+                "CREATE READWRITE_SPLITTING RULE `readwrite_ds` (WRITE_STORAGE_UNIT=`write_ds`, READ_STORAGE_UNITS(`read_ds_0`), TRANSACTIONAL_READ_QUERY_STRATEGY='DYNAMIC')"));
         return result;
     }
     
@@ -153,7 +153,7 @@ class ReadwriteSplittingToolHandlerTest {
         request.setTargetStatus("disable");
         request.setOperationType("disable");
         WorkflowContextSnapshot result = createSnapshot(request, ReadwriteSplittingFeatureDefinition.STATUS_WORKFLOW_KIND.getValue());
-        result.getRuleArtifacts().add(new RuleArtifact("disable", "ALTER READWRITE_SPLITTING RULE readwrite_ds DISABLE read_ds_0 FROM logic_db"));
+        result.getRuleArtifacts().add(new RuleArtifact("disable", "ALTER READWRITE_SPLITTING RULE `readwrite_ds` DISABLE `read_ds_0` FROM `logic_db`"));
         return result;
     }
     

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingDistSQLPlanningServiceTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingDistSQLPlanningServiceTest.java
@@ -34,7 +34,7 @@ class ReadwriteSplittingDistSQLPlanningServiceTest {
     void assertPlanCreateRule() {
         ReadwriteSplittingRuleWorkflowRequest request = createRuleRequest();
         assertThat(new ReadwriteSplittingRuleDistSQLPlanningService().planCreateRule(request).getSql(),
-                is("CREATE READWRITE_SPLITTING RULE readwrite_ds (WRITE_STORAGE_UNIT=write_ds, READ_STORAGE_UNITS(read_ds_0, read_ds_1), "
+                is("CREATE READWRITE_SPLITTING RULE `readwrite_ds` (WRITE_STORAGE_UNIT=`write_ds`, READ_STORAGE_UNITS(`read_ds_0`, `read_ds_1`), "
                         + "TRANSACTIONAL_READ_QUERY_STRATEGY='DYNAMIC', TYPE(NAME='weight', PROPERTIES('read_ds_0'='2')))"));
     }
     
@@ -58,7 +58,7 @@ class ReadwriteSplittingDistSQLPlanningServiceTest {
     
     @Test
     void assertPlanDropRule() {
-        assertThat(new ReadwriteSplittingRuleDistSQLPlanningService().planDropRule("readwrite_ds").getSql(), is("DROP READWRITE_SPLITTING RULE readwrite_ds"));
+        assertThat(new ReadwriteSplittingRuleDistSQLPlanningService().planDropRule("readwrite_ds").getSql(), is("DROP READWRITE_SPLITTING RULE `readwrite_ds`"));
     }
     
     @Test
@@ -69,7 +69,7 @@ class ReadwriteSplittingDistSQLPlanningServiceTest {
         request.setStorageUnit("read_ds_0");
         request.setTargetStatus("enable");
         assertThat(new ReadwriteSplittingStatusDistSQLPlanningService().planStatus(request).getSql(),
-                is("ALTER READWRITE_SPLITTING RULE readwrite_ds ENABLE read_ds_0 FROM logic_db"));
+                is("ALTER READWRITE_SPLITTING RULE `readwrite_ds` ENABLE `read_ds_0` FROM `logic_db`"));
     }
     
     @Test

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingWorkflowPlanningServiceTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingWorkflowPlanningServiceTest.java
@@ -46,7 +46,7 @@ class ReadwriteSplittingWorkflowPlanningServiceTest {
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
         assertThat(actual.getWorkflowKind().getValue(), is("readwrite.rule"));
         assertThat(actual.getRuleArtifacts().getFirst().getSql(),
-                is("CREATE READWRITE_SPLITTING RULE readwrite_ds (WRITE_STORAGE_UNIT=write_ds, READ_STORAGE_UNITS(read_ds_0), TRANSACTIONAL_READ_QUERY_STRATEGY='DYNAMIC')"));
+                is("CREATE READWRITE_SPLITTING RULE `readwrite_ds` (WRITE_STORAGE_UNIT=`write_ds`, READ_STORAGE_UNITS(`read_ds_0`), TRANSACTIONAL_READ_QUERY_STRATEGY='DYNAMIC')"));
         assertFalse(actual.getDdlArtifacts().iterator().hasNext());
         assertFalse(actual.getIndexPlans().iterator().hasNext());
     }
@@ -59,7 +59,7 @@ class ReadwriteSplittingWorkflowPlanningServiceTest {
         WorkflowContextSnapshot actual = createRuleService().plan(new TestWorkflowSessionContext(), mockRuleQueryFacade(List.of()), "session-1", request);
         assertThat(actual.getAlgorithmCandidates().getFirst().getAlgorithmType(), is("WEIGHT"));
         assertThat(actual.getPropertyRequirements().getFirst().getPropertyKey(), is("read_ds_0"));
-        String expectedSQL = "CREATE READWRITE_SPLITTING RULE readwrite_ds (WRITE_STORAGE_UNIT=write_ds, READ_STORAGE_UNITS(read_ds_0), "
+        String expectedSQL = "CREATE READWRITE_SPLITTING RULE `readwrite_ds` (WRITE_STORAGE_UNIT=`write_ds`, READ_STORAGE_UNITS(`read_ds_0`), "
                 + "TRANSACTIONAL_READ_QUERY_STRATEGY='DYNAMIC', TYPE(NAME='weight', PROPERTIES('read_ds_0'='2')))";
         assertThat(actual.getRuleArtifacts().getFirst().getSql(), is(expectedSQL));
     }
@@ -101,7 +101,7 @@ class ReadwriteSplittingWorkflowPlanningServiceTest {
         request.setOperationType("drop");
         WorkflowContextSnapshot actual = createRuleService().plan(new TestWorkflowSessionContext(), mockRuleQueryFacade(List.of(Map.of("name", "readwrite_ds"))), "session-1", request);
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
-        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("DROP READWRITE_SPLITTING RULE readwrite_ds"));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("DROP READWRITE_SPLITTING RULE `readwrite_ds`"));
     }
     
     @Test
@@ -147,7 +147,7 @@ class ReadwriteSplittingWorkflowPlanningServiceTest {
                 createStatusService().plan(new TestWorkflowSessionContext(), mockStatusQueryFacade(List.of(createStatusRow("ENABLED"))), "session-1", createStatusRequest("disable"));
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
         assertThat(actual.getWorkflowKind().getValue(), is("readwrite.status"));
-        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("ALTER READWRITE_SPLITTING RULE readwrite_ds DISABLE read_ds_0 FROM logic_db"));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("ALTER READWRITE_SPLITTING RULE `readwrite_ds` DISABLE `read_ds_0` FROM `logic_db`"));
     }
     
     @Test
@@ -159,7 +159,7 @@ class ReadwriteSplittingWorkflowPlanningServiceTest {
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
         assertThat(((ReadwriteSplittingStatusWorkflowRequest) actual.getRequest()).getTargetStatus(), is("disable"));
         assertThat(actual.getRequest().getOperationType(), is(""));
-        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("ALTER READWRITE_SPLITTING RULE readwrite_ds DISABLE read_ds_0 FROM logic_db"));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("ALTER READWRITE_SPLITTING RULE `readwrite_ds` DISABLE `read_ds_0` FROM `logic_db`"));
     }
     
     @Test

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingWorkflowValidationServiceTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingWorkflowValidationServiceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.tool.service;
 
+import org.apache.shardingsphere.infra.algorithm.loadbalancer.spi.LoadBalanceAlgorithm;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mcp.feature.readwritesplitting.ReadwriteSplittingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.readwritesplitting.TestWorkflowSessionContext;
 import org.apache.shardingsphere.mcp.feature.readwritesplitting.tool.model.ReadwriteSplittingRuleWorkflowRequest;
@@ -31,8 +33,13 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationException;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationSupport;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactBundle.ExecutableWorkflowArtifact;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSQLUtils;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.internal.configuration.plugins.Plugins;
 
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
@@ -41,13 +48,14 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class ReadwriteSplittingWorkflowValidationServiceTest {
     
     @Test
-    void assertValidateRejectsDifferentSession() {
+    void assertValidateRejectsDifferentSession() throws ReflectiveOperationException {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         workflowSessionContext.save(createRuleSnapshot("plan-1", "session-1", "executed", "create"));
         Map<String, Object> actual = createRuleService(mock(ReadwriteSplittingInspectionService.class))
@@ -58,7 +66,7 @@ class ReadwriteSplittingWorkflowValidationServiceTest {
     }
     
     @Test
-    void assertValidateRuleHappyPath() {
+    void assertValidateRuleHappyPath() throws ReflectiveOperationException {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         WorkflowContextSnapshot snapshot = createRuleSnapshot("plan-1", "session-1", "executed", "create");
         workflowSessionContext.save(snapshot);
@@ -76,7 +84,35 @@ class ReadwriteSplittingWorkflowValidationServiceTest {
     }
     
     @Test
-    void assertValidateRuleMismatch() {
+    void assertValidateApplyArtifactsRejectsUnavailableLoadBalancer() {
+        WorkflowContextSnapshot snapshot = createRuleSnapshot("plan-1", "session-1", "executed", "create");
+        ReadwriteSplittingRuleWorkflowRequest request = (ReadwriteSplittingRuleWorkflowRequest) snapshot.getRequest();
+        request.setLoadBalancerType("RANDOM");
+        try (MockedStatic<TypedSPILoader> mockedStatic = mockStatic(TypedSPILoader.class)) {
+            mockedStatic.when(() -> TypedSPILoader.checkService(LoadBalanceAlgorithm.class, "RANDOM",
+                    WorkflowSQLUtils.createProperties(request.getLoadBalancerProperties()))).thenThrow(new IllegalArgumentException("unavailable"));
+            List<Map<String, Object>> actual = new ReadwriteSplittingRuleWorkflowValidationService().validate(snapshot, List.of(createRuleDistSQLArtifact()));
+            assertThat(actual.size(), is(1));
+            assertThat(actual.getFirst().get("code"), is(WorkflowIssueCode.SQL_EXECUTABILITY_FAILED));
+        }
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsRejectsInvalidWeightProperties() {
+        WorkflowContextSnapshot snapshot = createRuleSnapshot("plan-1", "session-1", "executed", "create");
+        ReadwriteSplittingRuleWorkflowRequest request = (ReadwriteSplittingRuleWorkflowRequest) snapshot.getRequest();
+        request.setReadStorageUnits("read_ds_0,read_ds_1");
+        request.setLoadBalancerType("WEIGHT");
+        request.putLoadBalancerProperties(Map.of("read_ds_0", "2", "unknown_ds", "1"));
+        try (MockedStatic<TypedSPILoader> ignored = mockStatic(TypedSPILoader.class)) {
+            List<Map<String, Object>> actual = new ReadwriteSplittingRuleWorkflowValidationService().validate(snapshot, List.of(createRuleDistSQLArtifact()));
+            assertThat(actual.size(), is(2));
+            assertThat(actual.getFirst().get("code"), is(WorkflowIssueCode.SQL_EXECUTABILITY_FAILED));
+        }
+    }
+    
+    @Test
+    void assertValidateRuleMismatch() throws ReflectiveOperationException {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         WorkflowContextSnapshot snapshot = createRuleSnapshot("plan-1", "session-1", "executed", "create");
         workflowSessionContext.save(snapshot);
@@ -89,7 +125,7 @@ class ReadwriteSplittingWorkflowValidationServiceTest {
     }
     
     @Test
-    void assertValidateDropWorkflowAfterRuleRemoval() {
+    void assertValidateDropWorkflowAfterRuleRemoval() throws ReflectiveOperationException {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         WorkflowContextSnapshot snapshot = createRuleSnapshot("plan-1", "session-1", "executed", "drop");
         workflowSessionContext.save(snapshot);
@@ -101,7 +137,7 @@ class ReadwriteSplittingWorkflowValidationServiceTest {
     }
     
     @Test
-    void assertValidateStatusHappyPath() {
+    void assertValidateStatusHappyPath() throws ReflectiveOperationException {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         WorkflowContextSnapshot snapshot = createStatusSnapshot("plan-1", "session-1", "executed", "enable");
         workflowSessionContext.save(snapshot);
@@ -116,7 +152,7 @@ class ReadwriteSplittingWorkflowValidationServiceTest {
     }
     
     @Test
-    void assertSynchronizeStatusWhenStateDoesNotConverge() {
+    void assertSynchronizeStatusWhenStateDoesNotConverge() throws ReflectiveOperationException {
         WorkflowContextSnapshot snapshot = createStatusSnapshot("plan-1", "session-1", "executed", "enable");
         ReadwriteSplittingInspectionService inspectionService = mock(ReadwriteSplittingInspectionService.class);
         when(inspectionService.queryRuleStatus(any(), any(), any())).thenReturn(List.of(createStatusRow("DISABLED")));
@@ -126,12 +162,23 @@ class ReadwriteSplittingWorkflowValidationServiceTest {
         assertThat(actual.getIssueCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
     }
     
-    private ReadwriteSplittingRuleWorkflowValidationService createRuleService(final ReadwriteSplittingInspectionService inspectionService) {
-        return new ReadwriteSplittingRuleWorkflowValidationService(inspectionService, new WorkflowSynchronizationSupport(1, 0L));
+    private ReadwriteSplittingRuleWorkflowValidationService createRuleService(final ReadwriteSplittingInspectionService inspectionService) throws ReflectiveOperationException {
+        ReadwriteSplittingRuleWorkflowValidationService result = new ReadwriteSplittingRuleWorkflowValidationService();
+        setField(result, "inspectionService", inspectionService);
+        setField(result, "workflowSynchronizationSupport", new WorkflowSynchronizationSupport(1, 0L));
+        return result;
     }
     
-    private ReadwriteSplittingStatusWorkflowValidationService createStatusService(final ReadwriteSplittingInspectionService inspectionService) {
-        return new ReadwriteSplittingStatusWorkflowValidationService(inspectionService, new ReadwriteSplittingStatusDistSQLPlanningService(), new WorkflowSynchronizationSupport(1, 0L));
+    private ReadwriteSplittingStatusWorkflowValidationService createStatusService(final ReadwriteSplittingInspectionService inspectionService) throws ReflectiveOperationException {
+        ReadwriteSplittingStatusWorkflowValidationService result = new ReadwriteSplittingStatusWorkflowValidationService();
+        setField(result, "inspectionService", inspectionService);
+        setField(result, "workflowSynchronizationSupport", new WorkflowSynchronizationSupport(1, 0L));
+        return result;
+    }
+    
+    private void setField(final Object target, final String fieldName, final Object value) throws ReflectiveOperationException {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        Plugins.getMemberAccessor().set(field, target, value);
     }
     
     private WorkflowContextSnapshot createRuleSnapshot(final String planId, final String sessionId, final String status, final String operationType) {
@@ -183,5 +230,10 @@ class ReadwriteSplittingWorkflowValidationServiceTest {
     
     private Map<String, Object> createStatusRow(final String status) {
         return Map.of("name", "readwrite_ds", "storage_unit", "read_ds_0", "status", status);
+    }
+    
+    private ExecutableWorkflowArtifact createRuleDistSQLArtifact() {
+        return new ExecutableWorkflowArtifact("review-rule-sql", "rule_dist_sql",
+                "CREATE READWRITE_SPLITTING RULE `readwrite_ds` (WRITE_STORAGE_UNIT=`write_ds`, READ_STORAGE_UNITS(`read_ds_0`), TRANSACTIONAL_READ_QUERY_STRATEGY='DYNAMIC')", true);
     }
 }

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowDistSQLPlanningService.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowDistSQLPlanningService.java
@@ -35,10 +35,10 @@ public final class ShadowDistSQLPlanningService {
      */
     public RuleArtifact planCreateRule(final ShadowRuleWorkflowRequest request) {
         return new RuleArtifact("create", String.format("CREATE SHADOW RULE %s(SOURCE=%s, SHADOW=%s, %s(%s))",
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getRuleName()),
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getSourceStorageUnit()),
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getShadowStorageUnit()),
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getTableName()),
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getRuleName()),
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getSourceStorageUnit()),
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getShadowStorageUnit()),
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getTableName()),
                 WorkflowSQLUtils.createAlgorithmFragment(request.getAlgorithmType(), request.getAlgorithmProperties())));
     }
     
@@ -50,10 +50,10 @@ public final class ShadowDistSQLPlanningService {
      */
     public RuleArtifact planAlterRule(final ShadowRuleWorkflowRequest request) {
         return new RuleArtifact("alter", String.format("ALTER SHADOW RULE %s(SOURCE=%s, SHADOW=%s, %s(%s))",
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getRuleName()),
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getSourceStorageUnit()),
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getShadowStorageUnit()),
-                WorkflowSQLUtils.formatDistSQLIdentifier(request.getTableName()),
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getRuleName()),
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getSourceStorageUnit()),
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getShadowStorageUnit()),
+                WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(request.getTableName()),
                 WorkflowSQLUtils.createAlgorithmFragment(request.getAlgorithmType(), request.getAlgorithmProperties())));
     }
     
@@ -64,7 +64,7 @@ public final class ShadowDistSQLPlanningService {
      * @return rule artifact
      */
     public RuleArtifact planDropRule(final String ruleName) {
-        return new RuleArtifact("drop", String.format("DROP SHADOW RULE %s", WorkflowSQLUtils.formatDistSQLIdentifier(ruleName)));
+        return new RuleArtifact("drop", String.format("DROP SHADOW RULE %s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(ruleName)));
     }
     
     /**
@@ -105,6 +105,6 @@ public final class ShadowDistSQLPlanningService {
      * @return rule artifact
      */
     public RuleArtifact planDropAlgorithm(final String algorithmName) {
-        return new RuleArtifact("drop", String.format("DROP SHADOW ALGORITHM %s", WorkflowSQLUtils.formatDistSQLIdentifier(algorithmName)));
+        return new RuleArtifact("drop", String.format("DROP SHADOW ALGORITHM %s", WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(algorithmName)));
     }
 }

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowValidationService.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowValidationService.java
@@ -27,22 +27,30 @@ import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.ValidationReport;
 import org.apache.shardingsphere.mcp.support.workflow.model.ValidationSection;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssue;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowAlgorithmUtils;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactBundle.ExecutableWorkflowArtifact;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowLifecycleUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowRuleValueUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSQLUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationSupport;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowValidationSupport;
+import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowApplyArtifactValidator;
 import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowRuntimeHandler;
+import org.apache.shardingsphere.shadow.spi.ShadowAlgorithm;
 
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
  * Shadow workflow validation service.
  */
-public final class ShadowWorkflowValidationService implements MCPWorkflowRuntimeHandler {
+public final class ShadowWorkflowValidationService implements MCPWorkflowRuntimeHandler, MCPWorkflowApplyArtifactValidator {
     
     private final WorkflowValidationSupport validationSupport = new WorkflowValidationSupport();
     
@@ -53,11 +61,6 @@ public final class ShadowWorkflowValidationService implements MCPWorkflowRuntime
     public ShadowWorkflowValidationService() {
         inspectionService = new ShadowInspectionService();
         workflowSynchronizationSupport = new WorkflowSynchronizationSupport();
-    }
-    
-    ShadowWorkflowValidationService(final ShadowInspectionService inspectionService, final WorkflowSynchronizationSupport workflowSynchronizationSupport) {
-        this.inspectionService = inspectionService;
-        this.workflowSynchronizationSupport = workflowSynchronizationSupport;
     }
     
     @Override
@@ -74,9 +77,55 @@ public final class ShadowWorkflowValidationService implements MCPWorkflowRuntime
     }
     
     @Override
+    public List<Map<String, Object>> validate(final WorkflowContextSnapshot snapshot, final Collection<ExecutableWorkflowArtifact> artifacts) {
+        List<Map<String, Object>> result = new LinkedList<>();
+        for (ExecutableWorkflowArtifact each : artifacts) {
+            if (each.ruleDistSql()) {
+                addRuleDistSQLIssues(result, snapshot, each.sql(), each.displaySql());
+            }
+        }
+        return result;
+    }
+    
+    @Override
     public void synchronize(final WorkflowContextSnapshot snapshot, final MCPMetadataQueryFacade metadataQueryFacade,
                             final MCPFeatureQueryFacade queryFacade, final MCPFeatureExecutionFacade executionFacade, final String sessionId) {
         workflowSynchronizationSupport.synchronize(() -> createValidationReport(snapshot, queryFacade));
+    }
+    
+    private void addRuleDistSQLIssues(final List<Map<String, Object>> issues, final WorkflowContextSnapshot snapshot, final String sql, final String displaySql) {
+        if (!isCreateOrAlterShadowDistSQL(sql)) {
+            return;
+        }
+        if (snapshot.getRequest() instanceof ShadowRuleWorkflowRequest) {
+            ShadowRuleWorkflowRequest request = (ShadowRuleWorkflowRequest) snapshot.getRequest();
+            addShadowAlgorithmIssue(issues, request.getAlgorithmType(), request.getAlgorithmProperties(), displaySql);
+        }
+        if (snapshot.getRequest() instanceof ShadowDefaultAlgorithmWorkflowRequest) {
+            ShadowDefaultAlgorithmWorkflowRequest request = (ShadowDefaultAlgorithmWorkflowRequest) snapshot.getRequest();
+            addShadowAlgorithmIssue(issues, request.getAlgorithmType(), request.getAlgorithmProperties(), displaySql);
+        }
+    }
+    
+    private boolean isCreateOrAlterShadowDistSQL(final String sql) {
+        String actualSQL = sql.trim().toUpperCase(Locale.ENGLISH);
+        return actualSQL.startsWith("CREATE SHADOW RULE") || actualSQL.startsWith("ALTER SHADOW RULE")
+                || actualSQL.startsWith("CREATE DEFAULT SHADOW ALGORITHM") || actualSQL.startsWith("ALTER DEFAULT SHADOW ALGORITHM");
+    }
+    
+    private void addShadowAlgorithmIssue(final List<Map<String, Object>> issues, final String algorithmType, final Map<String, String> properties, final String displaySql) {
+        if (algorithmType.isEmpty()) {
+            return;
+        }
+        if (!WorkflowAlgorithmUtils.isAlgorithmServiceAvailable(ShadowAlgorithm.class, algorithmType, properties)) {
+            issues.add(createValidationIssue(String.format("Generated shadow DistSQL references algorithm `%s`, but it cannot be loaded or initialized by ShadowAlgorithm SPI.",
+                    algorithmType), displaySql));
+        }
+    }
+    
+    private Map<String, Object> createValidationIssue(final String message, final String sql) {
+        return new WorkflowIssue(WorkflowIssueCode.SQL_EXECUTABILITY_FAILED, "error", WorkflowLifecycle.STEP_REVIEW,
+                message, "Regenerate the workflow artifact through the feature planner before approval.", true, Map.of("sql", sql)).toMap();
     }
     
     private ValidationReport createValidationReport(final WorkflowContextSnapshot snapshot, final MCPFeatureQueryFacade queryFacade) {
@@ -93,7 +142,7 @@ public final class ShadowWorkflowValidationService implements MCPWorkflowRuntime
             return validateRule(snapshot, queryFacade, validationReport, databaseType);
         }
         if (snapshot.getRequest() instanceof ShadowDefaultAlgorithmWorkflowRequest) {
-            return validateDefaultAlgorithm(snapshot, queryFacade, validationReport, databaseType);
+            return validateDefaultAlgorithm(snapshot, queryFacade, validationReport);
         }
         return validateAlgorithmCleanup(snapshot, queryFacade, validationReport, databaseType);
     }
@@ -115,7 +164,7 @@ public final class ShadowWorkflowValidationService implements MCPWorkflowRuntime
     }
     
     private ValidationSection validateDefaultAlgorithm(final WorkflowContextSnapshot snapshot, final MCPFeatureQueryFacade queryFacade,
-                                                       final ValidationReport validationReport, final String databaseType) {
+                                                       final ValidationReport validationReport) {
         ShadowDefaultAlgorithmWorkflowRequest request = (ShadowDefaultAlgorithmWorkflowRequest) snapshot.getRequest();
         List<Map<String, Object>> defaultAlgorithm = inspectionService.queryDefaultAlgorithm(queryFacade, request.getDatabase());
         boolean exists = !defaultAlgorithm.isEmpty();

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/handler/ShadowToolHandlerTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/handler/ShadowToolHandlerTest.java
@@ -115,7 +115,7 @@ class ShadowToolHandlerTest {
         clarifiedIntent.setOperationType("create");
         result.setClarifiedIntent(clarifiedIntent);
         result.setInteractionPlan(InteractionPlan.create("plan-1", request, "Shadow workflow plan.", List.of("review"), List.of("rules")));
-        result.getRuleArtifacts().add(new RuleArtifact("create", "CREATE SHADOW RULE shadow_rule(SOURCE=demo_ds, SHADOW=demo_ds_shadow, t_order(TYPE(NAME='sql_hint')))"));
+        result.getRuleArtifacts().add(new RuleArtifact("create", "CREATE SHADOW RULE `shadow_rule`(SOURCE=`demo_ds`, SHADOW=`demo_ds_shadow`, `t_order`(TYPE(NAME='sql_hint')))"));
         return result;
     }
     

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowDistSQLPlanningServiceTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowDistSQLPlanningServiceTest.java
@@ -34,8 +34,8 @@ class ShadowDistSQLPlanningServiceTest {
     @Test
     void assertPlanCreateRule() {
         RuleArtifact actual = new ShadowDistSQLPlanningService().planCreateRule(createRuleRequest());
-        assertThat(actual.getSql(), is("CREATE SHADOW RULE shadow_rule(SOURCE=demo_ds, SHADOW=demo_ds_shadow, "
-                + "t_order(TYPE(NAME='value_match', PROPERTIES('column'='user_id', 'operation'='insert', 'value'='1'))))"));
+        assertThat(actual.getSql(), is("CREATE SHADOW RULE `shadow_rule`(SOURCE=`demo_ds`, SHADOW=`demo_ds_shadow`, "
+                + "`t_order`(TYPE(NAME='value_match', PROPERTIES('column'='user_id', 'operation'='insert', 'value'='1'))))"));
         assertNoForbiddenArtifacts(actual.getSql());
     }
     
@@ -53,12 +53,12 @@ class ShadowDistSQLPlanningServiceTest {
     
     @Test
     void assertPlanAlterRule() {
-        assertTrue(new ShadowDistSQLPlanningService().planAlterRule(createRuleRequest()).getSql().startsWith("ALTER SHADOW RULE shadow_rule"));
+        assertTrue(new ShadowDistSQLPlanningService().planAlterRule(createRuleRequest()).getSql().startsWith("ALTER SHADOW RULE `shadow_rule`"));
     }
     
     @Test
     void assertPlanDropRule() {
-        assertThat(new ShadowDistSQLPlanningService().planDropRule("shadow_rule").getSql(), is("DROP SHADOW RULE shadow_rule"));
+        assertThat(new ShadowDistSQLPlanningService().planDropRule("shadow_rule").getSql(), is("DROP SHADOW RULE `shadow_rule`"));
     }
     
     @Test
@@ -72,7 +72,7 @@ class ShadowDistSQLPlanningServiceTest {
     
     @Test
     void assertPlanCleanup() {
-        assertThat(new ShadowDistSQLPlanningService().planDropAlgorithm("unused_algorithm").getSql(), is("DROP SHADOW ALGORITHM unused_algorithm"));
+        assertThat(new ShadowDistSQLPlanningService().planDropAlgorithm("unused_algorithm").getSql(), is("DROP SHADOW ALGORITHM `unused_algorithm`"));
     }
     
     private ShadowRuleWorkflowRequest createRuleRequest() {

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowPlanningServiceTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowPlanningServiceTest.java
@@ -48,7 +48,7 @@ class ShadowWorkflowPlanningServiceTest {
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
         assertThat(actual.getAlgorithmCandidates().getFirst().getAlgorithmType(), is("VALUE_MATCH"));
         assertThat(actual.getPropertyRequirements().getFirst().getPropertyKey(), is("operation"));
-        assertTrue(actual.getRuleArtifacts().getFirst().getSql().startsWith("CREATE SHADOW RULE shadow_rule"));
+        assertTrue(actual.getRuleArtifacts().getFirst().getSql().startsWith("CREATE SHADOW RULE `shadow_rule`"));
     }
     
     @Test
@@ -101,7 +101,7 @@ class ShadowWorkflowPlanningServiceTest {
         when(inspectionService.queryDefaultAlgorithm(queryFacade, "logic_db")).thenReturn(List.of());
         WorkflowContextSnapshot actual = new ShadowWorkflowPlanningService(inspectionService, new ShadowDistSQLPlanningService())
                 .planAlgorithmCleanup(new TestWorkflowSessionContext(), queryFacade, "session-1", request);
-        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("DROP SHADOW ALGORITHM unused_algorithm"));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("DROP SHADOW ALGORITHM `unused_algorithm`"));
     }
     
     @Test

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowValidationServiceTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowValidationServiceTest.java
@@ -17,31 +17,41 @@
 
 package org.apache.shardingsphere.mcp.feature.shadow.tool.service;
 
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mcp.feature.shadow.TestWorkflowSessionContext;
 import org.apache.shardingsphere.mcp.feature.shadow.tool.model.ShadowAlgorithmCleanupWorkflowRequest;
+import org.apache.shardingsphere.mcp.feature.shadow.tool.model.ShadowDefaultAlgorithmWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.shadow.tool.model.ShadowRuleWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureExecutionFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.model.ClarifiedIntent;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactBundle.ExecutableWorkflowArtifact;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSQLUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationSupport;
+import org.apache.shardingsphere.shadow.spi.ShadowAlgorithm;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.internal.configuration.plugins.Plugins;
 
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 class ShadowWorkflowValidationServiceTest {
     
     @Test
-    void assertValidateRule() {
+    void assertValidateRule() throws ReflectiveOperationException {
         ShadowInspectionService inspectionService = mock(ShadowInspectionService.class);
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         when(inspectionService.queryRules(queryFacade, "logic_db")).thenReturn(List.of(Map.of(
@@ -50,19 +60,61 @@ class ShadowWorkflowValidationServiceTest {
                 "shadow_name", "demo_ds_shadow",
                 "shadow_table", "t_order",
                 "algorithm_type", "VALUE_MATCH")));
-        Map<String, Object> actual = new ShadowWorkflowValidationService(inspectionService, new WorkflowSynchronizationSupport(1, 0))
+        Map<String, Object> actual = createService(inspectionService)
                 .validate(new TestWorkflowSessionContext(), mock(MCPMetadataQueryFacade.class), queryFacade, mock(MCPFeatureExecutionFacade.class), "session-1", createRuleSnapshot());
         assertThat(actual.get("overall_status"), is(WorkflowLifecycle.STATUS_PASSED));
     }
     
     @Test
-    void assertValidateCleanupFailure() {
+    void assertValidateCleanupFailure() throws ReflectiveOperationException {
         ShadowInspectionService inspectionService = mock(ShadowInspectionService.class);
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         when(inspectionService.queryAlgorithms(queryFacade, "logic_db")).thenReturn(List.of(Map.of("shadow_algorithm_name", "unused_algorithm")));
-        Map<String, Object> actual = new ShadowWorkflowValidationService(inspectionService, new WorkflowSynchronizationSupport(1, 0))
+        Map<String, Object> actual = createService(inspectionService)
                 .validate(new TestWorkflowSessionContext(), mock(MCPMetadataQueryFacade.class), queryFacade, mock(MCPFeatureExecutionFacade.class), "session-1", createCleanupSnapshot());
         assertThat(actual.get("status"), is(WorkflowLifecycle.STATUS_FAILED));
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsRejectsUnavailableRuleAlgorithm() {
+        WorkflowContextSnapshot snapshot = createRuleSnapshot();
+        ShadowRuleWorkflowRequest request = (ShadowRuleWorkflowRequest) snapshot.getRequest();
+        try (MockedStatic<TypedSPILoader> mockedStatic = mockStatic(TypedSPILoader.class)) {
+            mockedStatic.when(() -> TypedSPILoader.checkService(ShadowAlgorithm.class, "VALUE_MATCH",
+                    WorkflowSQLUtils.createProperties(request.getAlgorithmProperties()))).thenThrow(new IllegalArgumentException("unavailable"));
+            List<Map<String, Object>> actual = new ShadowWorkflowValidationService().validate(snapshot, List.of(createRuleDistSQLArtifact("CREATE SHADOW RULE `shadow_rule`(...)")));
+            assertThat(actual.size(), is(1));
+            assertThat(actual.getFirst().get("code"), is(WorkflowIssueCode.SQL_EXECUTABILITY_FAILED));
+        }
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsRejectsUnavailableDefaultAlgorithm() {
+        ShadowDefaultAlgorithmWorkflowRequest request = new ShadowDefaultAlgorithmWorkflowRequest();
+        request.setAlgorithmType("SQL_HINT");
+        request.putAlgorithmProperties(Map.of("foo", "bar"));
+        WorkflowContextSnapshot snapshot = createSnapshot(request, "create");
+        try (MockedStatic<TypedSPILoader> mockedStatic = mockStatic(TypedSPILoader.class)) {
+            mockedStatic.when(() -> TypedSPILoader.checkService(ShadowAlgorithm.class, "SQL_HINT",
+                    WorkflowSQLUtils.createProperties(request.getAlgorithmProperties()))).thenThrow(new IllegalArgumentException("unavailable"));
+            List<Map<String, Object>> actual = new ShadowWorkflowValidationService().validate(snapshot,
+                    List.of(createRuleDistSQLArtifact("CREATE DEFAULT SHADOW ALGORITHM TYPE(NAME='sql_hint')")));
+            assertThat(actual.size(), is(1));
+            assertThat(actual.getFirst().get("message"), is("Generated shadow DistSQL references algorithm `SQL_HINT`, "
+                    + "but it cannot be loaded or initialized by ShadowAlgorithm SPI."));
+        }
+    }
+    
+    private ShadowWorkflowValidationService createService(final ShadowInspectionService inspectionService) throws ReflectiveOperationException {
+        ShadowWorkflowValidationService result = new ShadowWorkflowValidationService();
+        setField(result, "inspectionService", inspectionService);
+        setField(result, "workflowSynchronizationSupport", new WorkflowSynchronizationSupport(1, 0L));
+        return result;
+    }
+    
+    private void setField(final Object target, final String fieldName, final Object value) throws ReflectiveOperationException {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        Plugins.getMemberAccessor().set(field, target, value);
     }
     
     private WorkflowContextSnapshot createRuleSnapshot() {
@@ -93,5 +145,9 @@ class ShadowWorkflowValidationServiceTest {
         clarifiedIntent.setOperationType(operationType);
         result.setClarifiedIntent(clarifiedIntent);
         return result;
+    }
+    
+    private ExecutableWorkflowArtifact createRuleDistSQLArtifact(final String sql) {
+        return new ExecutableWorkflowArtifact("review-rule-sql", "rule_dist_sql", sql, true);
     }
 }

--- a/mcp/features/sharding/pom.xml
+++ b/mcp/features/sharding/pom.xml
@@ -37,5 +37,10 @@
             <artifactId>shardingsphere-sharding-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-algorithm-key-generator-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingDistSQLPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingDistSQLPlanningService.java
@@ -226,6 +226,6 @@ public final class ShardingDistSQLPlanningService {
     }
     
     private String format(final String value) {
-        return WorkflowSQLUtils.formatDistSQLIdentifier(value);
+        return WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier(value);
     }
 }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowValidationService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowValidationService.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
+import org.apache.shardingsphere.infra.algorithm.keygen.spi.KeyGenerateAlgorithm;
 import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureExecutionFacade;
@@ -26,22 +27,31 @@ import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.ValidationReport;
 import org.apache.shardingsphere.mcp.support.workflow.model.ValidationSection;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssue;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowAlgorithmUtils;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactBundle.ExecutableWorkflowArtifact;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowLifecycleUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowRuleValueUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSQLUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationSupport;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowValidationSupport;
+import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowApplyArtifactValidator;
 import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowRuntimeHandler;
+import org.apache.shardingsphere.sharding.spi.ShardingAlgorithm;
+import org.apache.shardingsphere.sharding.spi.ShardingAuditAlgorithm;
 
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
  * Sharding workflow validation service.
  */
-public final class ShardingWorkflowValidationService implements MCPWorkflowRuntimeHandler {
+public final class ShardingWorkflowValidationService implements MCPWorkflowRuntimeHandler, MCPWorkflowApplyArtifactValidator {
     
     private final WorkflowValidationSupport validationSupport = new WorkflowValidationSupport();
     
@@ -52,11 +62,6 @@ public final class ShardingWorkflowValidationService implements MCPWorkflowRunti
     public ShardingWorkflowValidationService() {
         inspectionService = new ShardingInspectionService();
         workflowSynchronizationSupport = new WorkflowSynchronizationSupport();
-    }
-    
-    ShardingWorkflowValidationService(final ShardingInspectionService inspectionService, final WorkflowSynchronizationSupport workflowSynchronizationSupport) {
-        this.inspectionService = inspectionService;
-        this.workflowSynchronizationSupport = workflowSynchronizationSupport;
     }
     
     @Override
@@ -73,9 +78,104 @@ public final class ShardingWorkflowValidationService implements MCPWorkflowRunti
     }
     
     @Override
+    public List<Map<String, Object>> validate(final WorkflowContextSnapshot snapshot, final Collection<ExecutableWorkflowArtifact> artifacts) {
+        List<Map<String, Object>> result = new LinkedList<>();
+        for (ExecutableWorkflowArtifact each : artifacts) {
+            if (each.ruleDistSql()) {
+                addRuleDistSQLIssues(result, snapshot, each.sql(), each.displaySql());
+            }
+        }
+        return result;
+    }
+    
+    @Override
     public void synchronize(final WorkflowContextSnapshot snapshot, final MCPMetadataQueryFacade metadataQueryFacade,
                             final MCPFeatureQueryFacade queryFacade, final MCPFeatureExecutionFacade executionFacade, final String sessionId) {
         workflowSynchronizationSupport.synchronize(() -> createValidationReport(snapshot, queryFacade));
+    }
+    
+    private void addRuleDistSQLIssues(final List<Map<String, Object>> issues, final WorkflowContextSnapshot snapshot, final String sql, final String displaySql) {
+        if (!isCreateOrAlterShardingDistSQL(sql) || !(snapshot.getRequest() instanceof ShardingWorkflowRequest)) {
+            return;
+        }
+        ShardingWorkflowRequest request = (ShardingWorkflowRequest) snapshot.getRequest();
+        if (ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND.equals(snapshot.getWorkflowKind())) {
+            addTableRuleAlgorithmIssues(issues, request, displaySql);
+            return;
+        }
+        if (ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND.equals(snapshot.getWorkflowKind())) {
+            addShardingAlgorithmIssue(issues, request.getAlgorithmType(), request.getPrimaryAlgorithmProperties(), displaySql);
+            return;
+        }
+        if (ShardingFeatureDefinition.KEY_GENERATOR_WORKFLOW_KIND.equals(snapshot.getWorkflowKind())) {
+            addKeyGeneratorTypeIssue(issues, request, displaySql);
+            return;
+        }
+        if (ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND.equals(snapshot.getWorkflowKind())) {
+            addKeyGeneratorIssue(issues, request, displaySql);
+        }
+    }
+    
+    private boolean isCreateOrAlterShardingDistSQL(final String sql) {
+        String actualSQL = sql.trim().toUpperCase(Locale.ENGLISH);
+        return actualSQL.startsWith("CREATE SHARDING ") || actualSQL.startsWith("ALTER SHARDING ")
+                || actualSQL.startsWith("CREATE DEFAULT SHARDING ") || actualSQL.startsWith("ALTER DEFAULT SHARDING ");
+    }
+    
+    private void addTableRuleAlgorithmIssues(final List<Map<String, Object>> issues, final ShardingWorkflowRequest request, final String displaySql) {
+        if (!request.getStorageUnits().isEmpty() || !"none".equals(normalizeStrategyType(request))) {
+            addShardingAlgorithmIssue(issues, request.getAlgorithmType(), request.getPrimaryAlgorithmProperties(), displaySql);
+        }
+        addKeyGeneratorIssue(issues, request, displaySql);
+        for (String each : request.getAuditorNames()) {
+            addAuditorIssue(issues, each, displaySql);
+        }
+    }
+    
+    private void addShardingAlgorithmIssue(final List<Map<String, Object>> issues, final String algorithmType, final Map<String, String> properties, final String displaySql) {
+        if (algorithmType.isEmpty()) {
+            return;
+        }
+        if (!WorkflowAlgorithmUtils.isAlgorithmServiceAvailable(ShardingAlgorithm.class, algorithmType, properties)) {
+            issues.add(createValidationIssue(String.format("Generated sharding DistSQL references sharding algorithm `%s`, "
+                    + "but it cannot be loaded or initialized by ShardingAlgorithm SPI.", algorithmType), displaySql));
+        }
+    }
+    
+    private void addKeyGeneratorIssue(final List<Map<String, Object>> issues, final ShardingWorkflowRequest request, final String displaySql) {
+        if (!request.getKeyGeneratorName().isEmpty() || request.getKeyGeneratorType().isEmpty()) {
+            return;
+        }
+        addKeyGeneratorTypeIssue(issues, request, displaySql);
+    }
+    
+    private void addKeyGeneratorTypeIssue(final List<Map<String, Object>> issues, final ShardingWorkflowRequest request, final String displaySql) {
+        if (request.getKeyGeneratorType().isEmpty()) {
+            return;
+        }
+        if (!WorkflowAlgorithmUtils.isAlgorithmServiceAvailable(KeyGenerateAlgorithm.class, request.getKeyGeneratorType(), request.getKeyGeneratorProperties())) {
+            issues.add(createValidationIssue(String.format("Generated sharding DistSQL references key generator algorithm `%s`, "
+                    + "but it cannot be loaded or initialized by KeyGenerateAlgorithm SPI.", request.getKeyGeneratorType()), displaySql));
+        }
+    }
+    
+    private void addAuditorIssue(final List<Map<String, Object>> issues, final String algorithmType, final String displaySql) {
+        if (algorithmType.isEmpty()) {
+            return;
+        }
+        if (!WorkflowAlgorithmUtils.isAlgorithmServiceAvailable(ShardingAuditAlgorithm.class, algorithmType, Map.of())) {
+            issues.add(createValidationIssue(String.format("Generated sharding DistSQL references auditor algorithm `%s`, "
+                    + "but it cannot be loaded or initialized by ShardingAuditAlgorithm SPI.", algorithmType), displaySql));
+        }
+    }
+    
+    private String normalizeStrategyType(final ShardingWorkflowRequest request) {
+        return request.getStrategyType().isEmpty() ? "standard" : request.getStrategyType().toLowerCase(Locale.ENGLISH);
+    }
+    
+    private Map<String, Object> createValidationIssue(final String message, final String sql) {
+        return new WorkflowIssue(WorkflowIssueCode.SQL_EXECUTABILITY_FAILED, "error", WorkflowLifecycle.STEP_REVIEW,
+                message, "Regenerate the workflow artifact through the feature planner before approval.", true, Map.of("sql", sql)).toMap();
     }
     
     private ValidationReport createValidationReport(final WorkflowContextSnapshot snapshot, final MCPFeatureQueryFacade queryFacade) {

--- a/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-sharding.yaml
+++ b/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-sharding.yaml
@@ -777,7 +777,7 @@ tools:
         key_generator: {type: string, description: "Existing or target key generator name."}
         key_generator_type: {type: string, description: "Key generator algorithm type."}
         key_generator_properties: {type: object, description: "Key generator properties.", additionalProperties: {type: string}}
-        auditors: {type: string, description: "Comma-separated auditor names."}
+        auditors: {type: string, description: "Comma-separated auditor algorithm types for AUDIT_STRATEGY TYPE(NAME='...') entries."}
         allow_hint_disable: {type: string, description: "Whether audit strategy allows hint disable."}
         natural_language_intent: {type: string, description: "Original user request."}
         structured_intent_evidence: {type: object, description: "Structured intent extracted by the model.", additionalProperties: true}

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/ShardingToolHandlerTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/ShardingToolHandlerTest.java
@@ -55,7 +55,7 @@ class ShardingToolHandlerTest {
     void assertHandlePlanTableRule() {
         ShardingWorkflowPlanningService planningService = mock(ShardingWorkflowPlanningService.class);
         when(planningService.planTableRule(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
-                createRequest(), "CREATE SHARDING TABLE RULE t_order(DATANODES('ds_${0..1}.t_order_${0..1}'))"));
+                createRequest(), "CREATE SHARDING TABLE RULE `t_order`(DATANODES('ds_${0..1}.t_order_${0..1}'))"));
         WorkflowContextFixture fixture = createWorkflowContextFixture();
         MCPResponse actual = new PlanShardingTableRuleToolHandler(planningService).handle(fixture.workflowContext, new MCPToolCall("session-1", Map.of(
                 "database", "logic_db",
@@ -75,7 +75,7 @@ class ShardingToolHandlerTest {
     void assertHandlePlanTableReferenceRule() {
         ShardingWorkflowPlanningService planningService = mock(ShardingWorkflowPlanningService.class);
         when(planningService.planTableReferenceRule(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.TABLE_REFERENCE_WORKFLOW_KIND,
-                createRequest(), "CREATE SHARDING TABLE REFERENCE RULE ref_rule(t_order, t_order_item)"));
+                createRequest(), "CREATE SHARDING TABLE REFERENCE RULE `ref_rule`(`t_order`, `t_order_item`)"));
         WorkflowContextFixture fixture = createWorkflowContextFixture();
         new PlanShardingTableReferenceRuleToolHandler(planningService)
                 .handle(fixture.workflowContext, new MCPToolCall("session-1", Map.of("database", "logic_db", "rule", "ref_rule", "reference_tables", "t_order,t_order_item")));
@@ -102,7 +102,7 @@ class ShardingToolHandlerTest {
     void assertHandlePlanKeyGenerator() {
         ShardingWorkflowPlanningService planningService = mock(ShardingWorkflowPlanningService.class);
         when(planningService.planKeyGenerator(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.KEY_GENERATOR_WORKFLOW_KIND,
-                createRequest(), "CREATE SHARDING KEY GENERATOR snowflake_generator(TYPE(NAME='snowflake'))"));
+                createRequest(), "CREATE SHARDING KEY GENERATOR `snowflake_generator`(TYPE(NAME='snowflake'))"));
         WorkflowContextFixture fixture = createWorkflowContextFixture();
         new PlanShardingKeyGeneratorToolHandler(planningService).handle(fixture.workflowContext, new MCPToolCall("session-1", Map.of(
                 "database", "logic_db", "key_generator", "snowflake_generator", "key_generator_type", "SNOWFLAKE", "key_generator_properties", Map.of("worker-id", "1"))));
@@ -116,7 +116,7 @@ class ShardingToolHandlerTest {
     void assertHandlePlanKeyGenerateStrategy() {
         ShardingWorkflowPlanningService planningService = mock(ShardingWorkflowPlanningService.class);
         when(planningService.planKeyGenerateStrategy(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
-                createRequest(), "CREATE SHARDING KEY GENERATE STRATEGY order_key_strategy(TABLE=t_order, COLUMN=id, GENERATOR=snowflake_generator)"));
+                createRequest(), "CREATE SHARDING KEY GENERATE STRATEGY `order_key_strategy`(TABLE=`t_order`, COLUMN=`id`, GENERATOR=`snowflake_generator`)"));
         WorkflowContextFixture fixture = createWorkflowContextFixture();
         new PlanShardingKeyGenerateStrategyToolHandler(planningService).handle(fixture.workflowContext, new MCPToolCall("session-1", Map.of(
                 "database", "logic_db", "key_generate_strategy", "order_key_strategy", "table", "t_order", "column", "id", "key_generator", "snowflake_generator")));
@@ -130,7 +130,7 @@ class ShardingToolHandlerTest {
     void assertHandlePlanComponentCleanup() {
         ShardingWorkflowPlanningService planningService = mock(ShardingWorkflowPlanningService.class);
         when(planningService.planComponentCleanup(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.COMPONENT_CLEANUP_WORKFLOW_KIND,
-                createRequest(), "DROP SHARDING ALGORITHM unused_algorithm"));
+                createRequest(), "DROP SHARDING ALGORITHM `unused_algorithm`"));
         WorkflowContextFixture fixture = createWorkflowContextFixture();
         MCPResponse actual = new PlanShardingRuleComponentCleanupToolHandler(planningService).handle(fixture.workflowContext, new MCPToolCall("session-1", Map.of(
                 "database", "logic_db", "component_type", "algorithm", "component_name", "unused_algorithm")));

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingDistSQLPlanningServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingDistSQLPlanningServiceTest.java
@@ -33,10 +33,10 @@ class ShardingDistSQLPlanningServiceTest {
     @Test
     void assertPlanTableRuleCreate() {
         RuleArtifact actual = new ShardingDistSQLPlanningService().planTableRule(createTableRuleRequest(), "create");
-        assertThat(actual.getSql(), is("CREATE SHARDING TABLE RULE t_order(DATANODES('ds_${0..1}.t_order_${0..1}'), "
-                + "TABLE_STRATEGY(TYPE='standard', SHARDING_COLUMN=order_id, "
+        assertThat(actual.getSql(), is("CREATE SHARDING TABLE RULE `t_order`(DATANODES('ds_${0..1}.t_order_${0..1}'), "
+                + "TABLE_STRATEGY(TYPE='standard', SHARDING_COLUMN=`order_id`, "
                 + "SHARDING_ALGORITHM(TYPE(NAME='inline', PROPERTIES('algorithm-expression'='t_order_${order_id % 2}')))), "
-                + "KEY_GENERATE_STRATEGY(COLUMN=id, TYPE(NAME='snowflake')))"));
+                + "KEY_GENERATE_STRATEGY(COLUMN=`id`, TYPE(NAME='snowflake')))"));
         assertNoForbiddenArtifacts(actual.getSql());
     }
     
@@ -60,10 +60,10 @@ class ShardingDistSQLPlanningServiceTest {
         request.setStrategyType("complex");
         request.setShardingColumns("order_id, user_id");
         assertThat(new ShardingDistSQLPlanningService().planTableRule(request, "create").getSql(),
-                is("CREATE SHARDING TABLE RULE t_order(DATANODES('ds_${0..1}.t_order_${0..1}'), "
-                        + "TABLE_STRATEGY(TYPE='complex', SHARDING_COLUMNS=order_id, user_id, "
+                is("CREATE SHARDING TABLE RULE `t_order`(DATANODES('ds_${0..1}.t_order_${0..1}'), "
+                        + "TABLE_STRATEGY(TYPE='complex', SHARDING_COLUMNS=`order_id`, `user_id`, "
                         + "SHARDING_ALGORITHM(TYPE(NAME='inline', PROPERTIES('algorithm-expression'='t_order_${order_id % 2}')))), "
-                        + "KEY_GENERATE_STRATEGY(COLUMN=id, TYPE(NAME='snowflake')))"));
+                        + "KEY_GENERATE_STRATEGY(COLUMN=`id`, TYPE(NAME='snowflake')))"));
     }
     
     @Test
@@ -72,9 +72,9 @@ class ShardingDistSQLPlanningServiceTest {
         request.setColumn("");
         request.setStrategyType("hint");
         assertThat(new ShardingDistSQLPlanningService().planTableRule(request, "create").getSql(),
-                is("CREATE SHARDING TABLE RULE t_order(DATANODES('ds_${0..1}.t_order_${0..1}'), "
+                is("CREATE SHARDING TABLE RULE `t_order`(DATANODES('ds_${0..1}.t_order_${0..1}'), "
                         + "TABLE_STRATEGY(TYPE='hint', SHARDING_ALGORITHM(TYPE(NAME='inline', PROPERTIES('algorithm-expression'='t_order_${order_id % 2}')))), "
-                        + "KEY_GENERATE_STRATEGY(COLUMN=id, TYPE(NAME='snowflake')))"));
+                        + "KEY_GENERATE_STRATEGY(COLUMN=`id`, TYPE(NAME='snowflake')))"));
     }
     
     @Test
@@ -84,7 +84,7 @@ class ShardingDistSQLPlanningServiceTest {
         request.setStrategyType("none");
         request.setAlgorithmType("");
         assertThat(new ShardingDistSQLPlanningService().planTableRule(request, "create").getSql(),
-                is("CREATE SHARDING TABLE RULE t_order(DATANODES('ds_${0..1}.t_order_${0..1}'), KEY_GENERATE_STRATEGY(COLUMN=id, TYPE(NAME='snowflake')))"));
+                is("CREATE SHARDING TABLE RULE `t_order`(DATANODES('ds_${0..1}.t_order_${0..1}'), KEY_GENERATE_STRATEGY(COLUMN=`id`, TYPE(NAME='snowflake')))"));
     }
     
     @Test
@@ -99,13 +99,13 @@ class ShardingDistSQLPlanningServiceTest {
         request.setKeyGeneratorType("SNOWFLAKE");
         request.putKeyGeneratorProperties(Map.of("worker-id", "1"));
         assertThat(new ShardingDistSQLPlanningService().planTableRule(request, "create").getSql(),
-                is("CREATE SHARDING TABLE RULE t_order(STORAGE_UNITS(ds_0, ds_1), SHARDING_COLUMN=order_id, TYPE(NAME='hash_mod', PROPERTIES('sharding-count'='4')), "
-                        + "KEY_GENERATE_STRATEGY(COLUMN=id, TYPE(NAME='snowflake', PROPERTIES('worker-id'='1'))))"));
+                is("CREATE SHARDING TABLE RULE `t_order`(STORAGE_UNITS(`ds_0`, `ds_1`), SHARDING_COLUMN=`order_id`, TYPE(NAME='hash_mod', PROPERTIES('sharding-count'='4')), "
+                        + "KEY_GENERATE_STRATEGY(COLUMN=`id`, TYPE(NAME='snowflake', PROPERTIES('worker-id'='1'))))"));
     }
     
     @Test
     void assertPlanTableRuleDrop() {
-        assertThat(new ShardingDistSQLPlanningService().planTableRule(createTableRuleRequest(), "drop").getSql(), is("DROP SHARDING TABLE RULE t_order"));
+        assertThat(new ShardingDistSQLPlanningService().planTableRule(createTableRuleRequest(), "drop").getSql(), is("DROP SHARDING TABLE RULE `t_order`"));
     }
     
     @Test
@@ -114,7 +114,7 @@ class ShardingDistSQLPlanningServiceTest {
         request.setRuleName("ref_rule");
         request.getReferenceTables().addAll(List.of("t_order", "t_order_item"));
         assertThat(new ShardingDistSQLPlanningService().planTableReferenceRule(request, "create").getSql(),
-                is("CREATE SHARDING TABLE REFERENCE RULE ref_rule(t_order, t_order_item)"));
+                is("CREATE SHARDING TABLE REFERENCE RULE `ref_rule`(`t_order`, `t_order_item`)"));
     }
     
     @Test
@@ -122,7 +122,7 @@ class ShardingDistSQLPlanningServiceTest {
         ShardingWorkflowRequest request = createTableRuleRequest();
         request.setDefaultStrategyType("DATABASE");
         assertThat(new ShardingDistSQLPlanningService().planDefaultStrategy(request, "create").getSql(),
-                is("CREATE DEFAULT SHARDING DATABASE STRATEGY (TYPE='standard', SHARDING_COLUMN=order_id, "
+                is("CREATE DEFAULT SHARDING DATABASE STRATEGY (TYPE='standard', SHARDING_COLUMN=`order_id`, "
                         + "SHARDING_ALGORITHM(TYPE(NAME='inline', PROPERTIES('algorithm-expression'='t_order_${order_id % 2}'))))"));
     }
     
@@ -134,7 +134,7 @@ class ShardingDistSQLPlanningServiceTest {
         request.setStrategyType("complex");
         request.setShardingColumns("order_id, user_id");
         assertThat(new ShardingDistSQLPlanningService().planDefaultStrategy(request, "create").getSql(),
-                is("CREATE DEFAULT SHARDING DATABASE STRATEGY (TYPE='complex', SHARDING_COLUMNS=order_id, user_id, "
+                is("CREATE DEFAULT SHARDING DATABASE STRATEGY (TYPE='complex', SHARDING_COLUMNS=`order_id`, `user_id`, "
                         + "SHARDING_ALGORITHM(TYPE(NAME='inline', PROPERTIES('algorithm-expression'='t_order_${order_id % 2}'))))"));
     }
     
@@ -166,7 +166,7 @@ class ShardingDistSQLPlanningServiceTest {
         request.setKeyGeneratorType("SNOWFLAKE");
         request.putKeyGeneratorProperties(Map.of("worker-id", "1"));
         assertThat(new ShardingDistSQLPlanningService().planKeyGenerator(request, "create").getSql(),
-                is("CREATE SHARDING KEY GENERATOR snowflake_generator(TYPE(NAME='snowflake', PROPERTIES('worker-id'='1')))"));
+                is("CREATE SHARDING KEY GENERATOR `snowflake_generator`(TYPE(NAME='snowflake', PROPERTIES('worker-id'='1')))"));
     }
     
     @Test
@@ -175,7 +175,7 @@ class ShardingDistSQLPlanningServiceTest {
         request.setKeyGenerateStrategyName("order_key_strategy");
         request.setKeyGenerateColumn("");
         assertThat(new ShardingDistSQLPlanningService().planKeyGenerateStrategy(request, "create").getSql(),
-                is("CREATE SHARDING KEY GENERATE STRATEGY order_key_strategy(TABLE=t_order, COLUMN=order_id, TYPE(NAME='snowflake'))"));
+                is("CREATE SHARDING KEY GENERATE STRATEGY `order_key_strategy`(TABLE=`t_order`, COLUMN=`order_id`, TYPE(NAME='snowflake'))"));
     }
     
     @Test
@@ -183,7 +183,7 @@ class ShardingDistSQLPlanningServiceTest {
         ShardingWorkflowRequest request = new ShardingWorkflowRequest();
         request.setComponentType("key_generator");
         request.setComponentName("snowflake_generator");
-        assertThat(new ShardingDistSQLPlanningService().planComponentCleanup(request).getSql(), is("DROP SHARDING KEY GENERATOR snowflake_generator"));
+        assertThat(new ShardingDistSQLPlanningService().planComponentCleanup(request).getSql(), is("DROP SHARDING KEY GENERATOR `snowflake_generator`"));
     }
     
     private ShardingWorkflowRequest createTableRuleRequest() {

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowPlanningServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowPlanningServiceTest.java
@@ -48,7 +48,7 @@ class ShardingWorkflowPlanningServiceTest {
         assertThat(actual.getWorkflowKind().getValue(), is("sharding.table.rule"));
         assertThat(actual.getAlgorithmCandidates().getFirst().getAlgorithmType(), is("INLINE"));
         assertThat(actual.getPropertyRequirements().getFirst().getPropertyKey(), is("algorithm-expression"));
-        assertTrue(actual.getRuleArtifacts().getFirst().getSql().startsWith("CREATE SHARDING TABLE RULE t_order"));
+        assertTrue(actual.getRuleArtifacts().getFirst().getSql().startsWith("CREATE SHARDING TABLE RULE `t_order`"));
     }
     
     @Test
@@ -79,8 +79,8 @@ class ShardingWorkflowPlanningServiceTest {
         WorkflowContextSnapshot actual = createPlanningService(inspectionService)
                 .planTableRule(new TestWorkflowSessionContext(), queryFacade, "session-1", request);
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
-        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE SHARDING TABLE RULE t_order(DATANODES('ds_${0..1}.t_order_${0..1}'), "
-                + "TABLE_STRATEGY(TYPE='complex', SHARDING_COLUMNS=order_id, user_id, "
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE SHARDING TABLE RULE `t_order`(DATANODES('ds_${0..1}.t_order_${0..1}'), "
+                + "TABLE_STRATEGY(TYPE='complex', SHARDING_COLUMNS=`order_id`, `user_id`, "
                 + "SHARDING_ALGORITHM(TYPE(NAME='inline', PROPERTIES('algorithm-expression'='t_order_${order_id % 2}')))))"));
     }
     
@@ -95,7 +95,7 @@ class ShardingWorkflowPlanningServiceTest {
         WorkflowContextSnapshot actual = createPlanningService(inspectionService)
                 .planTableRule(new TestWorkflowSessionContext(), queryFacade, "session-1", request);
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
-        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE SHARDING TABLE RULE t_order(DATANODES('ds_${0..1}.t_order_${0..1}'), "
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE SHARDING TABLE RULE `t_order`(DATANODES('ds_${0..1}.t_order_${0..1}'), "
                 + "TABLE_STRATEGY(TYPE='hint', SHARDING_ALGORITHM(TYPE(NAME='inline', PROPERTIES('algorithm-expression'='t_order_${order_id % 2}')))))"));
     }
     
@@ -111,7 +111,7 @@ class ShardingWorkflowPlanningServiceTest {
         WorkflowContextSnapshot actual = createPlanningService(inspectionService)
                 .planTableRule(new TestWorkflowSessionContext(), queryFacade, "session-1", request);
         assertThat(actual.getStatus(), is(WorkflowLifecycle.STATUS_PLANNED));
-        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE SHARDING TABLE RULE t_order(DATANODES('ds_${0..1}.t_order_${0..1}'))"));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE SHARDING TABLE RULE `t_order`(DATANODES('ds_${0..1}.t_order_${0..1}'))"));
     }
     
     @Test
@@ -162,7 +162,7 @@ class ShardingWorkflowPlanningServiceTest {
         when(inspectionService.queryTableReferenceRule(queryFacade, "logic_db", "ref_rule")).thenReturn(List.of());
         WorkflowContextSnapshot actual = createPlanningService(inspectionService)
                 .planTableReferenceRule(new TestWorkflowSessionContext(), queryFacade, "session-1", createReferenceRuleRequest());
-        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE SHARDING TABLE REFERENCE RULE ref_rule(t_order, t_order_item)"));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("CREATE SHARDING TABLE REFERENCE RULE `ref_rule`(`t_order`, `t_order_item`)"));
     }
     
     @Test
@@ -200,7 +200,7 @@ class ShardingWorkflowPlanningServiceTest {
                 .planKeyGenerator(new TestWorkflowSessionContext(), queryFacade, "session-1", createKeyGeneratorRequest());
         assertThat(actual.getAlgorithmCandidates().getFirst().getAlgorithmRole(), is("key_generator"));
         assertThat(actual.getPropertyRequirements().getFirst().getPropertyKey(), is("worker-id"));
-        assertTrue(actual.getRuleArtifacts().getFirst().getSql().startsWith("CREATE SHARDING KEY GENERATOR snowflake_generator"));
+        assertTrue(actual.getRuleArtifacts().getFirst().getSql().startsWith("CREATE SHARDING KEY GENERATOR `snowflake_generator`"));
     }
     
     @Test
@@ -210,7 +210,7 @@ class ShardingWorkflowPlanningServiceTest {
         when(inspectionService.queryKeyGenerateStrategy(queryFacade, "logic_db", "order_key_strategy")).thenReturn(List.of());
         WorkflowContextSnapshot actual = createPlanningService(inspectionService)
                 .planKeyGenerateStrategy(new TestWorkflowSessionContext(), queryFacade, "session-1", createKeyGenerateStrategyRequest());
-        assertTrue(actual.getRuleArtifacts().getFirst().getSql().startsWith("CREATE SHARDING KEY GENERATE STRATEGY order_key_strategy"));
+        assertTrue(actual.getRuleArtifacts().getFirst().getSql().startsWith("CREATE SHARDING KEY GENERATE STRATEGY `order_key_strategy`"));
     }
     
     @Test
@@ -222,7 +222,7 @@ class ShardingWorkflowPlanningServiceTest {
         when(inspectionService.queryTableRulesUsedAlgorithm(queryFacade, "logic_db", "unused_algorithm")).thenReturn(List.of());
         WorkflowContextSnapshot actual = createPlanningService(inspectionService)
                 .planComponentCleanup(new TestWorkflowSessionContext(), queryFacade, "session-1", request);
-        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("DROP SHARDING ALGORITHM unused_algorithm"));
+        assertThat(actual.getRuleArtifacts().getFirst().getSql(), is("DROP SHARDING ALGORITHM `unused_algorithm`"));
     }
     
     @Test

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowValidationServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowValidationServiceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
+import org.apache.shardingsphere.infra.algorithm.keygen.spi.KeyGenerateAlgorithm;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.TestWorkflowSessionContext;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
@@ -29,10 +31,17 @@ import org.apache.shardingsphere.mcp.support.workflow.model.InteractionPlan;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactBundle.ExecutableWorkflowArtifact;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSQLUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationException;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchronizationSupport;
+import org.apache.shardingsphere.sharding.spi.ShardingAlgorithm;
+import org.apache.shardingsphere.sharding.spi.ShardingAuditAlgorithm;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.internal.configuration.plugins.Plugins;
 
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
@@ -41,13 +50,14 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class ShardingWorkflowValidationServiceTest {
     
     @Test
-    void assertValidateRejectsDifferentSession() {
+    void assertValidateRejectsDifferentSession() throws ReflectiveOperationException {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         workflowSessionContext.save(createSnapshot("plan-1", "session-1", "executed", "create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND, createTableRuleRequest()));
         Map<String, Object> actual = createService(mock(ShardingInspectionService.class)).validate(workflowSessionContext, mock(MCPMetadataQueryFacade.class),
@@ -57,7 +67,7 @@ class ShardingWorkflowValidationServiceTest {
     }
     
     @Test
-    void assertValidateTableRuleHappyPath() {
+    void assertValidateTableRuleHappyPath() throws ReflectiveOperationException {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create",
                 ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND, createTableRuleRequest());
@@ -75,7 +85,57 @@ class ShardingWorkflowValidationServiceTest {
     }
     
     @Test
-    void assertValidateTableRuleMismatch() {
+    void assertValidateApplyArtifactsRejectsUnavailableShardingAlgorithm() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setAlgorithmType("INLINE");
+        request.putAlgorithmProperties(Map.of("algorithm-expression", "t_order_${order_id % 2}"));
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND, request);
+        try (MockedStatic<TypedSPILoader> mockedStatic = mockStatic(TypedSPILoader.class)) {
+            mockedStatic.when(() -> TypedSPILoader.checkService(ShardingAlgorithm.class, "INLINE",
+                    WorkflowSQLUtils.createProperties(request.getPrimaryAlgorithmProperties()))).thenThrow(new IllegalArgumentException("unavailable"));
+            List<Map<String, Object>> actual = new ShardingWorkflowValidationService().validate(snapshot, List.of(createRuleDistSQLArtifact("CREATE SHARDING TABLE RULE `t_order`(...)")));
+            assertThat(actual.size(), is(1));
+            assertThat(actual.getFirst().get("message"), is("Generated sharding DistSQL references sharding algorithm `INLINE`, "
+                    + "but it cannot be loaded or initialized by ShardingAlgorithm SPI."));
+        }
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsRejectsUnavailableKeyGenerator() {
+        ShardingWorkflowRequest request = new ShardingWorkflowRequest();
+        request.setKeyGeneratorName("snowflake_generator");
+        request.setKeyGeneratorType("SNOWFLAKE");
+        request.putKeyGeneratorProperties(Map.of("worker-id", "1"));
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create", ShardingFeatureDefinition.KEY_GENERATOR_WORKFLOW_KIND, request);
+        try (MockedStatic<TypedSPILoader> mockedStatic = mockStatic(TypedSPILoader.class)) {
+            mockedStatic.when(() -> TypedSPILoader.checkService(KeyGenerateAlgorithm.class, "SNOWFLAKE",
+                    WorkflowSQLUtils.createProperties(request.getKeyGeneratorProperties()))).thenThrow(new IllegalArgumentException("unavailable"));
+            List<Map<String, Object>> actual = new ShardingWorkflowValidationService().validate(snapshot,
+                    List.of(createRuleDistSQLArtifact("CREATE SHARDING KEY GENERATOR `snowflake_generator`(TYPE(NAME='snowflake'))")));
+            assertThat(actual.size(), is(1));
+            assertThat(actual.getFirst().get("code"), is(WorkflowIssueCode.SQL_EXECUTABILITY_FAILED));
+        }
+    }
+    
+    @Test
+    void assertValidateApplyArtifactsRejectsUnavailableAuditor() {
+        ShardingWorkflowRequest request = createTableRuleRequest();
+        request.setStrategyType("none");
+        request.setAlgorithmType("");
+        request.getAuditorNames().add("DML_SHARDING_CONDITIONS");
+        WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create", ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND, request);
+        try (MockedStatic<TypedSPILoader> mockedStatic = mockStatic(TypedSPILoader.class)) {
+            mockedStatic.when(() -> TypedSPILoader.checkService(ShardingAuditAlgorithm.class, "DML_SHARDING_CONDITIONS",
+                    WorkflowSQLUtils.createProperties(Map.of()))).thenThrow(new IllegalArgumentException("unavailable"));
+            List<Map<String, Object>> actual = new ShardingWorkflowValidationService().validate(snapshot, List.of(createRuleDistSQLArtifact("CREATE SHARDING TABLE RULE `t_order`(...)")));
+            assertThat(actual.size(), is(1));
+            assertThat(actual.getFirst().get("message"), is("Generated sharding DistSQL references auditor algorithm `DML_SHARDING_CONDITIONS`, "
+                    + "but it cannot be loaded or initialized by ShardingAuditAlgorithm SPI."));
+        }
+    }
+    
+    @Test
+    void assertValidateTableRuleMismatch() throws ReflectiveOperationException {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create",
                 ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND, createTableRuleRequest());
@@ -89,7 +149,7 @@ class ShardingWorkflowValidationServiceTest {
     }
     
     @Test
-    void assertValidateDefaultStrategyDrop() {
+    void assertValidateDefaultStrategyDrop() throws ReflectiveOperationException {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         ShardingWorkflowRequest request = createTableRuleRequest();
         request.setDefaultStrategyType("DATABASE");
@@ -104,7 +164,7 @@ class ShardingWorkflowValidationServiceTest {
     }
     
     @Test
-    void assertValidateCleanupHappyPath() {
+    void assertValidateCleanupHappyPath() throws ReflectiveOperationException {
         WorkflowSessionContext workflowSessionContext = new TestWorkflowSessionContext();
         WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "drop",
                 ShardingFeatureDefinition.COMPONENT_CLEANUP_WORKFLOW_KIND, createCleanupRequest());
@@ -117,7 +177,7 @@ class ShardingWorkflowValidationServiceTest {
     }
     
     @Test
-    void assertSynchronizeWhenStateDoesNotConverge() {
+    void assertSynchronizeWhenStateDoesNotConverge() throws ReflectiveOperationException {
         WorkflowContextSnapshot snapshot = createSnapshot("plan-1", "session-1", "executed", "create",
                 ShardingFeatureDefinition.TABLE_REFERENCE_WORKFLOW_KIND, createReferenceRuleRequest());
         ShardingInspectionService inspectionService = mock(ShardingInspectionService.class);
@@ -128,8 +188,16 @@ class ShardingWorkflowValidationServiceTest {
         assertThat(actual.getIssueCode(), is(WorkflowIssueCode.RULE_STATE_MISMATCH));
     }
     
-    private ShardingWorkflowValidationService createService(final ShardingInspectionService inspectionService) {
-        return new ShardingWorkflowValidationService(inspectionService, new WorkflowSynchronizationSupport(1, 0L));
+    private ShardingWorkflowValidationService createService(final ShardingInspectionService inspectionService) throws ReflectiveOperationException {
+        ShardingWorkflowValidationService result = new ShardingWorkflowValidationService();
+        setField(result, "inspectionService", inspectionService);
+        setField(result, "workflowSynchronizationSupport", new WorkflowSynchronizationSupport(1, 0L));
+        return result;
+    }
+    
+    private void setField(final Object target, final String fieldName, final Object value) throws ReflectiveOperationException {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        Plugins.getMemberAccessor().set(field, target, value);
     }
     
     private MCPFeatureQueryFacade createQueryFacade() {
@@ -176,5 +244,9 @@ class ShardingWorkflowValidationServiceTest {
         result.setComponentType("algorithm");
         result.setComponentName("unused_algorithm");
         return result;
+    }
+    
+    private ExecutableWorkflowArtifact createRuleDistSQLArtifact(final String sql) {
+        return new ExecutableWorkflowArtifact("review-rule-sql", "rule_dist_sql", sql, true);
     }
 }

--- a/mcp/support/pom.xml
+++ b/mcp/support/pom.xml
@@ -44,6 +44,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-infra-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowAlgorithmUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowAlgorithmUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.workflow.service;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.exception.external.ShardingSphereExternalException;
+import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPI;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Workflow algorithm utilities.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class WorkflowAlgorithmUtils {
+    
+    private static final String SECRET_REFERENCE_PREFIX = "secret_reference:";
+    
+    /**
+     * Check whether an algorithm service can be used by workflow generated artifacts.
+     *
+     * @param serviceInterface typed SPI service interface
+     * @param algorithmType algorithm type
+     * @param properties algorithm properties
+     * @param <T> SPI class type
+     * @return whether the algorithm service is available
+     */
+    public static <T extends TypedSPI> boolean isAlgorithmServiceAvailable(final Class<T> serviceInterface, final String algorithmType, final Map<String, String> properties) {
+        String actualAlgorithmType = Objects.toString(algorithmType, "").trim();
+        if (actualAlgorithmType.isEmpty()) {
+            return true;
+        }
+        if (hasSecretReference(properties)) {
+            return containsServiceType(serviceInterface, actualAlgorithmType);
+        }
+        try {
+            TypedSPILoader.checkService(serviceInterface, actualAlgorithmType, WorkflowSQLUtils.createProperties(properties));
+            return true;
+        } catch (final ShardingSphereExternalException | IllegalArgumentException ignored) {
+            return false;
+        }
+    }
+    
+    private static boolean hasSecretReference(final Map<String, String> properties) {
+        return properties.values().stream().anyMatch(each -> Objects.toString(each, "").startsWith(SECRET_REFERENCE_PREFIX));
+    }
+    
+    private static <T extends TypedSPI> boolean containsServiceType(final Class<T> serviceInterface, final String algorithmType) {
+        for (T each : ShardingSphereServiceLoader.getServiceInstances(serviceInterface)) {
+            if (matchesType(algorithmType, each)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private static boolean matchesType(final String type, final TypedSPI instance) {
+        Object instanceType = instance.getType();
+        if (null == instanceType) {
+            return false;
+        }
+        if (instanceType instanceof String) {
+            return instanceType.toString().equalsIgnoreCase(type) || instance.getTypeAliases().contains(type);
+        }
+        return instanceType.equals(type) || instance.getTypeAliases().contains(type);
+    }
+}

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSQLUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSQLUtils.java
@@ -138,6 +138,18 @@ public final class WorkflowSQLUtils {
     }
     
     /**
+     * Format an identifier rendered by generated rule DistSQL artifacts.
+     *
+     * @param identifier identifier to format
+     * @return formatted DistSQL identifier
+     */
+    public static String formatGeneratedRuleDistSQLIdentifier(final String identifier) {
+        String actualIdentifier = normalizeIdentifier(trimToEmpty(identifier));
+        checkSupportedIdentifier("identifier", actualIdentifier);
+        return actualIdentifier.isEmpty() ? actualIdentifier : IdentifierQuoteStyle.BACK_QUOTE.wrap(actualIdentifier);
+    }
+    
+    /**
      * Format a database SQL identifier.
      *
      * @param databaseType database type

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowAlgorithmUtilsTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowAlgorithmUtilsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.workflow.service;
+
+import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.infra.spi.exception.ServiceProviderNotFoundException;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPI;
+import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+class WorkflowAlgorithmUtilsTest {
+    
+    @Test
+    void assertAlgorithmServiceAvailable() {
+        try (MockedStatic<TypedSPILoader> ignored = mockStatic(TypedSPILoader.class)) {
+            assertTrue(WorkflowAlgorithmUtils.isAlgorithmServiceAvailable(TypedSPIFixture.class, "FIXTURE", Map.of("foo", "bar")));
+            ignored.verify(() -> TypedSPILoader.checkService(TypedSPIFixture.class, "FIXTURE", WorkflowSQLUtils.createProperties(Map.of("foo", "bar"))));
+        }
+    }
+    
+    @Test
+    void assertAlgorithmServiceAvailableWithTrimmedType() {
+        try (MockedStatic<TypedSPILoader> ignored = mockStatic(TypedSPILoader.class)) {
+            assertTrue(WorkflowAlgorithmUtils.isAlgorithmServiceAvailable(TypedSPIFixture.class, " FIXTURE ", Map.of()));
+            ignored.verify(() -> TypedSPILoader.checkService(TypedSPIFixture.class, "FIXTURE", new Properties()));
+        }
+    }
+    
+    @Test
+    void assertAlgorithmServiceUnavailable() {
+        try (MockedStatic<TypedSPILoader> mockedStatic = mockStatic(TypedSPILoader.class)) {
+            mockedStatic.when(() -> TypedSPILoader.checkService(TypedSPIFixture.class, "MISSING", new Properties()))
+                    .thenThrow(new ServiceProviderNotFoundException(TypedSPIFixture.class, "MISSING"));
+            assertFalse(WorkflowAlgorithmUtils.isAlgorithmServiceAvailable(TypedSPIFixture.class, "MISSING", Map.of()));
+        }
+    }
+    
+    @Test
+    void assertSecretReferenceOnlyRequiresTypeAvailability() {
+        try (
+                MockedStatic<TypedSPILoader> typedSPILoader = mockStatic(TypedSPILoader.class);
+                MockedStatic<ShardingSphereServiceLoader> serviceLoader = mockStatic(ShardingSphereServiceLoader.class)) {
+            serviceLoader.when(() -> ShardingSphereServiceLoader.getServiceInstances(TypedSPIFixture.class)).thenReturn(List.of(new TypedSPIFixture()));
+            assertTrue(WorkflowAlgorithmUtils.isAlgorithmServiceAvailable(TypedSPIFixture.class, "fixture", Map.of("secret-key", "secret_reference:primary.secret-key")));
+            typedSPILoader.verifyNoInteractions();
+        }
+    }
+    
+    @Test
+    void assertSecretReferenceRejectsMissingType() {
+        try (MockedStatic<ShardingSphereServiceLoader> serviceLoader = mockStatic(ShardingSphereServiceLoader.class)) {
+            serviceLoader.when(() -> ShardingSphereServiceLoader.getServiceInstances(TypedSPIFixture.class)).thenReturn(List.of(new TypedSPIFixture()));
+            assertFalse(WorkflowAlgorithmUtils.isAlgorithmServiceAvailable(TypedSPIFixture.class, "MISSING", Map.of("secret-key", "secret_reference:primary.secret-key")));
+        }
+    }
+    
+    private static final class TypedSPIFixture implements TypedSPI {
+        
+        @Override
+        public Object getType() {
+            return "FIXTURE";
+        }
+        
+        @Override
+        public Collection<Object> getTypeAliases() {
+            return List.of("FIXTURE_ALIAS");
+        }
+    }
+}

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSQLUtilsTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowSQLUtilsTest.java
@@ -136,6 +136,24 @@ class WorkflowSQLUtilsTest {
     }
     
     @Test
+    void assertFormatGeneratedRuleDistSQLIdentifierQuotesSafeIdentifier() {
+        String actualValue = WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier("orders_01");
+        assertThat(actualValue, is("`orders_01`"));
+    }
+    
+    @Test
+    void assertFormatGeneratedRuleDistSQLIdentifierQuotesDelimitedSafeIdentifier() {
+        String actualValue = WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier("`orders`");
+        assertThat(actualValue, is("`orders`"));
+    }
+    
+    @Test
+    void assertFormatGeneratedRuleDistSQLIdentifierReturnsEmptyForBlankIdentifier() {
+        String actualValue = WorkflowSQLUtils.formatGeneratedRuleDistSQLIdentifier("");
+        assertThat(actualValue, is(""));
+    }
+    
+    @Test
     void assertFormatSQLIdentifierUsesMysqlQuoteStyle() {
         String actualValue = WorkflowSQLUtils.formatSQLIdentifier("MySQL", "order detail");
         assertThat(actualValue, is("`order detail`"));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyEncryptWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyEncryptWorkflowE2ETest.java
@@ -93,7 +93,7 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
             List<Map<String, Object>> distSqlArtifacts = getMapList(plannedResponse.get("distsql_artifacts"));
             assertThat(distSqlArtifacts.size(), is(1));
             assertThat(String.valueOf(distSqlArtifacts.getFirst().get("sql")), containsString("'aes-key-value'='******'"));
-            assertThat(String.valueOf(distSqlArtifacts.getFirst().get("sql")), containsString("CIPHER=status_cipher"));
+            assertThat(String.valueOf(distSqlArtifacts.getFirst().get("sql")), containsString("CIPHER=`status_cipher`"));
             assertSecretRedacted(interactionClient.readResource(String.format(WORKFLOW_RESOURCE_URI, planId)), TEMPLATE_SECRET_VALUE);
             Map<String, Object> applyResponse = applyReviewedWorkflow(interactionClient, planId, TEMPLATE_SECRET_VALUE);
             assertApplyCompleted(applyResponse);
@@ -146,7 +146,7 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
             assertFalse(actualPlannedResponse.containsKey("index_plan"));
             List<Map<String, Object>> actualDistSqlArtifacts = getMapList(actualPlannedResponse.get("distsql_artifacts"));
             assertThat(actualDistSqlArtifacts.size(), is(1));
-            assertThat(String.valueOf(actualDistSqlArtifacts.getFirst().get("sql")), containsString("ASSISTED_QUERY_COLUMN=status_assisted_query"));
+            assertThat(String.valueOf(actualDistSqlArtifacts.getFirst().get("sql")), containsString("ASSISTED_QUERY_COLUMN=`status_assisted_query`"));
             Map<String, Object> actualApplyResponse = applyReviewedWorkflow(interactionClient, planId);
             assertApplyCompleted(actualApplyResponse);
             assertThat(getMapList(actualApplyResponse.get("step_results")).size(), is(1));
@@ -290,7 +290,7 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
             assertThat(getIssueCodes(actualDropPlanResponse), hasItem(WorkflowIssueCode.ENCRYPT_DROP_SCOPE_LIMITED));
             assertFalse(getIssueCodes(actualDropPlanResponse).contains(WorkflowIssueCode.PHYSICAL_CLEANUP_REQUIRED));
             assertFalse(actualDropPlanResponse.containsKey("ddl_artifacts"));
-            assertThat(String.valueOf(getMapList(actualDropPlanResponse.get("distsql_artifacts")).getFirst().get("sql")), is("DROP ENCRYPT RULE orders"));
+            assertThat(String.valueOf(getMapList(actualDropPlanResponse.get("distsql_artifacts")).getFirst().get("sql")), is("DROP ENCRYPT RULE `orders`"));
             String planId = String.valueOf(actualDropPlanResponse.get("plan_id"));
             Map<String, Object> actualApplyResponse = applyReviewedWorkflow(interactionClient, planId);
             assertApplyCompleted(actualApplyResponse);

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
@@ -72,7 +72,7 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
                             "operation_type", "create", "algorithm_type", "KEEP_FIRST_N_LAST_M",
                             "primary_algorithm_properties", Map.of("first-n", "1", "last-m", "1", "replace-char", "*")));
             assertThat(String.valueOf(actualCreatePlanResponse.get("status")), is("planned"));
-            assertThat(String.valueOf(getMapList(actualCreatePlanResponse.get("distsql_artifacts")).getFirst().get("sql")), containsString("CREATE MASK RULE orders"));
+            assertThat(String.valueOf(getMapList(actualCreatePlanResponse.get("distsql_artifacts")).getFirst().get("sql")), containsString("CREATE MASK RULE `orders`"));
             String createPlanId = String.valueOf(actualCreatePlanResponse.get("plan_id"));
             assertApplyCompleted(applyReviewedWorkflow(interactionClient, createPlanId));
             Map<String, Object> actualCreateValidationResponse = interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", createPlanId));
@@ -96,7 +96,7 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
             Map<String, Object> actualDropPlanResponse = interactionClient.call(PLAN_TOOL_NAME,
                     Map.of("database", getLogicalDatabaseName(), "table", "orders", "column", "status", "operation_type", "drop"));
             assertThat(String.valueOf(actualDropPlanResponse.get("status")), is("planned"));
-            assertThat(String.valueOf(getMapList(actualDropPlanResponse.get("distsql_artifacts")).getFirst().get("sql")), is("DROP MASK RULE orders"));
+            assertThat(String.valueOf(getMapList(actualDropPlanResponse.get("distsql_artifacts")).getFirst().get("sql")), is("DROP MASK RULE `orders`"));
             String planId = String.valueOf(actualDropPlanResponse.get("plan_id"));
             assertApplyCompleted(applyReviewedWorkflow(interactionClient, planId));
             Map<String, Object> actualValidationResponse = interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId));


### PR DESCRIPTION
Add a generated-rule DistSQL identifier formatter that always quotes workflow-generated rule identifiers, and apply it across encrypt, mask, readwrite-splitting, sharding, broadcast, and shadow planners.

Add generic workflow algorithm SPI availability validation, including secret-reference-safe type checks, and wire it into encrypt, mask, readwrite-splitting, sharding, and shadow apply artifact validators.

Update MCP descriptors and regression tests for the expanded quoting and algorithm validation coverage.

For #35294.