### PR TITLE
Refine review-pr evidence access and script helpers

### DIFF
--- a/.codex/skills/review-pr/SKILL.md
+++ b/.codex/skills/review-pr/SKILL.md
@@ -23,14 +23,7 @@ description: >-
   - `Formal Review Mode`: use when the user asks for a PR review, mergeability decision, or formal GitHub review body. Output exactly one `Review Result`.
   - `PR Discussion Reply Mode`: use when the user asks how to reply to PR comments, review threads, author or maintainer pushback, or challenged findings.
     Output a copy-ready committer reply draft by default, and do not force a formal `Review Result` unless the user asks for one.
-- In `Formal Review Mode`, output exactly one `Review Result`:
-  - `Mergeable`: the reviewed scope, triggered gates, and public evidence support merge readiness.
-  - `Not Mergeable`: public evidence confirms a necessary, in-scope blocker that passed the `Blocker Proof Gate`.
-  - `Review Incomplete`: the reviewer cannot make a reliable mergeability judgment because required public facts are unavailable, inaccessible, or not attributable.
-- For `Not Mergeable`, choose exactly one feedback mode:
-  - `Change Request`: the direction is valid, but the patch needs implementation, test, scope, compatibility, or evidence changes.
-  - `Needs Discussion`: public evidence shows the PR direction, root-cause model, or problem framing must be reopened before implementation continues.
-- For `Review Incomplete`, do not output patch-level change requests. State what was verified, what required public fact is missing, and what must be checked next.
+- In `Formal Review Mode`, choose the result and feedback mode from the `Verdict Matrix`.
 
 ## Trigger Scenarios
 Use when the user asks to review a PR, decide mergeability or root-cause repair, write committer feedback,
@@ -38,41 +31,31 @@ reconsider PR direction, or reply to PR comments, review threads, author pushbac
 
 ## Mandatory Constraints
 
-Before applying the numbered review gates, enforce the public evidence boundary:
-
-- Treat every GitHub-facing review body as community-visible output that may be copied directly to a public Apache PR or issue.
-- Base community-visible output only on public PR / issue facts, public commits, public diff, public review threads, public documentation, repository code, and sanitized local verification summaries.
-- Do not include non-public downstream project names, private or internal repository names, customer-specific or vendor-specific context, private chats,
-  intermediate discussion results, prompt process, internal self-review notes, local-only archive details, or private migration background in community-visible output.
-- Do not use non-public context as review evidence. If such context helps orient the reviewer privately, convert it into a public-evidence question
-  and verify it against public artifacts before output.
-
 1. Verify root-cause repair first; fallback logic, defaults, null checks, try-catch blocks, or swallowed errors cannot substitute for root-cause repair.
-2. In `Formal Review Mode`, output exactly one `Review Result`. Choose one `Feedback Mode` only when the result is `Not Mergeable`.
-3. Treat every issue as a candidate until it passes the `Blocker Proof Gate`.
+2. In `Formal Review Mode`, output exactly one `Review Result` from the `Verdict Matrix`.
+3. Enforce the `GitHub and Evidence Access` boundary before using or reporting evidence.
+4. Treat every issue as a candidate until it passes the `Blocker Proof Gate`.
    Do not convert reviewer uncertainty, tool failure, inaccessible GitHub data, or missing local verification into a PR blocker.
    Use `Review Incomplete` in `Formal Review Mode`, or a clarification-style reply in `PR Discussion Reply Mode`, when required public facts cannot be checked or attributed.
-4. In `Formal Review Mode`, if public evidence confirms a wrong root-cause model, problem framing, expected behavior, ownership boundary, or solution direction,
+5. In `Formal Review Mode`, if public evidence confirms a wrong root-cause model, problem framing, expected behavior, ownership boundary, or solution direction,
    use `Review Result: Not Mergeable` with `Feedback Mode: Needs Discussion`.
