### PR TITLE
Simplify MCP helper code

### DIFF
--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/validator/HttpTransportConfigurationValidator.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/yaml/validator/HttpTransportConfigurationValidator.java
@@ -47,10 +47,7 @@ public final class HttpTransportConfigurationValidator implements ConstraintVali
             addViolation(context, "endpointPath", "must be a single absolute path without query or fragment");
             return false;
         }
-        if (!isValidSessionAttributionSource(value.getSessionAttributionSource(), context)) {
-            return false;
-        }
-        return true;
+        return isValidSessionAttributionSource(value.getSessionAttributionSource(), context);
     }
     
     private boolean isValidBindHost(final String value) {

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/SQLStatementScanner.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/SQLStatementScanner.java
@@ -164,9 +164,9 @@ final class SQLStatementScanner {
                 currentIndex = stopIndex + 1;
                 continue;
             }
-            if (isWordCharacter(currentChar)) {
+            if (isIdentifierCharacter(currentChar)) {
                 int stopIndex = currentIndex;
-                while (stopIndex < sql.length() && isWordCharacter(sql.charAt(stopIndex))) {
+                while (stopIndex < sql.length() && isIdentifierCharacter(sql.charAt(stopIndex))) {
                     stopIndex++;
                 }
                 result.add(new SQLStatementToken(sql.substring(currentIndex, stopIndex), false));
@@ -323,10 +323,6 @@ final class SQLStatementScanner {
     
     private boolean isIdentifierCharacter(final char value) {
         return Character.isLetterOrDigit(value) || '_' == value || '$' == value;
-    }
-    
-    private boolean isWordCharacter(final char value) {
-        return isIdentifierCharacter(value);
     }
     
     private boolean isQuotedIdentifierStart(final char value) {

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/SQLStatementTargetResolver.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/SQLStatementTargetResolver.java
@@ -198,10 +198,7 @@ final class SQLStatementTargetResolver {
     
     private void collectCreateSourceObjectNames(final SQLStatementStructure statementStructure, final List<SQLStatementToken> tokens, final Collection<String> visitedAliases,
                                                 final Collection<String> objectNames) {
-        if (isStatementObjectType(tokens, "INDEX")) {
-            collectObjectNamesAfterKeyword(statementStructure, tokens, "ON", visitedAliases, objectNames);
-        }
-        if (isStatementObjectType(tokens, "TRIGGER", "POLICY")) {
+        if (isStatementObjectType(tokens, "INDEX", "TRIGGER", "POLICY")) {
             collectObjectNamesAfterKeyword(statementStructure, tokens, "ON", visitedAliases, objectNames);
         }
         if (isStatementObjectType(tokens, "TABLE")) {

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptMCPHandlerProvider.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptMCPHandlerProvider.java
@@ -28,9 +28,7 @@ import org.apache.shardingsphere.mcp.feature.encrypt.tool.service.EncryptWorkflo
 import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowDefinitionProvider;
 import org.apache.shardingsphere.mcp.support.workflow.spi.WorkflowRuntimeDefinition;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -40,12 +38,12 @@ public final class EncryptMCPHandlerProvider implements MCPHandlerProvider, MCPW
     
     @Override
     public Collection<MCPResourceHandler<?>> getResourceHandlers() {
-        return Arrays.asList(new EncryptAlgorithmsHandler(), new EncryptRulesHandler(), new EncryptRuleHandler());
+        return List.of(new EncryptAlgorithmsHandler(), new EncryptRulesHandler(), new EncryptRuleHandler());
     }
     
     @Override
     public Collection<MCPToolHandler<?>> getToolHandlers() {
-        return Collections.singleton(new PlanEncryptRuleToolHandler());
+        return List.of(new PlanEncryptRuleToolHandler());
     }
     
     @Override

--- a/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/MaskMCPHandlerProvider.java
+++ b/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/MaskMCPHandlerProvider.java
@@ -28,9 +28,7 @@ import org.apache.shardingsphere.mcp.feature.mask.tool.service.MaskWorkflowValid
 import org.apache.shardingsphere.mcp.support.workflow.spi.MCPWorkflowDefinitionProvider;
 import org.apache.shardingsphere.mcp.support.workflow.spi.WorkflowRuntimeDefinition;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -40,12 +38,12 @@ public final class MaskMCPHandlerProvider implements MCPHandlerProvider, MCPWork
     
     @Override
     public Collection<MCPResourceHandler<?>> getResourceHandlers() {
-        return Arrays.asList(new MaskAlgorithmsHandler(), new MaskRulesHandler(), new MaskRuleHandler());
+        return List.of(new MaskAlgorithmsHandler(), new MaskRulesHandler(), new MaskRuleHandler());
     }
     
     @Override
     public Collection<MCPToolHandler<?>> getToolHandlers() {
-        return Collections.singleton(new PlanMaskRuleToolHandler());
+        return List.of(new PlanMaskRuleToolHandler());
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowPlanningKernel.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowPlanningKernel.java
@@ -131,7 +131,7 @@ final class ShardingWorkflowPlanningKernel {
                 "create", "Default sharding strategy workflow plan.", actual -> containsDefaultStrategy(inspectionService.queryDefaultStrategy(queryFacade, actual.getDatabase()),
                         queryFacade.getDatabaseType(actual.getDatabase()), actual.getDefaultStrategyType()),
                 this::hasRequiredDefaultStrategyInputs,
-                (actual, snapshot) -> planAlgorithms(queryFacade, actual, shouldPlanDefaultStrategyAlgorithm(actual), false, snapshot),
+                (actual, snapshot) -> planAlgorithms(queryFacade, actual, shouldPlanShardingAlgorithm(actual), false, snapshot),
                 actual -> distSQLPlanningService.planDefaultStrategy(actual, actual.getOperationType()));
     }
     
@@ -426,19 +426,15 @@ final class ShardingWorkflowPlanningKernel {
     private List<AlgorithmPropertyRequirement> findPropertyRequirements(final ShardingWorkflowRequest request, final boolean includeShardingAlgorithm,
                                                                         final boolean includeKeyGenerator) {
         if (includeShardingAlgorithm && includeKeyGenerator) {
-            return algorithmPropertyTemplateService.findRequirements(request.getAlgorithmType(), resolveKeyGeneratorType(request));
+            return algorithmPropertyTemplateService.findRequirements(request.getAlgorithmType(), request.getKeyGeneratorType());
         }
         return includeShardingAlgorithm
                 ? algorithmPropertyTemplateService.findAlgorithmRequirements(request.getAlgorithmType())
-                : algorithmPropertyTemplateService.findKeyGeneratorRequirements(resolveKeyGeneratorType(request));
+                : algorithmPropertyTemplateService.findKeyGeneratorRequirements(request.getKeyGeneratorType());
     }
     
     private boolean shouldPlanShardingAlgorithm(final ShardingWorkflowRequest request) {
         return !WorkflowLifecycle.OPERATION_DROP.equalsIgnoreCase(request.getOperationType()) && !"none".equalsIgnoreCase(normalizeStrategyType(request));
-    }
-    
-    private boolean shouldPlanDefaultStrategyAlgorithm(final ShardingWorkflowRequest request) {
-        return shouldPlanShardingAlgorithm(request);
     }
     
     private boolean shouldPlanTableRuleKeyGenerator(final ShardingWorkflowRequest request) {
@@ -448,10 +444,6 @@ final class ShardingWorkflowPlanningKernel {
     
     private boolean shouldPlanKeyGenerateStrategyGenerator(final ShardingWorkflowRequest request) {
         return !WorkflowLifecycle.OPERATION_DROP.equalsIgnoreCase(request.getOperationType()) && request.getKeyGeneratorName().isEmpty();
-    }
-    
-    private String resolveKeyGeneratorType(final ShardingWorkflowRequest request) {
-        return request.getKeyGeneratorType();
     }
     
     private boolean isUnusedComponent(final MCPFeatureQueryFacade queryFacade, final ShardingWorkflowRequest request) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilder.java
@@ -77,24 +77,16 @@ final class MCPDescriptorCatalogPayloadBuilder {
     }
     
     private Map<String, Object> toResourcePayload(final MCPResourceDescriptor descriptor) {
-        Map<String, Object> result = new LinkedHashMap<>(8, 1F);
-        result.put(MCPPayloadFieldNames.URI, descriptor.getUriTemplate());
-        result.put("name", descriptor.getName());
-        result.put("title", descriptor.getTitle());
-        result.put("description", descriptor.getDescription());
-        result.put("mimeType", descriptor.getMimeType());
-        if (!descriptor.getAnnotations().isEmpty()) {
-            result.put("annotations", toResourceAnnotationsPayload(descriptor.getAnnotations()));
-        }
-        if (!descriptor.getMeta().isEmpty()) {
-            result.put("_meta", descriptor.getMeta());
-        }
-        return result;
+        return createResourcePayload(descriptor, MCPPayloadFieldNames.URI);
     }
     
     private Map<String, Object> toResourceTemplatePayload(final MCPResourceDescriptor descriptor) {
+        return createResourcePayload(descriptor, "uriTemplate");
+    }
+    
+    private Map<String, Object> createResourcePayload(final MCPResourceDescriptor descriptor, final String uriFieldName) {
         Map<String, Object> result = new LinkedHashMap<>(8, 1F);
-        result.put("uriTemplate", descriptor.getUriTemplate());
+        result.put(uriFieldName, descriptor.getUriTemplate());
         result.put("name", descriptor.getName());
         result.put("title", descriptor.getTitle());
         result.put("description", descriptor.getDescription());

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanningSupport.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanningSupport.java
@@ -252,29 +252,29 @@ public final class WorkflowPlanningSupport {
         if (isEmptyIdentifier(request.getSchema())) {
             clarifiedIntent.getClarificationMessages().add("Please specify schema.");
         }
+        addMissingTableQuestion(request, clarifiedIntent, snapshot, "Table is required before planning.");
+        addMissingColumnQuestion(request, clarifiedIntent, snapshot, "Column is required before planning.");
+    }
+    
+    private void addMissingTableQuestion(final WorkflowRequest request, final ClarifiedIntent clarifiedIntent, final WorkflowContextSnapshot snapshot, final String message) {
         if (isEmptyIdentifier(request.getTable())) {
             clarifiedIntent.getClarificationMessages().add("Please specify target table.");
             snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.TABLE_REQUIRED, "error", "intaking",
-                    "Table is required before planning.", "Provide the logical table name.", true, Map.of()));
+                    message, "Provide the logical table name.", true, Map.of()));
         }
+    }
+    
+    private void addMissingColumnQuestion(final WorkflowRequest request, final ClarifiedIntent clarifiedIntent, final WorkflowContextSnapshot snapshot, final String message) {
         if (isEmptyIdentifier(request.getColumn())) {
             clarifiedIntent.getClarificationMessages().add("Please specify target column.");
             snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.COLUMN_REQUIRED, "error", "intaking",
-                    "Column is required before planning.", "Provide the logical column name.", true, Map.of()));
+                    message, "Provide the logical column name.", true, Map.of()));
         }
     }
     
     private void addMissingRuleQuestions(final WorkflowRequest request, final ClarifiedIntent clarifiedIntent, final WorkflowContextSnapshot snapshot) {
-        if (isEmptyIdentifier(request.getTable())) {
-            clarifiedIntent.getClarificationMessages().add("Please specify target table.");
-            snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.TABLE_REQUIRED, "error", "intaking",
-                    "Table is required before planning rule DistSQL.", "Provide the logical table name.", true, Map.of()));
-        }
-        if (isEmptyIdentifier(request.getColumn())) {
-            clarifiedIntent.getClarificationMessages().add("Please specify target column.");
-            snapshot.getIssues().add(new WorkflowIssue(WorkflowIssueCode.COLUMN_REQUIRED, "error", "intaking",
-                    "Column is required before planning rule DistSQL.", "Provide the logical column name.", true, Map.of()));
-        }
+        addMissingTableQuestion(request, clarifiedIntent, snapshot, "Table is required before planning rule DistSQL.");
+        addMissingColumnQuestion(request, clarifiedIntent, snapshot, "Column is required before planning rule DistSQL.");
     }
     
     private boolean ensureSupportedIdentifier(final String fieldName, final String identifier, final WorkflowContextSnapshot snapshot) {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/MCPJdbcMetadataLoaderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/MCPJdbcMetadataLoaderTest.java
@@ -623,42 +623,7 @@ class MCPJdbcMetadataLoaderTest {
     }
     
     private boolean containsMetadata(final MCPDatabaseMetadata databaseMetadata, final SupportedMCPMetadataObjectType objectType, final String objectName) {
-        for (MCPSchemaMetadata each : databaseMetadata.getSchemas()) {
-            if (SupportedMCPMetadataObjectType.SCHEMA == objectType && objectName.equals(each.getSchema())) {
-                return true;
-            }
-            for (MCPTableMetadata table : each.getTables()) {
-                if (SupportedMCPMetadataObjectType.TABLE == objectType && objectName.equals(table.getTable())) {
-                    return true;
-                }
-                for (MCPColumnMetadata column : table.getColumns()) {
-                    if (SupportedMCPMetadataObjectType.COLUMN == objectType && objectName.equals(column.getColumn())) {
-                        return true;
-                    }
-                }
-                for (MCPIndexMetadata index : table.getIndexes()) {
-                    if (SupportedMCPMetadataObjectType.INDEX == objectType && objectName.equals(index.getIndex())) {
-                        return true;
-                    }
-                }
-            }
-            for (MCPViewMetadata view : each.getViews()) {
-                if (SupportedMCPMetadataObjectType.VIEW == objectType && objectName.equals(view.getView())) {
-                    return true;
-                }
-                for (MCPColumnMetadata column : view.getColumns()) {
-                    if (SupportedMCPMetadataObjectType.COLUMN == objectType && objectName.equals(column.getColumn())) {
-                        return true;
-                    }
-                }
-            }
-            for (MCPSequenceMetadata sequence : each.getSequences()) {
-                if (SupportedMCPMetadataObjectType.SEQUENCE == objectType && objectName.equals(sequence.getSequence())) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return 0 < countMetadata(databaseMetadata, objectType, objectName);
     }
     
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPModelFacingToolResponseFormatter.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPModelFacingToolResponseFormatter.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.util.json.JsonUtils;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -30,36 +31,21 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class LLMMCPModelFacingToolResponseFormatter {
     
+    private static final List<String> GENERAL_FIELD_NAMES = List.of(
+            "response_mode", "error_code", "message", "recovery_category", "result_kind", "status", "statement_type", "normalized_sql", "rows", "row_objects",
+            "returned_row_count", "plan_id", "workflow_resource", "manual_artifact_summary", "manual_follow_up");
+    
+    private static final List<String> POST_ACTION_FIELD_NAMES = List.of(
+            "completion", "count", "has_more", "total_match_count", "returned_count", "truncated", "large_result_guidance", "search_context", "ambiguity_state");
+    
     static String format(final Map<String, Object> response) {
         Map<String, Object> result = new LinkedHashMap<>(16, 1F);
-        copyIfPresent(response, result, "response_mode");
-        copyIfPresent(response, result, "error_code");
-        copyIfPresent(response, result, "message");
-        copyIfPresent(response, result, "recovery_category");
-        copyIfPresent(response, result, "result_kind");
-        copyIfPresent(response, result, "status");
-        copyIfPresent(response, result, "statement_type");
-        copyIfPresent(response, result, "normalized_sql");
-        copyIfPresent(response, result, "rows");
-        copyIfPresent(response, result, "row_objects");
-        copyIfPresent(response, result, "returned_row_count");
-        copyIfPresent(response, result, "plan_id");
-        copyIfPresent(response, result, "workflow_resource");
-        copyIfPresent(response, result, "manual_artifact_summary");
-        copyIfPresent(response, result, "manual_follow_up");
+        copyFields(response, result, GENERAL_FIELD_NAMES);
         copyCompactArtifactList(response, result, "manual_artifacts");
         copyCompactArtifactList(response, result, "exported_artifacts");
         copyIfPresent(response, result, "resources_to_read");
         copyModelFacingNextActions(response, result);
-        copyIfPresent(response, result, "completion");
-        copyIfPresent(response, result, "count");
-        copyIfPresent(response, result, "has_more");
-        copyIfPresent(response, result, "total_match_count");
-        copyIfPresent(response, result, "returned_count");
-        copyIfPresent(response, result, "truncated");
-        copyIfPresent(response, result, "large_result_guidance");
-        copyIfPresent(response, result, "search_context");
-        copyIfPresent(response, result, "ambiguity_state");
+        copyFields(response, result, POST_ACTION_FIELD_NAMES);
         List<Map<String, Object>> resources = LLMMCPJsonValues.castToList(response.get("resources"));
         if (!resources.isEmpty()) {
             List<Map<String, Object>> compactResources = new LinkedList<>();
@@ -78,6 +64,12 @@ final class LLMMCPModelFacingToolResponseFormatter {
         copyCompactItems(response, result);
         copyCompactRecovery(response, result);
         return JsonUtils.toJsonString(result.isEmpty() ? response : result);
+    }
+    
+    private static void copyFields(final Map<String, Object> source, final Map<String, Object> target, final Collection<String> fieldNames) {
+        for (String each : fieldNames) {
+            copyIfPresent(source, target, each);
+        }
     }
     
     private static void copyIfPresent(final Map<String, Object> source, final Map<String, Object> target, final String fieldName) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/AbstractHttpProgrammaticRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/AbstractHttpProgrammaticRuntimeE2ETest.java
@@ -119,12 +119,12 @@ abstract class AbstractHttpProgrammaticRuntimeE2ETest extends AbstractConfigBack
     
     protected final Map<String, Object> getStructuredContent(final String responseBody) {
         Map<String, Object> payload = MCPInteractionPayloads.parseJsonPayload(responseBody);
-        return MCPInteractionPayloads.hasJsonRpcError(payload) ? MCPInteractionPayloads.getJsonRpcErrorPayload(payload) : MCPInteractionPayloads.getStructuredContent(payload);
+        return MCPInteractionPayloads.getStructuredContent(payload);
     }
     
     protected final Map<String, Object> getFirstResourcePayload(final String responseBody) {
         Map<String, Object> payload = MCPInteractionPayloads.parseJsonPayload(responseBody);
-        return MCPInteractionPayloads.hasJsonRpcError(payload) ? MCPInteractionPayloads.getJsonRpcErrorPayload(payload) : MCPInteractionPayloads.getFirstResourcePayload(payload);
+        return MCPInteractionPayloads.getFirstResourcePayload(payload);
     }
     
     protected final Map<String, Object> parseJsonBody(final String responseBody) {


### PR DESCRIPTION
Refactor small duplicated MCP and MCP E2E helper flows without changing public behavior. Reuse shared payload field builders, remove redundant wrapper methods, simplify repeated provider collections, and keep existing descriptor, SQL classification, workflow, and model-facing formatter tests passing.

For #35294.