### PR TITLE
Refactor MCP workflow descriptor validation

### DIFF
--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPErrorConverter.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPErrorConverter.java
@@ -103,7 +103,7 @@ public final class MCPErrorConverter {
             return createError(cause, "Invalid request.");
         }
         if (cause instanceof IllegalStateException) {
-            return createError(cause, "MCP transaction operation failed.");
+            return createError(cause, "MCP operation failed.");
         }
         return createError(cause, "Service is temporarily unavailable.");
     }

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/protocol/MCPErrorConverterTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/protocol/MCPErrorConverterTest.java
@@ -442,7 +442,8 @@ class MCPErrorConverterTest {
                 Arguments.of("unavailable exception", new MCPUnavailableException("Unavailable."), "Unavailable."),
                 Arguments.of("unsupported operation exception", new UnsupportedOperationException("Unsupported operation."), "Unsupported operation."),
                 Arguments.of("illegal argument exception", new IllegalArgumentException("Illegal argument."), "Illegal argument."),
-                Arguments.of("illegal state exception", new IllegalStateException(" Transaction already active. "), "Transaction already active."),
+                Arguments.of("illegal state exception", new IllegalStateException(), "MCP operation failed."),
+                Arguments.of("illegal state exception message", new IllegalStateException(" Operation state mismatch. "), "Operation state mismatch."),
                 Arguments.of("unknown exception", new RuntimeException(), "Service is temporarily unavailable."));
     }
     

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/descriptor/BroadcastToolDescriptorValidator.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/descriptor/BroadcastToolDescriptorValidator.java
@@ -21,26 +21,11 @@ import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.feature.broadcast.BroadcastFeatureDefinition;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidationUtils;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidator;
-import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
-import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Broadcast tool descriptor validator.
  */
 public final class BroadcastToolDescriptorValidator implements MCPToolDescriptorValidator {
-    
-    private static final List<String> REQUIRED_OUTPUT_FIELDS = List.of(
-            "response_mode", WorkflowFieldNames.PLAN_ID, "workflow_kind", "status", "missing_required_inputs", "clarification_questions",
-            "elicitation_support", "fallback_reason", "issues", "global_steps", "current_step", "algorithm_recommendations", "property_requirements",
-            "validation_strategy", "delivery_mode", "execution_mode", "intent_inference", "argument_provenance", "review_focus", "proxy_topology_hint",
-            "distsql_artifacts", MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS);
-    
-    private static final List<String> REQUIRED_META_FIELDS = List.of(
-            "org.apache.shardingsphere/workflow-kind", "org.apache.shardingsphere/artifact-categories", "org.apache.shardingsphere/side-effect-scope",
-            "org.apache.shardingsphere/related-resource-uris", "org.apache.shardingsphere/follow-up-tools");
     
     @Override
     public boolean supports(final MCPToolDescriptor toolDescriptor) {
@@ -49,16 +34,7 @@ public final class BroadcastToolDescriptorValidator implements MCPToolDescriptor
     
     @Override
     public void validate(final MCPToolDescriptor toolDescriptor) {
-        MCPToolDescriptorValidationUtils.validateRequiredOutputFields(toolDescriptor, REQUIRED_OUTPUT_FIELDS);
-        validateRequiredMetaFields(toolDescriptor);
-    }
-    
-    private void validateRequiredMetaFields(final MCPToolDescriptor toolDescriptor) {
-        Map<String, Object> meta = toolDescriptor.getMeta();
-        for (String each : REQUIRED_META_FIELDS) {
-            if (!meta.containsKey(each)) {
-                throw new IllegalStateException(String.format("Tool `%s` metadata must declare `%s`.", toolDescriptor.getName(), each));
-            }
-        }
+        MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanOutputFields(toolDescriptor);
+        MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanMetaFields(toolDescriptor);
     }
 }

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/descriptor/EncryptToolDescriptorValidator.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/descriptor/EncryptToolDescriptorValidator.java
@@ -21,8 +21,6 @@ import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.feature.encrypt.EncryptFeatureDefinition;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidator;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidationUtils;
-import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
-import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 
 import java.util.Collection;
 import java.util.List;
@@ -34,11 +32,7 @@ import java.util.Map;
  */
 public final class EncryptToolDescriptorValidator implements MCPToolDescriptorValidator {
     
-    private static final List<String> REQUIRED_OUTPUT_FIELDS = List.of(
-            "response_mode", WorkflowFieldNames.PLAN_ID, "workflow_kind", "status", "missing_required_inputs", "clarification_questions",
-            "elicitation_support", "fallback_reason", "issues", "global_steps", "current_step", "algorithm_recommendations", "property_requirements",
-            "validation_strategy", "delivery_mode", "execution_mode", "intent_inference", "argument_provenance", "review_focus", "proxy_topology_hint",
-            "distsql_artifacts", "masked_property_preview", MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS, "secret_reference_summary");
+    private static final Collection<String> REQUIRED_SECRET_WORKFLOW_OUTPUT_FIELDS = List.of("masked_property_preview", "secret_reference_summary");
     
     @Override
     public boolean supports(final MCPToolDescriptor toolDescriptor) {
@@ -47,7 +41,7 @@ public final class EncryptToolDescriptorValidator implements MCPToolDescriptorVa
     
     @Override
     public void validate(final MCPToolDescriptor toolDescriptor) {
-        MCPToolDescriptorValidationUtils.validateRequiredOutputFields(toolDescriptor, REQUIRED_OUTPUT_FIELDS);
+        MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanOutputFields(toolDescriptor, REQUIRED_SECRET_WORKFLOW_OUTPUT_FIELDS);
         validateExecutableDistSQLArtifacts(toolDescriptor);
     }
     

--- a/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/descriptor/MaskToolDescriptorValidator.java
+++ b/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/descriptor/MaskToolDescriptorValidator.java
@@ -21,24 +21,18 @@ import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.feature.mask.MaskFeatureDefinition;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidator;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidationUtils;
-import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
-import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Mask tool descriptor validator.
  */
 public final class MaskToolDescriptorValidator implements MCPToolDescriptorValidator {
     
-    private static final List<String> REQUIRED_OUTPUT_FIELDS = List.of(
-            "response_mode", WorkflowFieldNames.PLAN_ID, "workflow_kind", "status", "missing_required_inputs", "clarification_questions",
-            "elicitation_support", "fallback_reason", "issues", "global_steps", "current_step", "algorithm_recommendations", "property_requirements",
-            "validation_strategy", "delivery_mode", "execution_mode", "intent_inference", "argument_provenance", "review_focus", "proxy_topology_hint",
-            "distsql_artifacts", "masked_property_preview", MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS, "secret_reference_summary");
+    private static final Collection<String> REQUIRED_SECRET_WORKFLOW_OUTPUT_FIELDS = List.of("masked_property_preview", "secret_reference_summary");
     
-    private static final List<String> REQUIRED_META_FIELDS = List.of(
+    private static final Collection<String> REQUIRED_META_FIELDS = List.of(
             "org.apache.shardingsphere/workflow-kind", "org.apache.shardingsphere/related-resource-uris", "org.apache.shardingsphere/follow-up-tools");
     
     @Override
@@ -48,16 +42,7 @@ public final class MaskToolDescriptorValidator implements MCPToolDescriptorValid
     
     @Override
     public void validate(final MCPToolDescriptor toolDescriptor) {
-        MCPToolDescriptorValidationUtils.validateRequiredOutputFields(toolDescriptor, REQUIRED_OUTPUT_FIELDS);
-        validateRequiredMetaFields(toolDescriptor);
-    }
-    
-    private void validateRequiredMetaFields(final MCPToolDescriptor toolDescriptor) {
-        Map<String, Object> meta = toolDescriptor.getMeta();
-        for (String each : REQUIRED_META_FIELDS) {
-            if (!meta.containsKey(each)) {
-                throw new IllegalStateException(String.format("Tool `%s` metadata must declare `%s`.", toolDescriptor.getName(), each));
-            }
-        }
+        MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanOutputFields(toolDescriptor, REQUIRED_SECRET_WORKFLOW_OUTPUT_FIELDS);
+        MCPToolDescriptorValidationUtils.validateRequiredMetaFields(toolDescriptor, REQUIRED_META_FIELDS);
     }
 }

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/descriptor/ReadwriteSplittingToolDescriptorValidator.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/descriptor/ReadwriteSplittingToolDescriptorValidator.java
@@ -21,26 +21,11 @@ import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.feature.readwritesplitting.ReadwriteSplittingFeatureDefinition;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidationUtils;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidator;
-import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
-import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Readwrite-splitting tool descriptor validator.
  */
 public final class ReadwriteSplittingToolDescriptorValidator implements MCPToolDescriptorValidator {
-    
-    private static final List<String> REQUIRED_OUTPUT_FIELDS = List.of(
-            "response_mode", WorkflowFieldNames.PLAN_ID, "workflow_kind", "status", "missing_required_inputs", "clarification_questions",
-            "elicitation_support", "fallback_reason", "issues", "global_steps", "current_step", "algorithm_recommendations", "property_requirements",
-            "validation_strategy", "delivery_mode", "execution_mode", "intent_inference", "argument_provenance", "review_focus", "proxy_topology_hint",
-            "distsql_artifacts", MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS);
-    
-    private static final List<String> REQUIRED_META_FIELDS = List.of(
-            "org.apache.shardingsphere/workflow-kind", "org.apache.shardingsphere/artifact-categories", "org.apache.shardingsphere/side-effect-scope",
-            "org.apache.shardingsphere/related-resource-uris", "org.apache.shardingsphere/follow-up-tools");
     
     @Override
     public boolean supports(final MCPToolDescriptor toolDescriptor) {
@@ -50,16 +35,7 @@ public final class ReadwriteSplittingToolDescriptorValidator implements MCPToolD
     
     @Override
     public void validate(final MCPToolDescriptor toolDescriptor) {
-        MCPToolDescriptorValidationUtils.validateRequiredOutputFields(toolDescriptor, REQUIRED_OUTPUT_FIELDS);
-        validateRequiredMetaFields(toolDescriptor);
-    }
-    
-    private void validateRequiredMetaFields(final MCPToolDescriptor toolDescriptor) {
-        Map<String, Object> meta = toolDescriptor.getMeta();
-        for (String each : REQUIRED_META_FIELDS) {
-            if (!meta.containsKey(each)) {
-                throw new IllegalStateException(String.format("Tool `%s` metadata must declare `%s`.", toolDescriptor.getName(), each));
-            }
-        }
+        MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanOutputFields(toolDescriptor);
+        MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanMetaFields(toolDescriptor);
     }
 }

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/descriptor/ShadowToolDescriptorValidator.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/descriptor/ShadowToolDescriptorValidator.java
@@ -21,26 +21,11 @@ import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.feature.shadow.ShadowFeatureDefinition;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidationUtils;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidator;
-import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
-import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Shadow tool descriptor validator.
  */
 public final class ShadowToolDescriptorValidator implements MCPToolDescriptorValidator {
-    
-    private static final List<String> REQUIRED_OUTPUT_FIELDS = List.of(
-            "response_mode", WorkflowFieldNames.PLAN_ID, "workflow_kind", "status", "missing_required_inputs", "clarification_questions",
-            "elicitation_support", "fallback_reason", "issues", "global_steps", "current_step", "algorithm_recommendations", "property_requirements",
-            "validation_strategy", "delivery_mode", "execution_mode", "intent_inference", "argument_provenance", "review_focus", "proxy_topology_hint",
-            "distsql_artifacts", MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS);
-    
-    private static final List<String> REQUIRED_META_FIELDS = List.of(
-            "org.apache.shardingsphere/workflow-kind", "org.apache.shardingsphere/artifact-categories", "org.apache.shardingsphere/side-effect-scope",
-            "org.apache.shardingsphere/related-resource-uris", "org.apache.shardingsphere/follow-up-tools");
     
     @Override
     public boolean supports(final MCPToolDescriptor toolDescriptor) {
@@ -51,16 +36,7 @@ public final class ShadowToolDescriptorValidator implements MCPToolDescriptorVal
     
     @Override
     public void validate(final MCPToolDescriptor toolDescriptor) {
-        MCPToolDescriptorValidationUtils.validateRequiredOutputFields(toolDescriptor, REQUIRED_OUTPUT_FIELDS);
-        validateRequiredMetaFields(toolDescriptor);
-    }
-    
-    private void validateRequiredMetaFields(final MCPToolDescriptor toolDescriptor) {
-        Map<String, Object> meta = toolDescriptor.getMeta();
-        for (String each : REQUIRED_META_FIELDS) {
-            if (!meta.containsKey(each)) {
-                throw new IllegalStateException(String.format("Tool `%s` metadata must declare `%s`.", toolDescriptor.getName(), each));
-            }
-        }
+        MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanOutputFields(toolDescriptor);
+        MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanMetaFields(toolDescriptor);
     }
 }

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowPlanningService.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/service/ShadowWorkflowPlanningService.java
@@ -186,7 +186,6 @@ public final class ShadowWorkflowPlanningService {
         List<Map<String, Object>> algorithms = inspectionService.queryAlgorithms(queryFacade, mergedRequest.getDatabase());
         List<Map<String, Object>> tableRules = inspectionService.queryTableRules(queryFacade, mergedRequest.getDatabase());
         List<Map<String, Object>> defaultAlgorithm = inspectionService.queryDefaultAlgorithm(queryFacade, mergedRequest.getDatabase());
-        inspectionService.queryRules(queryFacade, mergedRequest.getDatabase());
         if (!ensureAlgorithmCleanupState(mergedRequest, algorithms, tableRules, defaultAlgorithm, result, queryFacade.getDatabaseType(mergedRequest.getDatabase()))) {
             return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_FAILED, WorkflowLifecycle.STATUS_FAILED);
         }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/descriptor/ShardingToolDescriptorValidator.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/descriptor/ShardingToolDescriptorValidator.java
@@ -21,26 +21,11 @@ import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidationUtils;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPToolDescriptorValidator;
-import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
-import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Sharding tool descriptor validator.
  */
 public final class ShardingToolDescriptorValidator implements MCPToolDescriptorValidator {
-    
-    private static final List<String> REQUIRED_OUTPUT_FIELDS = List.of(
-            "response_mode", WorkflowFieldNames.PLAN_ID, "workflow_kind", "status", "missing_required_inputs", "clarification_questions",
-            "elicitation_support", "fallback_reason", "issues", "global_steps", "current_step", "algorithm_recommendations", "property_requirements",
-            "validation_strategy", "delivery_mode", "execution_mode", "intent_inference", "argument_provenance", "review_focus", "proxy_topology_hint",
-            "distsql_artifacts", MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS);
-    
-    private static final List<String> REQUIRED_META_FIELDS = List.of(
-            "org.apache.shardingsphere/workflow-kind", "org.apache.shardingsphere/artifact-categories", "org.apache.shardingsphere/side-effect-scope",
-            "org.apache.shardingsphere/related-resource-uris", "org.apache.shardingsphere/follow-up-tools");
     
     @Override
     public boolean supports(final MCPToolDescriptor toolDescriptor) {
@@ -54,16 +39,7 @@ public final class ShardingToolDescriptorValidator implements MCPToolDescriptorV
     
     @Override
     public void validate(final MCPToolDescriptor toolDescriptor) {
-        MCPToolDescriptorValidationUtils.validateRequiredOutputFields(toolDescriptor, REQUIRED_OUTPUT_FIELDS);
-        validateRequiredMetaFields(toolDescriptor);
-    }
-    
-    private void validateRequiredMetaFields(final MCPToolDescriptor toolDescriptor) {
-        Map<String, Object> meta = toolDescriptor.getMeta();
-        for (String each : REQUIRED_META_FIELDS) {
-            if (!meta.containsKey(each)) {
-                throw new IllegalStateException(String.format("Tool `%s` metadata must declare `%s`.", toolDescriptor.getName(), each));
-            }
-        }
+        MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanOutputFields(toolDescriptor);
+        MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanMetaFields(toolDescriptor);
     }
 }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowPlanningKernel.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowPlanningKernel.java
@@ -93,7 +93,7 @@ final class ShardingWorkflowPlanningKernel {
      */
     public WorkflowContextSnapshot planTableRule(final WorkflowSessionContext workflowSessionContext, final MCPFeatureQueryFacade queryFacade,
                                                  final String sessionId, final ShardingWorkflowRequest request) {
-        return planLifecycleWorkflow(workflowSessionContext, queryFacade, sessionId, request, ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
+        return planLifecycleWorkflow(workflowSessionContext, sessionId, request, ShardingFeatureDefinition.TABLE_RULE_WORKFLOW_KIND,
                 "create", "Sharding table rule workflow plan.", actual -> !inspectionService.queryTableRule(queryFacade, actual.getDatabase(), actual.getTable()).isEmpty(),
                 this::hasRequiredTableRuleInputs, (actual, snapshot) -> planAlgorithms(queryFacade, actual,
                         shouldPlanShardingAlgorithm(actual), shouldPlanTableRuleKeyGenerator(actual), snapshot),
@@ -111,7 +111,7 @@ final class ShardingWorkflowPlanningKernel {
      */
     public WorkflowContextSnapshot planTableReferenceRule(final WorkflowSessionContext workflowSessionContext, final MCPFeatureQueryFacade queryFacade,
                                                           final String sessionId, final ShardingWorkflowRequest request) {
-        return planLifecycleWorkflow(workflowSessionContext, queryFacade, sessionId, request, ShardingFeatureDefinition.TABLE_REFERENCE_WORKFLOW_KIND,
+        return planLifecycleWorkflow(workflowSessionContext, sessionId, request, ShardingFeatureDefinition.TABLE_REFERENCE_WORKFLOW_KIND,
                 "create", "Sharding table reference rule workflow plan.", actual -> !inspectionService.queryTableReferenceRule(queryFacade, actual.getDatabase(), actual.getRuleName()).isEmpty(),
                 this::hasRequiredReferenceRuleInputs, (actual, snapshot) -> true, actual -> distSQLPlanningService.planTableReferenceRule(actual, actual.getOperationType()));
     }
@@ -127,7 +127,7 @@ final class ShardingWorkflowPlanningKernel {
      */
     public WorkflowContextSnapshot planDefaultStrategy(final WorkflowSessionContext workflowSessionContext, final MCPFeatureQueryFacade queryFacade,
                                                        final String sessionId, final ShardingWorkflowRequest request) {
-        return planLifecycleWorkflow(workflowSessionContext, queryFacade, sessionId, request, ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND,
+        return planLifecycleWorkflow(workflowSessionContext, sessionId, request, ShardingFeatureDefinition.DEFAULT_STRATEGY_WORKFLOW_KIND,
                 "create", "Default sharding strategy workflow plan.", actual -> containsDefaultStrategy(inspectionService.queryDefaultStrategy(queryFacade, actual.getDatabase()),
                         queryFacade.getDatabaseType(actual.getDatabase()), actual.getDefaultStrategyType()),
                 this::hasRequiredDefaultStrategyInputs,
@@ -146,7 +146,7 @@ final class ShardingWorkflowPlanningKernel {
      */
     public WorkflowContextSnapshot planKeyGenerator(final WorkflowSessionContext workflowSessionContext, final MCPFeatureQueryFacade queryFacade,
                                                     final String sessionId, final ShardingWorkflowRequest request) {
-        return planLifecycleWorkflow(workflowSessionContext, queryFacade, sessionId, request, ShardingFeatureDefinition.KEY_GENERATOR_WORKFLOW_KIND,
+        return planLifecycleWorkflow(workflowSessionContext, sessionId, request, ShardingFeatureDefinition.KEY_GENERATOR_WORKFLOW_KIND,
                 "create", "Sharding key generator workflow plan.", actual -> !inspectionService.queryKeyGenerator(queryFacade, actual.getDatabase(), actual.getKeyGeneratorName()).isEmpty(),
                 this::hasRequiredKeyGeneratorInputs, (actual, snapshot) -> planAlgorithms(queryFacade, actual, false, true, snapshot),
                 actual -> distSQLPlanningService.planKeyGenerator(actual, actual.getOperationType()));
@@ -163,7 +163,7 @@ final class ShardingWorkflowPlanningKernel {
      */
     public WorkflowContextSnapshot planKeyGenerateStrategy(final WorkflowSessionContext workflowSessionContext, final MCPFeatureQueryFacade queryFacade,
                                                            final String sessionId, final ShardingWorkflowRequest request) {
-        return planLifecycleWorkflow(workflowSessionContext, queryFacade, sessionId, request, ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
+        return planLifecycleWorkflow(workflowSessionContext, sessionId, request, ShardingFeatureDefinition.KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
                 "create", "Sharding key generate strategy workflow plan.",
                 actual -> !inspectionService.queryKeyGenerateStrategy(queryFacade, actual.getDatabase(), actual.getKeyGenerateStrategyName()).isEmpty(),
                 this::hasRequiredKeyGenerateStrategyInputs, (actual, snapshot) -> planAlgorithms(queryFacade, actual, false,
@@ -212,10 +212,9 @@ final class ShardingWorkflowPlanningKernel {
         return false;
     }
     
-    private WorkflowContextSnapshot planLifecycleWorkflow(final WorkflowSessionContext workflowSessionContext, final MCPFeatureQueryFacade queryFacade,
-                                                          final String sessionId, final ShardingWorkflowRequest request, final WorkflowKind workflowKind,
-                                                          final String defaultOperationType, final String summary, final Function<ShardingWorkflowRequest, Boolean> existsSupplier,
-                                                          final Function<ShardingWorkflowRequest, Boolean> requiredInputSupplier,
+    private WorkflowContextSnapshot planLifecycleWorkflow(final WorkflowSessionContext workflowSessionContext, final String sessionId, final ShardingWorkflowRequest request,
+                                                          final WorkflowKind workflowKind, final String defaultOperationType, final String summary,
+                                                          final Function<ShardingWorkflowRequest, Boolean> existsSupplier, final Function<ShardingWorkflowRequest, Boolean> requiredInputSupplier,
                                                           final BiFunction<ShardingWorkflowRequest, WorkflowContextSnapshot, Boolean> algorithmPlanSupplier,
                                                           final Function<ShardingWorkflowRequest, RuleArtifact> artifactSupplier) {
         WorkflowContextSnapshot result = prepareSnapshot(workflowSessionContext, sessionId, request, workflowKind, defaultOperationType, summary);
@@ -238,7 +237,6 @@ final class ShardingWorkflowPlanningKernel {
         if (!algorithmPlanSupplier.apply(mergedRequest, result)) {
             return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_CLARIFYING, WorkflowLifecycle.STATUS_CLARIFYING);
         }
-        queryFacade.getDatabaseType(mergedRequest.getDatabase());
         result.getRuleArtifacts().add(artifactSupplier.apply(mergedRequest));
         return workflowSessionContext.persist(result, WorkflowLifecycle.STEP_REVIEW, WorkflowLifecycle.STATUS_PLANNED);
     }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorValidationUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorValidationUtils.java
@@ -19,8 +19,12 @@ package org.apache.shardingsphere.mcp.support.descriptor;
 
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
+import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -28,7 +32,38 @@ import java.util.Map;
  */
 public final class MCPToolDescriptorValidationUtils {
     
+    private static final Collection<String> REQUIRED_WORKFLOW_PLAN_OUTPUT_FIELDS = List.of(
+            "response_mode", WorkflowFieldNames.PLAN_ID, "workflow_kind", "status", "missing_required_inputs", "clarification_questions",
+            "elicitation_support", "fallback_reason", "issues", "global_steps", "current_step", "algorithm_recommendations", "property_requirements",
+            "validation_strategy", "delivery_mode", "execution_mode", "intent_inference", "argument_provenance", "review_focus", "proxy_topology_hint",
+            "distsql_artifacts", MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS);
+    
+    private static final Collection<String> REQUIRED_WORKFLOW_PLAN_META_FIELDS = List.of(
+            "org.apache.shardingsphere/workflow-kind", "org.apache.shardingsphere/artifact-categories", "org.apache.shardingsphere/side-effect-scope",
+            "org.apache.shardingsphere/related-resource-uris", "org.apache.shardingsphere/follow-up-tools");
+    
     private MCPToolDescriptorValidationUtils() {
+    }
+    
+    /**
+     * Validate required workflow planning output fields.
+     *
+     * @param descriptor tool descriptor
+     */
+    public static void validateRequiredWorkflowPlanOutputFields(final MCPToolDescriptor descriptor) {
+        validateRequiredOutputFields(descriptor, REQUIRED_WORKFLOW_PLAN_OUTPUT_FIELDS);
+    }
+    
+    /**
+     * Validate required workflow planning output fields with additional fields.
+     *
+     * @param descriptor tool descriptor
+     * @param additionalFields additional required fields
+     */
+    public static void validateRequiredWorkflowPlanOutputFields(final MCPToolDescriptor descriptor, final Collection<String> additionalFields) {
+        Collection<String> requiredFields = new LinkedList<>(REQUIRED_WORKFLOW_PLAN_OUTPUT_FIELDS);
+        requiredFields.addAll(additionalFields);
+        validateRequiredOutputFields(descriptor, requiredFields);
     }
     
     /**
@@ -47,6 +82,29 @@ public final class MCPToolDescriptorValidationUtils {
                     () -> new IllegalStateException(String.format("Tool `%s` outputSchema property `%s` must be an object.", descriptor.getName(), each)));
             Object description = ((Map<?, ?>) property).get("description");
             checkDescription(null == description ? "" : description.toString(), String.format("Tool output field `%s.%s` description", descriptor.getName(), each));
+        }
+    }
+    
+    /**
+     * Validate required workflow planning metadata fields.
+     *
+     * @param descriptor tool descriptor
+     */
+    public static void validateRequiredWorkflowPlanMetaFields(final MCPToolDescriptor descriptor) {
+        validateRequiredMetaFields(descriptor, REQUIRED_WORKFLOW_PLAN_META_FIELDS);
+    }
+    
+    /**
+     * Validate required metadata fields.
+     *
+     * @param descriptor tool descriptor
+     * @param requiredFields required fields
+     */
+    public static void validateRequiredMetaFields(final MCPToolDescriptor descriptor, final Collection<String> requiredFields) {
+        Map<String, Object> meta = descriptor.getMeta();
+        for (String each : requiredFields) {
+            ShardingSpherePreconditions.checkState(meta.containsKey(each),
+                    () -> new IllegalStateException(String.format("Tool `%s` metadata must declare `%s`.", descriptor.getName(), each)));
         }
     }
     

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorValidationUtilsTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorValidationUtilsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.descriptor;
+
+import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolAnnotations;
+import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
+import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
+import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MCPToolDescriptorValidationUtilsTest {
+    
+    private static final Collection<String> WORKFLOW_PLAN_OUTPUT_FIELDS = List.of(
+            "response_mode", WorkflowFieldNames.PLAN_ID, "workflow_kind", "status", "missing_required_inputs", "clarification_questions",
+            "elicitation_support", "fallback_reason", "issues", "global_steps", "current_step", "algorithm_recommendations", "property_requirements",
+            "validation_strategy", "delivery_mode", "execution_mode", "intent_inference", "argument_provenance", "review_focus", "proxy_topology_hint",
+            "distsql_artifacts", MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.NEXT_ACTIONS);
+    
+    private static final Collection<String> WORKFLOW_PLAN_META_FIELDS = List.of(
+            "org.apache.shardingsphere/workflow-kind", "org.apache.shardingsphere/artifact-categories", "org.apache.shardingsphere/side-effect-scope",
+            "org.apache.shardingsphere/related-resource-uris", "org.apache.shardingsphere/follow-up-tools");
+    
+    @Test
+    void assertValidateRequiredWorkflowPlanOutputFields() {
+        MCPToolDescriptor descriptor = createDescriptor(WORKFLOW_PLAN_OUTPUT_FIELDS, createWorkflowPlanMeta());
+        assertDoesNotThrow(() -> MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanOutputFields(descriptor));
+    }
+    
+    @Test
+    void assertValidateRequiredWorkflowPlanOutputFieldsRejectsMissingAdditionalField() {
+        MCPToolDescriptor descriptor = createDescriptor(WORKFLOW_PLAN_OUTPUT_FIELDS, createWorkflowPlanMeta());
+        IllegalStateException actual = assertThrows(IllegalStateException.class,
+                () -> MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanOutputFields(descriptor, List.of("secret_reference_summary")));
+        assertThat(actual.getMessage(), is("Tool `fixture_tool` outputSchema must declare `secret_reference_summary`."));
+    }
+    
+    @Test
+    void assertValidateRequiredOutputFieldsRejectsNonObjectField() {
+        MCPToolDescriptor descriptor = new MCPToolDescriptor("fixture_tool", "Fixture Tool", "Fixture tool.", Map.of(),
+                Map.of("properties", Map.of("status", "ready")), createAnnotations(), Map.of());
+        IllegalStateException actual = assertThrows(IllegalStateException.class,
+                () -> MCPToolDescriptorValidationUtils.validateRequiredOutputFields(descriptor, List.of("status")));
+        assertThat(actual.getMessage(), is("Tool `fixture_tool` outputSchema property `status` must be an object."));
+    }
+    
+    @Test
+    void assertValidateRequiredWorkflowPlanMetaFields() {
+        MCPToolDescriptor descriptor = createDescriptor(WORKFLOW_PLAN_OUTPUT_FIELDS, createWorkflowPlanMeta());
+        assertDoesNotThrow(() -> MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanMetaFields(descriptor));
+    }
+    
+    @Test
+    void assertValidateRequiredMetaFieldsRejectsMissingField() {
+        MCPToolDescriptor descriptor = createDescriptor(WORKFLOW_PLAN_OUTPUT_FIELDS, Map.of("fixture/meta", "value"));
+        IllegalStateException actual = assertThrows(IllegalStateException.class,
+                () -> MCPToolDescriptorValidationUtils.validateRequiredMetaFields(descriptor, List.of("fixture/missing")));
+        assertThat(actual.getMessage(), is("Tool `fixture_tool` metadata must declare `fixture/missing`."));
+    }
+    
+    @Test
+    void assertCheckDescriptionRejectsBlankValue() {
+        IllegalStateException actual = assertThrows(IllegalStateException.class, () -> MCPToolDescriptorValidationUtils.checkDescription(" ", "Fixture description"));
+        assertThat(actual.getMessage(), is("Fixture description is required."));
+    }
+    
+    private MCPToolDescriptor createDescriptor(final Collection<String> outputFields, final Map<String, Object> meta) {
+        return new MCPToolDescriptor("fixture_tool", "Fixture Tool", "Fixture tool.", Map.of(),
+                Map.of("type", "object", "properties", createOutputProperties(outputFields)), createAnnotations(), meta);
+    }
+    
+    private MCPToolAnnotations createAnnotations() {
+        return new MCPToolAnnotations("Fixture Tool", true, false, true, false);
+    }
+    
+    private Map<String, Object> createOutputProperties(final Collection<String> outputFields) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (String each : outputFields) {
+            result.put(each, Map.of("type", "string", "description", each + " field."));
+        }
+        return result;
+    }
+    
+    private Map<String, Object> createWorkflowPlanMeta() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (String each : WORKFLOW_PLAN_META_FIELDS) {
+            result.put(each, "value");
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Centralize shared workflow planning descriptor validation in MCP support utilities and reuse it across feature descriptor validators. Remove unused workflow planning query calls and map plain IllegalStateException to a generic MCP operation failure.

Add focused tests for descriptor validation utilities and error conversion semantics.

For #35294.