-5. Review only the latest PR code version, and use GitHub PR metadata plus `/pulls/{number}/files` as the authoritative scope boundary.
-6. Use repository-declared formatting/style gates as the formatting authority.
-   For ShardingSphere, Spotless and Checkstyle are authoritative.
-   Do not run `git diff --check`, editor whitespace lint, or other generic whitespace diagnostics as routine review verification.
-   Use them only when repository workflows explicitly require them, the user asks for whitespace review, the review target is formatting rules, or whitespace has direct semantic impact.
-   Do not report Spotless-stable whitespace, including formatter-preserved blank-line indentation, as a blocker.
-7. Treat substantive unrelated changes or substantive scope expansion as blockers; ignore non-behavioral import-only, whitespace-only, formatter-only, or IDE cleanup churn unless it hides behavior,
-   fails declared gates, touches broad unrelated areas, or violates explicit scope rules.
+6. Review only the latest PR code version, and use GitHub PR metadata plus `/pulls/{number}/files` as the authoritative scope boundary.
+7. Apply the `Style and Non-Behavioral Churn Authority` before reporting formatting, whitespace, import-only, or formatter-only findings.
 8. Before considering `Mergeable`, apply all triggered hard gates and specialized review gates, including semantic compatibility, counterexamples, blast-radius/shared-layer ownership,
    linked-issue completeness, implicit-state review, high-frequency `computeIfAbsent` review, CI evidence judgment when relevant, and local verification freshness.
 9. Before final output, complete the `Pre-Publication Finding Audit`; do not expose intermediate findings, and output one consolidated review.
 
-## Core Verdict Principle
+## Verdict Matrix
 
 The goal is the correct mergeability judgment, not conservative avoidance or aggressive blocking.
 
 - Use `Mergeable` when the reviewed latest scope, all triggered gates, and public evidence support merge readiness.
 - Use `Not Mergeable` only for confirmed, necessary, in-scope blockers.
+  - Use `Feedback Mode: Change Request` when the PR direction is valid, but the patch needs implementation, test, scope, compatibility, or evidence changes.
+  - Use `Feedback Mode: Needs Discussion` when public evidence shows the PR direction, root-cause model, problem framing, expected behavior, ownership boundary, protocol or SQL semantics,
+    compatibility assumption, or solution direction must be reopened before implementation continues.
 - Use `Review Incomplete` only when a required public fact is unavailable, inaccessible, stale, or unattributable and that gap affects mergeability.
+  Do not include patch-level code requests; state what was verified, what required public fact is missing, and what must be checked next.
 - If a concern is real but not required for merge safety, classify it as non-blocking, ask a scoped question, or omit it from GitHub-facing output.
 
 ## Blocker Proof Gate
@@ -90,14 +73,12 @@ If any check fails, downgrade the candidate to `Review Incomplete`, a non-blocki
 
 ## Evidence Sufficiency and CI Judgment
 
-- `Not Mergeable` requires a candidate to pass the `Blocker Proof Gate`; otherwise it remains internal or becomes `Review Incomplete`.
-- `Review Incomplete` is not a soft approval and must not contain patch-level code requests.
-  If a code issue is already confirmed, use `Not Mergeable`.
 - CI success never replaces code review, root-cause review, scope review, or test adequacy review.
 - Relevant CI failure means the PR cannot be `Mergeable`.
   If the failure is attributable to the PR, use `Not Mergeable`; if attribution is unclear, use `Review Incomplete`.
 - Inspect CI, check-runs, or workflow logs when the PR goal, linked issue, author/user statement, generated artifact, native image, E2E,
   test-infra, or a candidate blocker depends on runtime verification.
+- If required CI or Actions logs are unavailable after the authenticated access ladder in `GitHub and Evidence Access`, classify the effect through the `Verdict Matrix`.
 - Do not wait for or query CI when code, docs, or static evidence is sufficient for the current review result.
   State the reason in `Verification` when CI was not reviewed.
 
@@ -169,13 +150,8 @@ Do not turn speculative risks, personal style preferences, or out-of-scope polis
 
 ## Not Mergeable Feedback Mode
 
