### PR TITLE
Rename session attribution object to identity

### DIFF
--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/MCPHandlerContext.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/MCPHandlerContext.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.mcp.api;
 
-import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionIdentity;
 
 import java.util.Optional;
 
@@ -27,11 +27,11 @@ import java.util.Optional;
 public interface MCPHandlerContext {
     
     /**
-     * Find session attribution.
+     * Find session identity.
      *
-     * @return session attribution
+     * @return session identity
      */
-    default Optional<MCPSessionAttribution> findSessionAttribution() {
+    default Optional<MCPSessionIdentity> findSessionIdentity() {
         return Optional.empty();
     }
 }

--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/session/MCPSessionIdentity.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/session/MCPSessionIdentity.java
@@ -24,12 +24,12 @@ import lombok.RequiredArgsConstructor;
 import java.util.Map;
 
 /**
- * MCP session attribution.
+ * MCP session identity.
  */
 @RequiredArgsConstructor
 @Getter
 @EqualsAndHashCode
-public final class MCPSessionAttribution {
+public final class MCPSessionIdentity {
     
     private final String subject;
     

--- a/mcp/api/src/test/java/org/apache/shardingsphere/mcp/api/session/MCPSessionIdentityTest.java
+++ b/mcp/api/src/test/java/org/apache/shardingsphere/mcp/api/session/MCPSessionIdentityTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.api.session;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+class MCPSessionIdentityTest {
+    
+    @Test
+    void assertEquals() {
+        MCPSessionIdentity actual = new MCPSessionIdentity("subject", "gateway", Map.of("region", "ap-south"));
+        MCPSessionIdentity expected = new MCPSessionIdentity("subject", "gateway", Map.of("region", "ap-south"));
+        assertThat(actual, is(expected));
+    }
+    
+    @Test
+    void assertHashCode() {
+        MCPSessionIdentity actual = new MCPSessionIdentity("subject", "gateway", Map.of("region", "ap-south"));
+        MCPSessionIdentity expected = new MCPSessionIdentity("subject", "gateway", Map.of("region", "ap-south"));
+        assertThat(actual.hashCode(), is(expected.hashCode()));
+    }
+    
+    @Test
+    void assertNotEquals() {
+        MCPSessionIdentity actual = new MCPSessionIdentity("subject", "gateway", Map.of("region", "ap-south"));
+        MCPSessionIdentity expected = new MCPSessionIdentity("other", "gateway", Map.of("region", "ap-south"));
+        assertThat(actual, is(not(expected)));
+    }
+}

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolver.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolver.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.mcp.bootstrap.transport.server.http;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
-import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionIdentity;
 import org.apache.shardingsphere.mcp.bootstrap.config.SessionAttributionSourceConfiguration;
 
 import java.util.Collections;
@@ -44,12 +44,12 @@ public final class SessionAttributionResolver {
     }
     
     /**
-     * Resolve session attribution from HTTP request.
+     * Resolve session identity from HTTP request.
      *
      * @param request HTTP request
-     * @return session attribution
+     * @return session identity
      */
-    public Optional<MCPSessionAttribution> resolve(final HttpServletRequest request) {
+    public Optional<MCPSessionIdentity> resolve(final HttpServletRequest request) {
         if (!isEnabled()) {
             return Optional.empty();
         }
@@ -57,17 +57,17 @@ public final class SessionAttributionResolver {
         if (subject.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(new MCPSessionAttribution(subject, getHeaderValue(request, config.getSourceHeader()),
+        return Optional.of(new MCPSessionIdentity(subject, getHeaderValue(request, config.getSourceHeader()),
                 resolveAttributes(Collections.list(request.getHeaderNames()), name -> getHeaderValue(request, name))));
     }
     
     /**
-     * Resolve session attribution from header map.
+     * Resolve session identity from header map.
      *
      * @param headers headers
-     * @return session attribution
+     * @return session identity
      */
-    public Optional<MCPSessionAttribution> resolve(final Map<String, List<String>> headers) {
+    public Optional<MCPSessionIdentity> resolve(final Map<String, List<String>> headers) {
         if (!isEnabled()) {
             return Optional.empty();
         }
@@ -75,7 +75,7 @@ public final class SessionAttributionResolver {
         if (subject.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(new MCPSessionAttribution(subject, getHeaderValue(headers, config.getSourceHeader()),
+        return Optional.of(new MCPSessionIdentity(subject, getHeaderValue(headers, config.getSourceHeader()),
                 resolveAttributes(headers.keySet(), name -> getHeaderValue(headers, name))));
     }
     

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServlet.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServlet.java
@@ -157,7 +157,7 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
         }
         SessionAwareHttpServletResponse actualResponse = withInitializeProtocolHeader(response);
         serviceRequest(request, actualResponse);
-        bindSessionAttribution(request, actualResponse);
+        bindSessionIdentity(request, actualResponse);
     }
     
     private boolean isJsonContentType(final HttpServletRequest request) {
@@ -234,12 +234,12 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
         }
     }
     
-    private void bindSessionAttribution(final HttpServletRequest request, final SessionAwareHttpServletResponse response) {
+    private void bindSessionIdentity(final HttpServletRequest request, final SessionAwareHttpServletResponse response) {
         String sessionId = response.getSessionId();
         if (sessionId.isEmpty()) {
             return;
         }
-        sessionAttributionResolver.resolve(request).ifPresent(sessionAttribution -> sessionManager.bindSessionAttribution(sessionId, sessionAttribution));
+        sessionAttributionResolver.resolve(request).ifPresent(sessionIdentity -> sessionManager.bindSessionIdentity(sessionId, sessionIdentity));
     }
     
     private SessionAwareHttpServletResponse withInitializeProtocolHeader(final HttpServletResponse response) {

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidator.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidator.java
@@ -21,7 +21,7 @@ import io.modelcontextprotocol.server.transport.ServerTransportSecurityException
 import io.modelcontextprotocol.server.transport.ServerTransportSecurityValidator;
 import io.modelcontextprotocol.spec.HttpHeaders;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionIdentity;
 import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.SessionAttributionResolver;
 import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator.constraint.SessionRequiredTransportHeaderConstraint;
 import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator.constraint.TransportHeaderConstraint;
@@ -46,7 +46,7 @@ public final class ShardingSphereServerTransportSecurityValidator implements Ser
     
     @Override
     public void validateHeaders(final Map<String, List<String>> headers) throws ServerTransportSecurityException {
-        validateSessionAttribution(headers);
+        validateSessionIdentity(headers);
         for (TransportHeaderConstraint each : constraints) {
             if (each instanceof SessionRequiredTransportHeaderConstraint) {
                 String sessionId = getFirstHeaderValue(headers, HttpHeaders.MCP_SESSION_ID);
@@ -58,21 +58,21 @@ public final class ShardingSphereServerTransportSecurityValidator implements Ser
         }
     }
     
-    private void validateSessionAttribution(final Map<String, List<String>> headers) throws ServerTransportSecurityException {
+    private void validateSessionIdentity(final Map<String, List<String>> headers) throws ServerTransportSecurityException {
         String sessionId = getFirstHeaderValue(headers, HttpHeaders.MCP_SESSION_ID);
         if (sessionId.isEmpty() || !sessionManager.hasSession(sessionId) || !sessionAttributionResolver.isEnabled()) {
             return;
         }
-        Optional<MCPSessionAttribution> sessionAttribution = sessionAttributionResolver.resolve(headers);
-        if (sessionAttribution.isEmpty()) {
+        Optional<MCPSessionIdentity> sessionIdentity = sessionAttributionResolver.resolve(headers);
+        if (sessionIdentity.isEmpty()) {
             return;
         }
-        Optional<MCPSessionAttribution> boundSessionAttribution = sessionManager.findSessionAttribution(sessionId);
-        if (boundSessionAttribution.isEmpty()) {
+        Optional<MCPSessionIdentity> boundSessionIdentity = sessionManager.findSessionIdentity(sessionId);
+        if (boundSessionIdentity.isEmpty()) {
             throw new MCPTransportSecurityException(400, "Session attribution is not bound for this MCP session.",
                     MCPTransportSecurityException.CATEGORY_SESSION_ATTRIBUTION_MISMATCH);
         }
-        if (!boundSessionAttribution.get().equals(sessionAttribution.get())) {
+        if (!boundSessionIdentity.get().equals(sessionIdentity.get())) {
             throw new MCPTransportSecurityException(400, "Session attribution does not match this MCP session.",
                     MCPTransportSecurityException.CATEGORY_SESSION_ATTRIBUTION_MISMATCH);
         }

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServletTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServletTest.java
@@ -26,7 +26,7 @@ import io.modelcontextprotocol.spec.ProtocolVersions;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionIdentity;
 import org.apache.shardingsphere.mcp.bootstrap.config.HttpTransportConfiguration;
 import org.apache.shardingsphere.mcp.bootstrap.config.SessionAttributionSourceConfiguration;
 import org.apache.shardingsphere.mcp.bootstrap.transport.MCPTransportConstants;
@@ -235,7 +235,7 @@ class StreamableHttpMCPServletTest {
     }
     
     @Test
-    void assertServicePostBindSessionAttribution() throws ServletException, IOException, ReflectiveOperationException {
+    void assertServicePostBindSessionIdentity() throws ServletException, IOException, ReflectiveOperationException {
         HttpServletStreamableServerTransportProvider delegate = mock(HttpServletStreamableServerTransportProvider.class);
         MCPSessionManager sessionManager = mock(MCPSessionManager.class);
         HttpServletRequest request = mock(HttpServletRequest.class);
@@ -255,7 +255,7 @@ class StreamableHttpMCPServletTest {
             return null;
         }).when(delegate).service(any(HttpServletRequest.class), any(HttpServletResponse.class));
         actual.service(request, response);
-        verify(sessionManager).bindSessionAttribution("session-id", new MCPSessionAttribution("subject", "gateway", Map.of("region", "ap-south")));
+        verify(sessionManager).bindSessionIdentity("session-id", new MCPSessionIdentity("subject", "gateway", Map.of("region", "ap-south")));
     }
     
     @Test

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidatorTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/validator/ShardingSphereServerTransportSecurityValidatorTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.mcp.bootstrap.transport.server.http.validator;
 
 import io.modelcontextprotocol.spec.HttpHeaders;
-import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionIdentity;
 import org.apache.shardingsphere.mcp.bootstrap.config.SessionAttributionSourceConfiguration;
 import org.apache.shardingsphere.mcp.bootstrap.transport.server.http.SessionAttributionResolver;
 import org.apache.shardingsphere.mcp.core.session.MCPSessionManager;
@@ -36,10 +36,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ShardingSphereServerTransportSecurityValidatorTest {
     
     @Test
-    void assertValidateHeadersWithMatchedSessionAttribution() {
+    void assertValidateHeadersWithMatchedSessionIdentity() {
         MCPSessionManager sessionManager = new MCPSessionManager(Map.of());
         sessionManager.createSession("session-1");
-        sessionManager.bindSessionAttribution("session-1", new MCPSessionAttribution("subject", "gateway", Map.of()));
+        sessionManager.bindSessionIdentity("session-1", new MCPSessionIdentity("subject", "gateway", Map.of()));
         ShardingSphereServerTransportSecurityValidator actual = new ShardingSphereServerTransportSecurityValidator(sessionManager, List.of(),
                 new SessionAttributionResolver(new SessionAttributionSourceConfiguration("X-Test-Subject", "X-Test-Source", "X-Test-Attr-")));
         assertDoesNotThrow(() -> actual.validateHeaders(Map.of(HttpHeaders.MCP_SESSION_ID, List.of("session-1"), "X-Test-Subject", List.of("subject"),
@@ -47,10 +47,10 @@ class ShardingSphereServerTransportSecurityValidatorTest {
     }
     
     @Test
-    void assertValidateHeadersWithMismatchedSessionAttribution() {
+    void assertValidateHeadersWithMismatchedSessionIdentity() {
         MCPSessionManager sessionManager = new MCPSessionManager(Map.of());
         sessionManager.createSession("session-1");
-        sessionManager.bindSessionAttribution("session-1", new MCPSessionAttribution("subject", "gateway", Map.of()));
+        sessionManager.bindSessionIdentity("session-1", new MCPSessionIdentity("subject", "gateway", Map.of()));
         ShardingSphereServerTransportSecurityValidator actual = new ShardingSphereServerTransportSecurityValidator(sessionManager, List.of(),
                 new SessionAttributionResolver(new SessionAttributionSourceConfiguration("X-Test-Subject", "X-Test-Source", "X-Test-Attr-")));
         MCPTransportSecurityException exception = assertThrows(MCPTransportSecurityException.class, () -> actual.validateHeaders(
@@ -61,7 +61,7 @@ class ShardingSphereServerTransportSecurityValidatorTest {
     }
     
     @Test
-    void assertValidateHeadersWithUnboundSessionAttribution() {
+    void assertValidateHeadersWithUnboundSessionIdentity() {
         MCPSessionManager sessionManager = new MCPSessionManager(Map.of());
         sessionManager.createSession("session-1");
         ShardingSphereServerTransportSecurityValidator actual = new ShardingSphereServerTransportSecurityValidator(sessionManager, List.of(),
@@ -71,6 +71,6 @@ class ShardingSphereServerTransportSecurityValidatorTest {
         assertThat(exception.getStatusCode(), is(400));
         assertThat(exception.getMessage(), is("Session attribution is not bound for this MCP session."));
         assertThat(exception.getCategory(), is("session_attribution_mismatch"));
-        assertThat(sessionManager.findSessionAttribution("session-1"), is(Optional.empty()));
+        assertThat(sessionManager.findSessionIdentity("session-1"), is(Optional.empty()));
     }
 }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/context/MCPRequestScope.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/context/MCPRequestScope.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.mcp.core.context;
 
 import lombok.AccessLevel;
 import lombok.Getter;
-import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionIdentity;
 import org.apache.shardingsphere.mcp.core.session.MCPSessionManager;
 import org.apache.shardingsphere.mcp.core.tool.handler.execute.MCPSQLExecutionFacade;
 import org.apache.shardingsphere.mcp.core.workflow.WorkflowProxyQueryService;
@@ -55,7 +55,7 @@ public final class MCPRequestScope implements MCPServiceHandlerContext, MCPDatab
     @Getter(AccessLevel.NONE)
     private final RequestScopedMetadataContext metadataContext;
     
-    private final Optional<MCPSessionAttribution> sessionAttribution;
+    private final Optional<MCPSessionIdentity> sessionIdentity;
     
     private final WorkflowSessionContext workflowSessionContext;
     
@@ -75,7 +75,7 @@ public final class MCPRequestScope implements MCPServiceHandlerContext, MCPDatab
         databaseCapabilityProvider = runtimeContext.getDatabaseCapabilityProvider();
         runtimeDatabases = sessionManager.getTransactionResourceManager().getRuntimeDatabases();
         metadataContext = new RequestScopedMetadataContext(runtimeDatabases, databaseCapabilityProvider);
-        sessionAttribution = sessionManager.findSessionAttribution(sessionId);
+        sessionIdentity = sessionManager.findSessionIdentity(sessionId);
         workflowSessionContext = runtimeContext.getWorkflowSessionContext();
         metadataQueryFacade = new MetadataQueryService(databaseCapabilityProvider, metadataContext);
         executionFacade = new MCPSQLExecutionFacade(databaseCapabilityProvider, sessionManager);
@@ -98,8 +98,8 @@ public final class MCPRequestScope implements MCPServiceHandlerContext, MCPDatab
     }
     
     @Override
-    public Optional<MCPSessionAttribution> findSessionAttribution() {
-        return sessionAttribution;
+    public Optional<MCPSessionIdentity> findSessionIdentity() {
+        return sessionIdentity;
     }
     
     @Override

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/session/MCPSessionManager.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/session/MCPSessionManager.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.mcp.core.session;
 
 import lombok.Getter;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
-import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionIdentity;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
 import org.apache.shardingsphere.mcp.core.tool.handler.execute.MCPJdbcTransactionResourceManager;
 
@@ -43,7 +43,7 @@ public final class MCPSessionManager {
     
     private final Map<String, ReentrantLock> sessions = new ConcurrentHashMap<>();
     
-    private final Map<String, MCPSessionAttribution> sessionAttributions = new ConcurrentHashMap<>();
+    private final Map<String, MCPSessionIdentity> sessionIdentities = new ConcurrentHashMap<>();
     
     private final List<Consumer<String>> sessionCloseListeners = new CopyOnWriteArrayList<>();
     
@@ -61,26 +61,26 @@ public final class MCPSessionManager {
     }
     
     /**
-     * Bind session attribution to one existing session.
+     * Bind session identity to one existing session.
      *
      * @param sessionId session id
-     * @param sessionAttribution session attribution
+     * @param sessionIdentity session identity
      */
-    public void bindSessionAttribution(final String sessionId, final MCPSessionAttribution sessionAttribution) {
+    public void bindSessionIdentity(final String sessionId, final MCPSessionIdentity sessionIdentity) {
         ShardingSpherePreconditions.checkState(hasSession(sessionId), MCPSessionNotExistedException::new);
-        MCPSessionAttribution existing = sessionAttributions.putIfAbsent(sessionId, sessionAttribution);
-        ShardingSpherePreconditions.checkState(null == existing || existing.equals(sessionAttribution),
-                () -> new IllegalStateException(String.format("Session attribution does not match existing binding for session `%s`.", sessionId)));
+        MCPSessionIdentity existing = sessionIdentities.putIfAbsent(sessionId, sessionIdentity);
+        ShardingSpherePreconditions.checkState(null == existing || existing.equals(sessionIdentity),
+                () -> new IllegalStateException(String.format("Session identity does not match existing binding for session `%s`.", sessionId)));
     }
     
     /**
-     * Find session attribution.
+     * Find session identity.
      *
      * @param sessionId session id
-     * @return session attribution
+     * @return session identity
      */
-    public Optional<MCPSessionAttribution> findSessionAttribution(final String sessionId) {
-        return Optional.ofNullable(sessionAttributions.get(sessionId));
+    public Optional<MCPSessionIdentity> findSessionIdentity(final String sessionId) {
+        return Optional.ofNullable(sessionIdentities.get(sessionId));
     }
     
     /**
@@ -116,7 +116,7 @@ public final class MCPSessionManager {
             transactionResourceManager.closeSession(sessionId);
         } finally {
             if (sessions.remove(sessionId, executionLock)) {
-                sessionAttributions.remove(sessionId);
+                sessionIdentities.remove(sessionId);
                 notifySessionCloseListeners(sessionId);
             }
         }

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/context/MCPRequestScopeTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/context/MCPRequestScopeTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.mcp.core.context;
 
-import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionIdentity;
 import org.apache.shardingsphere.mcp.core.session.MCPSessionManager;
 import org.apache.shardingsphere.mcp.support.database.capability.MCPDatabaseCapabilityProvider;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
@@ -32,22 +32,22 @@ import static org.hamcrest.Matchers.is;
 class MCPRequestScopeTest {
     
     @Test
-    void assertFindSessionAttribution() {
+    void assertFindSessionIdentity() {
         MCPSessionManager sessionManager = new MCPSessionManager(Map.of());
-        MCPSessionAttribution sessionAttribution = new MCPSessionAttribution("subject", "gateway", Map.of("cluster", "demo"));
+        MCPSessionIdentity sessionIdentity = new MCPSessionIdentity("subject", "gateway", Map.of("cluster", "demo"));
         sessionManager.createSession("session-1");
-        sessionManager.bindSessionAttribution("session-1", sessionAttribution);
+        sessionManager.bindSessionIdentity("session-1", sessionIdentity);
         MCPRuntimeContext runtimeContext = new MCPRuntimeContext(sessionManager, new MCPDatabaseCapabilityProvider(Map.of()), "http");
         try (MCPRequestScope requestScope = new MCPRequestScope(runtimeContext, "session-1")) {
-            assertThat(requestScope.findSessionAttribution(), is(Optional.of(sessionAttribution)));
+            assertThat(requestScope.findSessionIdentity(), is(Optional.of(sessionIdentity)));
         }
     }
     
     @Test
-    void assertFindSessionAttributionWithoutSession() {
+    void assertFindSessionIdentityWithoutSession() {
         MCPRuntimeContext runtimeContext = new MCPRuntimeContext(new MCPSessionManager(Map.of()), new MCPDatabaseCapabilityProvider(Map.of()), "http");
         try (MCPRequestScope requestScope = new MCPRequestScope(runtimeContext)) {
-            assertThat(requestScope.findSessionAttribution(), is(Optional.empty()));
+            assertThat(requestScope.findSessionIdentity(), is(Optional.empty()));
         }
     }
     

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/session/MCPSessionManagerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/session/MCPSessionManagerTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.mcp.core.session;
 
-import org.apache.shardingsphere.mcp.api.session.MCPSessionAttribution;
+import org.apache.shardingsphere.mcp.api.session.MCPSessionIdentity;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
 import org.junit.jupiter.api.Test;
 
@@ -136,30 +136,30 @@ class MCPSessionManagerTest {
     }
     
     @Test
-    void assertBindSessionAttribution() {
+    void assertBindSessionIdentity() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
-        MCPSessionAttribution sessionAttribution = new MCPSessionAttribution("subject", "gateway", Map.of("region", "ap-south"));
+        MCPSessionIdentity sessionIdentity = new MCPSessionIdentity("subject", "gateway", Map.of("region", "ap-south"));
         sessionManager.createSession("session-1");
-        assertDoesNotThrow(() -> sessionManager.bindSessionAttribution("session-1", sessionAttribution));
-        assertThat(sessionManager.findSessionAttribution("session-1"), is(Optional.of(sessionAttribution)));
+        assertDoesNotThrow(() -> sessionManager.bindSessionIdentity("session-1", sessionIdentity));
+        assertThat(sessionManager.findSessionIdentity("session-1"), is(Optional.of(sessionIdentity)));
     }
     
     @Test
-    void assertBindSessionAttributionWithDifferentBinding() {
+    void assertBindSessionIdentityWithDifferentBinding() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
         sessionManager.createSession("session-1");
-        sessionManager.bindSessionAttribution("session-1", new MCPSessionAttribution("subject", "gateway", Map.of()));
+        sessionManager.bindSessionIdentity("session-1", new MCPSessionIdentity("subject", "gateway", Map.of()));
         IllegalStateException actual = assertThrows(IllegalStateException.class,
-                () -> sessionManager.bindSessionAttribution("session-1", new MCPSessionAttribution("other", "gateway", Map.of())));
-        assertThat(actual.getMessage(), is("Session attribution does not match existing binding for session `session-1`."));
+                () -> sessionManager.bindSessionIdentity("session-1", new MCPSessionIdentity("other", "gateway", Map.of())));
+        assertThat(actual.getMessage(), is("Session identity does not match existing binding for session `session-1`."));
     }
     
     @Test
-    void assertCloseSessionRemovesSessionAttribution() {
+    void assertCloseSessionRemovesSessionIdentity() {
         MCPSessionManager sessionManager = new MCPSessionManager(Collections.emptyMap());
         sessionManager.createSession("session-1");
-        sessionManager.bindSessionAttribution("session-1", new MCPSessionAttribution("subject", "gateway", Map.of()));
+        sessionManager.bindSessionIdentity("session-1", new MCPSessionIdentity("subject", "gateway", Map.of()));
         sessionManager.closeSession("session-1");
-        assertThat(sessionManager.findSessionAttribution("session-1"), is(Optional.empty()));
+        assertThat(sessionManager.findSessionIdentity("session-1"), is(Optional.empty()));
     }
 }


### PR DESCRIPTION
Rename MCPSessionAttribution to MCPSessionIdentity and update the session binding APIs to use identity terminology.

Keep session attribution source configuration and transport diagnostics unchanged because they are external configuration and error surfaces.

Add focused value-semantics tests for MCPSessionIdentity and update the affected MCP session and HTTP transport tests.

For #35294.