### PR TITLE
Split MCP E2E workflow and reduce LLM readiness checks

### DIFF
--- a/.github/workflows/e2e-mcp.yml
+++ b/.github/workflows/e2e-mcp.yml
@@ -143,7 +143,13 @@ jobs:
           set -euo pipefail
           artifact_dir="${RUNNER_TEMP}/mcp-e2e-build-artifacts"
           mkdir -p "${artifact_dir}"
+          distribution_home="$(find distribution/mcp/target -maxdepth 1 -type d -name 'apache-shardingsphere-mcp-*' | head -n 1)"
+          if [[ -z "${distribution_home}" ]]; then
+            echo "Packaged MCP distribution was not found." 1>&2
+            exit 1
+          fi
           tar -czf "${artifact_dir}/maven-repo-output.tar.gz" -C "${HOME}/.m2/repository" org/apache/shardingsphere
+          tar -czf "${artifact_dir}/mcp-distribution-home.tar.gz" -C distribution/mcp/target "$(basename "${distribution_home}")"
           docker save -o "${artifact_dir}/mcp-distribution-image.tar" "${{ env.MCP_DISTRIBUTION_IMAGE }}"
           docker save -o "${artifact_dir}/mcp-llm-runtime-image.tar" "${{ steps.mcp-e2e-properties.outputs.server_image }}"
       - name: Upload MCP E2E Maven Repository
@@ -157,6 +163,12 @@ jobs:
         with:
           name: mcp-e2e-distribution-image
           path: ${{ runner.temp }}/mcp-e2e-build-artifacts/mcp-distribution-image.tar
+          retention-days: 3
+      - name: Upload MCP Distribution Home
+        uses: actions/upload-artifact@v6
+        with:
+          name: mcp-e2e-distribution-home
+          path: ${{ runner.temp }}/mcp-e2e-build-artifacts/mcp-distribution-home.tar.gz
           retention-days: 3
       - name: Upload MCP LLM Runtime Image
         uses: actions/upload-artifact@v6
@@ -189,12 +201,19 @@ jobs:
         with:
           name: mcp-e2e-distribution-image
           path: ${{ runner.temp }}/mcp-e2e-build-artifacts
+      - name: Download MCP Distribution Home
+        uses: actions/download-artifact@v8
+        with:
+          name: mcp-e2e-distribution-home
+          path: ${{ runner.temp }}/mcp-e2e-build-artifacts
       - name: Restore MCP E2E Build Artifacts
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p "${HOME}/.m2/repository"
+          mkdir -p distribution/mcp/target
           tar -xzf "${RUNNER_TEMP}/mcp-e2e-build-artifacts/maven-repo-output.tar.gz" -C "${HOME}/.m2/repository"
+          tar -xzf "${RUNNER_TEMP}/mcp-e2e-build-artifacts/mcp-distribution-home.tar.gz" -C distribution/mcp/target
           docker load -i "${RUNNER_TEMP}/mcp-e2e-build-artifacts/mcp-distribution-image.tar"
       - name: Run MCP Core E2E
         shell: bash

--- a/.github/workflows/e2e-mcp.yml
+++ b/.github/workflows/e2e-mcp.yml
@@ -47,8 +47,8 @@ env:
   MCP_DISTRIBUTION_IMAGE: apache/shardingsphere-mcp-e2e:local
 
 jobs:
-  e2e-mcp-mysql-runtime:
-    name: E2E - MCP MySQL Runtime
+  e2e-mcp-build-images:
+    name: E2E - MCP Build Images
     if: github.repository == 'apache/shardingsphere'
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -115,6 +115,12 @@ jobs:
             echo "model_file_name=$(load_property 'mcp.llm.model-file-name')"
             echo "model_sha256=$(load_property 'mcp.llm.model-sha256')"
           } >> "${GITHUB_OUTPUT}"