-Choose the feedback mode before writing the GitHub-facing review:
+Choose the feedback mode from the `Verdict Matrix` before writing the GitHub-facing review.
 
-- Use `Change Request` when the PR direction is aligned with the confirmed root cause,
-  but the current patch still needs implementation, test, scope, compatibility, or evidence changes.
-- Use `Needs Discussion` when public evidence shows the PR is built on a confirmed-wrong or publicly disputed problem model,
-  root-cause model, expected behavior, ownership boundary, protocol or SQL semantics,
-  compatibility assumption, or solution direction.
 - Do not use `Needs Discussion` for ordinary incomplete patches, missing tests, or missing logs when the direction is otherwise correct; request the minimum missing information or changes instead.
 - Do not ask for patch-level refinement after selecting `Needs Discussion`; ask maintainers and the author to pause the current implementation direction and resolve the discussion first.
 - For label recommendations, suggest existing labels only:
@@ -187,23 +163,40 @@ Choose the feedback mode before writing the GitHub-facing review:
 - Review only the latest PR code, tests, behavior, compatibility, regression risk, and scope.
 - Derive authoritative scope from GitHub PR metadata and `/pulls/{number}/files`; reproduce locally with triple-dot semantics.
   Record head SHA, base ref/SHA, merge-base, and whether the local file list matches GitHub.
-- Do not base the result solely on CI, and do not wait for CI when static/code evidence is already sufficient.
-- Use repository-declared style gates as authority. For ShardingSphere, Spotless and Checkstyle are authoritative.
-  Do not use `git diff --check` or other generic whitespace diagnostics as routine review verification unless the Mandatory Constraints exception applies.
 
-## Non-Behavioral Churn Rule
+## Style and Non-Behavioral Churn Authority
 
+- Use repository-declared formatting/style gates as authority. For ShardingSphere, Spotless and Checkstyle are authoritative.
+- Do not run `git diff --check`, editor whitespace lint, or other generic whitespace diagnostics as routine review verification.
+  Use them only when repository workflows explicitly require them, the user asks for whitespace review, the review target is formatting rules, or whitespace has direct semantic impact.
+- Do not report Spotless-stable whitespace, including formatter-preserved blank-line indentation, as a blocker.
 - Include import-only, whitespace-only, and formatter-only files in `Reviewed Scope` when GitHub lists them.
 - Do not report them as blockers or rollback requests unless they hide behavior, fail style gates, touch broad unrelated areas, or violate explicit scope rules.
 
 ## GitHub and Evidence Access
 
-- Prefer authenticated GitHub connector/app tools, then `gh`, then token-backed REST without printing token values, then anonymous API/HTML.
+- Treat every GitHub-facing review body as community-visible output that may be copied directly to a public Apache PR or issue.
+- Base community-visible output only on public PR / issue facts, public commits, public diff, public review threads, public documentation, repository code, and sanitized local verification summaries.
+- Do not include non-public downstream project names, private or internal repository names, customer-specific or vendor-specific context, private chats,
+  intermediate discussion results, prompt process, internal self-review notes, local-only archive details, private migration background, tokens, auth method details,
+  temporary file paths, raw private diagnostics, local absolute paths, private identifiers, or internal reasoning in community-visible output.
+- Do not use non-public context as review evidence. If such context helps orient the reviewer privately, convert it into a public-evidence question
+  and verify it against public artifacts before output.
+- Prefer authenticated GitHub connector/app tools, then authenticated `gh`, then token-backed REST, then anonymous API/HTML.
+- For `gh` and REST fallback, prefer the local configured token sources in this order: `gh auth token`, `GH_TOKEN`, then `GITHUB_TOKEN`.
+  Never print token values, write them to the skill, ledger, temporary logs, review output, shell history, debug traces, or command summaries.
 - Fetch all pages for PR files, commits, comments, reviews, and required check data.
 - Do not treat anonymous `404` or secondary-endpoint `403` as unavailable evidence until authenticated access has been tried or shown unavailable.
 - Classify access by endpoint; inaccessible checks/logs block mergeability only when required under `Evidence Sufficiency and CI Judgment`.
