### PR TITLE
Correct SQLServer offset fetch pagination merge

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dql/pagination/builder/dialect/SQLServerPaginationDecoratorMergedResultBuilder.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dql/pagination/builder/dialect/SQLServerPaginationDecoratorMergedResultBuilder.java
@@ -23,7 +23,7 @@ import org.apache.shardingsphere.infra.merge.result.impl.decorator.DecoratorMerg
 import org.apache.shardingsphere.sharding.merge.dql.pagination.LimitDecoratorMergedResult;
 import org.apache.shardingsphere.sharding.merge.dql.pagination.TopAndRowNumberDecoratorMergedResult;
 import org.apache.shardingsphere.sharding.merge.dql.pagination.builder.PaginationDecoratorMergedResultBuilder;
-import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.limit.LimitValueSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.rownum.RowNumberValueSegment;
 
 import java.sql.SQLException;
 
@@ -34,9 +34,10 @@ public final class SQLServerPaginationDecoratorMergedResultBuilder implements Pa
     
     @Override
     public DecoratorMergedResult build(final MergedResult mergedResult, final PaginationContext paginationContext) throws SQLException {
-        return paginationContext.getRowCountSegment().filter(LimitValueSegment.class::isInstance).isPresent()
-                ? new LimitDecoratorMergedResult(mergedResult, paginationContext)
-                : new TopAndRowNumberDecoratorMergedResult(mergedResult, paginationContext);
+        return paginationContext.getOffsetSegment().filter(RowNumberValueSegment.class::isInstance).isPresent()
+                || paginationContext.getRowCountSegment().filter(RowNumberValueSegment.class::isInstance).isPresent()
+                        ? new TopAndRowNumberDecoratorMergedResult(mergedResult, paginationContext)
+                        : new LimitDecoratorMergedResult(mergedResult, paginationContext);
     }
     
     @Override

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dql/pagination/builder/dialect/SQLServerPaginationDecoratorMergedResultBuilder.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dql/pagination/builder/dialect/SQLServerPaginationDecoratorMergedResultBuilder.java
@@ -20,8 +20,10 @@ package org.apache.shardingsphere.sharding.merge.dql.pagination.builder.dialect;
 import org.apache.shardingsphere.infra.binder.context.segment.select.pagination.PaginationContext;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
 import org.apache.shardingsphere.infra.merge.result.impl.decorator.DecoratorMergedResult;
+import org.apache.shardingsphere.sharding.merge.dql.pagination.LimitDecoratorMergedResult;
 import org.apache.shardingsphere.sharding.merge.dql.pagination.TopAndRowNumberDecoratorMergedResult;
 import org.apache.shardingsphere.sharding.merge.dql.pagination.builder.PaginationDecoratorMergedResultBuilder;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.limit.LimitValueSegment;
 
 import java.sql.SQLException;
 
@@ -32,7 +34,9 @@ public final class SQLServerPaginationDecoratorMergedResultBuilder implements Pa
     
     @Override
     public DecoratorMergedResult build(final MergedResult mergedResult, final PaginationContext paginationContext) throws SQLException {
-        return new TopAndRowNumberDecoratorMergedResult(mergedResult, paginationContext);
+        return paginationContext.getRowCountSegment().filter(LimitValueSegment.class::isInstance).isPresent()
+                ? new LimitDecoratorMergedResult(mergedResult, paginationContext)
+                : new TopAndRowNumberDecoratorMergedResult(mergedResult, paginationContext);
     }
     
     @Override

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
@@ -160,8 +160,8 @@ class ShardingDQLResultMergerTest {
         SelectStatementContext selectStatementContext = new SelectStatementContext(
                 selectStatement, createShardingSphereMetaData(database), "foo_db", Collections.emptyList());
         MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createSQLServerDatabase(), mock(ConnectionContext.class));