+      - name: Build MCP E2E Test Dependencies
+        run: ./mvnw -pl test/e2e/mcp -am install -DskipTests -DskipITs -Dspotless.skip=true -B -ntp
+      - name: Package MCP Distribution
+        run: ./mvnw -pl distribution/mcp -am -DskipTests package -B -ntp
+      - name: Build MCP Distribution Image
+        run: docker build --platform "${{ steps.mcp-e2e-properties.outputs.target_platform }}" -f distribution/mcp/Dockerfile -t "${{ env.MCP_DISTRIBUTION_IMAGE }}" distribution/mcp/target
       - name: Build MCP LLM Runtime Image
         shell: bash
         run: |
@@ -131,18 +137,128 @@ jobs:
             --build-arg "MODEL_FILE_NAME=${{ steps.mcp-e2e-properties.outputs.model_file_name }}" \
             --build-arg "MODEL_SHA256=${{ steps.mcp-e2e-properties.outputs.model_sha256 }}" \
             test/e2e/mcp/src/test/resources/docker/llm-runtime
-      - name: Build MCP E2E Test Dependencies
-        run: ./mvnw -pl test/e2e/mcp -am install -DskipTests -DskipITs -Dspotless.skip=true -B -ntp
-      - name: Package MCP Distribution
-        run: ./mvnw -pl distribution/mcp -am -DskipTests package -B -ntp
-      - name: Build MCP Distribution Image
-        run: docker build --platform "${{ steps.mcp-e2e-properties.outputs.target_platform }}" -f distribution/mcp/Dockerfile -t "${{ env.MCP_DISTRIBUTION_IMAGE }}" distribution/mcp/target
-      - name: Run MCP E2E
+      - name: Package MCP E2E Build Artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/mcp-e2e-build-artifacts"
+          mkdir -p "${artifact_dir}"
+          tar -czf "${artifact_dir}/maven-repo-output.tar.gz" -C "${HOME}/.m2/repository" org/apache/shardingsphere
+          docker save -o "${artifact_dir}/mcp-distribution-image.tar" "${{ env.MCP_DISTRIBUTION_IMAGE }}"
+          docker save -o "${artifact_dir}/mcp-llm-runtime-image.tar" "${{ steps.mcp-e2e-properties.outputs.server_image }}"
+      - name: Upload MCP E2E Maven Repository
+        uses: actions/upload-artifact@v6
+        with:
+          name: mcp-e2e-maven-repository
+          path: ${{ runner.temp }}/mcp-e2e-build-artifacts/maven-repo-output.tar.gz
+          retention-days: 3
+      - name: Upload MCP Distribution Image
+        uses: actions/upload-artifact@v6
+        with:
+          name: mcp-e2e-distribution-image
+          path: ${{ runner.temp }}/mcp-e2e-build-artifacts/mcp-distribution-image.tar
+          retention-days: 3
+      - name: Upload MCP LLM Runtime Image
+        uses: actions/upload-artifact@v6
+        with:
+          name: mcp-e2e-llm-runtime-image
+          path: ${{ runner.temp }}/mcp-e2e-build-artifacts/mcp-llm-runtime-image.tar
+          retention-days: 3
+
+  e2e-mcp-core:
+    name: E2E - MCP Core
+    if: github.repository == 'apache/shardingsphere'
+    needs: e2e-mcp-build-images
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6.0.1
+      - uses: ./.github/workflows/resources/actions/setup-build-environment
+        with:
+          java-version: '21'
+          cache-suffix: 'e2e-mcp'
+          cache-save-enabled: 'false'
+          enable-docker-setup: 'true'
+      - name: Download MCP E2E Maven Repository
+        uses: actions/download-artifact@v8
+        with:
+          name: mcp-e2e-maven-repository
+          path: ${{ runner.temp }}/mcp-e2e-build-artifacts
+      - name: Download MCP Distribution Image
+        uses: actions/download-artifact@v8
+        with:
+          name: mcp-e2e-distribution-image
+          path: ${{ runner.temp }}/mcp-e2e-build-artifacts
+      - name: Restore MCP E2E Build Artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${HOME}/.m2/repository"
+          tar -xzf "${RUNNER_TEMP}/mcp-e2e-build-artifacts/maven-repo-output.tar.gz" -C "${HOME}/.m2/repository"
+          docker load -i "${RUNNER_TEMP}/mcp-e2e-build-artifacts/mcp-distribution-image.tar"
+      - name: Run MCP Core E2E
         shell: bash
         run: |
           set -euo pipefail
           ./mvnw -pl test/e2e/mcp test -DskipITs -Dspotless.skip=true \
             -Dtest='*E2ETest' \