-- GitHub-facing output may cite only public PR/issue facts, repository code, public docs/specs, public CI/logs, or sanitized local verification summaries.
-- Never output tokens, auth method details, temporary file paths, raw private diagnostics, local absolute paths, private identifiers, prompt text, or internal reasoning.
+- When GitHub Actions logs are required evidence, do not stop after `gh run view --log` or anonymous API/HTML failure.
+  Try authenticated `gh` first, then token-backed REST for workflow or job logs, and record authenticated access as unavailable only after the configured token sources are missing,
+  expired, unauthorized, or still cannot access the endpoint.
+- Keep Actions log retrieval read-only. Do not rerun workflows, write comments, alter PR state, or request new token permissions without explicit user confirmation.
+- Download large logs to a temporary file and report only status, exit code, log path for internal use, and a small sanitized summary. Do not expose redirect URLs or raw long logs.
+- Official references for the access behavior:
+  - GitHub CLI environment variables: https://cli.github.com/manual/gh_help_environment
+  - GitHub CLI run log limitations: https://cli.github.com/manual/gh_run_view
+  - GitHub REST workflow run logs: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#download-workflow-run-logs
 
 ## Execution Boundary
 
@@ -216,7 +209,6 @@ Choose the feedback mode before writing the GitHub-facing review:
 ## Evidence Source Strategy
 
 - Evidence priority: PR facts; same-repo issues/code/tests; ShardingSphere docs and conventions; external official specs only when needed.
-- CI status and check-runs are evidence only when relevant under `Evidence Sufficiency and CI Judgment`.
 - For SQL parser reviews, read `references/sql-parser-review.md` when SQL grammar, visitors, syntax docs, dialect behavior, or parser baselines are touched.
 - Do not rely on unverifiable blogs, forum posts, or AI-reposted content.
 
@@ -286,14 +278,14 @@ Triage policy:
 - Required public facts unavailable, inaccessible, stale, or unattributable: set `Review Result: Review Incomplete` and request only the facts needed to complete the review.
 - Wrong problem model, root-cause model, or direction: set `Review Result: Not Mergeable`, use `Feedback Mode: Needs Discussion`, and recommend `type: discussion`.
 - Any substantive off-topic/unrelated changes or substantive scope expansion: set `Review Result: Not Mergeable` and require rollback or scope narrowing.
-  Ignore non-behavioral import-only, whitespace-only, and formatter-only churn for mergeability unless it meets the Non-Behavioral Churn Rule escalation conditions.
+  Ignore non-behavioral import-only, whitespace-only, and formatter-only churn for mergeability unless it meets the `Style and Non-Behavioral Churn Authority`.
 - Change set too large: request split first, and provide only blocker-level feedback for current version.
 - If `Full Coverage Ledger Mode` is active, triage decisions select review depth and ledger setup only. They do not authorize early final output.
 
 ## Minimum Required Information
 
 - Request only facts required by the unresolved gate, and map every requested item to that gate.
-- Do not ask the author for evidence the reviewer can obtain from public PR, issue, code, CI, or workflow data.
+- Do not ask the author for evidence the reviewer can obtain through `GitHub and Evidence Access`, repository code, public docs, target-tool source, or official specs.
 - Common requests: latest changed-file scope, runtime topology, database type/version, minimal reproducible input, key logs,
   targeted test evidence, docs/release impact, or SQL parser official documentation.
 
@@ -309,7 +301,7 @@ CI/check-run review is not a substitute for code review. Query and report CI onl
 5. Verify validation: trace tests through real entry paths where applicable, map tests to fix points,
    and apply the `Specialized Proof Mini-Gates` for test, metadata, native, and docs claims.
 6. Screen unrelated change: require rollback or scope narrowing only for substantive unrelated code, config, behavior, or broad cleanup.
