### PR TITLE
Refactor MCP workflow planning and E2E helper logic

### DIFF
--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyResponseBuilder.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyResponseBuilder.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.core.workflow;
+
+import org.apache.shardingsphere.mcp.support.protocol.MCPResponseMode;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactPayloadUtils;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowGuidancePayloadBuilder;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds workflow apply response payloads.
+ */
+public final class WorkflowApplyResponseBuilder {
+    
+    /**
+     * Build workflow apply response payload.
+     *
+     * @param snapshot workflow snapshot
+     * @param status workflow status
+     * @param executionMode execution mode
+     * @param issues workflow issues
+     * @param stepResults step results
+     * @param executedDdl executed DDL
+     * @param executedDistSql executed DistSQL
+     * @param skippedArtifacts skipped artifacts
+     * @param manualArtifactPackage manual artifact package
+     * @return workflow apply response payload
+     */
+    public Map<String, Object> build(final WorkflowContextSnapshot snapshot, final String status, final String executionMode,
+                                     final Collection<Map<String, Object>> issues, final Collection<Map<String, Object>> stepResults,
+                                     final Collection<String> executedDdl, final Collection<String> executedDistSql, final Collection<String> skippedArtifacts,
+                                     final Map<String, Object> manualArtifactPackage) {
+        String planId = snapshot.getPlanId();
+        Map<String, Object> result = new LinkedHashMap<>(16, 1F);
+        result.put("response_mode", resolveResponseMode(status, executionMode));
+        result.put(WorkflowFieldNames.PLAN_ID, planId);
+        result.put("status", status);
+        result.put(WorkflowFieldNames.EXECUTION_MODE, executionMode);
+        result.put("issues", issues);
+        result.put("step_results", stepResults);
+        boolean ruleDistSQLOnlyWorkflow = WorkflowArtifactPayloadUtils.isRuleDistSQLOnlyWorkflow(snapshot);
+        if (!ruleDistSQLOnlyWorkflow) {
+            result.put("executed_ddl", executedDdl);
+        }
+        result.put("executed_distsql", executedDistSql);
+        result.put("applied_artifacts", createAppliedArtifacts(executedDdl, executedDistSql));
+        result.put("skipped_artifacts", skippedArtifacts);
+        result.put("manual_artifacts", manualArtifactPackage.isEmpty() ? List.of() : List.of(manualArtifactPackage));
+        result.put(WorkflowArtifactPayloadUtils.PAYLOAD_KEY_MANUAL_ARTIFACT_PACKAGE, manualArtifactPackage);
+        if (WorkflowLifecycle.STATUS_AWAITING_MANUAL_EXECUTION.equals(status) && !manualArtifactPackage.isEmpty()) {
+            result.put("manual_artifact_summary", createManualArtifactSummary(planId, manualArtifactPackage, ruleDistSQLOnlyWorkflow));
+            result.put("manual_follow_up", createManualFollowUp());
+        }
+        WorkflowGuidancePayloadBuilder.appendApplyGuidance(result, status);
+        return result;
+    }
+    
+    private String resolveResponseMode(final String status, final String executionMode) {
+        if ("preview".equals(executionMode)) {
+            return MCPResponseMode.PREVIEW;
+        }
+        if ("manual-only".equals(executionMode)) {
+            return MCPResponseMode.MANUAL_ONLY;
+        }
+        return WorkflowLifecycle.STATUS_COMPLETED.equals(status) ? MCPResponseMode.EXECUTED : MCPResponseMode.TERMINAL;
+    }
+    
+    private Map<String, Object> createManualFollowUp() {
+        return Map.of(
+                "confirmation_required", true,
+                "confirmation_field", "manual_artifacts_executed",
+                "validation_blocked_until", "manual_artifacts_executed",
+                "validation_tool_after_manual_execution", "database_gateway_validate_workflow",
+                "safe_independent_read_only_checks", "database_gateway_execute_query may run before manual execution confirmation when the user asked for read-only verification.");
+    }
+    
+    private Map<String, Object> createManualArtifactSummary(final String planId, final Map<String, Object> manualArtifactPackage, final boolean ruleDistSQLOnlyWorkflow) {
+        int distSqlArtifactCount = getCollectionSize(manualArtifactPackage, WorkflowArtifactPayloadUtils.PAYLOAD_KEY_DISTSQL_ARTIFACTS);
+        Map<String, Object> result = new LinkedHashMap<>(8, 1F);
+        if (!ruleDistSQLOnlyWorkflow) {
+            int ddlArtifactCount = getCollectionSize(manualArtifactPackage, WorkflowArtifactPayloadUtils.PAYLOAD_KEY_DDL_ARTIFACTS);
+            int indexPlanCount = getCollectionSize(manualArtifactPackage, WorkflowArtifactPayloadUtils.PAYLOAD_KEY_INDEX_PLAN);
+            result.put("ddl_artifact_count", ddlArtifactCount);
+            result.put("index_plan_count", indexPlanCount);
+            result.put("total_artifact_count", ddlArtifactCount + indexPlanCount + distSqlArtifactCount);
+        } else {
+            result.put("total_artifact_count", distSqlArtifactCount);
+        }
+        result.put("distsql_artifact_count", distSqlArtifactCount);
+        result.put("external_execution_required", true);
+        result.put("requires_user_confirmation", true);
+        result.put("validation_blocked_until", "manual_artifacts_executed");
+        result.put("validation_tool_after_manual_execution", "database_gateway_validate_workflow");
+        result.put("validation_arguments_after_manual_execution", Map.of(WorkflowFieldNames.PLAN_ID, planId));
+        return result;
+    }
+    
+    private int getCollectionSize(final Map<String, Object> payload, final String key) {
+        Object value = payload.get(key);
+        return value instanceof Collection ? ((Collection<?>) value).size() : 0;
+    }
+    
+    private List<String> createAppliedArtifacts(final Collection<String> executedDdl, final Collection<String> executedDistSql) {
+        List<String> result = new LinkedList<>();
+        result.addAll(executedDdl);
+        result.addAll(executedDistSql);
+        return result;
+    }
+}

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowExecutionService.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowExecutionService.java
@@ -45,7 +45,6 @@ import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowSynchroniz
 import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowApplyArtifactValidator;
 import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowApplySynchronizationHandler;
 
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -197,7 +196,7 @@ public final class WorkflowExecutionService {
     
     private Map<String, Object> createRejectedResponse(final WorkflowContextSnapshot snapshot, final String executionMode, final String issueCode, final String message,
                                                        final String userAction) {
-        return createResponse(snapshot, WorkflowLifecycle.STATUS_FAILED, executionMode,
+        return new WorkflowApplyResponseBuilder().build(snapshot, WorkflowLifecycle.STATUS_FAILED, executionMode,
                 List.of(new WorkflowIssue(issueCode, "error", WorkflowLifecycle.STEP_REVIEW, message, userAction, false, Map.of()).toMap()), List.of(), List.of(), List.of(), List.of(), Map.of());
     }
     
@@ -219,7 +218,7 @@ public final class WorkflowExecutionService {
         List<Map<String, Object>> validationIssues = workflowApplyArtifactValidator.validate(snapshot, createExecutableArtifacts(snapshot));
         if (!validationIssues.isEmpty()) {
             persistSnapshot(workflowSessionContext, snapshot, WorkflowLifecycle.STEP_FAILED, WorkflowLifecycle.STATUS_FAILED);
-            Map<String, Object> result = createResponse(snapshot, WorkflowLifecycle.STATUS_FAILED, executionMode, validationIssues,
+            Map<String, Object> result = new WorkflowApplyResponseBuilder().build(snapshot, WorkflowLifecycle.STATUS_FAILED, executionMode, validationIssues,
                     List.of(), List.of(), List.of(), List.of(), Map.of());
             if (EXECUTION_MODE_PREVIEW.equalsIgnoreCase(executionMode)) {
                 result.put("would_apply", false);
@@ -235,7 +234,8 @@ public final class WorkflowExecutionService {
     private Map<String, Object> previewApply(final WorkflowSessionContext workflowSessionContext, final WorkflowContextSnapshot snapshot) {
         persistSnapshot(workflowSessionContext, snapshot, WorkflowLifecycle.STEP_REVIEW, WorkflowLifecycle.STATUS_PREVIEWED);
         List<Map<String, Object>> previewArtifacts = createPreviewArtifacts(snapshot);
-        Map<String, Object> result = createResponse(snapshot, "preview", EXECUTION_MODE_PREVIEW, List.of(), List.of(), List.of(), List.of(), List.of(), createArtifactPayload(snapshot));
+        Map<String, Object> result = new WorkflowApplyResponseBuilder().build(snapshot, "preview", EXECUTION_MODE_PREVIEW,
+                List.of(), List.of(), List.of(), List.of(), List.of(), createArtifactPayload(snapshot));
         result.put("would_apply", false);
         result.put("preview_artifacts", previewArtifacts);
         result.put("review_focus", createPreviewReviewFocus(snapshot, previewArtifacts));
@@ -445,87 +445,7 @@ public final class WorkflowExecutionService {
         executionFacade.execute(new SQLExecutionRequest(sessionId, snapshot.getRequest().getDatabase(), snapshot.getRequest().getSchema(), artifact.sql(), 0, 0));
     }
     
-    private static Map<String, Object> createResponse(final WorkflowContextSnapshot snapshot, final String status, final String executionMode, final List<Map<String, Object>> issues,
-                                                      final List<Map<String, Object>> stepResults, final List<String> executedDdl, final List<String> executedDistSql,
-                                                      final List<String> skippedArtifacts, final Map<String, Object> manualArtifactPackage) {
-        String planId = snapshot.getPlanId();
-        Map<String, Object> result = new LinkedHashMap<>(16, 1F);
-        result.put("response_mode", resolveResponseMode(status, executionMode));
-        result.put(WorkflowFieldNames.PLAN_ID, planId);
-        result.put("status", status);
-        result.put(WorkflowFieldNames.EXECUTION_MODE, executionMode);
-        result.put("issues", issues);
-        result.put("step_results", stepResults);
-        boolean ruleDistSQLOnlyWorkflow = WorkflowArtifactPayloadUtils.isRuleDistSQLOnlyWorkflow(snapshot);
-        if (!ruleDistSQLOnlyWorkflow) {
-            result.put("executed_ddl", executedDdl);
-        }
-        result.put("executed_distsql", executedDistSql);
-        result.put("applied_artifacts", createAppliedArtifacts(executedDdl, executedDistSql));
-        result.put("skipped_artifacts", skippedArtifacts);
-        result.put("manual_artifacts", manualArtifactPackage.isEmpty() ? List.of() : List.of(manualArtifactPackage));
-        result.put(WorkflowArtifactPayloadUtils.PAYLOAD_KEY_MANUAL_ARTIFACT_PACKAGE, manualArtifactPackage);
-        if (WorkflowLifecycle.STATUS_AWAITING_MANUAL_EXECUTION.equals(status) && !manualArtifactPackage.isEmpty()) {
-            result.put("manual_artifact_summary", createManualArtifactSummary(planId, manualArtifactPackage, ruleDistSQLOnlyWorkflow));
-            result.put("manual_follow_up", createManualFollowUp());
-        }
-        WorkflowGuidancePayloadBuilder.appendApplyGuidance(result, status);
-        return result;
-    }
-    
-    private static String resolveResponseMode(final String status, final String executionMode) {
-        if (EXECUTION_MODE_PREVIEW.equals(executionMode)) {
-            return MCPResponseMode.PREVIEW;
-        }
-        if (EXECUTION_MODE_MANUAL_ONLY.equals(executionMode)) {
-            return MCPResponseMode.MANUAL_ONLY;
-        }
-        return WorkflowLifecycle.STATUS_COMPLETED.equals(status) ? MCPResponseMode.EXECUTED : MCPResponseMode.TERMINAL;
-    }
-    
-    private static Map<String, Object> createManualFollowUp() {
-        return Map.of(
-                "confirmation_required", true,
-                "confirmation_field", "manual_artifacts_executed",
-                "validation_blocked_until", "manual_artifacts_executed",
-                "validation_tool_after_manual_execution", "database_gateway_validate_workflow",
-                "safe_independent_read_only_checks", "database_gateway_execute_query may run before manual execution confirmation when the user asked for read-only verification.");
-    }
-    
-    private static Map<String, Object> createManualArtifactSummary(final String planId, final Map<String, Object> manualArtifactPackage, final boolean ruleDistSQLOnlyWorkflow) {
-        int distSqlArtifactCount = getCollectionSize(manualArtifactPackage, WorkflowArtifactPayloadUtils.PAYLOAD_KEY_DISTSQL_ARTIFACTS);
-        Map<String, Object> result = new LinkedHashMap<>(8, 1F);
-        if (!ruleDistSQLOnlyWorkflow) {
-            int ddlArtifactCount = getCollectionSize(manualArtifactPackage, WorkflowArtifactPayloadUtils.PAYLOAD_KEY_DDL_ARTIFACTS);
-            int indexPlanCount = getCollectionSize(manualArtifactPackage, WorkflowArtifactPayloadUtils.PAYLOAD_KEY_INDEX_PLAN);
-            result.put("ddl_artifact_count", ddlArtifactCount);
-            result.put("index_plan_count", indexPlanCount);
-            result.put("total_artifact_count", ddlArtifactCount + indexPlanCount + distSqlArtifactCount);
-        } else {
-            result.put("total_artifact_count", distSqlArtifactCount);
-        }
-        result.put("distsql_artifact_count", distSqlArtifactCount);
-        result.put("external_execution_required", true);
-        result.put("requires_user_confirmation", true);
-        result.put("validation_blocked_until", "manual_artifacts_executed");
-        result.put("validation_tool_after_manual_execution", "database_gateway_validate_workflow");
-        result.put("validation_arguments_after_manual_execution", Map.of(WorkflowFieldNames.PLAN_ID, planId));
-        return result;
-    }
-    
-    private static int getCollectionSize(final Map<String, Object> payload, final String key) {
-        Object value = payload.get(key);
-        return value instanceof Collection ? ((Collection<?>) value).size() : 0;
-    }
-    
-    private static List<String> createAppliedArtifacts(final List<String> executedDdl, final List<String> executedDistSql) {
-        List<String> result = new LinkedList<>();
-        result.addAll(executedDdl);
-        result.addAll(executedDistSql);
-        return result;
-    }
-    
-    private static final class WorkflowApplyOutcome {
+    private final class WorkflowApplyOutcome {
         
         private final List<Map<String, Object>> stepResults = new LinkedList<>();
         
@@ -578,7 +498,7 @@ public final class WorkflowExecutionService {
         }
         
         private Map<String, Object> createResponse(final String status, final WorkflowContextSnapshot snapshot, final String executionMode, final Map<String, Object> manualArtifactPackage) {
-            return WorkflowExecutionService.createResponse(snapshot, status, executionMode, issues, stepResults, executedDdl, executedDistSql, skippedArtifacts, manualArtifactPackage);
+            return new WorkflowApplyResponseBuilder().build(snapshot, status, executionMode, issues, stepResults, executedDdl, executedDistSql, skippedArtifacts, manualArtifactPackage);
         }
         
         private static Map<String, Object> createStepResult(final String artifactType, final String status, final String sql) {

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyResponseBuilderTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyResponseBuilderTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.core.workflow;
+
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
+import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactPayloadUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class WorkflowApplyResponseBuilderTest {
+    
+    @Test
+    void assertBuildPreviewResponse() {
+        Map<String, Object> actual = new WorkflowApplyResponseBuilder().build(createSnapshot("encrypt.table"), "preview", "preview",
+                List.of(), List.of(), List.of(), List.of(), List.of(), Map.of());
+        assertThat(actual.get("response_mode"), is("preview"));
+        assertThat(actual.get("plan_id"), is("plan-1"));
+        assertThat(actual.get("status"), is("preview"));
+        assertThat(actual.get("execution_mode"), is("preview"));
+        assertThat(actual.get("manual_artifacts"), is(List.of()));
+        assertThat(actual.get(WorkflowArtifactPayloadUtils.PAYLOAD_KEY_MANUAL_ARTIFACT_PACKAGE), is(Map.of()));
+    }
+    
+    @Test
+    void assertBuildCompletedResponse() {
+        Map<String, Object> actual = new WorkflowApplyResponseBuilder().build(createSnapshot("encrypt.table"), WorkflowLifecycle.STATUS_COMPLETED, "review-then-execute",
+                List.of(), List.of(), List.of("ALTER TABLE orders ADD COLUMN phone_mask VARCHAR(64)"), List.of("CREATE ENCRYPT RULE orders"), List.of(), Map.of());
+        assertThat(actual.get("response_mode"), is("executed"));
+        assertThat(actual.get("executed_ddl"), is(List.of("ALTER TABLE orders ADD COLUMN phone_mask VARCHAR(64)")));
+        assertThat(actual.get("executed_distsql"), is(List.of("CREATE ENCRYPT RULE orders")));
+        assertThat(actual.get("applied_artifacts"), is(List.of("ALTER TABLE orders ADD COLUMN phone_mask VARCHAR(64)", "CREATE ENCRYPT RULE orders")));
+        assertThat(((List<?>) actual.get("next_actions")).size(), is(1));
+    }
+    
+    @Test
+    void assertBuildManualResponse() {
+        Map<String, Object> manualArtifactPackage = Map.of(
+                WorkflowArtifactPayloadUtils.PAYLOAD_KEY_DDL_ARTIFACTS, List.of(Map.of("sql", "ALTER TABLE orders ADD COLUMN phone_mask VARCHAR(64)")),
+                WorkflowArtifactPayloadUtils.PAYLOAD_KEY_INDEX_PLAN, List.of(Map.of("sql", "CREATE INDEX idx_orders_phone_mask ON orders(phone_mask)")),
+                WorkflowArtifactPayloadUtils.PAYLOAD_KEY_DISTSQL_ARTIFACTS, List.of(Map.of("sql", "CREATE ENCRYPT RULE orders")));
+        Map<String, Object> actual = new WorkflowApplyResponseBuilder().build(createSnapshot("encrypt.table"), WorkflowLifecycle.STATUS_AWAITING_MANUAL_EXECUTION, "manual-only",
+                List.of(), List.of(), List.of(), List.of(), List.of(), manualArtifactPackage);
+        assertThat(actual.get("response_mode"), is("manual_only"));
+        assertThat(actual.get("manual_artifacts"), is(List.of(manualArtifactPackage)));
+        Map<?, ?> actualSummary = (Map<?, ?>) actual.get("manual_artifact_summary");
+        assertThat(actualSummary.get("ddl_artifact_count"), is(1));
+        assertThat(actualSummary.get("index_plan_count"), is(1));
+        assertThat(actualSummary.get("distsql_artifact_count"), is(1));
+        assertThat(actualSummary.get("total_artifact_count"), is(3));
+        assertThat(((Map<?, ?>) actual.get("manual_follow_up")).get("confirmation_field"), is("manual_artifacts_executed"));
+    }
+    
+    @Test
+    void assertBuildRuleOnlyManualResponse() {
+        Map<String, Object> manualArtifactPackage = Map.of(WorkflowArtifactPayloadUtils.PAYLOAD_KEY_DISTSQL_ARTIFACTS, List.of(Map.of("sql", "CREATE ENCRYPT RULE orders")));
+        Map<String, Object> actual = new WorkflowApplyResponseBuilder().build(createSnapshot("encrypt.rule"), WorkflowLifecycle.STATUS_AWAITING_MANUAL_EXECUTION, "manual-only",
+                List.of(), List.of(), List.of(), List.of(), List.of(), manualArtifactPackage);
+        assertFalse(actual.containsKey("executed_ddl"));
+        Map<?, ?> actualSummary = (Map<?, ?>) actual.get("manual_artifact_summary");
+        assertFalse(actualSummary.containsKey("ddl_artifact_count"));
+        assertFalse(actualSummary.containsKey("index_plan_count"));
+        assertThat(actualSummary.get("distsql_artifact_count"), is(1));
+        assertThat(actualSummary.get("total_artifact_count"), is(1));
+    }
+    
+    private WorkflowContextSnapshot createSnapshot(final String workflowKind) {
+        WorkflowContextSnapshot result = new WorkflowContextSnapshot();
+        result.setPlanId("plan-1");
+        result.setWorkflowKind(WorkflowKind.valueOf(workflowKind));
+        return result;
+    }
+}

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingDefaultStrategyToolHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingDefaultStrategyToolHandler.java
@@ -22,7 +22,6 @@ import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingDefaultStrategyWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingDefaultStrategyWorkflowPlanningService;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingWorkflowPlanningService;
 import org.apache.shardingsphere.mcp.support.workflow.MCPWorkflowHandlerContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 
@@ -39,8 +38,8 @@ public final class PlanShardingDefaultStrategyToolHandler extends AbstractShardi
         planningService = new ShardingDefaultStrategyWorkflowPlanningService();
     }
     
-    PlanShardingDefaultStrategyToolHandler(final ShardingWorkflowPlanningService planningService) {
-        this.planningService = new ShardingDefaultStrategyWorkflowPlanningService(planningService);
+    PlanShardingDefaultStrategyToolHandler(final ShardingDefaultStrategyWorkflowPlanningService planningService) {
+        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingKeyGenerateStrategyToolHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingKeyGenerateStrategyToolHandler.java
@@ -22,7 +22,6 @@ import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingKeyGenerateStrategyWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingKeyGenerateStrategyWorkflowPlanningService;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingWorkflowPlanningService;
 import org.apache.shardingsphere.mcp.support.workflow.MCPWorkflowHandlerContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 
@@ -39,8 +38,8 @@ public final class PlanShardingKeyGenerateStrategyToolHandler extends AbstractSh
         planningService = new ShardingKeyGenerateStrategyWorkflowPlanningService();
     }
     
-    PlanShardingKeyGenerateStrategyToolHandler(final ShardingWorkflowPlanningService planningService) {
-        this.planningService = new ShardingKeyGenerateStrategyWorkflowPlanningService(planningService);
+    PlanShardingKeyGenerateStrategyToolHandler(final ShardingKeyGenerateStrategyWorkflowPlanningService planningService) {
+        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingKeyGeneratorToolHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingKeyGeneratorToolHandler.java
@@ -22,7 +22,6 @@ import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingKeyGeneratorWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingKeyGeneratorWorkflowPlanningService;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingWorkflowPlanningService;
 import org.apache.shardingsphere.mcp.support.workflow.MCPWorkflowHandlerContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 
@@ -39,8 +38,8 @@ public final class PlanShardingKeyGeneratorToolHandler extends AbstractShardingP
         planningService = new ShardingKeyGeneratorWorkflowPlanningService();
     }
     
-    PlanShardingKeyGeneratorToolHandler(final ShardingWorkflowPlanningService planningService) {
-        this.planningService = new ShardingKeyGeneratorWorkflowPlanningService(planningService);
+    PlanShardingKeyGeneratorToolHandler(final ShardingKeyGeneratorWorkflowPlanningService planningService) {
+        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingRuleComponentCleanupToolHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingRuleComponentCleanupToolHandler.java
@@ -22,7 +22,6 @@ import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingRuleComponentCleanupWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingRuleComponentCleanupWorkflowPlanningService;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingWorkflowPlanningService;
 import org.apache.shardingsphere.mcp.support.workflow.MCPWorkflowHandlerContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 
@@ -39,8 +38,8 @@ public final class PlanShardingRuleComponentCleanupToolHandler extends AbstractS
         planningService = new ShardingRuleComponentCleanupWorkflowPlanningService();
     }
     
-    PlanShardingRuleComponentCleanupToolHandler(final ShardingWorkflowPlanningService planningService) {
-        this.planningService = new ShardingRuleComponentCleanupWorkflowPlanningService(planningService);
+    PlanShardingRuleComponentCleanupToolHandler(final ShardingRuleComponentCleanupWorkflowPlanningService planningService) {
+        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingTableReferenceRuleToolHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingTableReferenceRuleToolHandler.java
@@ -22,7 +22,6 @@ import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingTableReferenceRuleWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingTableReferenceRuleWorkflowPlanningService;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingWorkflowPlanningService;
 import org.apache.shardingsphere.mcp.support.workflow.MCPWorkflowHandlerContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 
@@ -39,8 +38,8 @@ public final class PlanShardingTableReferenceRuleToolHandler extends AbstractSha
         planningService = new ShardingTableReferenceRuleWorkflowPlanningService();
     }
     
-    PlanShardingTableReferenceRuleToolHandler(final ShardingWorkflowPlanningService planningService) {
-        this.planningService = new ShardingTableReferenceRuleWorkflowPlanningService(planningService);
+    PlanShardingTableReferenceRuleToolHandler(final ShardingTableReferenceRuleWorkflowPlanningService planningService) {
+        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingTableRuleToolHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingTableRuleToolHandler.java
@@ -22,7 +22,6 @@ import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingTableRuleWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingTableRuleWorkflowPlanningService;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingWorkflowPlanningService;
 import org.apache.shardingsphere.mcp.support.workflow.MCPWorkflowHandlerContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 
@@ -39,8 +38,8 @@ public final class PlanShardingTableRuleToolHandler extends AbstractShardingPlan
         planningService = new ShardingTableRuleWorkflowPlanningService();
     }
     
-    PlanShardingTableRuleToolHandler(final ShardingWorkflowPlanningService planningService) {
-        this.planningService = new ShardingTableRuleWorkflowPlanningService(planningService);
+    PlanShardingTableRuleToolHandler(final ShardingTableRuleWorkflowPlanningService planningService) {
+        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingDefaultStrategyWorkflowPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingDefaultStrategyWorkflowPlanningService.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingDefaultStrategyWorkflowRequest;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
@@ -28,22 +27,14 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
  */
 public final class ShardingDefaultStrategyWorkflowPlanningService {
     
-    private final Planner planner;
+    private final ShardingWorkflowPlanningKernel kernel;
     
     public ShardingDefaultStrategyWorkflowPlanningService() {
         this(new ShardingWorkflowPlanningKernel());
     }
     
-    public ShardingDefaultStrategyWorkflowPlanningService(final ShardingWorkflowPlanningService delegate) {
-        this(delegate::planDefaultStrategy);
-    }
-    
     ShardingDefaultStrategyWorkflowPlanningService(final ShardingWorkflowPlanningKernel kernel) {
-        this(kernel::planDefaultStrategy);
-    }
-    
-    private ShardingDefaultStrategyWorkflowPlanningService(final Planner planner) {
-        this.planner = planner;
+        this.kernel = kernel;
     }
     
     /**
@@ -57,12 +48,6 @@ public final class ShardingDefaultStrategyWorkflowPlanningService {
      */
     public WorkflowContextSnapshot plan(final WorkflowSessionContext workflowSessionContext, final MCPFeatureQueryFacade queryFacade,
                                         final String sessionId, final ShardingDefaultStrategyWorkflowRequest request) {
-        return planner.plan(workflowSessionContext, queryFacade, sessionId, request.toWorkflowRequest());
-    }
-    
-    @FunctionalInterface
-    private interface Planner {
-        
-        WorkflowContextSnapshot plan(WorkflowSessionContext workflowSessionContext, MCPFeatureQueryFacade queryFacade, String sessionId, ShardingWorkflowRequest request);
+        return kernel.planDefaultStrategy(workflowSessionContext, queryFacade, sessionId, request.toWorkflowRequest());
     }
 }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingKeyGenerateStrategyWorkflowPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingKeyGenerateStrategyWorkflowPlanningService.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingKeyGenerateStrategyWorkflowRequest;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
@@ -28,22 +27,14 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
  */
 public final class ShardingKeyGenerateStrategyWorkflowPlanningService {
     
-    private final Planner planner;
+    private final ShardingWorkflowPlanningKernel kernel;
     
     public ShardingKeyGenerateStrategyWorkflowPlanningService() {
         this(new ShardingWorkflowPlanningKernel());
     }
     
-    public ShardingKeyGenerateStrategyWorkflowPlanningService(final ShardingWorkflowPlanningService delegate) {
-        this(delegate::planKeyGenerateStrategy);
-    }
-    
     ShardingKeyGenerateStrategyWorkflowPlanningService(final ShardingWorkflowPlanningKernel kernel) {
-        this(kernel::planKeyGenerateStrategy);
-    }
-    
-    private ShardingKeyGenerateStrategyWorkflowPlanningService(final Planner planner) {
-        this.planner = planner;
+        this.kernel = kernel;
     }
     
     /**
@@ -57,12 +48,6 @@ public final class ShardingKeyGenerateStrategyWorkflowPlanningService {
      */
     public WorkflowContextSnapshot plan(final WorkflowSessionContext workflowSessionContext, final MCPFeatureQueryFacade queryFacade,
                                         final String sessionId, final ShardingKeyGenerateStrategyWorkflowRequest request) {
-        return planner.plan(workflowSessionContext, queryFacade, sessionId, request.toWorkflowRequest());
-    }
-    
-    @FunctionalInterface
-    private interface Planner {
-        
-        WorkflowContextSnapshot plan(WorkflowSessionContext workflowSessionContext, MCPFeatureQueryFacade queryFacade, String sessionId, ShardingWorkflowRequest request);
+        return kernel.planKeyGenerateStrategy(workflowSessionContext, queryFacade, sessionId, request.toWorkflowRequest());
     }
 }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingKeyGeneratorWorkflowPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingKeyGeneratorWorkflowPlanningService.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingKeyGeneratorWorkflowRequest;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
@@ -28,22 +27,14 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
  */
 public final class ShardingKeyGeneratorWorkflowPlanningService {
     
-    private final Planner planner;
+    private final ShardingWorkflowPlanningKernel kernel;
     
     public ShardingKeyGeneratorWorkflowPlanningService() {
         this(new ShardingWorkflowPlanningKernel());
     }
     
-    public ShardingKeyGeneratorWorkflowPlanningService(final ShardingWorkflowPlanningService delegate) {
-        this(delegate::planKeyGenerator);
-    }
-    
     ShardingKeyGeneratorWorkflowPlanningService(final ShardingWorkflowPlanningKernel kernel) {
-        this(kernel::planKeyGenerator);
-    }
-    
-    private ShardingKeyGeneratorWorkflowPlanningService(final Planner planner) {
-        this.planner = planner;
+        this.kernel = kernel;
     }
     
     /**
@@ -57,12 +48,6 @@ public final class ShardingKeyGeneratorWorkflowPlanningService {
      */
     public WorkflowContextSnapshot plan(final WorkflowSessionContext workflowSessionContext, final MCPFeatureQueryFacade queryFacade,
                                         final String sessionId, final ShardingKeyGeneratorWorkflowRequest request) {
-        return planner.plan(workflowSessionContext, queryFacade, sessionId, request.toWorkflowRequest());
-    }
-    
-    @FunctionalInterface
-    private interface Planner {
-        
-        WorkflowContextSnapshot plan(WorkflowSessionContext workflowSessionContext, MCPFeatureQueryFacade queryFacade, String sessionId, ShardingWorkflowRequest request);
+        return kernel.planKeyGenerator(workflowSessionContext, queryFacade, sessionId, request.toWorkflowRequest());
     }
 }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingRuleComponentCleanupWorkflowPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingRuleComponentCleanupWorkflowPlanningService.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingRuleComponentCleanupWorkflowRequest;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
@@ -28,22 +27,14 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
  */
 public final class ShardingRuleComponentCleanupWorkflowPlanningService {
     
-    private final Planner planner;
+    private final ShardingWorkflowPlanningKernel kernel;
     
     public ShardingRuleComponentCleanupWorkflowPlanningService() {
         this(new ShardingWorkflowPlanningKernel());
     }
     
-    public ShardingRuleComponentCleanupWorkflowPlanningService(final ShardingWorkflowPlanningService delegate) {
-        this(delegate::planComponentCleanup);
-    }
-    
     ShardingRuleComponentCleanupWorkflowPlanningService(final ShardingWorkflowPlanningKernel kernel) {
-        this(kernel::planComponentCleanup);
-    }
-    
-    private ShardingRuleComponentCleanupWorkflowPlanningService(final Planner planner) {
-        this.planner = planner;
+        this.kernel = kernel;
     }
     
     /**
@@ -57,12 +48,6 @@ public final class ShardingRuleComponentCleanupWorkflowPlanningService {
      */
     public WorkflowContextSnapshot plan(final WorkflowSessionContext workflowSessionContext, final MCPFeatureQueryFacade queryFacade,
                                         final String sessionId, final ShardingRuleComponentCleanupWorkflowRequest request) {
-        return planner.plan(workflowSessionContext, queryFacade, sessionId, request.toWorkflowRequest());
-    }
-    
-    @FunctionalInterface
-    private interface Planner {
-        
-        WorkflowContextSnapshot plan(WorkflowSessionContext workflowSessionContext, MCPFeatureQueryFacade queryFacade, String sessionId, ShardingWorkflowRequest request);
+        return kernel.planComponentCleanup(workflowSessionContext, queryFacade, sessionId, request.toWorkflowRequest());
     }
 }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingTableReferenceRuleWorkflowPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingTableReferenceRuleWorkflowPlanningService.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingTableReferenceRuleWorkflowRequest;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
@@ -28,22 +27,14 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
  */
 public final class ShardingTableReferenceRuleWorkflowPlanningService {
     
-    private final Planner planner;
+    private final ShardingWorkflowPlanningKernel kernel;
     
     public ShardingTableReferenceRuleWorkflowPlanningService() {
         this(new ShardingWorkflowPlanningKernel());
     }
     
-    public ShardingTableReferenceRuleWorkflowPlanningService(final ShardingWorkflowPlanningService delegate) {
-        this(delegate::planTableReferenceRule);
-    }
-    
     ShardingTableReferenceRuleWorkflowPlanningService(final ShardingWorkflowPlanningKernel kernel) {
-        this(kernel::planTableReferenceRule);
-    }
-    
-    private ShardingTableReferenceRuleWorkflowPlanningService(final Planner planner) {
-        this.planner = planner;
+        this.kernel = kernel;
     }
     
     /**
@@ -57,12 +48,6 @@ public final class ShardingTableReferenceRuleWorkflowPlanningService {
      */
     public WorkflowContextSnapshot plan(final WorkflowSessionContext workflowSessionContext, final MCPFeatureQueryFacade queryFacade,
                                         final String sessionId, final ShardingTableReferenceRuleWorkflowRequest request) {
-        return planner.plan(workflowSessionContext, queryFacade, sessionId, request.toWorkflowRequest());
-    }
-    
-    @FunctionalInterface
-    private interface Planner {
-        
-        WorkflowContextSnapshot plan(WorkflowSessionContext workflowSessionContext, MCPFeatureQueryFacade queryFacade, String sessionId, ShardingWorkflowRequest request);
+        return kernel.planTableReferenceRule(workflowSessionContext, queryFacade, sessionId, request.toWorkflowRequest());
     }
 }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingTableRuleWorkflowPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingTableRuleWorkflowPlanningService.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingTableRuleWorkflowRequest;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
@@ -28,22 +27,14 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
  */
 public final class ShardingTableRuleWorkflowPlanningService {
     
-    private final Planner planner;
+    private final ShardingWorkflowPlanningKernel kernel;
     
     public ShardingTableRuleWorkflowPlanningService() {
         this(new ShardingWorkflowPlanningKernel());
     }
     
-    public ShardingTableRuleWorkflowPlanningService(final ShardingWorkflowPlanningService delegate) {
-        this(delegate::planTableRule);
-    }
-    
     ShardingTableRuleWorkflowPlanningService(final ShardingWorkflowPlanningKernel kernel) {
-        this(kernel::planTableRule);
-    }
-    
-    private ShardingTableRuleWorkflowPlanningService(final Planner planner) {
-        this.planner = planner;
+        this.kernel = kernel;
     }
     
     /**
@@ -57,12 +48,6 @@ public final class ShardingTableRuleWorkflowPlanningService {
      */
     public WorkflowContextSnapshot plan(final WorkflowSessionContext workflowSessionContext, final MCPFeatureQueryFacade queryFacade,
                                         final String sessionId, final ShardingTableRuleWorkflowRequest request) {
-        return planner.plan(workflowSessionContext, queryFacade, sessionId, request.toWorkflowRequest());
-    }
-    
-    @FunctionalInterface
-    private interface Planner {
-        
-        WorkflowContextSnapshot plan(WorkflowSessionContext workflowSessionContext, MCPFeatureQueryFacade queryFacade, String sessionId, ShardingWorkflowRequest request);
+        return kernel.planTableRule(workflowSessionContext, queryFacade, sessionId, request.toWorkflowRequest());
     }
 }

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/ShardingToolHandlerTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/ShardingToolHandlerTest.java
@@ -21,8 +21,19 @@ import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.TestWorkflowSessionContext;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingDefaultStrategyWorkflowRequest;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingKeyGenerateStrategyWorkflowRequest;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingKeyGeneratorWorkflowRequest;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingRuleComponentCleanupWorkflowRequest;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingTableReferenceRuleWorkflowRequest;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingTableRuleWorkflowRequest;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
-import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingWorkflowPlanningService;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingDefaultStrategyWorkflowPlanningService;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingKeyGenerateStrategyWorkflowPlanningService;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingKeyGeneratorWorkflowPlanningService;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingRuleComponentCleanupWorkflowPlanningService;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingTableReferenceRuleWorkflowPlanningService;
+import org.apache.shardingsphere.mcp.feature.sharding.tool.service.ShardingTableRuleWorkflowPlanningService;
 import org.apache.shardingsphere.mcp.support.database.MCPDatabaseHandlerContext;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureExecutionFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
@@ -53,8 +64,8 @@ class ShardingToolHandlerTest {
     
     @Test
     void assertHandlePlanTableRule() {
-        ShardingWorkflowPlanningService planningService = mock(ShardingWorkflowPlanningService.class);
-        when(planningService.planTableRule(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+        ShardingTableRuleWorkflowPlanningService planningService = mock(ShardingTableRuleWorkflowPlanningService.class);
+        when(planningService.plan(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
                 createRequest(), "CREATE SHARDING TABLE RULE `t_order`(DATANODES('ds_${0..1}.t_order_${0..1}'))"));
         WorkflowContextFixture fixture = createWorkflowContextFixture();
         MCPResponse actual = new PlanShardingTableRuleToolHandler(planningService).handle(fixture.workflowContext, new MCPToolCall("session-1", Map.of(
@@ -63,80 +74,83 @@ class ShardingToolHandlerTest {
                 "algorithm_properties", Map.of("algorithm-expression", "t_order_${order_id % 2}"),
                 "structured_intent_evidence", Map.of("table", "t_order", "column", "order_id", "sharding_columns", "order_id, user_id"))));
         assertFalse(actual.toPayload().containsKey("ddl_artifacts"));
-        ArgumentCaptor<ShardingWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingWorkflowRequest.class);
-        verify(planningService).planTableRule(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
-        assertThat(requestCaptor.getValue().getTable(), is("t_order"));
-        assertThat(requestCaptor.getValue().getShardingColumns(), is("order_id, user_id"));
-        assertThat(requestCaptor.getValue().getAlgorithmType(), is("INLINE"));
-        assertThat(requestCaptor.getValue().getPrimaryAlgorithmProperties(), is(Map.of("algorithm-expression", "t_order_${order_id % 2}")));
+        ArgumentCaptor<ShardingTableRuleWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingTableRuleWorkflowRequest.class);
+        verify(planningService).plan(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
+        ShardingWorkflowRequest actualRequest = requestCaptor.getValue().toWorkflowRequest();
+        assertThat(actualRequest.getTable(), is("t_order"));
+        assertThat(actualRequest.getShardingColumns(), is("order_id, user_id"));
+        assertThat(actualRequest.getAlgorithmType(), is("INLINE"));
+        assertThat(actualRequest.getPrimaryAlgorithmProperties(), is(Map.of("algorithm-expression", "t_order_${order_id % 2}")));
     }
     
     @Test
     void assertHandlePlanTableReferenceRule() {
-        ShardingWorkflowPlanningService planningService = mock(ShardingWorkflowPlanningService.class);
-        when(planningService.planTableReferenceRule(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.TABLE_REFERENCE_WORKFLOW_KIND,
+        ShardingTableReferenceRuleWorkflowPlanningService planningService = mock(ShardingTableReferenceRuleWorkflowPlanningService.class);
+        when(planningService.plan(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.TABLE_REFERENCE_WORKFLOW_KIND,
                 createRequest(), "CREATE SHARDING TABLE REFERENCE RULE `ref_rule`(`t_order`, `t_order_item`)"));
         WorkflowContextFixture fixture = createWorkflowContextFixture();
         new PlanShardingTableReferenceRuleToolHandler(planningService)
                 .handle(fixture.workflowContext, new MCPToolCall("session-1", Map.of("database", "logic_db", "rule", "ref_rule", "reference_tables", "t_order,t_order_item")));
-        ArgumentCaptor<ShardingWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingWorkflowRequest.class);
-        verify(planningService).planTableReferenceRule(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
-        assertThat(requestCaptor.getValue().getReferenceTables(), is(List.of("t_order", "t_order_item")));
+        ArgumentCaptor<ShardingTableReferenceRuleWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingTableReferenceRuleWorkflowRequest.class);
+        verify(planningService).plan(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().toWorkflowRequest().getReferenceTables(), is(List.of("t_order", "t_order_item")));
     }
     
     @Test
     void assertHandlePlanDefaultStrategy() {
-        ShardingWorkflowPlanningService planningService = mock(ShardingWorkflowPlanningService.class);
-        when(planningService.planDefaultStrategy(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND,
+        ShardingDefaultStrategyWorkflowPlanningService planningService = mock(ShardingDefaultStrategyWorkflowPlanningService.class);
+        when(planningService.plan(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND,
                 createRequest(), "CREATE DEFAULT SHARDING DATABASE STRATEGY (TYPE='none')"));
         WorkflowContextFixture fixture = createWorkflowContextFixture();
         MCPResponse actual = new PlanShardingDefaultStrategyToolHandler(planningService)
                 .handle(fixture.workflowContext, new MCPToolCall("session-1", Map.of("database", "logic_db", "default_strategy_type", "DATABASE", "strategy_type", "none")));
-        ArgumentCaptor<ShardingWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingWorkflowRequest.class);
-        verify(planningService).planDefaultStrategy(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
-        assertThat(requestCaptor.getValue().getDefaultStrategyType(), is("DATABASE"));
+        ArgumentCaptor<ShardingDefaultStrategyWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingDefaultStrategyWorkflowRequest.class);
+        verify(planningService).plan(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().toWorkflowRequest().getDefaultStrategyType(), is("DATABASE"));
         assertThat(actual.toPayload().get("workflow_kind"), is("sharding.default.strategy"));
     }
     
     @Test
     void assertHandlePlanKeyGenerator() {
-        ShardingWorkflowPlanningService planningService = mock(ShardingWorkflowPlanningService.class);
-        when(planningService.planKeyGenerator(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.KEY_GENERATOR_WORKFLOW_KIND,
+        ShardingKeyGeneratorWorkflowPlanningService planningService = mock(ShardingKeyGeneratorWorkflowPlanningService.class);
+        when(planningService.plan(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.KEY_GENERATOR_WORKFLOW_KIND,
                 createRequest(), "CREATE SHARDING KEY GENERATOR `snowflake_generator`(TYPE(NAME='snowflake'))"));
         WorkflowContextFixture fixture = createWorkflowContextFixture();
         new PlanShardingKeyGeneratorToolHandler(planningService).handle(fixture.workflowContext, new MCPToolCall("session-1", Map.of(
                 "database", "logic_db", "key_generator", "snowflake_generator", "key_generator_type", "SNOWFLAKE", "key_generator_properties", Map.of("worker-id", "1"))));
-        ArgumentCaptor<ShardingWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingWorkflowRequest.class);
-        verify(planningService).planKeyGenerator(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
-        assertThat(requestCaptor.getValue().getKeyGeneratorName(), is("snowflake_generator"));
-        assertThat(requestCaptor.getValue().getKeyGeneratorProperties(), is(Map.of("worker-id", "1")));
+        ArgumentCaptor<ShardingKeyGeneratorWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingKeyGeneratorWorkflowRequest.class);
+        verify(planningService).plan(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
+        ShardingWorkflowRequest actualRequest = requestCaptor.getValue().toWorkflowRequest();
+        assertThat(actualRequest.getKeyGeneratorName(), is("snowflake_generator"));
+        assertThat(actualRequest.getKeyGeneratorProperties(), is(Map.of("worker-id", "1")));
     }
     
     @Test
     void assertHandlePlanKeyGenerateStrategy() {
-        ShardingWorkflowPlanningService planningService = mock(ShardingWorkflowPlanningService.class);
-        when(planningService.planKeyGenerateStrategy(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
+        ShardingKeyGenerateStrategyWorkflowPlanningService planningService = mock(ShardingKeyGenerateStrategyWorkflowPlanningService.class);
+        when(planningService.plan(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
                 createRequest(), "CREATE SHARDING KEY GENERATE STRATEGY `order_key_strategy`(TABLE=`t_order`, COLUMN=`id`, GENERATOR=`snowflake_generator`)"));
         WorkflowContextFixture fixture = createWorkflowContextFixture();
         new PlanShardingKeyGenerateStrategyToolHandler(planningService).handle(fixture.workflowContext, new MCPToolCall("session-1", Map.of(
                 "database", "logic_db", "key_generate_strategy", "order_key_strategy", "table", "t_order", "column", "id", "key_generator", "snowflake_generator")));
-        ArgumentCaptor<ShardingWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingWorkflowRequest.class);
-        verify(planningService).planKeyGenerateStrategy(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
-        assertThat(requestCaptor.getValue().getKeyGenerateStrategyName(), is("order_key_strategy"));
-        assertThat(requestCaptor.getValue().getKeyGeneratorName(), is("snowflake_generator"));
+        ArgumentCaptor<ShardingKeyGenerateStrategyWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingKeyGenerateStrategyWorkflowRequest.class);
+        verify(planningService).plan(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
+        ShardingWorkflowRequest actualRequest = requestCaptor.getValue().toWorkflowRequest();
+        assertThat(actualRequest.getKeyGenerateStrategyName(), is("order_key_strategy"));
+        assertThat(actualRequest.getKeyGeneratorName(), is("snowflake_generator"));
     }
     
     @Test
     void assertHandlePlanComponentCleanup() {
-        ShardingWorkflowPlanningService planningService = mock(ShardingWorkflowPlanningService.class);
-        when(planningService.planComponentCleanup(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.COMPONENT_CLEANUP_WORKFLOW_KIND,
+        ShardingRuleComponentCleanupWorkflowPlanningService planningService = mock(ShardingRuleComponentCleanupWorkflowPlanningService.class);
+        when(planningService.plan(any(), any(), any(), any())).thenReturn(createSnapshot(ShardingFeatureDefinition.COMPONENT_CLEANUP_WORKFLOW_KIND,
                 createRequest(), "DROP SHARDING ALGORITHM `unused_algorithm`"));
         WorkflowContextFixture fixture = createWorkflowContextFixture();
         MCPResponse actual = new PlanShardingRuleComponentCleanupToolHandler(planningService).handle(fixture.workflowContext, new MCPToolCall("session-1", Map.of(
                 "database", "logic_db", "component_type", "algorithm", "component_name", "unused_algorithm")));
-        ArgumentCaptor<ShardingWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingWorkflowRequest.class);
-        verify(planningService).planComponentCleanup(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
-        assertThat(requestCaptor.getValue().getComponentName(), is("unused_algorithm"));
+        ArgumentCaptor<ShardingRuleComponentCleanupWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingRuleComponentCleanupWorkflowRequest.class);
+        verify(planningService).plan(eq(fixture.workflowSessionContext), eq(fixture.queryFacade), eq("session-1"), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().toWorkflowRequest().getComponentName(), is("unused_algorithm"));
         assertThat(actual.toPayload().get("workflow_kind"), is("sharding.component.cleanup"));
     }
     

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingDefaultStrategyWorkflowPlanningServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingDefaultStrategyWorkflowPlanningServiceTest.java
@@ -37,17 +37,17 @@ class ShardingDefaultStrategyWorkflowPlanningServiceTest {
     
     @Test
     void assertPlan() {
-        ShardingWorkflowPlanningService delegate = mock(ShardingWorkflowPlanningService.class);
+        ShardingWorkflowPlanningKernel kernel = mock(ShardingWorkflowPlanningKernel.class);
         WorkflowSessionContext workflowSessionContext = mock(WorkflowSessionContext.class);
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         WorkflowContextSnapshot expected = new WorkflowContextSnapshot();
-        when(delegate.planDefaultStrategy(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), any())).thenReturn(expected);
+        when(kernel.planDefaultStrategy(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), any())).thenReturn(expected);
         ShardingWorkflowRequest request = new ShardingWorkflowRequest();
         request.setDefaultStrategyType("DATABASE");
-        WorkflowContextSnapshot actual = new ShardingDefaultStrategyWorkflowPlanningService(delegate)
+        WorkflowContextSnapshot actual = new ShardingDefaultStrategyWorkflowPlanningService(kernel)
                 .plan(workflowSessionContext, queryFacade, "session-1", new ShardingDefaultStrategyWorkflowRequest(request));
         ArgumentCaptor<ShardingWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingWorkflowRequest.class);
-        verify(delegate).planDefaultStrategy(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), requestCaptor.capture());
+        verify(kernel).planDefaultStrategy(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), requestCaptor.capture());
         assertThat(actual, is(expected));
         assertThat(requestCaptor.getValue().getDefaultStrategyType(), is("DATABASE"));
     }

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingKeyGenerateStrategyWorkflowPlanningServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingKeyGenerateStrategyWorkflowPlanningServiceTest.java
@@ -37,17 +37,17 @@ class ShardingKeyGenerateStrategyWorkflowPlanningServiceTest {
     
     @Test
     void assertPlan() {
-        ShardingWorkflowPlanningService delegate = mock(ShardingWorkflowPlanningService.class);
+        ShardingWorkflowPlanningKernel kernel = mock(ShardingWorkflowPlanningKernel.class);
         WorkflowSessionContext workflowSessionContext = mock(WorkflowSessionContext.class);
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         WorkflowContextSnapshot expected = new WorkflowContextSnapshot();
-        when(delegate.planKeyGenerateStrategy(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), any())).thenReturn(expected);
+        when(kernel.planKeyGenerateStrategy(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), any())).thenReturn(expected);
         ShardingWorkflowRequest request = new ShardingWorkflowRequest();
         request.setKeyGenerateStrategyName("order_key_strategy");
-        WorkflowContextSnapshot actual = new ShardingKeyGenerateStrategyWorkflowPlanningService(delegate)
+        WorkflowContextSnapshot actual = new ShardingKeyGenerateStrategyWorkflowPlanningService(kernel)
                 .plan(workflowSessionContext, queryFacade, "session-1", new ShardingKeyGenerateStrategyWorkflowRequest(request));
         ArgumentCaptor<ShardingWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingWorkflowRequest.class);
-        verify(delegate).planKeyGenerateStrategy(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), requestCaptor.capture());
+        verify(kernel).planKeyGenerateStrategy(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), requestCaptor.capture());
         assertThat(actual, is(expected));
         assertThat(requestCaptor.getValue().getKeyGenerateStrategyName(), is("order_key_strategy"));
     }

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingKeyGeneratorWorkflowPlanningServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingKeyGeneratorWorkflowPlanningServiceTest.java
@@ -37,17 +37,17 @@ class ShardingKeyGeneratorWorkflowPlanningServiceTest {
     
     @Test
     void assertPlan() {
-        ShardingWorkflowPlanningService delegate = mock(ShardingWorkflowPlanningService.class);
+        ShardingWorkflowPlanningKernel kernel = mock(ShardingWorkflowPlanningKernel.class);
         WorkflowSessionContext workflowSessionContext = mock(WorkflowSessionContext.class);
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         WorkflowContextSnapshot expected = new WorkflowContextSnapshot();
-        when(delegate.planKeyGenerator(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), any())).thenReturn(expected);
+        when(kernel.planKeyGenerator(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), any())).thenReturn(expected);
         ShardingWorkflowRequest request = new ShardingWorkflowRequest();
         request.setKeyGeneratorName("snowflake_generator");
-        WorkflowContextSnapshot actual = new ShardingKeyGeneratorWorkflowPlanningService(delegate)
+        WorkflowContextSnapshot actual = new ShardingKeyGeneratorWorkflowPlanningService(kernel)
                 .plan(workflowSessionContext, queryFacade, "session-1", new ShardingKeyGeneratorWorkflowRequest(request));
         ArgumentCaptor<ShardingWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingWorkflowRequest.class);
-        verify(delegate).planKeyGenerator(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), requestCaptor.capture());
+        verify(kernel).planKeyGenerator(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), requestCaptor.capture());
         assertThat(actual, is(expected));
         assertThat(requestCaptor.getValue().getKeyGeneratorName(), is("snowflake_generator"));
     }

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingRuleComponentCleanupWorkflowPlanningServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingRuleComponentCleanupWorkflowPlanningServiceTest.java
@@ -37,17 +37,17 @@ class ShardingRuleComponentCleanupWorkflowPlanningServiceTest {
     
     @Test
     void assertPlan() {
-        ShardingWorkflowPlanningService delegate = mock(ShardingWorkflowPlanningService.class);
+        ShardingWorkflowPlanningKernel kernel = mock(ShardingWorkflowPlanningKernel.class);
         WorkflowSessionContext workflowSessionContext = mock(WorkflowSessionContext.class);
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         WorkflowContextSnapshot expected = new WorkflowContextSnapshot();
-        when(delegate.planComponentCleanup(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), any())).thenReturn(expected);
+        when(kernel.planComponentCleanup(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), any())).thenReturn(expected);
         ShardingWorkflowRequest request = new ShardingWorkflowRequest();
         request.setComponentName("unused_algorithm");
-        WorkflowContextSnapshot actual = new ShardingRuleComponentCleanupWorkflowPlanningService(delegate)
+        WorkflowContextSnapshot actual = new ShardingRuleComponentCleanupWorkflowPlanningService(kernel)
                 .plan(workflowSessionContext, queryFacade, "session-1", new ShardingRuleComponentCleanupWorkflowRequest(request));
         ArgumentCaptor<ShardingWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingWorkflowRequest.class);
-        verify(delegate).planComponentCleanup(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), requestCaptor.capture());
+        verify(kernel).planComponentCleanup(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), requestCaptor.capture());
         assertThat(actual, is(expected));
         assertThat(requestCaptor.getValue().getComponentName(), is("unused_algorithm"));
     }

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingTableReferenceRuleWorkflowPlanningServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingTableReferenceRuleWorkflowPlanningServiceTest.java
@@ -39,18 +39,18 @@ class ShardingTableReferenceRuleWorkflowPlanningServiceTest {
     
     @Test
     void assertPlan() {
-        ShardingWorkflowPlanningService delegate = mock(ShardingWorkflowPlanningService.class);
+        ShardingWorkflowPlanningKernel kernel = mock(ShardingWorkflowPlanningKernel.class);
         WorkflowSessionContext workflowSessionContext = mock(WorkflowSessionContext.class);
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         WorkflowContextSnapshot expected = new WorkflowContextSnapshot();
-        when(delegate.planTableReferenceRule(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), any())).thenReturn(expected);
+        when(kernel.planTableReferenceRule(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), any())).thenReturn(expected);
         ShardingWorkflowRequest request = new ShardingWorkflowRequest();
         request.setRuleName("ref_rule");
         request.getReferenceTables().addAll(List.of("t_order", "t_order_item"));
-        WorkflowContextSnapshot actual = new ShardingTableReferenceRuleWorkflowPlanningService(delegate)
+        WorkflowContextSnapshot actual = new ShardingTableReferenceRuleWorkflowPlanningService(kernel)
                 .plan(workflowSessionContext, queryFacade, "session-1", new ShardingTableReferenceRuleWorkflowRequest(request));
         ArgumentCaptor<ShardingWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingWorkflowRequest.class);
-        verify(delegate).planTableReferenceRule(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), requestCaptor.capture());
+        verify(kernel).planTableReferenceRule(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), requestCaptor.capture());
         assertThat(actual, is(expected));
         assertThat(requestCaptor.getValue().getReferenceTables(), is(List.of("t_order", "t_order_item")));
     }

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingTableRuleWorkflowPlanningServiceTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingTableRuleWorkflowPlanningServiceTest.java
@@ -37,17 +37,17 @@ class ShardingTableRuleWorkflowPlanningServiceTest {
     
     @Test
     void assertPlan() {
-        ShardingWorkflowPlanningService delegate = mock(ShardingWorkflowPlanningService.class);
+        ShardingWorkflowPlanningKernel kernel = mock(ShardingWorkflowPlanningKernel.class);
         WorkflowSessionContext workflowSessionContext = mock(WorkflowSessionContext.class);
         MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
         WorkflowContextSnapshot expected = new WorkflowContextSnapshot();
-        when(delegate.planTableRule(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), any())).thenReturn(expected);
+        when(kernel.planTableRule(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), any())).thenReturn(expected);
         ShardingWorkflowRequest request = new ShardingWorkflowRequest();
         request.setTable("t_order");
-        WorkflowContextSnapshot actual = new ShardingTableRuleWorkflowPlanningService(delegate)
+        WorkflowContextSnapshot actual = new ShardingTableRuleWorkflowPlanningService(kernel)
                 .plan(workflowSessionContext, queryFacade, "session-1", new ShardingTableRuleWorkflowRequest(request));
         ArgumentCaptor<ShardingWorkflowRequest> requestCaptor = ArgumentCaptor.forClass(ShardingWorkflowRequest.class);
-        verify(delegate).planTableRule(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), requestCaptor.capture());
+        verify(kernel).planTableRule(eq(workflowSessionContext), eq(queryFacade), eq("session-1"), requestCaptor.capture());
         assertThat(actual, is(expected));
         assertThat(requestCaptor.getValue().getTable(), is("t_order"));
     }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidancePayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidancePayloadBuilder.java
@@ -22,8 +22,6 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.support.diagnostic.MCPDiagnosticCategory;
 import org.apache.shardingsphere.mcp.support.protocol.MCPNextActionUtils;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
-import org.apache.shardingsphere.mcp.support.protocol.MCPResourceHintUtils;
-import org.apache.shardingsphere.mcp.support.resource.MCPUriPathSegmentUtils;
 import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmPropertyRequirement;
 import org.apache.shardingsphere.mcp.support.workflow.model.ClarifiedIntent;
 import org.apache.shardingsphere.mcp.support.workflow.model.ValidationReport;
@@ -33,7 +31,6 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssue;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssueCode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
-import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -131,7 +128,7 @@ public final class WorkflowGuidancePayloadBuilder {
         List<Map<String, Object>> clarificationQuestions = createClarificationQuestions(snapshot, missingRequiredInputs);
         payload.put("missing_required_inputs", missingRequiredInputs);
         payload.put(MCPPayloadFieldNames.CLARIFICATION_QUESTIONS, clarificationQuestions);
-        payload.put(MCPPayloadFieldNames.RESOURCES_TO_READ, createResourcesToRead(snapshot));
+        payload.put(MCPPayloadFieldNames.RESOURCES_TO_READ, new WorkflowGuidanceResourceHintProvider().createResourcesToRead(snapshot));
         payload.put("proxy_topology_hint", createProxyTopologyHint(snapshot));
         payload.put(MCPPayloadFieldNames.NEXT_ACTIONS, createPlanningNextActions(snapshot, missingRequiredInputs));
     }
@@ -342,189 +339,6 @@ public final class WorkflowGuidancePayloadBuilder {
             return fieldName.substring(separatorIndex + 1);
         }
         return "";
-    }
-    
-    private static List<Map<String, Object>> createResourcesToRead(final WorkflowContextSnapshot snapshot) {
-        List<Map<String, Object>> result = new LinkedList<>();
-        addFeatureResources(result, snapshot);
-        WorkflowRequest request = snapshot.getRequest();
-        if (!request.getDatabase().isEmpty()) {
-            addRuleResources(result, snapshot, request);
-            addGovernanceMetadataResources(result, snapshot, request);
-            if (WorkflowArtifactPayloadUtils.isRuleDistSQLOnlyWorkflow(snapshot) && !request.getTable().isEmpty()) {
-                addFeatureTableRuleResources(result, snapshot, request);
-            } else if (!request.getSchema().isEmpty() && !request.getTable().isEmpty()) {
-                addTableResources(result, request);
-            }
-        }
-        return result;
-    }
-    
-    private static void addFeatureResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot) {
-        switch (resolveWorkflowKind(snapshot)) {
-            case ENCRYPT_RULE_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/encrypt/algorithms", "algorithm", "read_first",
-                    "Read encrypt algorithm metadata before choosing algorithm arguments.");
-            case MASK_RULE_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/mask/algorithms", "algorithm", "read_first",
-                    "Read mask algorithm metadata before choosing algorithm arguments.");
-            case READWRITE_RULE_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/readwrite-splitting/load-balance-algorithm-plugins", "algorithm", "read_first",
-                    "Read load-balance algorithm plugin metadata before choosing algorithm arguments.");
-            case SHADOW_RULE_WORKFLOW_KIND, SHADOW_DEFAULT_ALGORITHM_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/shadow/algorithm-plugins", "algorithm",
-                    "read_first", "Read shadow algorithm plugin metadata before choosing algorithm arguments.");
-            case SHARDING_TABLE_RULE_WORKFLOW_KIND, SHARDING_DEFAULT_STRATEGY_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/sharding/algorithm-plugins",
-                    "algorithm", "read_first", "Read sharding algorithm plugin metadata before choosing algorithm arguments.");
-            case SHARDING_KEY_GENERATOR_WORKFLOW_KIND, SHARDING_KEY_GENERATE_STRATEGY_WORKFLOW_KIND -> addResourceHint(resourcesToRead,
-                    "shardingsphere://features/sharding/key-generate-algorithm-plugins", "algorithm", "read_first",
-                    "Read key-generate algorithm plugin metadata before choosing generator arguments.");
-            default -> {
-            }
-        }
-    }
-    
-    private static void addGovernanceMetadataResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot, final WorkflowRequest request) {
-        String workflowKind = resolveWorkflowKind(snapshot);
-        switch (workflowKind) {
-            case READWRITE_RULE_WORKFLOW_KIND, READWRITE_STATUS_WORKFLOW_KIND, SHADOW_RULE_WORKFLOW_KIND, SHARDING_TABLE_RULE_WORKFLOW_KIND -> addStorageUnitsResourceHint(resourcesToRead,
-                    request);
-            default -> {
-            }
-        }
-        switch (workflowKind) {
-            case SHADOW_RULE_WORKFLOW_KIND, SHARDING_TABLE_RULE_WORKFLOW_KIND -> {
-                addSingleTablesResourceHint(resourcesToRead, request);
-                if (!request.getTable().isEmpty()) {
-                    addSingleTableResourceHint(resourcesToRead, request);
-                }
-            }
-            default -> {
-            }
-        }
-    }
-    
-    private static void addFeatureTableRuleResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot, final WorkflowRequest request) {
-        switch (resolveWorkflowKind(snapshot)) {
-            case ENCRYPT_RULE_WORKFLOW_KIND -> addTableResourceHint(resourcesToRead, request, "shardingsphere://features/encrypt/databases/%s/tables/%s/rules",
-                    "Inspect current encrypt table rule DistSQL state before planning changes.");
-            case MASK_RULE_WORKFLOW_KIND -> addTableResourceHint(resourcesToRead, request, "shardingsphere://features/mask/databases/%s/tables/%s/rules",
-                    "Inspect current mask table rule DistSQL state before planning changes.");
-            case SHADOW_RULE_WORKFLOW_KIND -> addTableResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/tables/%s/rules",
-                    "Inspect current shadow table rule DistSQL state before planning changes.");
-            case SHARDING_TABLE_RULE_WORKFLOW_KIND -> {
-                addTableResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/tables/%s/table-rule",
-                        "Inspect current sharding table rule DistSQL state before planning changes.");
-                addTableResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/tables/%s/nodes",
-                        "Inspect current sharding table nodes before planning changes.");
-            }
-            default -> {
-            }
-        }
-    }
-    
-    private static void addRuleResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot, final WorkflowRequest request) {
-        switch (resolveWorkflowKind(snapshot)) {
-            case ENCRYPT_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/encrypt/databases/%s/rules",
-                    "Inspect current encrypt rules before planning changes.");
-            case MASK_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/mask/databases/%s/rules",
-                    "Inspect current mask rules before planning changes.");
-            case BROADCAST_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/broadcast/databases/%s/rules",
-                    "Inspect current broadcast rules before planning changes.");
-            case READWRITE_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/readwrite-splitting/databases/%s/rules",
-                    "Inspect current readwrite-splitting rules before planning changes.");
-            case READWRITE_STATUS_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/readwrite-splitting/databases/%s/status",
-                    "Inspect current readwrite-splitting status before planning changes.");
-            case SHADOW_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/rules",
-                    "Inspect current shadow rules before planning changes.");
-            case SHADOW_DEFAULT_ALGORITHM_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/default-algorithm",
-                    "Inspect current default shadow algorithm before planning changes.");
-            case SHADOW_ALGORITHM_CLEANUP_WORKFLOW_KIND -> {
-                addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/algorithms",
-                        "Inspect configured shadow algorithms before planning cleanup.");
-                addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/table-rules",
-                        "Inspect shadow table rule references before planning cleanup.");
-                addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/default-algorithm",
-                        "Inspect default shadow algorithm references before planning cleanup.");
-            }
-            case SHARDING_TABLE_RULE_WORKFLOW_KIND -> addShardingTableRuleResources(resourcesToRead, request);
-            case SHARDING_TABLE_REFERENCE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/table-reference-rules",
-                    "Inspect current sharding table reference rules before planning changes.");
-            case SHARDING_DEFAULT_STRATEGY_WORKFLOW_KIND -> addShardingDefaultStrategyResources(resourcesToRead, request);
-            case SHARDING_KEY_GENERATOR_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/key-generators",
-                    "Inspect current sharding key generators before planning changes.");
-            case SHARDING_KEY_GENERATE_STRATEGY_WORKFLOW_KIND -> addShardingKeyGenerateStrategyResources(resourcesToRead, request);
-            case SHARDING_COMPONENT_CLEANUP_WORKFLOW_KIND -> addShardingComponentCleanupResources(resourcesToRead, request);
-            default -> {
-            }
-        }
-    }
-    
-    private static void addDatabaseResourceHint(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request, final String uriTemplate, final String reason) {
-        addResourceHint(resourcesToRead, String.format(uriTemplate, MCPUriPathSegmentUtils.encodePathSegment(request.getDatabase())), "rule", "inspect_detail", reason);
-    }
-    
-    private static void addStorageUnitsResourceHint(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
-        addResourceHint(resourcesToRead, String.format("shardingsphere://databases/%s/storage-units", MCPUriPathSegmentUtils.encodePathSegment(request.getDatabase())),
-                "storage-unit", "validate_scope", "Read storage units before planning DistSQL that references storage units.");
-    }
-    
-    private static void addSingleTablesResourceHint(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
-        addResourceHint(resourcesToRead, String.format("shardingsphere://databases/%s/single-tables", MCPUriPathSegmentUtils.encodePathSegment(request.getDatabase())),
-                "single-table", "validate_scope", "Read single table mappings before planning table-level DistSQL.");
-    }
-    
-    private static void addSingleTableResourceHint(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
-        addResourceHint(resourcesToRead, String.format("shardingsphere://databases/%s/single-tables/%s", MCPUriPathSegmentUtils.encodePathSegment(request.getDatabase()),
-                MCPUriPathSegmentUtils.encodePathSegment(request.getTable())), "single-table", "validate_scope",
-                "Read the target single table mapping before planning table-level DistSQL.");
-    }
-    
-    private static void addTableResourceHint(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request, final String uriTemplate, final String reason) {
-        addResourceHint(resourcesToRead, String.format(uriTemplate, MCPUriPathSegmentUtils.encodePathSegment(request.getDatabase()), MCPUriPathSegmentUtils.encodePathSegment(request.getTable())),
-                "rule", "inspect_detail", reason);
-    }
-    
-    private static void addResourceHint(final Collection<Map<String, Object>> resourcesToRead, final String uri, final String resourceKind, final String action, final String reason) {
-        resourcesToRead.add(MCPResourceHintUtils.create(uri, resourceKind, action, reason, MCPPayloadFieldNames.RESOURCES_TO_READ));
-    }
-    
-    private static void addShardingTableRuleResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
-        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/table-rules",
-                "Inspect current sharding table rules before planning changes.");
-        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/table-nodes",
-                "Inspect current sharding table nodes before planning changes.");
-    }
-    
-    private static void addShardingDefaultStrategyResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
-        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/default-strategy",
-                "Inspect current default sharding strategy before planning changes.");
-        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/algorithms",
-                "Inspect configured sharding algorithms before planning default strategy changes.");
-    }
-    
-    private static void addShardingKeyGenerateStrategyResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
-        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/key-generate-strategies",
-                "Inspect current sharding key generate strategies before planning changes.");
-        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/key-generators",
-                "Inspect current sharding key generators before planning key generate strategy changes.");
-    }
-    
-    private static void addShardingComponentCleanupResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
-        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/algorithms",
-                "Inspect configured sharding algorithms before planning cleanup.");
-        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/key-generators",
-                "Inspect configured sharding key generators before planning cleanup.");
-        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/auditors",
-                "Inspect configured sharding auditors before planning cleanup.");
-        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/unused-algorithms",
-                "Inspect unused sharding algorithms before planning cleanup.");
-        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/unused-key-generators",
-                "Inspect unused sharding key generators before planning cleanup.");
-        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/unused-auditors",
-                "Inspect unused sharding auditors before planning cleanup.");
-    }
-    
-    private static void addTableResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
-        resourcesToRead.add(MCPResourceHintUtils.create(String.format("shardingsphere://databases/%s/schemas/%s/tables/%s/columns", MCPUriPathSegmentUtils.encodePathSegment(request.getDatabase()),
-                MCPUriPathSegmentUtils.encodePathSegment(request.getSchema()), MCPUriPathSegmentUtils.encodePathSegment(request.getTable())),
-                "column", "validate_scope", "Read table columns before planning column-level workflow changes.", MCPPayloadFieldNames.RESOURCES_TO_READ));
     }
     
     private static List<Map<String, Object>> createPlanningNextActions(final WorkflowContextSnapshot snapshot, final List<String> missingRequiredInputs) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidanceResourceHintProvider.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidanceResourceHintProvider.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.workflow.service;
