### PR TITLE
Clarify API helper contracts

### DIFF
--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/MCPHandlerContext.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/MCPHandlerContext.java
@@ -22,7 +22,7 @@ import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
 import java.util.Optional;
 
 /**
- * Marker interface for MCP handler execution context.
+ * Base interface for MCP handler execution context.
  */
 public interface MCPHandlerContext {
     

--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/protocol/response/MCPResponse.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/protocol/response/MCPResponse.java
@@ -22,6 +22,7 @@ import java.util.Map;
 /**
  * MCP response.
  */
+@FunctionalInterface
 public interface MCPResponse {
     
     /**

--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/tool/descriptor/MCPToolAnnotations.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/tool/descriptor/MCPToolAnnotations.java
@@ -17,13 +17,12 @@
 
 package org.apache.shardingsphere.mcp.api.tool.descriptor;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * MCP tool annotations.
  */
-@RequiredArgsConstructor
 @Getter
 public final class MCPToolAnnotations {
     
@@ -36,4 +35,13 @@ public final class MCPToolAnnotations {
     private final boolean idempotentHint;
     
     private final boolean openWorldHint;
+    
+    @Builder
+    public MCPToolAnnotations(final String title, final boolean readOnlyHint, final boolean destructiveHint, final boolean idempotentHint, final boolean openWorldHint) {
+        this.title = title;
+        this.readOnlyHint = readOnlyHint;
+        this.destructiveHint = destructiveHint;
+        this.idempotentHint = idempotentHint;
+        this.openWorldHint = openWorldHint;
+    }
 }

--- a/mcp/api/src/test/java/org/apache/shardingsphere/mcp/api/resource/MCPUriVariablesTest.java
+++ b/mcp/api/src/test/java/org/apache/shardingsphere/mcp/api/resource/MCPUriVariablesTest.java
@@ -36,7 +36,7 @@ class MCPUriVariablesTest {
     }
     
     @Test
-    void assertDoesNotContainsVariable() {
+    void assertDoesNotContainVariable() {
         assertFalse(new MCPUriVariables(Map.of("foo_variable", "foo_value")).containsVariable("bar_variable"));
     }
     
@@ -46,13 +46,13 @@ class MCPUriVariablesTest {
     }
     
     @Test
-    void assertGetValueFalidWithMissedVariable() {
+    void assertGetValueFailedWithMissedVariable() {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> new MCPUriVariables(Collections.emptyMap()).getValue("foo_variable"));
         assertThat(ex.getMessage(), is("Missing URI variable `foo_variable`."));
     }
     
     @Test
-    void assertGetValueFalidWithEmptyVariable() {
+    void assertGetValueFailedWithEmptyVariable() {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> new MCPUriVariables(Collections.singletonMap("foo_variable", "")).getValue("foo_variable"));
         assertThat(ex.getMessage(), is("Missing URI variable `foo_variable`."));
     }

--- a/mcp/api/src/test/java/org/apache/shardingsphere/mcp/api/tool/descriptor/MCPToolAnnotationsTest.java
+++ b/mcp/api/src/test/java/org/apache/shardingsphere/mcp/api/tool/descriptor/MCPToolAnnotationsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.api.tool.descriptor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MCPToolAnnotationsTest {
+    
+    @Test
+    void assertConstructor() {
+        MCPToolAnnotations actual = new MCPToolAnnotations("Fixture Tool", true, false, true, true);
+        assertThat(actual.getTitle(), is("Fixture Tool"));
+        assertTrue(actual.isReadOnlyHint());
+        assertFalse(actual.isDestructiveHint());
+        assertTrue(actual.isIdempotentHint());
+        assertTrue(actual.isOpenWorldHint());
+    }
+    
+    @Test
+    void assertBuilder() {
+        MCPToolAnnotations actual = MCPToolAnnotations.builder().title("Fixture Tool").readOnlyHint(true).destructiveHint(false).idempotentHint(true).openWorldHint(true).build();
+        assertThat(actual.getTitle(), is("Fixture Tool"));
+        assertTrue(actual.isReadOnlyHint());
+        assertFalse(actual.isDestructiveHint());
+        assertTrue(actual.isIdempotentHint());
+        assertTrue(actual.isOpenWorldHint());
+    }
+}


### PR DESCRIPTION
Add a builder for MCPToolAnnotations while keeping the existing constructor compatible. Mark MCPResponse as a functional interface, fix MCPHandlerContext Javadoc, and clean up MCPUriVariables test names.

For #35294.