+            -DexcludedGroups=llm-e2e \
+            -Dsurefire.failIfNoSpecifiedTests=true \
+            -De2e.run.type=DOCKER \
+            -Dmcp.e2e.container.image="${{ env.MCP_DISTRIBUTION_IMAGE }}" \
+            -B -ntp
+      - name: Upload MCP Core E2E Artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: e2e-mcp-core-${{ github.run_id }}-${{ github.run_attempt }}
+          path: test/e2e/mcp/target/surefire-reports
+          if-no-files-found: warn
+
+  e2e-mcp-llm:
+    name: E2E - MCP LLM
+    if: github.repository == 'apache/shardingsphere'
+    needs: e2e-mcp-build-images
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6.0.1
+      - uses: ./.github/workflows/resources/actions/setup-build-environment
+        with:
+          java-version: '21'
+          cache-suffix: 'e2e-mcp'
+          cache-save-enabled: 'false'
+          enable-docker-setup: 'true'
+      - name: Download MCP E2E Maven Repository
+        uses: actions/download-artifact@v8
+        with:
+          name: mcp-e2e-maven-repository
+          path: ${{ runner.temp }}/mcp-e2e-build-artifacts
+      - name: Download MCP Distribution Image
+        uses: actions/download-artifact@v8
+        with:
+          name: mcp-e2e-distribution-image
+          path: ${{ runner.temp }}/mcp-e2e-build-artifacts
+      - name: Download MCP LLM Runtime Image
+        uses: actions/download-artifact@v8
+        with:
+          name: mcp-e2e-llm-runtime-image
+          path: ${{ runner.temp }}/mcp-e2e-build-artifacts
+      - name: Restore MCP E2E Build Artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${HOME}/.m2/repository"
+          tar -xzf "${RUNNER_TEMP}/mcp-e2e-build-artifacts/maven-repo-output.tar.gz" -C "${HOME}/.m2/repository"
+          docker load -i "${RUNNER_TEMP}/mcp-e2e-build-artifacts/mcp-distribution-image.tar"
+          docker load -i "${RUNNER_TEMP}/mcp-e2e-build-artifacts/mcp-llm-runtime-image.tar"
+      - name: Run MCP LLM E2E
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./mvnw -pl test/e2e/mcp test -DskipITs -Dspotless.skip=true \
+            -Dtest='*E2ETest' \
+            -Dgroups=llm-e2e \
             -Dsurefire.failIfNoSpecifiedTests=true \
             -De2e.run.type=DOCKER \
             -Dmcp.e2e.container.image="${{ env.MCP_DISTRIBUTION_IMAGE }}" \
@@ -151,11 +267,11 @@ jobs:
             -Dmcp.llm.artifact-root="${{ github.workspace }}/test/e2e/mcp/target/llm-e2e" \
             -Dmcp.llm.run-id=gha-${{ github.run_id }}-${{ github.run_attempt }} \
             -B -ntp