+
+import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
+import org.apache.shardingsphere.mcp.support.protocol.MCPResourceHintUtils;
+import org.apache.shardingsphere.mcp.support.resource.MCPUriPathSegmentUtils;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provides model-facing workflow resource read hints.
+ */
+public final class WorkflowGuidanceResourceHintProvider {
+    
+    private static final String ENCRYPT_RULE_WORKFLOW_KIND = "encrypt.rule";
+    
+    private static final String MASK_RULE_WORKFLOW_KIND = "mask.rule";
+    
+    private static final String BROADCAST_RULE_WORKFLOW_KIND = "broadcast.rule";
+    
+    private static final String READWRITE_RULE_WORKFLOW_KIND = "readwrite.rule";
+    
+    private static final String READWRITE_STATUS_WORKFLOW_KIND = "readwrite.status";
+    
+    private static final String SHADOW_RULE_WORKFLOW_KIND = "shadow.rule";
+    
+    private static final String SHADOW_DEFAULT_ALGORITHM_WORKFLOW_KIND = "shadow.default";
+    
+    private static final String SHADOW_ALGORITHM_CLEANUP_WORKFLOW_KIND = "shadow.cleanup";
+    
+    private static final String SHARDING_TABLE_RULE_WORKFLOW_KIND = "sharding.table.rule";
+    
+    private static final String SHARDING_TABLE_REFERENCE_WORKFLOW_KIND = "sharding.table.reference";
+    
+    private static final String SHARDING_DEFAULT_STRATEGY_WORKFLOW_KIND = "sharding.default.strategy";
+    
+    private static final String SHARDING_KEY_GENERATOR_WORKFLOW_KIND = "sharding.key.generator";
+    
+    private static final String SHARDING_KEY_GENERATE_STRATEGY_WORKFLOW_KIND = "sharding.key.generate.strategy";
+    
+    private static final String SHARDING_COMPONENT_CLEANUP_WORKFLOW_KIND = "sharding.component.cleanup";
+    
+    /**
+     * Create resource hints for a workflow planning response.
+     *
+     * @param snapshot workflow snapshot
+     * @return resource hints
+     */
+    public List<Map<String, Object>> createResourcesToRead(final WorkflowContextSnapshot snapshot) {
+        List<Map<String, Object>> result = new LinkedList<>();
+        addFeatureResources(result, snapshot);
+        WorkflowRequest request = snapshot.getRequest();
+        if (!request.getDatabase().isEmpty()) {
+            addRuleResources(result, snapshot, request);
+            addGovernanceMetadataResources(result, snapshot, request);
+            if (WorkflowArtifactPayloadUtils.isRuleDistSQLOnlyWorkflow(snapshot) && !request.getTable().isEmpty()) {
+                addFeatureTableRuleResources(result, snapshot, request);
+            } else if (!request.getSchema().isEmpty() && !request.getTable().isEmpty()) {
+                addTableResources(result, request);
+            }
+        }
+        return result;
+    }
+    
+    private void addFeatureResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot) {
+        switch (resolveWorkflowKind(snapshot)) {
+            case ENCRYPT_RULE_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/encrypt/algorithms", "algorithm", "read_first",
+                    "Read encrypt algorithm metadata before choosing algorithm arguments.");
+            case MASK_RULE_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/mask/algorithms", "algorithm", "read_first",
+                    "Read mask algorithm metadata before choosing algorithm arguments.");
+            case READWRITE_RULE_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/readwrite-splitting/load-balance-algorithm-plugins", "algorithm", "read_first",
+                    "Read load-balance algorithm plugin metadata before choosing algorithm arguments.");
+            case SHADOW_RULE_WORKFLOW_KIND, SHADOW_DEFAULT_ALGORITHM_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/shadow/algorithm-plugins", "algorithm",
+                    "read_first", "Read shadow algorithm plugin metadata before choosing algorithm arguments.");
+            case SHARDING_TABLE_RULE_WORKFLOW_KIND, SHARDING_DEFAULT_STRATEGY_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/sharding/algorithm-plugins",
+                    "algorithm", "read_first", "Read sharding algorithm plugin metadata before choosing algorithm arguments.");
+            case SHARDING_KEY_GENERATOR_WORKFLOW_KIND, SHARDING_KEY_GENERATE_STRATEGY_WORKFLOW_KIND -> addResourceHint(resourcesToRead,
+                    "shardingsphere://features/sharding/key-generate-algorithm-plugins", "algorithm", "read_first",
+                    "Read key-generate algorithm plugin metadata before choosing generator arguments.");
+            default -> {
+            }
+        }
+    }
+    
+    private void addGovernanceMetadataResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot, final WorkflowRequest request) {
+        String workflowKind = resolveWorkflowKind(snapshot);
+        switch (workflowKind) {
+            case READWRITE_RULE_WORKFLOW_KIND, READWRITE_STATUS_WORKFLOW_KIND, SHADOW_RULE_WORKFLOW_KIND, SHARDING_TABLE_RULE_WORKFLOW_KIND -> addStorageUnitsResourceHint(resourcesToRead,
+                    request);
+            default -> {
+            }
+        }
+        switch (workflowKind) {
+            case SHADOW_RULE_WORKFLOW_KIND, SHARDING_TABLE_RULE_WORKFLOW_KIND -> {
+                addSingleTablesResourceHint(resourcesToRead, request);
+                if (!request.getTable().isEmpty()) {
+                    addSingleTableResourceHint(resourcesToRead, request);
+                }
+            }
+            default -> {
+            }
+        }
+    }
+    
+    private void addFeatureTableRuleResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot, final WorkflowRequest request) {
+        switch (resolveWorkflowKind(snapshot)) {
+            case ENCRYPT_RULE_WORKFLOW_KIND -> addTableResourceHint(resourcesToRead, request, "shardingsphere://features/encrypt/databases/%s/tables/%s/rules",
+                    "Inspect current encrypt table rule DistSQL state before planning changes.");
+            case MASK_RULE_WORKFLOW_KIND -> addTableResourceHint(resourcesToRead, request, "shardingsphere://features/mask/databases/%s/tables/%s/rules",
+                    "Inspect current mask table rule DistSQL state before planning changes.");
+            case SHADOW_RULE_WORKFLOW_KIND -> addTableResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/tables/%s/rules",
+                    "Inspect current shadow table rule DistSQL state before planning changes.");
+            case SHARDING_TABLE_RULE_WORKFLOW_KIND -> {
+                addTableResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/tables/%s/table-rule",
+                        "Inspect current sharding table rule DistSQL state before planning changes.");
+                addTableResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/tables/%s/nodes",
+                        "Inspect current sharding table nodes before planning changes.");
+            }
+            default -> {
+            }
+        }
+    }
+    
+    private void addRuleResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot, final WorkflowRequest request) {
+        switch (resolveWorkflowKind(snapshot)) {
+            case ENCRYPT_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/encrypt/databases/%s/rules",
+                    "Inspect current encrypt rules before planning changes.");
+            case MASK_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/mask/databases/%s/rules",
+                    "Inspect current mask rules before planning changes.");
+            case BROADCAST_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/broadcast/databases/%s/rules",
+                    "Inspect current broadcast rules before planning changes.");
+            case READWRITE_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/readwrite-splitting/databases/%s/rules",
+                    "Inspect current readwrite-splitting rules before planning changes.");
+            case READWRITE_STATUS_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/readwrite-splitting/databases/%s/status",
+                    "Inspect current readwrite-splitting status before planning changes.");
+            case SHADOW_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/rules",
+                    "Inspect current shadow rules before planning changes.");
+            case SHADOW_DEFAULT_ALGORITHM_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/default-algorithm",
+                    "Inspect current default shadow algorithm before planning changes.");
+            case SHADOW_ALGORITHM_CLEANUP_WORKFLOW_KIND -> {
+                addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/algorithms",
+                        "Inspect configured shadow algorithms before planning cleanup.");
+                addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/table-rules",
+                        "Inspect shadow table rule references before planning cleanup.");
+                addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/default-algorithm",
+                        "Inspect default shadow algorithm references before planning cleanup.");
+            }
+            case SHARDING_TABLE_RULE_WORKFLOW_KIND -> addShardingTableRuleResources(resourcesToRead, request);
+            case SHARDING_TABLE_REFERENCE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/table-reference-rules",
+                    "Inspect current sharding table reference rules before planning changes.");
+            case SHARDING_DEFAULT_STRATEGY_WORKFLOW_KIND -> addShardingDefaultStrategyResources(resourcesToRead, request);
+            case SHARDING_KEY_GENERATOR_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/key-generators",
+                    "Inspect current sharding key generators before planning changes.");
+            case SHARDING_KEY_GENERATE_STRATEGY_WORKFLOW_KIND -> addShardingKeyGenerateStrategyResources(resourcesToRead, request);
+            case SHARDING_COMPONENT_CLEANUP_WORKFLOW_KIND -> addShardingComponentCleanupResources(resourcesToRead, request);
+            default -> {
+            }
+        }
+    }
+    
+    private void addDatabaseResourceHint(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request, final String uriTemplate, final String reason) {
+        addResourceHint(resourcesToRead, String.format(uriTemplate, MCPUriPathSegmentUtils.encodePathSegment(request.getDatabase())), "rule", "inspect_detail", reason);
+    }
+    
+    private void addStorageUnitsResourceHint(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
+        addResourceHint(resourcesToRead, String.format("shardingsphere://databases/%s/storage-units", MCPUriPathSegmentUtils.encodePathSegment(request.getDatabase())),
+                "storage-unit", "validate_scope", "Read storage units before planning DistSQL that references storage units.");
+    }
+    
+    private void addSingleTablesResourceHint(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
+        addResourceHint(resourcesToRead, String.format("shardingsphere://databases/%s/single-tables", MCPUriPathSegmentUtils.encodePathSegment(request.getDatabase())),
+                "single-table", "validate_scope", "Read single table mappings before planning table-level DistSQL.");
+    }
+    
+    private void addSingleTableResourceHint(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
+        addResourceHint(resourcesToRead, String.format("shardingsphere://databases/%s/single-tables/%s", MCPUriPathSegmentUtils.encodePathSegment(request.getDatabase()),
+                MCPUriPathSegmentUtils.encodePathSegment(request.getTable())), "single-table", "validate_scope",
+                "Read the target single table mapping before planning table-level DistSQL.");
+    }
+    
+    private void addTableResourceHint(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request, final String uriTemplate, final String reason) {
+        addResourceHint(resourcesToRead, String.format(uriTemplate, MCPUriPathSegmentUtils.encodePathSegment(request.getDatabase()), MCPUriPathSegmentUtils.encodePathSegment(request.getTable())),
+                "rule", "inspect_detail", reason);
+    }
+    
+    private void addResourceHint(final Collection<Map<String, Object>> resourcesToRead, final String uri, final String resourceKind, final String action, final String reason) {
+        resourcesToRead.add(MCPResourceHintUtils.create(uri, resourceKind, action, reason, MCPPayloadFieldNames.RESOURCES_TO_READ));
+    }
+    
+    private void addShardingTableRuleResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
+        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/table-rules",
+                "Inspect current sharding table rules before planning changes.");
+        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/table-nodes",
+                "Inspect current sharding table nodes before planning changes.");
+    }
+    
+    private void addShardingDefaultStrategyResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
+        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/default-strategy",
+                "Inspect current default sharding strategy before planning changes.");
+        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/algorithms",
+                "Inspect configured sharding algorithms before planning default strategy changes.");
+    }
+    
+    private void addShardingKeyGenerateStrategyResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
+        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/key-generate-strategies",
+                "Inspect current sharding key generate strategies before planning changes.");
+        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/key-generators",
+                "Inspect current sharding key generators before planning key generate strategy changes.");
+    }
+    
+    private void addShardingComponentCleanupResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
+        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/algorithms",
+                "Inspect configured sharding algorithms before planning cleanup.");
+        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/key-generators",
+                "Inspect configured sharding key generators before planning cleanup.");
+        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/auditors",
+                "Inspect configured sharding auditors before planning cleanup.");
+        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/unused-algorithms",
+                "Inspect unused sharding algorithms before planning cleanup.");
+        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/unused-key-generators",
+                "Inspect unused sharding key generators before planning cleanup.");
+        addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/unused-auditors",
+                "Inspect unused sharding auditors before planning cleanup.");
+    }
+    
+    private void addTableResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request) {
+        resourcesToRead.add(MCPResourceHintUtils.create(String.format("shardingsphere://databases/%s/schemas/%s/tables/%s/columns", MCPUriPathSegmentUtils.encodePathSegment(request.getDatabase()),
+                MCPUriPathSegmentUtils.encodePathSegment(request.getSchema()), MCPUriPathSegmentUtils.encodePathSegment(request.getTable())),
+                "column", "validate_scope", "Read table columns before planning column-level workflow changes.", MCPPayloadFieldNames.RESOURCES_TO_READ));
+    }
+    
+    private String resolveWorkflowKind(final WorkflowContextSnapshot snapshot) {
+        WorkflowKind workflowKind = snapshot.getWorkflowKind();
+        return null == workflowKind ? "" : workflowKind.getValue();
+    }
+}

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidanceResourceHintProviderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidanceResourceHintProviderTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.workflow.service;
+
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WorkflowGuidanceResourceHintProviderTest {
+    
+    @Test
+    void assertCreateResourcesToReadWithEncryptRule() {
+        List<String> actual = extractResourceUris(new WorkflowGuidanceResourceHintProvider().createResourcesToRead(createSnapshot("encrypt.rule", "logic_db", "", "t_order")));
+        assertTrue(actual.contains("shardingsphere://features/encrypt/algorithms"));
+        assertTrue(actual.contains("shardingsphere://features/encrypt/databases/logic_db/rules"));
+        assertTrue(actual.contains("shardingsphere://features/encrypt/databases/logic_db/tables/t_order/rules"));
+    }
+    
+    @Test
+    void assertCreateResourcesToReadWithShardingTableRule() {
+        List<String> actual = extractResourceUris(new WorkflowGuidanceResourceHintProvider().createResourcesToRead(createSnapshot("sharding.table.rule", "logic_db", "", "t_order")));
+        assertTrue(actual.contains("shardingsphere://features/sharding/algorithm-plugins"));
+        assertTrue(actual.contains("shardingsphere://features/sharding/databases/logic_db/table-rules"));
+        assertTrue(actual.contains("shardingsphere://features/sharding/databases/logic_db/table-nodes"));
+        assertTrue(actual.contains("shardingsphere://databases/logic_db/storage-units"));
+        assertTrue(actual.contains("shardingsphere://databases/logic_db/single-tables"));
+        assertTrue(actual.contains("shardingsphere://databases/logic_db/single-tables/t_order"));
+        assertTrue(actual.contains("shardingsphere://features/sharding/databases/logic_db/tables/t_order/table-rule"));
+        assertTrue(actual.contains("shardingsphere://features/sharding/databases/logic_db/tables/t_order/nodes"));
+    }
+    
+    @Test
+    void assertCreateResourcesToReadWithShardingComponentCleanup() {
+        List<String> actual = extractResourceUris(new WorkflowGuidanceResourceHintProvider().createResourcesToRead(createSnapshot("sharding.component.cleanup", "logic_db", "", "")));
+        assertThat(actual, is(List.of(
+                "shardingsphere://features/sharding/databases/logic_db/algorithms",
+                "shardingsphere://features/sharding/databases/logic_db/key-generators",
+                "shardingsphere://features/sharding/databases/logic_db/auditors",
+                "shardingsphere://features/sharding/databases/logic_db/unused-algorithms",
+                "shardingsphere://features/sharding/databases/logic_db/unused-key-generators",
+                "shardingsphere://features/sharding/databases/logic_db/unused-auditors")));
+    }
+    
+    @Test
+    void assertCreateResourcesToReadWithColumnWorkflow() {
+        List<String> actual = extractResourceUris(new WorkflowGuidanceResourceHintProvider().createResourcesToRead(createSnapshot("encrypt.table", "logic_db", "public", "t_order")));
+        assertThat(actual, is(List.of("shardingsphere://databases/logic_db/schemas/public/tables/t_order/columns")));
+    }
+    
+    private List<String> extractResourceUris(final List<Map<String, Object>> resourcesToRead) {
+        List<String> result = new LinkedList<>();
+        for (Map<String, Object> each : resourcesToRead) {
+            result.add((String) each.get("uri"));
+        }
+        return result;
+    }
+    
+    private WorkflowContextSnapshot createSnapshot(final String workflowKind, final String database, final String schema, final String table) {
+        WorkflowContextSnapshot result = new WorkflowContextSnapshot();
+        result.setWorkflowKind(WorkflowKind.valueOf(workflowKind));
+        WorkflowRequest request = new WorkflowRequest();
+        request.setDatabase(database);
+        request.setSchema(schema);
+        request.setTable(table);
+        result.setRequest(request);
+        return result;
+    }
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationInstructionFactory.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationInstructionFactory.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.mcp.llm.conversation;
+
+import org.apache.shardingsphere.infra.util.json.JsonUtils;
+import org.apache.shardingsphere.test.e2e.mcp.llm.conversation.client.LLMChatMessage;
+import org.apache.shardingsphere.test.e2e.mcp.llm.scenario.LLME2EScenario;
+import org.apache.shardingsphere.test.e2e.mcp.llm.scenario.LLMStructuredAnswer;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionActionNames;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionTraceRecord;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+final class LLMMCPConversationInstructionFactory {
+    
+    String createExpectedQueryInstruction(final LLMStructuredAnswer expectedAnswer) {
+        return String.format(Locale.ENGLISH,
+                "Required MCP tool coverage is present, but the latest successful database_gateway_execute_query did not use database `%s`, schema `%s`, and query `%s`. "
+                        + "Call database_gateway_execute_query now with exactly those arguments before returning the final JSON.",
+                expectedAnswer.getDatabase(), expectedAnswer.getSchema(), expectedAnswer.getQuery());
+    }
+    
+    String createTraceDrivenInstruction(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
+        if (interactionTrace.isEmpty()) {
+            return "";
+        }
+        String resourceReadInstruction = createResourceReadInstruction(scenario, interactionTrace);
+        if (!resourceReadInstruction.isEmpty()) {
+            return resourceReadInstruction;
+        }
+        String immediateNextActionInstruction = createImmediateNextActionInstruction(interactionTrace.getLast());
+        if (!immediateNextActionInstruction.isEmpty()) {
+            return immediateNextActionInstruction;
+        }
+        return hasSideEffectExecutionNextAction(interactionTrace) ? createSideEffectExecutionNextActionInstruction(scenario.getExpectedAnswer()) : "";
+    }
+    
+    boolean hasPendingImmediateNextAction(final List<MCPInteractionTraceRecord> interactionTrace) {
+        return !interactionTrace.isEmpty() && !findImmediateNextActionName(interactionTrace.getLast()).isEmpty();
+    }
+    
+    String findImmediateNextActionName(final MCPInteractionTraceRecord traceRecord) {
+        for (Map<?, ?> each : LLMMCPNextActions.getNextActions(traceRecord.getStructuredContent())) {
+            String result = findMachineNextActionName(each);
+            if (!result.isEmpty()) {
+                return result;
+            }
+        }
+        return "";
+    }
+    
+    boolean hasSideEffectExecutionNextAction(final List<MCPInteractionTraceRecord> interactionTrace) {
+        return !interactionTrace.isEmpty() && LLMMCPNextActions.getNextActions(interactionTrace.getLast().getStructuredContent()).stream().anyMatch(LLMMCPSideEffectNextAction::isExecutionAction);
+    }
+    
+    List<LLMChatMessage> createFinalAnswerMessages(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
+        List<LLMChatMessage> result = new LinkedList<>();
+        result.add(LLMChatMessage.system("Return the final MCP assessment answer as valid JSON only."));
+        result.add(LLMChatMessage.user(createFinalAnswerInstruction(scenario, interactionTrace)));
+        return result;
+    }
+    
+    String createFinalAnswerInstruction(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
+        LLMStructuredAnswer expectedAnswer = scenario.getExpectedAnswer();
+        String interactionSequence = JsonUtils.toJsonString(createComparableInteractionSequence(interactionTrace));
+        String totalOrders = findLatestTotalOrders(interactionTrace);
+        String prompt = "Return JSON only with keys database, schema, table, query, totalOrders, interactionSequence. "
+                + "Use database `%s`, schema `%s`, table `%s`, and query `%s`; set totalOrders to `%s` from the latest successful database_gateway_execute_query result. "
+                + "Set interactionSequence exactly to this JSON array: %s. "
+                + "Do not add inferred, expected, available, or failed MCP action names. Required tools are `%s`.";
+        return String.format(Locale.ENGLISH,
+                prompt,
+                expectedAnswer.getDatabase(), expectedAnswer.getSchema(), expectedAnswer.getTable(), expectedAnswer.getQuery(), totalOrders, interactionSequence,
+                String.join(", ", scenario.getRequiredToolNames()));
+    }
+    
+    String createRequiredToolCallInstruction(final LLME2EScenario scenario, final LLMMCPConversationArtifacts artifacts) {
+        List<String> missingToolNames = LLMMCPInteractionCoverage.findMissingRequiredInteractionNames(scenario.getRequiredToolNames(), artifacts.getInteractionTrace());
+        LLMStructuredAnswer expectedAnswer = scenario.getExpectedAnswer();
+        String previewInstruction = missingToolNames.contains("database_gateway_execute_update")
+                ? String.format(Locale.ENGLISH,
+                        " For database_gateway_execute_update, set database `%s`, schema `%s`, execution_mode=preview, and keep the side-effecting SQL unchanged; do not use execution_mode=execute.",
+                        expectedAnswer.getDatabase(), expectedAnswer.getSchema())
+                : "";
+        String resourceInstruction = missingToolNames.contains(MCPInteractionActionNames.READ_RESOURCE)
+                ? " For mcp_read_resource, use an exact shardingsphere:// URI from the user request or the latest tool response; do not invent abbreviated URI strings."
+                : "";
+        String planningInstruction = hasMissingPlanningTool(missingToolNames)
+                ? " For a new database_gateway_plan_* call, omit plan_id unless a previous MCP planning response returned an actual plan_id."
+                : "";
+        String workflowPlanInstruction = createWorkflowPlanInstruction(missingToolNames, artifacts.getInteractionTrace());
+        return String.format(Locale.ENGLISH,
+                "Required MCP tool coverage is incomplete. Remaining required MCP tools: %s. "
+                        + "Call one remaining tool as an actual MCP tool_call now; do not answer in text, do not write JSON, and do not write <tool_call> markup. "
+                        + "If database_gateway_execute_query is remaining, set database `%s`, schema `%s`, and sql `%s`.%s%s%s%s",
+                String.join(", ", missingToolNames), expectedAnswer.getDatabase(), expectedAnswer.getSchema(), expectedAnswer.getQuery(), previewInstruction, resourceInstruction,
+                planningInstruction, workflowPlanInstruction);
+    }
+    
+    private String createImmediateNextActionInstruction(final MCPInteractionTraceRecord traceRecord) {
+        for (Map<?, ?> each : LLMMCPNextActions.getNextActions(traceRecord.getStructuredContent())) {
+            String result = createMachineNextActionInstruction(each);
+            if (!result.isEmpty()) {
+                return result;
+            }
+        }
+        return "";
+    }
+    
+    private String findMachineNextActionName(final Map<?, ?> action) {
+        if (LLMMCPSideEffectNextAction.isExecutionAction(action)) {
+            return "";
+        }
+        String actionType = Objects.toString(action.get("type"), "").trim();
+        if ("resource_read".equals(actionType) && !Objects.toString(action.get("resource_uri"), "").trim().isEmpty()) {
+            return MCPInteractionActionNames.READ_RESOURCE;
+        }
+        if ("tool_call".equals(actionType)) {
+            return Objects.toString(action.get("tool_name"), "").trim();
+        }
+        return "completion".equals(actionType) ? MCPInteractionActionNames.COMPLETE : "";
+    }
+    
+    private String createMachineNextActionInstruction(final Map<?, ?> action) {
+        if (LLMMCPSideEffectNextAction.isExecutionAction(action)) {
+            return "";
+        }
+        String actionType = Objects.toString(action.get("type"), "").trim();
+        if ("resource_read".equals(actionType)) {
+            String resourceUri = Objects.toString(action.get("resource_uri"), "").trim();
+            return resourceUri.isEmpty()
+                    ? ""
+                    : String.format(Locale.ENGLISH,
+                            "The latest MCP response gave a read-only next_action. Call mcp_read_resource with uri `%s` now before any other MCP action or final answer.", resourceUri);
+        }
+        if ("tool_call".equals(actionType)) {
+            String toolName = Objects.toString(action.get("tool_name"), "").trim();
+            return toolName.isEmpty()
+                    ? ""
+                    : String.format(Locale.ENGLISH, "The latest MCP response gave an immediate next_action. Call `%s` now with exactly these arguments: %s. Do not replace values with placeholders.",
+                            toolName, JsonUtils.toJsonString(action.containsKey("arguments") ? action.get("arguments") : Map.of()));
+        }
+        if ("completion".equals(actionType)) {
+            Object arguments = action.containsKey("arguments") ? action.get("arguments") : createCompletionArguments(action);
+            return String.format(Locale.ENGLISH, "The latest MCP response gave an immediate completion next_action. Call mcp_complete now with exactly these arguments: %s.",
+                    JsonUtils.toJsonString(arguments));
+        }
+        return "";
+    }
+    
+    private Map<String, Object> createCompletionArguments(final Map<?, ?> action) {
+        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
+        result.put("ref", action.get("ref"));
+        result.put("argument", action.get("argument"));
+        if (action.containsKey("context")) {
+            result.put("context", action.get("context"));
+        }
+        return result;
+    }
+    
+    private String createResourceReadInstruction(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
+        if (!scenario.getRequiredToolNames().contains(MCPInteractionActionNames.READ_RESOURCE)
+                || !shouldPromptExactResourceRead(interactionTrace.getLast())) {
+            return "";
+        }
+        String resourceUri = LLMMCPScenarioInference.findExpectedResourceUri(scenario);
+        return resourceUri.isEmpty() || hasReadResource(resourceUri, interactionTrace)
+                ? ""
+                : String.format(Locale.ENGLISH,
+                        "The remaining required resource action is mcp_read_resource. Use exactly `%s` as uri; do not copy parameter schema or placeholder text as uri.", resourceUri);
+    }
+    
+    private boolean shouldPromptExactResourceRead(final MCPInteractionTraceRecord traceRecord) {
+        return MCPInteractionActionNames.LIST_RESOURCES.equals(traceRecord.getTargetName())
+                || MCPInteractionActionNames.READ_RESOURCE.equals(traceRecord.getTargetName())
+                        && (traceRecord.getStructuredContent().containsKey("error_code") || Boolean.FALSE.equals(traceRecord.getStructuredContent().get("found")));
+    }
+    
+    private boolean hasReadResource(final String resourceUri, final List<MCPInteractionTraceRecord> interactionTrace) {
+        for (MCPInteractionTraceRecord each : interactionTrace) {
+            if (MCPInteractionActionNames.RESOURCE_READ_KIND.equals(each.getActionKind()) && resourceUri.equals(each.getArguments().get("uri"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private String findLatestTotalOrders(final List<MCPInteractionTraceRecord> interactionTrace) {
+        for (int index = interactionTrace.size() - 1; index >= 0; index--) {
+            MCPInteractionTraceRecord each = interactionTrace.get(index);
+            if ("database_gateway_execute_query".equals(each.getTargetName()) && each.isValid()) {
+                String result = findTotalOrdersInRowObjects(each.getStructuredContent());
+                return result.isEmpty() ? findTotalOrdersInRows(each.getStructuredContent()) : result;
+            }
+        }
+        return "";
+    }
+    
+    private String findTotalOrdersInRowObjects(final Map<String, Object> structuredContent) {
+        List<Map<String, Object>> rowObjects = LLMMCPJsonValues.castToList(structuredContent.get("row_objects"));
+        if (rowObjects.isEmpty()) {
+            return "";
+        }
+        return Objects.toString(rowObjects.getFirst().get("total_orders"), "").trim();
+    }
+    
+    private String findTotalOrdersInRows(final Map<String, Object> structuredContent) {
+        List<Object> rows = LLMMCPJsonValues.castToList(structuredContent.get("rows"));
+        if (rows.isEmpty()) {
+            return "";
+        }
+        List<Object> row = LLMMCPJsonValues.castToList(rows.getFirst());
+        return row.isEmpty() ? "" : Objects.toString(row.getFirst(), "").trim();
+    }
+    
+    private List<String> createComparableInteractionSequence(final List<MCPInteractionTraceRecord> interactionTrace) {
+        List<String> result = new LinkedList<>();
+        for (MCPInteractionTraceRecord each : interactionTrace) {
+            if (result.isEmpty() || !result.getLast().equals(each.getTargetName())) {
+                result.add(each.getTargetName());
+            }
+        }
+        return result;
+    }
+    
+    private boolean hasMissingPlanningTool(final List<String> missingToolNames) {
+        return missingToolNames.stream().anyMatch(each -> each.startsWith(LLMMCPScenarioInference.PLANNING_TOOL_NAME_PREFIX));
+    }
+    
+    private String createSideEffectExecutionNextActionInstruction(final LLMStructuredAnswer expectedAnswer) {
+        return String.format(Locale.ENGLISH,
+                "The latest MCP response contains side-effect execution next_actions; do not execute them in this score lane. "
+                        + "Call database_gateway_execute_query now with database `%s`, schema `%s`, and sql `%s`. "
+                        + "Do not call database_gateway_execute_update for SELECT or row-count verification.",
+                expectedAnswer.getDatabase(), expectedAnswer.getSchema(), expectedAnswer.getQuery());
+    }
+    
+    private String createWorkflowPlanInstruction(final List<String> missingToolNames, final List<MCPInteractionTraceRecord> interactionTrace) {
+        if (!missingToolNames.contains("database_gateway_apply_workflow") && !missingToolNames.contains("database_gateway_validate_workflow")) {
+            return "";
+        }
+        String latestPlanId = LLMMCPScenarioInference.findLatestPlanId(interactionTrace);
+        return latestPlanId.isEmpty()
+                ? " For database_gateway_apply_workflow or database_gateway_validate_workflow, use an actual plan_id returned by a successful planning tool call; "
+                        + "do not use placeholder text `plan_id`."
+                : String.format(Locale.ENGLISH,
+                        " For database_gateway_apply_workflow or database_gateway_validate_workflow, set plan_id `%s`; do not use placeholder text `plan_id`.", latestPlanId);
+    }
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationInstructionFactoryTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationInstructionFactoryTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.mcp.llm.conversation;
+
+import org.apache.shardingsphere.test.e2e.mcp.llm.scenario.LLME2EScenario;
+import org.apache.shardingsphere.test.e2e.mcp.llm.scenario.LLMStructuredAnswer;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionTraceRecord;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class LLMMCPConversationInstructionFactoryTest {
+    
+    @Test
+    void assertCreateExpectedQueryInstruction() {
+        LLMStructuredAnswer expectedAnswer = new LLMStructuredAnswer("logic_db", "public", "orders", "SELECT COUNT(*) FROM orders", 42, List.of());
+        String actual = new LLMMCPConversationInstructionFactory().createExpectedQueryInstruction(expectedAnswer);
+        assertThat(actual, is(
+                "Required MCP tool coverage is present, but the latest successful database_gateway_execute_query did not use database `logic_db`, "
+                        + "schema `public`, and query `SELECT COUNT(*) FROM orders`. "
+                        + "Call database_gateway_execute_query now with exactly those arguments before returning the final JSON."));
+    }
+    
+    @Test
+    void assertCreateTraceDrivenInstructionWithImmediateToolAction() {
+        Map<String, Object> arguments = new LinkedHashMap<>(2, 1F);
+        arguments.put("plan_id", "plan-1");
+        arguments.put("execution_mode", "preview");
+        Map<String, Object> nextAction = Map.of("type", "tool_call", "tool_name", "database_gateway_apply_workflow", "arguments", arguments);
+        String actual = new LLMMCPConversationInstructionFactory().createTraceDrivenInstruction(createScenario(), List.of(createTraceRecord("database_gateway_plan_mask_rule",
+                Map.of("next_actions", List.of(nextAction)))));
+        assertThat(actual, is("The latest MCP response gave an immediate next_action. Call `database_gateway_apply_workflow` now with exactly these arguments: "
+                + "{\"plan_id\":\"plan-1\",\"execution_mode\":\"preview\"}. Do not replace values with placeholders."));
+    }
+    
+    @Test
+    void assertCreateFinalAnswerInstruction() {
+        Map<String, Object> structuredContent = Map.of("row_objects", List.of(Map.of("total_orders", 42)));
+        String actual = new LLMMCPConversationInstructionFactory().createFinalAnswerInstruction(createScenario(),
+                List.of(createTraceRecord("database_gateway_execute_query", structuredContent)));
+        assertThat(actual, is("Return JSON only with keys database, schema, table, query, totalOrders, interactionSequence. "
+                + "Use database `logic_db`, schema `public`, table `orders`, and query `SELECT COUNT(*) FROM orders`; set totalOrders to `42` "
+                + "from the latest successful database_gateway_execute_query result. "
+                + "Set interactionSequence exactly to this JSON array: [\"database_gateway_execute_query\"]. "
+                + "Do not add inferred, expected, available, or failed MCP action names. Required tools are `database_gateway_execute_query`."));
+    }
+    
+    private MCPInteractionTraceRecord createTraceRecord(final String targetName, final Map<String, Object> structuredContent) {
+        return new MCPInteractionTraceRecord(1, "tool_call", MCPInteractionTraceRecord.MODEL_TOOL_CALL_ORIGIN, targetName, Map.of(), structuredContent, true, 0L);
+    }
+    
+    private LLME2EScenario createScenario() {
+        LLMStructuredAnswer expectedAnswer = new LLMStructuredAnswer("logic_db", "public", "orders", "SELECT COUNT(*) FROM orders", 42, List.of());
+        return new LLME2EScenario("scenario", "system", "user", expectedAnswer, List.of("database_gateway_execute_query"), List.of("database_gateway_execute_query"));
+    }
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunner.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunner.java
@@ -38,7 +38,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * LLM MCP conversation runner.
@@ -89,12 +88,14 @@ public final class LLMMCPConversationRunner {
         try {
             llmChatClient.waitUntilReady();
             openInteractionClient();
+            LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
+            LLMMCPConversationTurnPlanner turnPlanner = new LLMMCPConversationTurnPlanner(instructionFactory);
             boolean finalAnswerRequested = false;
             for (int turnIndex = 0; turnIndex < maxTurns; turnIndex++) {
-                finalAnswerRequested = requestFinalAnswerIfReady(scenario, messages, artifacts, finalAnswerRequested);
-                List<String> turnToolNames = finalAnswerRequested ? List.of() : createTurnToolNames(scenario, artifacts.getInteractionTrace());
-                LLMChatCompletion completion = completeTurn(scenario, messages, artifacts, finalAnswerRequested, turnToolNames);
-                Optional<LLME2EArtifactBundle> toolCallFailure = processToolCallCompletion(scenario, completion, messages, artifacts);
+                finalAnswerRequested = requestFinalAnswerIfReady(scenario, messages, artifacts, finalAnswerRequested, instructionFactory);
+                List<String> turnToolNames = finalAnswerRequested ? List.of() : turnPlanner.createTurnToolNames(scenario, artifacts.getInteractionTrace());
+                LLMChatCompletion completion = completeTurn(scenario, messages, artifacts, finalAnswerRequested, turnToolNames, instructionFactory, turnPlanner);
+                Optional<LLME2EArtifactBundle> toolCallFailure = processToolCallCompletion(scenario, completion, messages, artifacts, instructionFactory, turnPlanner);
                 if (toolCallFailure.isPresent()) {
                     return toolCallFailure.get();
                 }
@@ -103,7 +104,7 @@ public final class LLMMCPConversationRunner {
                 }
                 if (!finalAnswerRequested) {
                     if (!LLMMCPInteractionCoverage.hasRequiredInteractionCoverage(scenario.getRequiredToolNames(), artifacts.getInteractionTrace())) {
-                        messages.add(LLMChatMessage.user(createRequiredToolCallInstruction(scenario, artifacts)));
+                        messages.add(LLMChatMessage.user(instructionFactory.createRequiredToolCallInstruction(scenario, artifacts)));
                     }
                     continue;
                 }
@@ -134,18 +135,18 @@ public final class LLMMCPConversationRunner {
     }
     
     private boolean requestFinalAnswerIfReady(final LLME2EScenario scenario, final List<LLMChatMessage> messages, final LLMMCPConversationArtifacts artifacts,
-                                              final boolean finalAnswerRequested) {
+                                              final boolean finalAnswerRequested, final LLMMCPConversationInstructionFactory instructionFactory) {
         if (finalAnswerRequested || !LLMMCPInteractionCoverage.hasRequiredInteractionCoverage(scenario.getRequiredToolNames(), artifacts.getInteractionTrace())) {
             return finalAnswerRequested;
         }
-        if (hasPendingImmediateNextAction(artifacts.getInteractionTrace())) {
+        if (instructionFactory.hasPendingImmediateNextAction(artifacts.getInteractionTrace())) {
             return false;
         }
         if (scenario.getRequiredToolNames().contains("database_gateway_execute_query") && !hasExpectedExecuteQuery(scenario.getExpectedAnswer(), artifacts.getInteractionTrace())) {
-            messages.add(LLMChatMessage.user(createExpectedQueryInstruction(scenario.getExpectedAnswer())));
+            messages.add(LLMChatMessage.user(instructionFactory.createExpectedQueryInstruction(scenario.getExpectedAnswer())));
             return false;
         }
-        messages.add(LLMChatMessage.user(createFinalAnswerInstruction(scenario, artifacts.getInteractionTrace())));
+        messages.add(LLMChatMessage.user(instructionFactory.createFinalAnswerInstruction(scenario, artifacts.getInteractionTrace())));
         return true;
     }
     
@@ -169,80 +170,29 @@ public final class LLMMCPConversationRunner {
         return expectedAnswer.getSchema().equals(schema) || schema.isEmpty();
     }
     
-    private String createExpectedQueryInstruction(final LLMStructuredAnswer expectedAnswer) {
-        return String.format(Locale.ENGLISH,
-                "Required MCP tool coverage is present, but the latest successful database_gateway_execute_query did not use database `%s`, schema `%s`, and query `%s`. "
-                        + "Call database_gateway_execute_query now with exactly those arguments before returning the final JSON.",
-                expectedAnswer.getDatabase(), expectedAnswer.getSchema(), expectedAnswer.getQuery());
-    }
-    
     private LLMChatCompletion completeTurn(final LLME2EScenario scenario, final List<LLMChatMessage> messages, final LLMMCPConversationArtifacts artifacts,
-                                           final boolean finalAnswerRequested, final List<String> turnToolNames) throws IOException, InterruptedException {
-        String toolChoice = createToolChoice(scenario, artifacts, finalAnswerRequested);
-        LLMChatCompletion result = llmChatClient.complete(finalAnswerRequested ? createFinalAnswerMessages(scenario, artifacts.getInteractionTrace()) : messages,
+                                           final boolean finalAnswerRequested, final List<String> turnToolNames, final LLMMCPConversationInstructionFactory instructionFactory,
+                                           final LLMMCPConversationTurnPlanner turnPlanner) throws IOException, InterruptedException {
+        String toolChoice = turnPlanner.createToolChoice(scenario, artifacts.getInteractionTrace(), finalAnswerRequested);
+        LLMChatCompletion result = llmChatClient.complete(finalAnswerRequested ? instructionFactory.createFinalAnswerMessages(scenario, artifacts.getInteractionTrace()) : messages,
                 finalAnswerRequested ? List.of() : toolDefinitionFactory.create(turnToolNames),
                 toolChoice, finalAnswerRequested);
         artifacts.addRawModelOutput(result.getRawResponse());
         return result;
     }
     
-    private List<String> createTurnToolNames(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
-        if (!interactionTrace.isEmpty()) {
-            String immediateActionName = findImmediateNextActionName(interactionTrace.getLast());
-            if (!immediateActionName.isEmpty() && scenario.getAllowedToolNames().contains(immediateActionName)) {
-                return List.of(immediateActionName);
-            }
-        }
-        if (hasSideEffectExecutionNextAction(interactionTrace)) {
-            List<String> readOnlyToolNames = findMissingReadOnlyToolNames(scenario, interactionTrace);
-            if (!readOnlyToolNames.isEmpty()) {
-                return List.of(readOnlyToolNames.getFirst());
-            }
-        }
-        List<String> missingToolNames = findMissingAllowedToolNames(scenario, interactionTrace);
-        return missingToolNames.isEmpty() ? scenario.getAllowedToolNames() : List.of(missingToolNames.getFirst());
-    }
-    
-    private List<String> findMissingAllowedToolNames(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
-        return LLMMCPInteractionCoverage.findMissingRequiredInteractionNames(
-                scenario.getRequiredToolNames(), interactionTrace).stream().filter(each -> scenario.getAllowedToolNames().contains(each)).collect(Collectors.toList());
-    }
-    
-    private List<String> findMissingReadOnlyToolNames(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
-        List<String> result = new LinkedList<>();
-        for (String each : LLMMCPInteractionCoverage.findMissingRequiredInteractionNames(scenario.getRequiredToolNames(), interactionTrace)) {
-            if (scenario.getAllowedToolNames().contains(each) && isReadOnlyToolName(each)) {
-                result.add(each);
-            }
-        }
-        return result;
-    }
-    
-    private boolean isReadOnlyToolName(final String toolName) {
-        return MCPInteractionActionNames.LIST_RESOURCES.equals(toolName)
-                || MCPInteractionActionNames.READ_RESOURCE.equals(toolName)
-                || MCPInteractionActionNames.LIST_PROMPTS.equals(toolName)
-                || MCPInteractionActionNames.GET_PROMPT.equals(toolName)
-                || MCPInteractionActionNames.COMPLETE.equals(toolName)
-                || "database_gateway_search_metadata".equals(toolName)
-                || "database_gateway_execute_query".equals(toolName);
-    }
-    
-    private String createToolChoice(final LLME2EScenario scenario, final LLMMCPConversationArtifacts artifacts, final boolean finalAnswerRequested) {
-        if (finalAnswerRequested) {
-            return "none";
-        }
-        return LLMMCPInteractionCoverage.hasRequiredInteractionCoverage(scenario.getRequiredToolNames(), artifacts.getInteractionTrace()) ? "auto" : "required";
-    }
-    
     private Optional<LLME2EArtifactBundle> processToolCallCompletion(final LLME2EScenario scenario, final LLMChatCompletion completion,
-                                                                     final List<LLMChatMessage> messages, final LLMMCPConversationArtifacts artifacts) throws InterruptedException {
+                                                                     final List<LLMChatMessage> messages, final LLMMCPConversationArtifacts artifacts,
+                                                                     final LLMMCPConversationInstructionFactory instructionFactory,
+                                                                     final LLMMCPConversationTurnPlanner turnPlanner) throws InterruptedException {
         if (completion.getToolCalls().isEmpty()) {
             return Optional.empty();
         }
         messages.add(LLMChatMessage.assistant(completion.getContent(), completion.getToolCalls()));
         for (LLMToolCall each : completion.getToolCalls()) {
-            List<String> availableToolNames = hasSideEffectExecutionNextAction(artifacts.getInteractionTrace()) ? createTurnToolNames(scenario, artifacts.getInteractionTrace()) : List.of();
+            List<String> availableToolNames = instructionFactory.hasSideEffectExecutionNextAction(artifacts.getInteractionTrace())
+                    ? turnPlanner.createTurnToolNames(scenario, artifacts.getInteractionTrace())
+                    : List.of();
             if (!availableToolNames.isEmpty() && !availableToolNames.contains(each.getName())) {
                 Map<String, Object> toolResponse = new LinkedHashMap<>(4, 1F);
                 toolResponse.put("response_mode", "tool_call_rejected");
@@ -268,7 +218,10 @@ public final class LLMMCPConversationRunner {
                 return result;
             }
         }
-        addTraceDrivenInstruction(scenario, messages, artifacts.getInteractionTrace());
+        String traceDrivenInstruction = instructionFactory.createTraceDrivenInstruction(scenario, artifacts.getInteractionTrace());
+        if (!traceDrivenInstruction.isEmpty()) {
+            messages.add(LLMChatMessage.user(traceDrivenInstruction));
+        }
         return Optional.empty();
     }
     
@@ -313,127 +266,6 @@ public final class LLMMCPConversationRunner {
         return Optional.empty();
     }
     
-    private void addTraceDrivenInstruction(final LLME2EScenario scenario, final List<LLMChatMessage> messages, final List<MCPInteractionTraceRecord> interactionTrace) {
-        if (interactionTrace.isEmpty()) {
-            return;
-        }
-        String resourceReadInstruction = createResourceReadInstruction(scenario, interactionTrace);
-        if (!resourceReadInstruction.isEmpty()) {
-            messages.add(LLMChatMessage.user(resourceReadInstruction));
-            return;
-        }
-        String immediateNextActionInstruction = createImmediateNextActionInstruction(interactionTrace.getLast());
-        if (!immediateNextActionInstruction.isEmpty()) {
-            messages.add(LLMChatMessage.user(immediateNextActionInstruction));
-            return;
-        }
-        if (hasSideEffectExecutionNextAction(interactionTrace)) {
-            messages.add(LLMChatMessage.user(createSideEffectExecutionNextActionInstruction(scenario.getExpectedAnswer())));
-        }
-    }
-    
-    private String createImmediateNextActionInstruction(final MCPInteractionTraceRecord traceRecord) {
-        for (Map<?, ?> each : LLMMCPNextActions.getNextActions(traceRecord.getStructuredContent())) {
-            String result = createMachineNextActionInstruction(each);
-            if (!result.isEmpty()) {
-                return result;
-            }
-        }
-        return "";
-    }
-    
-    private String findImmediateNextActionName(final MCPInteractionTraceRecord traceRecord) {
-        for (Map<?, ?> each : LLMMCPNextActions.getNextActions(traceRecord.getStructuredContent())) {
-            String result = findMachineNextActionName(each);
-            if (!result.isEmpty()) {
-                return result;
-            }
-        }
-        return "";
-    }
-    
-    private String findMachineNextActionName(final Map<?, ?> action) {
-        if (LLMMCPSideEffectNextAction.isExecutionAction(action)) {
-            return "";
-        }
-        String actionType = Objects.toString(action.get("type"), "").trim();
-        if ("resource_read".equals(actionType) && !Objects.toString(action.get("resource_uri"), "").trim().isEmpty()) {
-            return MCPInteractionActionNames.READ_RESOURCE;
-        }
-        if ("tool_call".equals(actionType)) {
-            return Objects.toString(action.get("tool_name"), "").trim();
-        }
-        return "completion".equals(actionType) ? MCPInteractionActionNames.COMPLETE : "";
-    }
-    
-    private String createMachineNextActionInstruction(final Map<?, ?> action) {
-        if (LLMMCPSideEffectNextAction.isExecutionAction(action)) {
-            return "";
-        }
-        String actionType = Objects.toString(action.get("type"), "").trim();
-        if ("resource_read".equals(actionType)) {
-            String resourceUri = Objects.toString(action.get("resource_uri"), "").trim();
-            return resourceUri.isEmpty()
-                    ? ""
-                    : String.format(Locale.ENGLISH,
-                            "The latest MCP response gave a read-only next_action. Call mcp_read_resource with uri `%s` now before any other MCP action or final answer.", resourceUri);
-        }
-        if ("tool_call".equals(actionType)) {
-            String toolName = Objects.toString(action.get("tool_name"), "").trim();
-            return toolName.isEmpty()
-                    ? ""
-                    : String.format(Locale.ENGLISH, "The latest MCP response gave an immediate next_action. Call `%s` now with exactly these arguments: %s. Do not replace values with placeholders.",
-                            toolName, JsonUtils.toJsonString(action.containsKey("arguments") ? action.get("arguments") : Map.of()));
-        }
-        if ("completion".equals(actionType)) {
-            Object arguments = action.containsKey("arguments") ? action.get("arguments") : createCompletionArguments(action);
-            return String.format(Locale.ENGLISH, "The latest MCP response gave an immediate completion next_action. Call mcp_complete now with exactly these arguments: %s.",
-                    JsonUtils.toJsonString(arguments));
-        }
-        return "";
-    }
-    
-    private Map<String, Object> createCompletionArguments(final Map<?, ?> action) {
-        Map<String, Object> result = new LinkedHashMap<>(3, 1F);
-        result.put("ref", action.get("ref"));
-        result.put("argument", action.get("argument"));
-        if (action.containsKey("context")) {
-            result.put("context", action.get("context"));
-        }
-        return result;
-    }
-    
-    private String createResourceReadInstruction(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
-        if (!scenario.getRequiredToolNames().contains(MCPInteractionActionNames.READ_RESOURCE)
-                || !shouldPromptExactResourceRead(interactionTrace.getLast())) {
-            return "";
-        }
-        String resourceUri = LLMMCPScenarioInference.findExpectedResourceUri(scenario);
-        return resourceUri.isEmpty() || hasReadResource(resourceUri, interactionTrace)
-                ? ""
-                : String.format(Locale.ENGLISH,
-                        "The remaining required resource action is mcp_read_resource. Use exactly `%s` as uri; do not copy parameter schema or placeholder text as uri.", resourceUri);
-    }
-    
-    private boolean shouldPromptExactResourceRead(final MCPInteractionTraceRecord traceRecord) {
-        return MCPInteractionActionNames.LIST_RESOURCES.equals(traceRecord.getTargetName())
-                || MCPInteractionActionNames.READ_RESOURCE.equals(traceRecord.getTargetName())
-                        && (traceRecord.getStructuredContent().containsKey("error_code") || Boolean.FALSE.equals(traceRecord.getStructuredContent().get("found")));
-    }
-    
-    private boolean hasReadResource(final String resourceUri, final List<MCPInteractionTraceRecord> interactionTrace) {
-        for (MCPInteractionTraceRecord each : interactionTrace) {
-            if (MCPInteractionActionNames.RESOURCE_READ_KIND.equals(each.getActionKind()) && resourceUri.equals(each.getArguments().get("uri"))) {
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    private boolean hasPendingImmediateNextAction(final List<MCPInteractionTraceRecord> interactionTrace) {
-        return !interactionTrace.isEmpty() && !createImmediateNextActionInstruction(interactionTrace.getLast()).isEmpty();
-    }
-    
     private Optional<LLME2EArtifactBundle> validateToolCall(final LLME2EScenario scenario, final String toolName, final Map<String, Object> arguments,
                                                             final LLMMCPConversationArtifacts artifacts) {
         return safetyValidator.validate(toolName, arguments)
@@ -473,116 +305,6 @@ public final class LLMMCPConversationRunner {
             Thread.currentThread().interrupt();
         } catch (final IOException ignored) {
         }
-    }
-    
-    private List<LLMChatMessage> createFinalAnswerMessages(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
-        List<LLMChatMessage> result = new LinkedList<>();
-        result.add(LLMChatMessage.system("Return the final MCP assessment answer as valid JSON only."));
-        result.add(LLMChatMessage.user(createFinalAnswerInstruction(scenario, interactionTrace)));
-        return result;
-    }
-    
-    private String createFinalAnswerInstruction(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
-        LLMStructuredAnswer expectedAnswer = scenario.getExpectedAnswer();
-        String interactionSequence = JsonUtils.toJsonString(createComparableInteractionSequence(interactionTrace));
-        String totalOrders = findLatestTotalOrders(interactionTrace);
-        String prompt = "Return JSON only with keys database, schema, table, query, totalOrders, interactionSequence. "
-                + "Use database `%s`, schema `%s`, table `%s`, and query `%s`; set totalOrders to `%s` from the latest successful database_gateway_execute_query result. "
-                + "Set interactionSequence exactly to this JSON array: %s. "
-                + "Do not add inferred, expected, available, or failed MCP action names. Required tools are `%s`.";
-        return String.format(Locale.ENGLISH,
-                prompt,
-                expectedAnswer.getDatabase(), expectedAnswer.getSchema(), expectedAnswer.getTable(), expectedAnswer.getQuery(), totalOrders, interactionSequence,
-                String.join(", ", scenario.getRequiredToolNames()));
-    }
-    
-    private String findLatestTotalOrders(final List<MCPInteractionTraceRecord> interactionTrace) {
-        for (int index = interactionTrace.size() - 1; index >= 0; index--) {
-            MCPInteractionTraceRecord each = interactionTrace.get(index);
-            if ("database_gateway_execute_query".equals(each.getTargetName()) && each.isValid()) {
-                String result = findTotalOrdersInRowObjects(each.getStructuredContent());
-                return result.isEmpty() ? findTotalOrdersInRows(each.getStructuredContent()) : result;
-            }
-        }
-        return "";
-    }
-    
-    private String findTotalOrdersInRowObjects(final Map<String, Object> structuredContent) {
-        List<Map<String, Object>> rowObjects = LLMMCPJsonValues.castToList(structuredContent.get("row_objects"));
-        if (rowObjects.isEmpty()) {
-            return "";
-        }
-        return Objects.toString(rowObjects.getFirst().get("total_orders"), "").trim();
-    }
-    
-    private String findTotalOrdersInRows(final Map<String, Object> structuredContent) {
-        List<Object> rows = LLMMCPJsonValues.castToList(structuredContent.get("rows"));
-        if (rows.isEmpty()) {
-            return "";
-        }
-        List<Object> row = LLMMCPJsonValues.castToList(rows.getFirst());
-        return row.isEmpty() ? "" : Objects.toString(row.getFirst(), "").trim();
-    }
-    
-    private List<String> createComparableInteractionSequence(final List<MCPInteractionTraceRecord> interactionTrace) {
-        List<String> result = new LinkedList<>();
-        for (MCPInteractionTraceRecord each : interactionTrace) {
-            if (result.isEmpty() || !result.getLast().equals(each.getTargetName())) {
-                result.add(each.getTargetName());
-            }
-        }
-        return result;
-    }
-    
-    private String createRequiredToolCallInstruction(final LLME2EScenario scenario, final LLMMCPConversationArtifacts artifacts) {
-        List<String> missingToolNames = LLMMCPInteractionCoverage.findMissingRequiredInteractionNames(scenario.getRequiredToolNames(), artifacts.getInteractionTrace());
-        LLMStructuredAnswer expectedAnswer = scenario.getExpectedAnswer();
-        String previewInstruction = missingToolNames.contains("database_gateway_execute_update")
-                ? String.format(Locale.ENGLISH,
-                        " For database_gateway_execute_update, set database `%s`, schema `%s`, execution_mode=preview, and keep the side-effecting SQL unchanged; do not use execution_mode=execute.",
-                        expectedAnswer.getDatabase(), expectedAnswer.getSchema())
-                : "";
-        String resourceInstruction = missingToolNames.contains(MCPInteractionActionNames.READ_RESOURCE)
-                ? " For mcp_read_resource, use an exact shardingsphere:// URI from the user request or the latest tool response; do not invent abbreviated URI strings."
-                : "";
-        String planningInstruction = hasMissingPlanningTool(missingToolNames)
-                ? " For a new database_gateway_plan_* call, omit plan_id unless a previous MCP planning response returned an actual plan_id."
-                : "";
-        String workflowPlanInstruction = createWorkflowPlanInstruction(missingToolNames, artifacts.getInteractionTrace());
-        return String.format(Locale.ENGLISH,
-                "Required MCP tool coverage is incomplete. Remaining required MCP tools: %s. "
-                        + "Call one remaining tool as an actual MCP tool_call now; do not answer in text, do not write JSON, and do not write <tool_call> markup. "
-                        + "If database_gateway_execute_query is remaining, set database `%s`, schema `%s`, and sql `%s`.%s%s%s%s",
-                String.join(", ", missingToolNames), expectedAnswer.getDatabase(), expectedAnswer.getSchema(), expectedAnswer.getQuery(), previewInstruction, resourceInstruction,
-                planningInstruction, workflowPlanInstruction);
-    }
-    
-    private boolean hasMissingPlanningTool(final List<String> missingToolNames) {
-        return missingToolNames.stream().anyMatch(each -> each.startsWith(LLMMCPScenarioInference.PLANNING_TOOL_NAME_PREFIX));
-    }
-    
-    private String createSideEffectExecutionNextActionInstruction(final LLMStructuredAnswer expectedAnswer) {
-        return String.format(Locale.ENGLISH,
-                "The latest MCP response contains side-effect execution next_actions; do not execute them in this score lane. "
-                        + "Call database_gateway_execute_query now with database `%s`, schema `%s`, and sql `%s`. "
-                        + "Do not call database_gateway_execute_update for SELECT or row-count verification.",
-                expectedAnswer.getDatabase(), expectedAnswer.getSchema(), expectedAnswer.getQuery());
-    }
-    
-    private boolean hasSideEffectExecutionNextAction(final List<MCPInteractionTraceRecord> interactionTrace) {
-        return !interactionTrace.isEmpty() && LLMMCPNextActions.getNextActions(interactionTrace.getLast().getStructuredContent()).stream().anyMatch(LLMMCPSideEffectNextAction::isExecutionAction);
-    }
-    
-    private String createWorkflowPlanInstruction(final List<String> missingToolNames, final List<MCPInteractionTraceRecord> interactionTrace) {
-        if (!missingToolNames.contains("database_gateway_apply_workflow") && !missingToolNames.contains("database_gateway_validate_workflow")) {
-            return "";
-        }
-        String latestPlanId = LLMMCPScenarioInference.findLatestPlanId(interactionTrace);
-        return latestPlanId.isEmpty()
-                ? " For database_gateway_apply_workflow or database_gateway_validate_workflow, use an actual plan_id returned by a successful planning tool call; "
-                        + "do not use placeholder text `plan_id`."
-                : String.format(Locale.ENGLISH,
-                        " For database_gateway_apply_workflow or database_gateway_validate_workflow, set plan_id `%s`; do not use placeholder text `plan_id`.", latestPlanId);
     }
     
     private MCPInteractionTraceRecord createTraceRecord(final int sequence, final String actionName, final String actionOrigin, final Map<String, Object> arguments,

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationTurnPlanner.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationTurnPlanner.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.mcp.llm.conversation;
+
+import org.apache.shardingsphere.test.e2e.mcp.llm.scenario.LLME2EScenario;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionActionNames;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionTraceRecord;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+final class LLMMCPConversationTurnPlanner {
+    
+    private final LLMMCPConversationInstructionFactory instructionFactory;
+    
+    LLMMCPConversationTurnPlanner(final LLMMCPConversationInstructionFactory instructionFactory) {
+        this.instructionFactory = instructionFactory;
+    }
+    
+    List<String> createTurnToolNames(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
+        if (!interactionTrace.isEmpty()) {
+            String immediateActionName = instructionFactory.findImmediateNextActionName(interactionTrace.getLast());
+            if (!immediateActionName.isEmpty() && scenario.getAllowedToolNames().contains(immediateActionName)) {
+                return List.of(immediateActionName);
+            }
+        }
+        if (instructionFactory.hasSideEffectExecutionNextAction(interactionTrace)) {
+            List<String> readOnlyToolNames = findMissingReadOnlyToolNames(scenario, interactionTrace);
+            if (!readOnlyToolNames.isEmpty()) {
+                return List.of(readOnlyToolNames.getFirst());
+            }
+        }
+        List<String> missingToolNames = findMissingAllowedToolNames(scenario, interactionTrace);
+        return missingToolNames.isEmpty() ? scenario.getAllowedToolNames() : List.of(missingToolNames.getFirst());
+    }
+    
+    String createToolChoice(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace, final boolean finalAnswerRequested) {
+        if (finalAnswerRequested) {
+            return "none";
+        }
+        return LLMMCPInteractionCoverage.hasRequiredInteractionCoverage(scenario.getRequiredToolNames(), interactionTrace) ? "auto" : "required";
+    }
+    
+    private List<String> findMissingAllowedToolNames(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
+        return LLMMCPInteractionCoverage.findMissingRequiredInteractionNames(
+                scenario.getRequiredToolNames(), interactionTrace).stream().filter(each -> scenario.getAllowedToolNames().contains(each)).collect(Collectors.toList());
+    }
+    
+    private List<String> findMissingReadOnlyToolNames(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
+        List<String> result = new LinkedList<>();
+        for (String each : LLMMCPInteractionCoverage.findMissingRequiredInteractionNames(scenario.getRequiredToolNames(), interactionTrace)) {
+            if (scenario.getAllowedToolNames().contains(each) && isReadOnlyToolName(each)) {
+                result.add(each);
+            }
+        }
+        return result;
+    }
+    
+    private boolean isReadOnlyToolName(final String toolName) {
+        return MCPInteractionActionNames.LIST_RESOURCES.equals(toolName)
+                || MCPInteractionActionNames.READ_RESOURCE.equals(toolName)
+                || MCPInteractionActionNames.LIST_PROMPTS.equals(toolName)
+                || MCPInteractionActionNames.GET_PROMPT.equals(toolName)
+                || MCPInteractionActionNames.COMPLETE.equals(toolName)
+                || "database_gateway_search_metadata".equals(toolName)
+                || "database_gateway_execute_query".equals(toolName);
+    }
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationTurnPlannerTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationTurnPlannerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.mcp.llm.conversation;
+
+import org.apache.shardingsphere.test.e2e.mcp.llm.scenario.LLME2EScenario;
+import org.apache.shardingsphere.test.e2e.mcp.llm.scenario.LLMStructuredAnswer;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionActionNames;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionTraceRecord;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class LLMMCPConversationTurnPlannerTest {
+    
+    @Test
+    void assertCreateTurnToolNamesWithImmediateResourceAction() {
+        LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
+        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory);
+        List<String> actual = planner.createTurnToolNames(createScenario(List.of(MCPInteractionActionNames.READ_RESOURCE, "database_gateway_execute_query"),
+                List.of(MCPInteractionActionNames.READ_RESOURCE, "database_gateway_execute_query")),
+                List.of(createTraceRecord("database_gateway_plan_mask_rule",
+                        Map.of("next_actions", List.of(Map.of("type", "resource_read", "resource_uri", "shardingsphere://databases"))))));
+        assertThat(actual, is(List.of(MCPInteractionActionNames.READ_RESOURCE)));
+    }
+    
+    @Test
+    void assertCreateTurnToolNamesPrefersReadOnlyAfterSideEffectNextAction() {
+        LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
+        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory);
+        Map<String, Object> nextAction = Map.of("type", "tool_call", "tool_name", "database_gateway_execute_update", "arguments", Map.of("execution_mode", "execute"));
+        List<String> actual = planner.createTurnToolNames(createScenario(List.of("database_gateway_execute_update", "database_gateway_execute_query"),
+                List.of("database_gateway_execute_update", "database_gateway_execute_query")),
+                List.of(createTraceRecord("database_gateway_execute_update", Map.of("next_actions", List.of(nextAction)))));
+        assertThat(actual, is(List.of("database_gateway_execute_query")));
+    }
+    
+    @Test
+    void assertCreateToolChoiceWithMissingCoverage() {
+        LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
+        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory);
+        assertThat(planner.createToolChoice(createScenario(List.of("database_gateway_execute_query"), List.of("database_gateway_execute_query")), List.of(), false), is("required"));
+    }
+    
+    @Test
+    void assertCreateToolChoiceWithCoveredRequiredTools() {
+        LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
+        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory);
+        assertThat(planner.createToolChoice(createScenario(List.of("database_gateway_execute_query"), List.of("database_gateway_execute_query")),
+                List.of(createTraceRecord("database_gateway_execute_query", Map.of("row_objects", List.of()))), false), is("auto"));
+    }
+    
+    @Test
+    void assertCreateToolChoiceWithFinalAnswer() {
+        LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
+        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory);
+        assertThat(planner.createToolChoice(createScenario(List.of("database_gateway_execute_query"), List.of("database_gateway_execute_query")), List.of(), true), is("none"));
+    }
+    
+    private MCPInteractionTraceRecord createTraceRecord(final String targetName, final Map<String, Object> structuredContent) {
+        return new MCPInteractionTraceRecord(1, "tool_call", MCPInteractionTraceRecord.MODEL_TOOL_CALL_ORIGIN, targetName, Map.of(), structuredContent, true, 0L);
+    }
+    
+    private LLME2EScenario createScenario(final List<String> allowedToolNames, final List<String> requiredToolNames) {
+        return new LLME2EScenario("scenario", "system", "user", new LLMStructuredAnswer("logic_db", "public", "orders", "SELECT COUNT(*) FROM orders", 1, List.of()),
+                allowedToolNames, requiredToolNames);
+    }
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/assessment/LLMUsabilityMetricCalculator.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/assessment/LLMUsabilityMetricCalculator.java
@@ -17,17 +17,13 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.llm.suite.usability.assessment;
 
-import org.apache.shardingsphere.test.e2e.mcp.llm.conversation.LLMMCPNextActions;
 import org.apache.shardingsphere.test.e2e.mcp.llm.conversation.artifact.LLME2EArtifactBundle;
 import org.apache.shardingsphere.test.e2e.mcp.llm.conversation.artifact.LLME2EAssertionReport;
 import org.apache.shardingsphere.test.e2e.mcp.llm.suite.usability.scenario.LLMUsabilityScenario;
-import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionActionNames;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionTraceRecord;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
@@ -64,12 +60,13 @@ public final class LLMUsabilityMetricCalculator {
      */
     public LLMUsabilityScenarioResult evaluateScenario(final LLMUsabilityScenario scenario, final LLME2EArtifactBundle artifactBundle) {
         List<MCPInteractionTraceRecord> interactionTrace = artifactBundle.getInteractionTrace();
+        LLMUsabilityTraceMetrics traceMetrics = new LLMUsabilityTraceMetrics();
         boolean firstCorrectAction = interactionTrace.isEmpty() || scenario.getExpectedFirstActionNames().isEmpty()
                 ? !interactionTrace.isEmpty()
                 : scenario.getExpectedFirstActionNames().contains(interactionTrace.getFirst().getTargetName());
-        int invalidCallCount = getInvalidCallCount(interactionTrace, scenario.getExpectedRecoveryCategory());
-        boolean resourceHit = hasResourceHit(scenario.getExpectedResourceUris(), interactionTrace);
-        boolean expectedRecoveryObserved = hasExpectedRecoveryInteraction(interactionTrace, scenario.getExpectedRecoveryCategory());
+        int invalidCallCount = traceMetrics.getInvalidCallCount(interactionTrace, scenario.getExpectedRecoveryCategory());
+        boolean resourceHit = traceMetrics.hasResourceHit(scenario.getExpectedResourceUris(), interactionTrace);
+        boolean expectedRecoveryObserved = traceMetrics.hasExpectedRecoveryInteraction(interactionTrace, scenario.getExpectedRecoveryCategory());
         boolean boundaryConfusion = !scenario.getExpectedFirstActionNames().isEmpty() && !firstCorrectAction;
         LLME2EAssertionReport assertionReport = artifactBundle.getAssertionReport();
         boolean success = assertionReport.isSuccess();
@@ -88,10 +85,10 @@ public final class LLMUsabilityMetricCalculator {
         }
         boolean recoveredAfterError = success && (!scenario.isRecoveryExpected() || expectedRecoveryObserved);
         double queryAnswerFidelity = scenario.isQueryScenario() && success ? 1.0D : 0.0D;
-        boolean nextActionFollowed = isNextActionFollowed(interactionTrace);
-        boolean approvalViolation = hasApprovalViolation(interactionTrace);
-        boolean nativeToolCallCoverage = hasNativeRequiredToolCoverage(scenario.getLlmScenario().getRequiredToolNames(), interactionTrace);
-        boolean harnessRecoveryUsed = hasHarnessRecovery(interactionTrace);
+        boolean nextActionFollowed = traceMetrics.isNextActionFollowed(interactionTrace);
+        boolean approvalViolation = traceMetrics.hasApprovalViolation(interactionTrace);
+        boolean nativeToolCallCoverage = traceMetrics.hasNativeRequiredToolCoverage(scenario.getLlmScenario().getRequiredToolNames(), interactionTrace);
+        boolean harnessRecoveryUsed = traceMetrics.hasHarnessRecovery(interactionTrace);
         return new LLMUsabilityScenarioResult(scenario.getScenarioId(), scenario.getDimension(), scenario.getRuntimeKind(), scenario.getTags(), success, failureType, message,
                 firstCorrectAction, invalidCallCount, interactionTrace.size(), resourceHit, recoveredAfterError, queryAnswerFidelity,
                 boundaryConfusion, nextActionFollowed, approvalViolation, nativeToolCallCoverage, harnessRecoveryUsed, interactionTrace);
@@ -239,221 +236,5 @@ public final class LLMUsabilityMetricCalculator {
             total += each.getRoundTripCount();
         }
         return total;
-    }
-    
-    private int getInvalidCallCount(final List<MCPInteractionTraceRecord> interactionTrace, final String expectedRecoveryCategory) {
-        int result = 0;
-        boolean expectedRecoverySignalObserved = false;
-        for (MCPInteractionTraceRecord each : interactionTrace) {
-            if (!isErrorInteraction(each)) {
-                continue;
-            }
-            if (!expectedRecoverySignalObserved && isExpectedRecoveryInteraction(each, expectedRecoveryCategory)) {
-                expectedRecoverySignalObserved = true;
-            } else {
-                result++;
-            }
-        }
-        return result;
-    }
-    
-    private boolean hasResourceHit(final List<String> expectedResourceUris, final List<MCPInteractionTraceRecord> interactionTrace) {
-        if (expectedResourceUris.isEmpty()) {
-            return true;
-        }
-        for (MCPInteractionTraceRecord each : interactionTrace) {
-            if (!MCPInteractionActionNames.RESOURCE_READ_KIND.equals(each.getActionKind())) {
-                continue;
-            }
-            String resourceUri = String.valueOf(each.getArguments().getOrDefault("uri", ""));
-            if (expectedResourceUris.contains(resourceUri)) {
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    private boolean hasNativeRequiredToolCoverage(final List<String> requiredToolNames, final List<MCPInteractionTraceRecord> interactionTrace) {
-        for (String each : requiredToolNames) {
-            if (!hasNativeRequiredTool(each, interactionTrace)) {
-                return false;
-            }
-        }
-        return true;
-    }
-    
-    private boolean hasNativeRequiredTool(final String requiredToolName, final List<MCPInteractionTraceRecord> interactionTrace) {
-        for (MCPInteractionTraceRecord each : interactionTrace) {
-            if (each.isValid() && requiredToolName.equals(each.getTargetName()) && isNativeToolOrigin(each.getActionOrigin())) {
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    private boolean isNativeToolOrigin(final String actionOrigin) {
-        return MCPInteractionTraceRecord.MODEL_TOOL_CALL_ORIGIN.equals(actionOrigin) || MCPInteractionTraceRecord.PROTOCOL_BRIDGE_ORIGIN.equals(actionOrigin);
-    }
-    
-    private boolean hasHarnessRecovery(final List<MCPInteractionTraceRecord> interactionTrace) {
-        for (MCPInteractionTraceRecord each : interactionTrace) {
-            if (isHarnessOrigin(each.getActionOrigin())) {
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    private boolean isHarnessOrigin(final String actionOrigin) {
-        return MCPInteractionTraceRecord.HARNESS_TEXT_RECOVERY_ORIGIN.equals(actionOrigin);
-    }
-    
-    private boolean hasExpectedRecoveryInteraction(final List<MCPInteractionTraceRecord> interactionTrace, final String expectedRecoveryCategory) {
-        for (MCPInteractionTraceRecord each : interactionTrace) {
-            if (isExpectedRecoveryInteraction(each, expectedRecoveryCategory)) {
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    private boolean isExpectedRecoveryInteraction(final MCPInteractionTraceRecord interactionTraceRecord, final String expectedRecoveryCategory) {
-        return null != expectedRecoveryCategory && !expectedRecoveryCategory.isBlank() && isErrorInteraction(interactionTraceRecord)
-                && expectedRecoveryCategory.equals(getRecoveryCategory(interactionTraceRecord));
-    }
-    
-    private String getRecoveryCategory(final MCPInteractionTraceRecord interactionTraceRecord) {
-        Map<String, Object> structuredContent = interactionTraceRecord.getStructuredContent();
-        if (structuredContent.containsKey("recovery_category")) {
-            return Objects.toString(structuredContent.get("recovery_category"), "");
-        }
-        String recoveryCategory = getNestedRecoveryCategory(structuredContent.get("recovery"));
-        if (!recoveryCategory.isBlank()) {
-            return recoveryCategory;
-        }
-        String emptyStateCategory = getNestedRecoveryCategory(structuredContent.get("empty_state"));
-        if (!emptyStateCategory.isBlank()) {
-            return emptyStateCategory;
-        }
-        if (structuredContent.containsKey("ambiguity_state")) {
-            return getAmbiguityRecoveryCategory(structuredContent.get("ambiguity_state"));
-        }
-        return Objects.toString(structuredContent.get("error_code"), "");
-    }
-    
-    private String getNestedRecoveryCategory(final Object value) {
-        if (!(value instanceof Map)) {
-            return "";
-        }
-        Map<?, ?> map = (Map<?, ?>) value;
-        if (map.containsKey("recovery_category")) {
-            return Objects.toString(map.get("recovery_category"), "");
-        }
-        if (map.containsKey("category")) {
-            return Objects.toString(map.get("category"), "");
-        }
-        return Objects.toString(map.get("state"), "");
-    }
-    
-    private String getAmbiguityRecoveryCategory(final Object value) {
-        if (!(value instanceof Map)) {
-            return "ambiguous";
-        }
-        Map<?, ?> map = (Map<?, ?>) value;
-        if (map.containsKey("recovery_category")) {
-            return Objects.toString(map.get("recovery_category"), "");
-        }
-        return map.containsKey("category") ? Objects.toString(map.get("category"), "") : "ambiguous";
-    }
-    
-    private boolean isErrorInteraction(final MCPInteractionTraceRecord interactionTraceRecord) {
-        if (!interactionTraceRecord.isValid() || interactionTraceRecord.getStructuredContent().containsKey("error_code")) {
-            return true;
-        }
-        return isRecoverableEmptyState(interactionTraceRecord);
-    }
-    
-    private boolean isRecoverableEmptyState(final MCPInteractionTraceRecord interactionTraceRecord) {
-        return Boolean.FALSE.equals(interactionTraceRecord.getStructuredContent().get("found"))
-                || interactionTraceRecord.getStructuredContent().containsKey("empty_state")
-                || interactionTraceRecord.getStructuredContent().containsKey("ambiguity_state");
-    }
-    
-    private boolean isNextActionFollowed(final List<MCPInteractionTraceRecord> interactionTrace) {
-        boolean hasActionableGuidance = false;
-        for (int index = 0; index < interactionTrace.size() - 1; index++) {
-            List<Map<?, ?>> actions = getImmediateMachineNextActions(interactionTrace.get(index));
-            if (actions.isEmpty()) {
-                continue;
-            }
-            hasActionableGuidance = true;
-            if (!matchesAnyNextAction(actions, interactionTrace.get(index), interactionTrace.get(index + 1))) {
-                return false;
-            }
-        }
-        return !hasActionableGuidance || !interactionTrace.isEmpty();
-    }
-    
-    private List<Map<?, ?>> getImmediateMachineNextActions(final MCPInteractionTraceRecord interactionTraceRecord) {
-        List<Map<?, ?>> result = new LinkedList<>();
-        for (Map<?, ?> each : LLMMCPNextActions.getNextActions(interactionTraceRecord.getStructuredContent())) {
-            if (isMachineAction(each)) {
-                result.add(each);
-            }
-        }
-        return result;
-    }
-    
-    private boolean isMachineAction(final Map<?, ?> action) {
-        String type = Objects.toString(action.get("type"), "");
-        if (!"resource_read".equals(type) && !"tool_call".equals(type) && !"completion".equals(type)) {
-            return false;
-        }
-        if (!"tool_call".equals(type) || !(action.get("arguments") instanceof Map)) {
-            return true;
-        }
-        String executionMode = Objects.toString(((Map<?, ?>) action.get("arguments")).get("execution_mode"), "");
-        return !"execute".equals(executionMode) && !"review-then-execute".equals(executionMode);
-    }
-    
-    private boolean matchesAnyNextAction(final List<Map<?, ?>> actions, final MCPInteractionTraceRecord current, final MCPInteractionTraceRecord next) {
-        for (Map<?, ?> each : actions) {
-            if (matchesNextAction(each, current, next)) {
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    private boolean matchesNextAction(final Map<?, ?> action, final MCPInteractionTraceRecord current, final MCPInteractionTraceRecord next) {
-        String type = Objects.toString(action.get("type"), "");
-        if ("resource_read".equals(type)) {
-            return MCPInteractionActionNames.RESOURCE_READ_KIND.equals(next.getActionKind())
-                    && (Objects.equals(action.get("resource_uri"), next.getArguments().get("uri"))
-                            || isRecoverableResourceCorrection(current, next));
-        }
-        if ("tool_call".equals(type)) {
-            String targetTool = Objects.toString(action.get("tool_name"), current.getTargetName());
-            return Objects.equals(targetTool, next.getTargetName());
-        }
-        return "completion".equals(type) && MCPInteractionActionNames.COMPLETION_KIND.equals(next.getActionKind());
-    }
-    
-    private boolean isRecoverableResourceCorrection(final MCPInteractionTraceRecord current, final MCPInteractionTraceRecord next) {
-        return isRecoverableEmptyState(current) && Boolean.TRUE.equals(next.getStructuredContent().get("found"));
-    }
-    
-    private boolean hasApprovalViolation(final List<MCPInteractionTraceRecord> interactionTrace) {
-        for (int index = 0; index < interactionTrace.size(); index++) {
-            if (hasUnsafeApprovalError(interactionTrace.get(index))) {
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    private boolean hasUnsafeApprovalError(final MCPInteractionTraceRecord interactionTraceRecord) {
-        Object errorCode = interactionTraceRecord.getStructuredContent().get("error_code");
-        return "unsafe_sql_execution_attempted".equals(errorCode) || "unsafe_workflow_execution_attempted".equals(errorCode);
     }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/assessment/LLMUsabilityTraceMetrics.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/assessment/LLMUsabilityTraceMetrics.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.mcp.llm.suite.usability.assessment;
+
+import org.apache.shardingsphere.test.e2e.mcp.llm.conversation.LLMMCPNextActions;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionActionNames;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionTraceRecord;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+final class LLMUsabilityTraceMetrics {
+    
+    int getInvalidCallCount(final List<MCPInteractionTraceRecord> interactionTrace, final String expectedRecoveryCategory) {
+        int result = 0;
+        boolean expectedRecoverySignalObserved = false;
+        for (MCPInteractionTraceRecord each : interactionTrace) {
+            if (!isErrorInteraction(each)) {
+                continue;
+            }
+            if (!expectedRecoverySignalObserved && isExpectedRecoveryInteraction(each, expectedRecoveryCategory)) {
+                expectedRecoverySignalObserved = true;
+            } else {
+                result++;
+            }
+        }
+        return result;
+    }
+    
+    boolean hasResourceHit(final List<String> expectedResourceUris, final List<MCPInteractionTraceRecord> interactionTrace) {
+        if (expectedResourceUris.isEmpty()) {
+            return true;
+        }
+        for (MCPInteractionTraceRecord each : interactionTrace) {
+            if (!MCPInteractionActionNames.RESOURCE_READ_KIND.equals(each.getActionKind())) {
+                continue;
+            }
+            String resourceUri = String.valueOf(each.getArguments().getOrDefault("uri", ""));
+            if (expectedResourceUris.contains(resourceUri)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    boolean hasNativeRequiredToolCoverage(final List<String> requiredToolNames, final List<MCPInteractionTraceRecord> interactionTrace) {
+        for (String each : requiredToolNames) {
+            if (!hasNativeRequiredTool(each, interactionTrace)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    boolean hasHarnessRecovery(final List<MCPInteractionTraceRecord> interactionTrace) {
+        for (MCPInteractionTraceRecord each : interactionTrace) {
+            if (isHarnessOrigin(each.getActionOrigin())) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    boolean hasExpectedRecoveryInteraction(final List<MCPInteractionTraceRecord> interactionTrace, final String expectedRecoveryCategory) {
+        for (MCPInteractionTraceRecord each : interactionTrace) {
+            if (isExpectedRecoveryInteraction(each, expectedRecoveryCategory)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    boolean isNextActionFollowed(final List<MCPInteractionTraceRecord> interactionTrace) {
+        boolean hasActionableGuidance = false;
+        for (int index = 0; index < interactionTrace.size() - 1; index++) {
+            List<Map<?, ?>> actions = getImmediateMachineNextActions(interactionTrace.get(index));
+            if (actions.isEmpty()) {
+                continue;
+            }
+            hasActionableGuidance = true;
+            if (!matchesAnyNextAction(actions, interactionTrace.get(index), interactionTrace.get(index + 1))) {
+                return false;
+            }
+        }
+        return !hasActionableGuidance || !interactionTrace.isEmpty();
+    }
+    
+    boolean hasApprovalViolation(final List<MCPInteractionTraceRecord> interactionTrace) {
+        for (int index = 0; index < interactionTrace.size(); index++) {
+            if (hasUnsafeApprovalError(interactionTrace.get(index))) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private boolean hasNativeRequiredTool(final String requiredToolName, final List<MCPInteractionTraceRecord> interactionTrace) {
+        for (MCPInteractionTraceRecord each : interactionTrace) {
+            if (each.isValid() && requiredToolName.equals(each.getTargetName()) && isNativeToolOrigin(each.getActionOrigin())) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private boolean isNativeToolOrigin(final String actionOrigin) {
+        return MCPInteractionTraceRecord.MODEL_TOOL_CALL_ORIGIN.equals(actionOrigin) || MCPInteractionTraceRecord.PROTOCOL_BRIDGE_ORIGIN.equals(actionOrigin);
+    }
+    
+    private boolean isHarnessOrigin(final String actionOrigin) {
+        return MCPInteractionTraceRecord.HARNESS_TEXT_RECOVERY_ORIGIN.equals(actionOrigin);
+    }
+    
+    private boolean isExpectedRecoveryInteraction(final MCPInteractionTraceRecord interactionTraceRecord, final String expectedRecoveryCategory) {
+        return null != expectedRecoveryCategory && !expectedRecoveryCategory.isBlank() && isErrorInteraction(interactionTraceRecord)
+                && expectedRecoveryCategory.equals(getRecoveryCategory(interactionTraceRecord));
+    }
+    
+    private String getRecoveryCategory(final MCPInteractionTraceRecord interactionTraceRecord) {
+        Map<String, Object> structuredContent = interactionTraceRecord.getStructuredContent();
+        if (structuredContent.containsKey("recovery_category")) {
+            return Objects.toString(structuredContent.get("recovery_category"), "");
+        }
+        String recoveryCategory = getNestedRecoveryCategory(structuredContent.get("recovery"));
+        if (!recoveryCategory.isBlank()) {
+            return recoveryCategory;
+        }
+        String emptyStateCategory = getNestedRecoveryCategory(structuredContent.get("empty_state"));
+        if (!emptyStateCategory.isBlank()) {
+            return emptyStateCategory;
+        }
+        if (structuredContent.containsKey("ambiguity_state")) {
+            return getAmbiguityRecoveryCategory(structuredContent.get("ambiguity_state"));
+        }
+        return Objects.toString(structuredContent.get("error_code"), "");
+    }
+    
+    private String getNestedRecoveryCategory(final Object value) {
+        if (!(value instanceof Map)) {
+            return "";
+        }
+        Map<?, ?> map = (Map<?, ?>) value;
+        if (map.containsKey("recovery_category")) {
+            return Objects.toString(map.get("recovery_category"), "");
+        }
+        if (map.containsKey("category")) {
+            return Objects.toString(map.get("category"), "");
+        }
+        return Objects.toString(map.get("state"), "");
+    }
+    
+    private String getAmbiguityRecoveryCategory(final Object value) {
+        if (!(value instanceof Map)) {
+            return "ambiguous";
+        }
+        Map<?, ?> map = (Map<?, ?>) value;
+        if (map.containsKey("recovery_category")) {
+            return Objects.toString(map.get("recovery_category"), "");
+        }
+        return map.containsKey("category") ? Objects.toString(map.get("category"), "") : "ambiguous";
+    }
+    
+    private boolean isErrorInteraction(final MCPInteractionTraceRecord interactionTraceRecord) {
+        if (!interactionTraceRecord.isValid() || interactionTraceRecord.getStructuredContent().containsKey("error_code")) {
+            return true;
+        }
+        return isRecoverableEmptyState(interactionTraceRecord);
+    }
+    
+    private boolean isRecoverableEmptyState(final MCPInteractionTraceRecord interactionTraceRecord) {
+        return Boolean.FALSE.equals(interactionTraceRecord.getStructuredContent().get("found"))
+                || interactionTraceRecord.getStructuredContent().containsKey("empty_state")
+                || interactionTraceRecord.getStructuredContent().containsKey("ambiguity_state");
+    }
+    
+    private List<Map<?, ?>> getImmediateMachineNextActions(final MCPInteractionTraceRecord interactionTraceRecord) {
+        List<Map<?, ?>> result = new LinkedList<>();
+        for (Map<?, ?> each : LLMMCPNextActions.getNextActions(interactionTraceRecord.getStructuredContent())) {
+            if (isMachineAction(each)) {
+                result.add(each);
+            }
+        }
+        return result;
+    }
+    
+    private boolean isMachineAction(final Map<?, ?> action) {
+        String type = Objects.toString(action.get("type"), "");
+        if (!"resource_read".equals(type) && !"tool_call".equals(type) && !"completion".equals(type)) {
+            return false;
+        }
+        if (!"tool_call".equals(type) || !(action.get("arguments") instanceof Map)) {
+            return true;
+        }
+        String executionMode = Objects.toString(((Map<?, ?>) action.get("arguments")).get("execution_mode"), "");
+        return !"execute".equals(executionMode) && !"review-then-execute".equals(executionMode);
+    }
+    
+    private boolean matchesAnyNextAction(final List<Map<?, ?>> actions, final MCPInteractionTraceRecord current, final MCPInteractionTraceRecord next) {
+        for (Map<?, ?> each : actions) {
+            if (matchesNextAction(each, current, next)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private boolean matchesNextAction(final Map<?, ?> action, final MCPInteractionTraceRecord current, final MCPInteractionTraceRecord next) {
+        String type = Objects.toString(action.get("type"), "");
+        if ("resource_read".equals(type)) {
+            return MCPInteractionActionNames.RESOURCE_READ_KIND.equals(next.getActionKind())
+                    && (Objects.equals(action.get("resource_uri"), next.getArguments().get("uri"))
+                            || isRecoverableResourceCorrection(current, next));
+        }
+        if ("tool_call".equals(type)) {
+            String targetTool = Objects.toString(action.get("tool_name"), current.getTargetName());
+            return Objects.equals(targetTool, next.getTargetName());
+        }
+        return "completion".equals(type) && MCPInteractionActionNames.COMPLETION_KIND.equals(next.getActionKind());
+    }
+    
+    private boolean isRecoverableResourceCorrection(final MCPInteractionTraceRecord current, final MCPInteractionTraceRecord next) {
+        return isRecoverableEmptyState(current) && Boolean.TRUE.equals(next.getStructuredContent().get("found"));
+    }
+    
+    private boolean hasUnsafeApprovalError(final MCPInteractionTraceRecord interactionTraceRecord) {
+        Object errorCode = interactionTraceRecord.getStructuredContent().get("error_code");
+        return "unsafe_sql_execution_attempted".equals(errorCode) || "unsafe_workflow_execution_attempted".equals(errorCode);
+    }
+}


### PR DESCRIPTION
- Replace sharding workflow planning test delegates with kernel-focused services
- Extract workflow apply response and guidance resource hint builders
- Split MCP E2E conversation instruction, turn planning, and trace metric logic
- Add focused tests for extracted MCP workflow and E2E helpers

For #35294.