-        assertThat(actual, isA(TopAndRowNumberDecoratorMergedResult.class));
-        assertThat(((TopAndRowNumberDecoratorMergedResult) actual).getMergedResult(), isA(IteratorStreamMergedResult.class));
+        assertThat(actual, isA(LimitDecoratorMergedResult.class));
+        assertThat(((LimitDecoratorMergedResult) actual).getMergedResult(), isA(IteratorStreamMergedResult.class));
     }
     
     @Test

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.sharding.merge.dql;
 
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
-
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.NullsOrderType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.binder.context.statement.type.dml.SelectStatementContext;
@@ -72,6 +71,8 @@ import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -161,6 +162,24 @@ class ShardingDQLResultMergerTest {
         MergedResult actual = resultMerger.merge(createQueryResults(), selectStatementContext, createSQLServerDatabase(), mock(ConnectionContext.class));
         assertThat(actual, isA(TopAndRowNumberDecoratorMergedResult.class));
         assertThat(((TopAndRowNumberDecoratorMergedResult) actual).getMergedResult(), isA(IteratorStreamMergedResult.class));
+    }
+    
+    @Test
+    void assertBuildIteratorStreamMergedResultWithSQLServerOffsetFetch() throws SQLException {
+        final ShardingDQLResultMerger resultMerger = new ShardingDQLResultMerger(sqlserverDatabaseType);
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        SelectStatement selectStatement = buildSelectStatement(sqlserverDatabaseType);
+        selectStatement = withProjections(selectStatement, new ProjectionsSegment(0, 0));
+        selectStatement = withLimit(selectStatement, new LimitSegment(0, 0, new NumberLiteralLimitValueSegment(0, 0, 10L), new NumberLiteralLimitValueSegment(0, 0, 10L)));
+        SelectStatementContext selectStatementContext = new SelectStatementContext(
+                selectStatement, createShardingSphereMetaData(database), "foo_db", Collections.emptyList());
+        MergedResult actual = resultMerger.merge(createTwentyQueryResults(), selectStatementContext, createSQLServerDatabase(), mock(ConnectionContext.class));
+        assertThat(actual, isA(LimitDecoratorMergedResult.class));
+        assertThat(((LimitDecoratorMergedResult) actual).getMergedResult(), isA(IteratorStreamMergedResult.class));
+        for (int i = 0; i < 10; i++) {
+            assertTrue(actual.next());
+        }
+        assertFalse(actual.next());
     }
     
     @Test
@@ -481,6 +500,16 @@ class ShardingDQLResultMergerTest {
         result.add(mock(QueryResult.class, RETURNS_DEEP_STUBS));
         result.add(mock(QueryResult.class, RETURNS_DEEP_STUBS));
         result.add(mock(QueryResult.class, RETURNS_DEEP_STUBS));
+        return result;
+    }
+    
+    private List<QueryResult> createTwentyQueryResults() throws SQLException {
+        List<QueryResult> result = new LinkedList<>();
+        for (int i = 0; i < 20; i++) {
+            QueryResult queryResult = createQueryResult();
+            when(queryResult.next()).thenReturn(true, true, false);
+            result.add(queryResult);
+        }
         return result;
     }
     

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/pagination/builder/dialect/SQLServerPaginationDecoratorMergedResultBuilderTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/pagination/builder/dialect/SQLServerPaginationDecoratorMergedResultBuilderTest.java
@@ -55,6 +55,15 @@ class SQLServerPaginationDecoratorMergedResultBuilderTest {
         assertThat(actual, isA(TopAndRowNumberDecoratorMergedResult.class));
     }
     