-      - name: Upload MCP E2E Artifacts
+      - name: Upload MCP LLM E2E Artifacts
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: e2e-mcp-${{ github.run_id }}-${{ github.run_attempt }}
+          name: e2e-mcp-llm-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             test/e2e/mcp/target/llm-e2e
             test/e2e/mcp/target/surefire-reports

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunner.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunner.java
@@ -86,7 +86,6 @@ public final class LLMMCPConversationRunner {
         List<LLMChatMessage> messages = createInitialMessages(scenario);
         LLMMCPConversationArtifacts artifacts = new LLMMCPConversationArtifacts(modelProvider, modelName);
         try {
-            llmChatClient.waitUntilReady();
             openInteractionClient();
             LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
             LLMMCPConversationTurnPlanner turnPlanner = new LLMMCPConversationTurnPlanner(instructionFactory);

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunnerFailureTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationRunnerFailureTest.java
@@ -145,12 +145,13 @@ class LLMMCPConversationRunnerFailureTest extends AbstractLLMMCPConversationRunn
     void assertRunWithModelServiceUnavailable() throws IOException, InterruptedException {
         LLME2EScenario actualScenario = createScenario(List.of("database_gateway_execute_query"));
         LLMMCPConversationRunner actualRunner = createRunner(1);
-        doThrow(new IllegalStateException("Model service is not ready for `ggml-org/Qwen3-1.7B-GGUF:Q4_K_M`.")).when(getLLMChatClient()).waitUntilReady();
+        when(getLLMChatClient().complete(anyList(), anyList(), eq("required"), eq(false))).thenThrow(
+                new IllegalStateException("Model service is not ready for `ggml-org/Qwen3-1.7B-GGUF:Q4_K_M`."));
         
         LLME2EArtifactBundle actual = actualRunner.run(actualScenario);
         
         assertThat(actual.getAssertionReport().getFailureType(), is("model_service_unavailable"));
-        verify(getMCPInteractionClient(), never()).open();
+        verify(getMCPInteractionClient()).open();
         verify(getMCPInteractionClient()).close();
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/LLMUsabilitySuiteRunner.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/suite/usability/LLMUsabilitySuiteRunner.java
@@ -66,13 +66,15 @@ final class LLMUsabilitySuiteRunner {
     
     void assertCoreSuite(final String suiteId, final Supplier<List<LLMUsabilityScenario>> scenarioSupplier,
                          final ConversationRunner conversationRunner, final LLME2EConfiguration configuration) throws IOException {
-        EvaluatedSuite evaluatedSuite = evaluateSuite(suiteId, scenarioSupplier, conversationRunner, configuration);
-        assumeModelServiceAvailable(evaluatedSuite.scorecard());
-        assertFullScore(evaluatedSuite.scorecard(), evaluatedSuite.scenarios());
-        assertDeterministicContract(evaluatedSuite);
+        assertSuite(suiteId, scenarioSupplier, conversationRunner, configuration);
     }
     
     void assertExtendedSuite(final String suiteId, final Supplier<List<LLMUsabilityScenario>> scenarioSupplier,
+                             final ConversationRunner conversationRunner, final LLME2EConfiguration configuration) throws IOException {
+        assertSuite(suiteId, scenarioSupplier, conversationRunner, configuration);
+    }
+    
+    private void assertSuite(final String suiteId, final Supplier<List<LLMUsabilityScenario>> scenarioSupplier,
                              final ConversationRunner conversationRunner, final LLME2EConfiguration configuration) throws IOException {
         EvaluatedSuite evaluatedSuite = evaluateSuite(suiteId, scenarioSupplier, conversationRunner, configuration);
         assumeModelServiceAvailable(evaluatedSuite.scorecard());

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionProxyWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionProxyWorkflowE2ETest.java
@@ -18,10 +18,12 @@
 package org.apache.shardingsphere.test.e2e.mcp.runtime.production;
 
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowToolDescriptors;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.MySQLRuntimeTestSupport;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.ProxyEncryptWorkflowRuntimeTestSupport;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.ProxyEncryptWorkflowRuntimeTestSupport.ProxyEncryptWorkflowRuntimeFixture;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.RuntimeTransport;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.client.MCPInteractionClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
@@ -114,6 +116,24 @@ abstract class AbstractProductionProxyWorkflowE2ETest extends AbstractProduction
     
     protected final void assertApplyCompleted(final Map<String, Object> actualApplyResponse) {
         assertThat(actualApplyResponse.toString(), String.valueOf(actualApplyResponse.get("status")), is("completed"));
+    }
+    
+    protected final Map<String, Object> applyReviewedWorkflow(final MCPInteractionClient interactionClient, final String planId) throws IOException, InterruptedException {
+        return interactionClient.call(WorkflowToolDescriptors.APPLY_TOOL_NAME, createReviewThenExecuteArguments(planId, getApprovedSteps(previewWorkflow(interactionClient, planId))));
+    }
+    
+    protected final Map<String, Object> previewWorkflow(final MCPInteractionClient interactionClient, final String planId) throws IOException, InterruptedException {
+        Map<String, Object> result = interactionClient.call(WorkflowToolDescriptors.APPLY_TOOL_NAME, Map.of("plan_id", planId, "execution_mode", "preview"));
+        assertThat(String.valueOf(result.get("status")), is("preview"));
+        return result;
+    }
+    
+    protected final List<String> getApprovedSteps(final Map<String, Object> previewResponse) {
+        return getMapList(previewResponse.get("preview_artifacts")).stream().map(each -> String.valueOf(each.get("approval_step"))).distinct().toList();
+    }
+    
+    protected final Map<String, Object> createReviewThenExecuteArguments(final String planId, final List<String> approvedSteps) {
+        return Map.of("plan_id", planId, "execution_mode", "review-then-execute", "approved_steps", approvedSteps);
     }
     
     protected final List<String> getIssueCodes(final Map<String, Object> payload) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyEncryptWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyEncryptWorkflowE2ETest.java
@@ -249,12 +249,11 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
                             "cipher_column_name", "status_cipher", "primary_algorithm_properties", Map.of("aes-key-value", "approved-secret")));
             assertThat(String.valueOf(actualPlannedResponse.get("status")), is("planned"));
             String planId = String.valueOf(actualPlannedResponse.get("plan_id"));
-            Map<String, Object> actualPreviewResponse = interactionClient.call(APPLY_TOOL_NAME, Map.of("plan_id", planId, "execution_mode", "preview"));
-            assertThat(String.valueOf(actualPreviewResponse.get("status")), is("preview"));
+            Map<String, Object> actualPreviewResponse = previewWorkflow(interactionClient, planId);
             List<Map<String, Object>> actualPreviewArtifacts = getMapList(actualPreviewResponse.get("preview_artifacts"));
             assertThat(actualPreviewArtifacts.size(), is(1));
             assertThat(String.valueOf(actualPreviewArtifacts.getFirst().get("approval_step")), is("rule_distsql"));
-            Map<String, Object> actualRuleApplyResponse = interactionClient.call(APPLY_TOOL_NAME, createApplyArguments(planId, List.of("rule_distsql")));
+            Map<String, Object> actualRuleApplyResponse = interactionClient.call(APPLY_TOOL_NAME, createReviewThenExecuteArguments(planId, List.of("rule_distsql")));
             assertThat(String.valueOf(actualRuleApplyResponse.get("status")), is("completed"));
             assertThat(getStringList(actualRuleApplyResponse.get("executed_ddl")).size(), is(0));
             assertThat(getStringList(actualRuleApplyResponse.get("executed_distsql")).size(), is(1));
@@ -344,22 +343,12 @@ class HttpProductionProxyEncryptWorkflowE2ETest extends AbstractProductionProxyW
         assertValidationPassed(interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId)));
     }
     