-   Ignore non-behavioral churn unless it meets the `Non-Behavioral Churn Rule`.
+   Ignore non-behavioral churn unless it meets the `Style and Non-Behavioral Churn Authority`.
 7. Materialize the anti-drip inventory when `Full Coverage Ledger Mode` is active;
    otherwise keep an internal inventory with the same evidence categories.
 8. Apply the `Blocker Proof Gate` to every candidate finding before it can become a public blocker.
@@ -455,7 +447,7 @@ Use this mode when the user asks for a committer reply to a PR comment, review t
 - Explain reasoning in the user's language, but draft GitHub-facing replies in English unless the user requests another language.
 - Keep private chats, private reproduction details, prompt process, and local-only analysis out of the copy-ready reply.
 - If evidence is closed, state whether to retain, withdraw, or revise; if incomplete or conflicting, draft a clarification-style reply.
-- Do not ask the author for evidence the reviewer can obtain from public PR, issue, code, CI, workflow data, target-tool source, or official docs.
+- Do not ask the author for evidence the reviewer can obtain under `Minimum Required Information`.
 - Protect committer credibility: do not provide a strong public claim, blame, or merge-blocking request unless the evidence chain is closed.
 
 ## Output Structure
@@ -476,13 +468,12 @@ Use these required structures:
 - `Correction`: prepend `### Correction` with `Previous Finding`, `Current Status` (`Retained`, `Withdrawn`, or `Changed to Review Incomplete`), and `Reason`;
   then output the applicable current result structure with exactly one bold `Review Result` line under `### Summary`.
 
-For `Not Mergeable`, choose `Feedback Mode: Change Request` for patch-level required changes or `Feedback Mode: Needs Discussion`
-when the current direction, root-cause model, problem framing, expected behavior, or ownership boundary must be reopened.
+For `Not Mergeable`, choose the feedback mode from the `Verdict Matrix`.
 Do not include patch-level `Required Change` bullets after choosing `Needs Discussion`.
 Use `P0`, `P1`, or `P2` issue severity, and include `Problem`, `Impact`, and either `Required Change` or `Discussion Needed`.
 Use `status: need more info` instead of `type: discussion` only when missing public evidence blocks root-cause or scope classification.
 Optional `Not Mergeable` sections are `Positive Feedback`, `Unrelated Changes`, `Next Steps`, and `Multi-Round Comparison`; omit placeholder headings.
-`Review Incomplete` must not contain patch-level code suggestions. If evidence already supports a concrete code change, use `Review Result: Not Mergeable`.
+`Review Incomplete` must follow the `Verdict Matrix`: no patch-level code suggestions, and use `Not Mergeable` once evidence supports a concrete required change.
 
 ## Feedback Tone Guidelines
 - Use "suggest / please / need" rather than accusatory commands.

--- a/.codex/skills/review-pr/scripts/build_review_inventory.py
+++ b/.codex/skills/review-pr/scripts/build_review_inventory.py
@@ -23,74 +23,16 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import subprocess
 import sys
 from collections import defaultdict
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
+
+from review_common import ChangedFile, categorize, compare_github_files, final_paths, get_repo_root, parse_name_status, run_git
 
 
 MAX_ITEMS = 30
 MAX_TEST_REFERENCES = 3