+    @Test
+    void assertBuildWithRowNumberOffsetAndLimitRowCount() throws SQLException {
+        SQLServerPaginationDecoratorMergedResultBuilder builder = new SQLServerPaginationDecoratorMergedResultBuilder();
+        PaginationContext paginationContext = new PaginationContext(
+                new NumberLiteralRowNumberValueSegment(0, 0, 10L, true), new NumberLiteralLimitValueSegment(0, 0, 10L), Collections.emptyList());
+        DecoratorMergedResult actual = builder.build(new StubMergedResult(), paginationContext);
+        assertThat(actual, isA(TopAndRowNumberDecoratorMergedResult.class));
+    }
+    
     private static final class StubMergedResult implements MergedResult {
         
         @Override

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/pagination/builder/dialect/SQLServerPaginationDecoratorMergedResultBuilderTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/pagination/builder/dialect/SQLServerPaginationDecoratorMergedResultBuilderTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.merge.dql.pagination.builder.dialect;
+
+import org.apache.shardingsphere.infra.binder.context.segment.select.pagination.PaginationContext;
+import org.apache.shardingsphere.infra.merge.result.MergedResult;
+import org.apache.shardingsphere.infra.merge.result.impl.decorator.DecoratorMergedResult;
+import org.apache.shardingsphere.sharding.merge.dql.pagination.LimitDecoratorMergedResult;
+import org.apache.shardingsphere.sharding.merge.dql.pagination.TopAndRowNumberDecoratorMergedResult;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.limit.NumberLiteralLimitValueSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.pagination.rownum.NumberLiteralRowNumberValueSegment;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.sql.SQLException;
+import java.util.Calendar;
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
+
+class SQLServerPaginationDecoratorMergedResultBuilderTest {
+    
+    @Test
+    void assertBuildWithLimitValueSegment() throws SQLException {
+        SQLServerPaginationDecoratorMergedResultBuilder builder = new SQLServerPaginationDecoratorMergedResultBuilder();
+        PaginationContext paginationContext = new PaginationContext(
+                new NumberLiteralLimitValueSegment(0, 0, 10L), new NumberLiteralLimitValueSegment(0, 0, 10L), Collections.emptyList());
+        DecoratorMergedResult actual = builder.build(new StubMergedResult(), paginationContext);
+        assertThat(actual, isA(LimitDecoratorMergedResult.class));
+    }
+    
+    @Test
+    void assertBuildWithRowNumberValueSegment() throws SQLException {
+        SQLServerPaginationDecoratorMergedResultBuilder builder = new SQLServerPaginationDecoratorMergedResultBuilder();
+        PaginationContext paginationContext = new PaginationContext(
+                new NumberLiteralRowNumberValueSegment(0, 0, 10L, true), new NumberLiteralRowNumberValueSegment(0, 0, 10L, true), Collections.emptyList());
+        DecoratorMergedResult actual = builder.build(new StubMergedResult(), paginationContext);
+        assertThat(actual, isA(TopAndRowNumberDecoratorMergedResult.class));
+    }
+    
+    private static final class StubMergedResult implements MergedResult {
+        
+        @Override
+        public boolean next() {
+            return false;
+        }
+        
+        @Override
+        public Object getValue(final int columnIndex, final Class<?> type) {
+            return null;
+        }
+        
+        @Override
+        public Object getCalendarValue(final int columnIndex, final Class<?> type, final Calendar calendar) {
+            return null;
+        }
+        
+        @Override
+        public InputStream getInputStream(final int columnIndex, final String type) {
+            return null;
+        }
+        
+        @Override
+        public Reader getCharacterStream(final int columnIndex) {
+            return null;
+        }
+        
+        @Override
+        public boolean wasNull() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #38935.

Changes proposed in this pull request:
  - Use `LimitDecoratorMergedResult` for SQLServer `OFFSET ... FETCH NEXT ...` pagination merge.
  - Keep `TopAndRowNumberDecoratorMergedResult` for SQLServer TOP + ROW_NUMBER pagination.
  - Add unit tests for SQLServer pagination decorator selection and `OFFSET FETCH` merge behavior.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [[code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/)](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [[Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)

Local verification:
- `./mvnw spotless:apply -Pcheck -T1C`
- `./mvnw checkstyle:check -Pcheck -T1C -pl features/sharding/core -am`
- `./mvnw -pl features/sharding/core -DskipITs -Dspotless.skip=true -Dtest=SQLServerPaginationDecoratorMergedResultBuilderTest -Dsurefire.failIfNoSpecifiedTests=false test`