-    private Map<String, Object> applyReviewedWorkflow(final MCPInteractionClient interactionClient, final String planId) throws IOException, InterruptedException {
-        return applyReviewedWorkflow(interactionClient, planId, "");
-    }
-    
     private Map<String, Object> applyReviewedWorkflow(final MCPInteractionClient interactionClient, final String planId, final String secretValue) throws IOException, InterruptedException {
-        Map<String, Object> previewResponse = interactionClient.call(APPLY_TOOL_NAME, Map.of("plan_id", planId, "execution_mode", "preview"));
-        assertThat(String.valueOf(previewResponse.get("status")), is("preview"));
+        Map<String, Object> previewResponse = previewWorkflow(interactionClient, planId);
         assertSecretRedacted(previewResponse, secretValue);
-        List<String> approvedSteps = getMapList(previewResponse.get("preview_artifacts")).stream().map(each -> String.valueOf(each.get("approval_step"))).distinct().toList();
-        Map<String, Object> result = interactionClient.call(APPLY_TOOL_NAME, createApplyArguments(planId, approvedSteps));
+        Map<String, Object> result = interactionClient.call(APPLY_TOOL_NAME, createReviewThenExecuteArguments(planId, getApprovedSteps(previewResponse)));
         assertSecretRedacted(result, secretValue);
         return result;
-    }
-    
-    private Map<String, Object> createApplyArguments(final String planId, final List<String> approvedSteps) {
-        return Map.of("plan_id", planId, "execution_mode", "review-then-execute", "approved_steps", approvedSteps);
     }
     
     private Map<String, Object> findItemByField(final List<Map<String, Object>> items, final String fieldName, final String expectedValue) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyFeatureWorkflowContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyFeatureWorkflowContractE2ETest.java
@@ -105,10 +105,8 @@ class HttpProductionProxyFeatureWorkflowContractE2ETest extends AbstractProducti
                     Map.of("database", getLogicalDatabaseName(), "operation_type", "create", "tables", "orders"));
             assertThat(String.valueOf(actualPlanResponse.get("status")), is("planned"));
             String planId = String.valueOf(actualPlanResponse.get("plan_id"));
-            Map<String, Object> actualPreviewResponse = interactionClient.call(APPLY_TOOL_NAME, Map.of("plan_id", planId, "execution_mode", "preview"));
-            assertThat(String.valueOf(actualPreviewResponse.get("status")), is("preview"));
-            List<String> approvedSteps = getMapList(actualPreviewResponse.get("preview_artifacts")).stream().map(each -> String.valueOf(each.get("approval_step"))).distinct().toList();
-            Map<String, Object> actualApplyResponse = interactionClient.call(APPLY_TOOL_NAME, Map.of("plan_id", planId, "execution_mode", "review-then-execute", "approved_steps", approvedSteps));
+            Map<String, Object> actualApplyResponse = interactionClient.call(APPLY_TOOL_NAME,
+                    createReviewThenExecuteArguments(planId, getApprovedSteps(previewWorkflow(interactionClient, planId))));
             assertApplyCompleted(actualApplyResponse);
             assertThat(getStringList(actualApplyResponse.get("executed_distsql")).size(), is(1));
             assertValidationPassed(interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId)));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
@@ -152,11 +152,10 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
                             "primary_algorithm_properties", Map.of("first-n", "1", "last-m", "1", "replace-char", "*")));
             assertThat(String.valueOf(actualPlanResponse.get("status")), is("planned"));
             String planId = String.valueOf(actualPlanResponse.get("plan_id"));
-            Map<String, Object> actualPreviewResponse = interactionClient.call(APPLY_TOOL_NAME, Map.of("plan_id", planId, "execution_mode", "preview"));
-            assertThat(String.valueOf(actualPreviewResponse.get("status")), is("preview"));
+            Map<String, Object> actualPreviewResponse = previewWorkflow(interactionClient, planId);
             assertThat(getMapList(actualPreviewResponse.get("preview_artifacts")).stream().map(each -> String.valueOf(each.get("approval_step"))).distinct().toList(),
                     is(List.of("rule_distsql")));
-            Map<String, Object> actualRuleApplyResponse = interactionClient.call(APPLY_TOOL_NAME, createApplyArguments(planId, List.of("rule_distsql")));
+            Map<String, Object> actualRuleApplyResponse = interactionClient.call(APPLY_TOOL_NAME, createReviewThenExecuteArguments(planId, List.of("rule_distsql")));
             assertThat(String.valueOf(actualRuleApplyResponse.get("status")), is("completed"));
             assertThat(getStringList(actualRuleApplyResponse.get("executed_distsql")).size(), is(1));
             assertThat(getStringList(actualRuleApplyResponse.get("skipped_artifacts")).size(), is(0));
@@ -196,17 +195,6 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
         String planId = String.valueOf(actualCreatePlanResponse.get("plan_id"));
         assertApplyCompleted(applyReviewedWorkflow(interactionClient, planId));
         assertValidationPassed(interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId)));