-
-
-@dataclass(frozen=True)
-class ChangedFile:
-    status: str
-    path: str
-    old_path: str | None = None
-
-
-def run_git(args: list[str], repo_root: Path, allow_empty: bool = False) -> str:
-    process = subprocess.run(["git", *args], cwd=repo_root, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
-    if 0 == process.returncode or allow_empty and 1 == process.returncode:
-        return process.stdout
-    command = "git " + " ".join(args)
-    raise RuntimeError(f"{command} failed with exit {process.returncode}: {process.stderr.strip()}")
-
-
-def get_repo_root() -> Path:
-    process = subprocess.run(["git", "rev-parse", "--show-toplevel"], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
-    if 0 != process.returncode:
-        raise RuntimeError("Current directory is not inside a git repository")
-    return Path(process.stdout.strip())
-
-
-def parse_name_status(output: str) -> list[ChangedFile]:
-    result: list[ChangedFile] = []
-    for line in output.splitlines():
-        if not line.strip():
-            continue
-        parts = line.split("\t")
-        status = parts[0]
-        if status.startswith("R") or status.startswith("C"):
-            result.append(ChangedFile(status=status, path=parts[-1], old_path=parts[1]))
-        else:
-            result.append(ChangedFile(status=status, path=parts[-1]))
-    return result
-
-
-def final_paths(changed_files: Iterable[ChangedFile]) -> list[str]:
-    return [each.path for each in changed_files]
-
-
-def categorize(path: str) -> str:
-    if path == "RELEASE-NOTES.md":
-        return "release-notes"
-    if "/src/main/java/" in path:
-        return "production-java"
-    if "/src/test/" in path:
-        return "tests"
-    if path.startswith("docs/") or path.endswith((".md", ".adoc")):
-        return "docs"
-    if path.startswith(".github/") or path.endswith((".xml", ".properties", ".yml", ".yaml", ".toml", ".gradle")):
-        return "build-config"
-    if "distribution" in path:
-        return "distribution"
-    if "target/" in path or "/generated/" in path:
-        return "generated"
-    return "other"
 
 
 def read_file_at_ref(repo_root: Path, ref: str, path: str) -> str:
@@ -155,21 +97,6 @@ def scan_diff_clues(repo_root: Path, base_ref: str, head_ref: str, paths: list[s
     return {key: limited(values)[0] for key, values in result.items() if values}
 
 
-def compare_github_files(local_paths: list[str], github_files_path: str | None) -> dict[str, object]:
-    if not github_files_path:
-        return {"provided": False}
-    github_paths = sorted(line.strip() for line in Path(github_files_path).read_text(encoding="utf-8").splitlines() if line.strip())
-    local_sorted = sorted(local_paths)
-    return {
-        "provided": True,
-        "matched": github_paths == local_sorted,
-        "github_count": len(github_paths),
-        "local_count": len(local_sorted),
-        "only_in_github": sorted(set(github_paths) - set(local_sorted))[:MAX_ITEMS],
-        "only_in_local": sorted(set(local_sorted) - set(github_paths))[:MAX_ITEMS],
-    }
-
-
 def group_by_category(changed_files: list[ChangedFile]) -> dict[str, list[str]]:
     result: dict[str, list[str]] = defaultdict(list)
     for changed_file in changed_files:
@@ -196,7 +123,7 @@ def build_inventory(args: argparse.Namespace) -> dict[str, object]:
             "head_sha": head_sha,
             "merge_base": merge_base,
             "changed_file_count": len(changed_files),
-            "github_files": compare_github_files(paths, args.github_files),
+            "github_files": compare_github_files(paths, args.github_files, MAX_ITEMS),
         },
         "dirty_worktree": run_git(["status", "--short"], repo_root, allow_empty=True).splitlines(),
         "changed_files_by_category": group_by_category(changed_files),
@@ -211,11 +138,7 @@ def build_inventory(args: argparse.Namespace) -> dict[str, object]:
         "manual_checklist": [
             "Confirm GitHub file list matches local triple-dot scope before reporting scope findings.",
             "Classify each blocker origin: PR-caused, base-existing, exposed-by-PR, latest-introduced, older-PR-revision, or out-of-scope.",
-            "Classify each Not Mergeable result as Change Request or Needs Discussion before drafting feedback.",
             "Deduplicate candidate issues by independent fix boundary before output.",
-            "Review lifecycle paths for every new registry/cache/session/handle state.",
-            "Review supported-vs-rejected feature matrix and flag unsupported-but-accepted inputs.",
-            "Map every new public production type to direct focused tests or record missing evidence.",
             "Run one final adversarial pass after findings are frozen; output only after no new independent fix boundary appears.",
         ],
     }

--- a/.codex/skills/review-pr/scripts/review_common.py
+++ b/.codex/skills/review-pr/scripts/review_common.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Shared helpers for review-pr local scripts."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    status: str
+    path: str
+    old_path: str | None = None
+
+
+def run_git(args: list[str], repo_root: Path, allow_empty: bool = False) -> str:
+    process = subprocess.run(["git", *args], cwd=repo_root, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if 0 == process.returncode or allow_empty and 1 == process.returncode:
+        return process.stdout
+    command = "git " + " ".join(args)
+    raise RuntimeError(f"{command} failed with exit {process.returncode}: {process.stderr.strip()}")
+
+
+def get_repo_root(path: Path | None = None) -> Path:
+    process = subprocess.run(["git", "rev-parse", "--show-toplevel"], cwd=path, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if 0 != process.returncode:
+        target = path if path else "current directory"
+        raise RuntimeError(f"{target} is not inside a git repository")
+    return Path(process.stdout.strip())
+
+
+def parse_name_status(output: str) -> list[ChangedFile]:
+    result: list[ChangedFile] = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        if status.startswith(("R", "C")):
+            result.append(ChangedFile(status=status, path=parts[-1], old_path=parts[1]))
+        else:
+            result.append(ChangedFile(status=status, path=parts[-1]))
+    return result
+
+
+def categorize(path: str) -> str:
+    if "RELEASE-NOTES.md" == path:
+        return "release-notes"
+    if "/src/main/java/" in path:
+        return "production-java"
+    if "/src/test/" in path:
+        return "tests"
+    if path.startswith("docs/") or path.endswith((".md", ".adoc")):
+        return "docs"
+    if path.startswith(".github/") or path.endswith((".xml", ".properties", ".yml", ".yaml", ".toml", ".gradle")):
+        return "build-config"
+    if "distribution" in path:
+        return "distribution"
+    if "target/" in path or "/generated/" in path:
+        return "generated"
+    return "other"
+
+
+def final_paths(changed_files: Iterable[ChangedFile]) -> list[str]:
+    return [each.path for each in changed_files]
+
+
+def compare_github_files(local_paths: Iterable[str], github_files_path: str | None, limit: int | None = None) -> dict[str, Any]:
+    if not github_files_path:
+        return {"provided": False}
+    github_paths = sorted(line.strip() for line in Path(github_files_path).read_text(encoding="utf-8").splitlines() if line.strip())
+    local_sorted = sorted(local_paths)
+    only_in_github = sorted(set(github_paths) - set(local_sorted))
+    only_in_local = sorted(set(local_sorted) - set(github_paths))
+    if limit is not None:
+        only_in_github = only_in_github[:limit]
+        only_in_local = only_in_local[:limit]
+    return {
+        "provided": True,
+        "matched": github_paths == local_sorted,
+        "github_count": len(github_paths),
+        "local_count": len(local_sorted),
+        "only_in_github": only_in_github,
+        "only_in_local": only_in_local,
+    }

--- a/.codex/skills/review-pr/scripts/review_ledger.py
+++ b/.codex/skills/review-pr/scripts/review_ledger.py
@@ -24,14 +24,14 @@ import argparse
 import json
 import re
 import shutil
-import subprocess
 import sys
 import tempfile
 import time
 from collections import Counter
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
+
+from review_common import categorize, compare_github_files, final_paths, get_repo_root, parse_name_status, run_git
 
 
 FILE_STATUSES = frozenset({"pending", "reviewed", "churn-only", "test-only-reviewed", "not-applicable", "blocked"})
@@ -40,75 +40,6 @@ FINDING_STATUSES = frozenset({"candidate", "confirmed", "withdrawn", "review-inc
 SEVERITIES = frozenset({"P0", "P1", "P2"})
 PROOF_GATE_RESULTS = frozenset({"pending", "passed", "failed", "not-applicable"})
 LEDGER_FILE_NAME = "ledger.json"
-
-
-@dataclass(frozen=True)
-class ChangedFile:
-    status: str
-    path: str
-    old_path: str | None = None
-
-
-def run_git(args: list[str], repo_root: Path, allow_empty: bool = False) -> str:
-    process = subprocess.run(["git", *args], cwd=repo_root, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
-    if 0 == process.returncode or allow_empty and 1 == process.returncode:
-        return process.stdout
-    command = "git " + " ".join(args)
-    raise RuntimeError(f"{command} failed with exit {process.returncode}: {process.stderr.strip()}")
-
-
-def get_repo_root(path: Path) -> Path:
-    process = subprocess.run(["git", "rev-parse", "--show-toplevel"], cwd=path, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
-    if 0 != process.returncode:
-        raise RuntimeError(f"{path} is not inside a git repository")
-    return Path(process.stdout.strip())
-
-
-def parse_name_status(output: str) -> list[ChangedFile]:
-    result: list[ChangedFile] = []
-    for line in output.splitlines():
-        if not line.strip():
-            continue
-        parts = line.split("\t")
-        status = parts[0]
-        if status.startswith(("R", "C")):
-            result.append(ChangedFile(status=status, path=parts[-1], old_path=parts[1]))
-        else:
-            result.append(ChangedFile(status=status, path=parts[-1]))
-    return result
-
-
-def categorize(path: str) -> str:
-    if "RELEASE-NOTES.md" == path:
-        return "release-notes"
-    if "/src/main/java/" in path:
-        return "production-java"
-    if "/src/test/" in path:
-        return "tests"
-    if path.startswith("docs/") or path.endswith((".md", ".adoc")):
-        return "docs"
-    if path.startswith(".github/") or path.endswith((".xml", ".properties", ".yml", ".yaml", ".toml", ".gradle")):
-        return "build-config"
-    if "distribution" in path:
-        return "distribution"
-    if "target/" in path or "/generated/" in path:
-        return "generated"
-    return "other"
-
-
-def compare_github_files(local_paths: Iterable[str], github_files_path: str | None) -> dict[str, Any]:
-    if not github_files_path:
-        return {"provided": False}
-    github_paths = sorted(line.strip() for line in Path(github_files_path).read_text(encoding="utf-8").splitlines() if line.strip())
-    local_sorted = sorted(local_paths)
-    return {
-        "provided": True,
-        "matched": github_paths == local_sorted,
-        "github_count": len(github_paths),
-        "local_count": len(local_sorted),
-        "only_in_github": sorted(set(github_paths) - set(local_sorted)),
-        "only_in_local": sorted(set(local_sorted) - set(github_paths)),
-    }
 
 
 def ledger_root() -> Path:
@@ -188,7 +119,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     head_sha = run_git(["rev-parse", args.head_ref], repo_root).strip()
     merge_base = run_git(["merge-base", args.base_ref, args.head_ref], repo_root).strip()
     changed_files = parse_name_status(run_git(["diff", "--name-status", f"{merge_base}..{args.head_ref}"], repo_root))
-    paths = [each.path for each in changed_files]
+    paths = final_paths(changed_files)
     current_dir = build_ledger_dir(repo_root, args.pr, head_sha)
     cleanup_matching_ledgers(repo_root, args.pr, keep=current_dir)
     remove_ledger_dir(current_dir)


### PR DESCRIPTION
Centralize review-pr verdict, evidence, and style authority rules to reduce duplicate guidance while preserving existing review modes and blocker gates.

Add explicit GitHub Actions log access guidance that uses local authenticated sources first, including gh auth token, GH_TOKEN, and GITHUB_TOKEN, without printing or persisting token values.

Extract shared review script helpers for git scope parsing, file categorization, and GitHub file-list comparison so inventory and ledger scripts no longer maintain duplicate implementations.