-    }
-    
-    private Map<String, Object> applyReviewedWorkflow(final MCPInteractionClient interactionClient, final String planId) throws IOException, InterruptedException {
-        Map<String, Object> previewResponse = interactionClient.call(APPLY_TOOL_NAME, Map.of("plan_id", planId, "execution_mode", "preview"));
-        assertThat(String.valueOf(previewResponse.get("status")), is("preview"));
-        List<String> approvedSteps = getMapList(previewResponse.get("preview_artifacts")).stream().map(each -> String.valueOf(each.get("approval_step"))).distinct().toList();
-        return interactionClient.call(APPLY_TOOL_NAME, createApplyArguments(planId, approvedSteps));
-    }
-    
-    private Map<String, Object> createApplyArguments(final String planId, final List<String> approvedSteps) {
-        return Map.of("plan_id", planId, "execution_mode", "review-then-execute", "approved_steps", approvedSteps);
     }
     
     private Map<String, Object> findItemByField(final List<Map<String, Object>> items, final String fieldName, final String expectedValue) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxySecretReferenceWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxySecretReferenceWorkflowE2ETest.java
@@ -56,7 +56,7 @@ class HttpProductionProxySecretReferenceWorkflowE2ETest extends AbstractProducti
             assertPlannedSecretReferencePayload(planResponse);
             Map<String, Object> previewResponse = previewWorkflow(interactionClient, planId);
             assertSecretReferencedPreview(previewResponse);
-            Map<String, Object> applyResponse = interactionClient.call(APPLY_TOOL_NAME, createApplyArguments(planId, getApprovedSteps(previewResponse)));
+            Map<String, Object> applyResponse = interactionClient.call(APPLY_TOOL_NAME, createReviewThenExecuteArguments(planId, getApprovedSteps(previewResponse)));
             assertThat(String.valueOf(applyResponse.get("response_mode")), is("recovery"));
             assertThat(String.valueOf(applyResponse.get("status")), is("failed"));
             assertThat(String.valueOf(applyResponse.get("category")), is(MCPDiagnosticCategory.SECRET_REFERENCE_MANUAL_EXECUTION_REQUIRED));
@@ -89,10 +89,6 @@ class HttpProductionProxySecretReferenceWorkflowE2ETest extends AbstractProducti
         MCPWorkflowSecretReferenceFixture.assertSecretReferenceRedacted(planResponse);
     }
     
-    private Map<String, Object> previewWorkflow(final MCPInteractionClient interactionClient, final String planId) throws IOException, InterruptedException {
-        return interactionClient.call(APPLY_TOOL_NAME, Map.of("plan_id", planId, "execution_mode", "preview"));
-    }
-    
     private void assertSecretReferencedPreview(final Map<String, Object> previewResponse) {
         assertThat(String.valueOf(previewResponse.get("status")), is("preview"));
         List<Map<String, Object>> previewArtifacts = getMapList(previewResponse.get("preview_artifacts"));
@@ -100,13 +96,5 @@ class HttpProductionProxySecretReferenceWorkflowE2ETest extends AbstractProducti
         assertThat(String.valueOf(previewArtifacts.getFirst().get("sql")), containsString("'aes-key-value'='<SECRET_VALUE_PRIMARY_AES_KEY_VALUE>'"));
         assertFalse(String.valueOf(previewArtifacts.getFirst().get("sql")).contains("secret_reference:primary.aes-key-value"));
         MCPWorkflowSecretReferenceFixture.assertSecretReferenceRedacted(previewResponse);
-    }
-    
-    private List<String> getApprovedSteps(final Map<String, Object> previewResponse) {
-        return getMapList(previewResponse.get("preview_artifacts")).stream().map(each -> String.valueOf(each.get("approval_step"))).distinct().toList();
-    }
-    
-    private Map<String, Object> createApplyArguments(final String planId, final List<String> approvedSteps) {
-        return Map.of("plan_id", planId, "execution_mode", "review-then-execute", "approved_steps", approvedSteps);
     }
 }


### PR DESCRIPTION
Split the MCP E2E workflow into build, core, and LLM jobs while reusing the same Maven and Docker image artifacts within the workflow run. Keep the LLM runtime image isolated to the LLM job so core tests do not download the large model image.

Remove the per-scenario LLM readiness probe from the conversation runner while preserving the suite startup readiness checks. Also consolidate review-then-execute helpers for Proxy workflow E2E tests and collapse the duplicated LLM usability suite runner path.

For #35294.