### PR TITLE
Remove unnecessary collection copies

### DIFF
--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/prompt/MCPPromptSpecificationFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/prompt/MCPPromptSpecificationFactoryTest.java
@@ -25,7 +25,6 @@ import org.apache.groovy.util.Maps;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPShardingSphereMetadataKeys;
 import org.junit.jupiter.api.Test;
 
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -43,7 +42,7 @@ class MCPPromptSpecificationFactoryTest {
     @Test
     void assertCreatePromptSpecifications() {
         List<SyncPromptSpecification> actual = new MCPPromptSpecificationFactory().createPromptSpecifications();
-        Set<String> actualNames = new LinkedHashSet<>(actual.stream().map(each -> each.prompt().name()).toList());
+        List<String> actualNames = actual.stream().map(each -> each.prompt().name()).toList();
         assertTrue(actualNames.containsAll(Set.of("inspect_metadata", "safe_sql_execution", "recover_workflow", "plan_encrypt_rule", "plan_mask_rule")));
         SyncPromptSpecification actualPromptSpecification = findPrompt(actual, "safe_sql_execution");
         assertThat(actualPromptSpecification.prompt().title(), is("Safe SQL Execution"));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/completion/provider/MetadataCompletionProviderTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/completion/provider/MetadataCompletionProviderTest.java
@@ -33,7 +33,7 @@ import org.apache.shardingsphere.mcp.support.database.spi.MCPMetadataQueryFacade
 import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -204,8 +204,8 @@ class MetadataCompletionProviderTest {
     }
     
     private void assertCandidate(final MCPCompletionProviderResult actual, final String expectedValue) {
-        List<MCPCompletionCandidate> actualCandidates = new ArrayList<>(actual.getCandidates());
+        Collection<MCPCompletionCandidate> actualCandidates = actual.getCandidates();
         assertThat(actualCandidates.size(), is(1));
-        assertThat(actualCandidates.get(0).getValue(), is(expectedValue));
+        assertThat(actualCandidates.iterator().next().getValue(), is(expectedValue));
     }
 }

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/completion/EncryptAlgorithmCompletionProviderTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/completion/EncryptAlgorithmCompletionProviderTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -75,14 +74,15 @@ class EncryptAlgorithmCompletionProviderTest {
                 Map.of("type", "")));
         MCPDatabaseHandlerContext handlerContext = mock(MCPDatabaseHandlerContext.class);
         when(handlerContext.getQueryFacade()).thenReturn(queryFacade);
-        List<MCPCompletionCandidate> actualCandidates = new ArrayList<>(new EncryptAlgorithmCompletionProvider().complete(handlerContext,
-                createRequestContext("prompt", EncryptFeatureDefinition.PLAN_PROMPT_NAME, "algorithm_type")).getCandidates());
+        Collection<MCPCompletionCandidate> actualCandidates = new EncryptAlgorithmCompletionProvider().complete(handlerContext,
+                createRequestContext("prompt", EncryptFeatureDefinition.PLAN_PROMPT_NAME, "algorithm_type")).getCandidates();
         assertThat(actualCandidates.size(), is(1));
-        assertThat(actualCandidates.getFirst().getValue(), is("AES"));
-        assertThat(actualCandidates.getFirst().getLabel(), is("AES encryptor"));
-        assertThat(actualCandidates.getFirst().getSource(), is("encrypt-algorithm"));
-        assertNull(actualCandidates.getFirst().getUpdateTime());
-        assertThat(actualCandidates.getFirst().getRankingReason(), is(""));
+        MCPCompletionCandidate actualCandidate = actualCandidates.iterator().next();
+        assertThat(actualCandidate.getValue(), is("AES"));
+        assertThat(actualCandidate.getLabel(), is("AES encryptor"));
+        assertThat(actualCandidate.getSource(), is("encrypt-algorithm"));
+        assertNull(actualCandidate.getUpdateTime());
+        assertThat(actualCandidate.getRankingReason(), is(""));
     }
     
     private static Collection<Arguments> supportedReferences() {

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/completion/MaskAlgorithmCompletionProviderTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/completion/MaskAlgorithmCompletionProviderTest.java
@@ -26,7 +26,7 @@ import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -69,10 +69,11 @@ class MaskAlgorithmCompletionProviderTest {
         when(handlerContext.getQueryFacade()).thenReturn(queryFacade);
         MCPCompletionProviderResult actual = new MaskAlgorithmCompletionProvider().complete(handlerContext,
                 createRequestContext(MaskFeatureDefinition.PLAN_PROMPT_NAME));
-        List<MCPCompletionCandidate> actualCandidates = new ArrayList<>(actual.getCandidates());
+        Collection<MCPCompletionCandidate> actualCandidates = actual.getCandidates();
         assertThat(actualCandidates.size(), is(1));
-        assertThat(actualCandidates.get(0).getValue(), is("MASK_FROM_X_TO_Y"));
-        assertThat(actualCandidates.get(0).getLabel(), is("Range mask"));
+        MCPCompletionCandidate actualCandidate = actualCandidates.iterator().next();
+        assertThat(actualCandidate.getValue(), is("MASK_FROM_X_TO_Y"));
+        assertThat(actualCandidate.getLabel(), is("Range mask"));
     }
     
     private MCPCompletionRequestContext createRequestContext(final String reference) {

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/completion/ReadwriteSplittingLoadBalanceAlgorithmCompletionProviderTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/completion/ReadwriteSplittingLoadBalanceAlgorithmCompletionProviderTest.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -72,11 +72,12 @@ class ReadwriteSplittingLoadBalanceAlgorithmCompletionProviderTest {
         when(handlerContext.getQueryFacade()).thenReturn(queryFacade);
         MCPCompletionProviderResult actual = new ReadwriteSplittingLoadBalanceAlgorithmCompletionProvider().complete(handlerContext,
                 createRequestContext(ReadwriteSplittingFeatureDefinition.PLAN_RULE_PROMPT_NAME));
-        List<MCPCompletionCandidate> actualCandidates = new ArrayList<>(actual.getCandidates());
+        Collection<MCPCompletionCandidate> actualCandidates = actual.getCandidates();
         assertThat(actualCandidates.size(), is(1));
-        assertThat(actualCandidates.getFirst().getValue(), is("ROUND_ROBIN"));
-        assertThat(actualCandidates.getFirst().getLabel(), is("Round robin load balance"));
-        assertThat(actualCandidates.getFirst().getSource(), is("readwrite-splitting-load-balance-algorithm"));
+        MCPCompletionCandidate actualCandidate = actualCandidates.iterator().next();
+        assertThat(actualCandidate.getValue(), is("ROUND_ROBIN"));
+        assertThat(actualCandidate.getLabel(), is("Round robin load balance"));
+        assertThat(actualCandidate.getSource(), is("readwrite-splitting-load-balance-algorithm"));
     }
     
     @Test

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/completion/ShadowAlgorithmCompletionProviderTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/completion/ShadowAlgorithmCompletionProviderTest.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -76,11 +76,12 @@ class ShadowAlgorithmCompletionProviderTest {
         when(handlerContext.getQueryFacade()).thenReturn(queryFacade);
         MCPCompletionProviderResult actual = new ShadowAlgorithmCompletionProvider().complete(handlerContext,
                 createRequestContext(ShadowFeatureDefinition.PLAN_RULE_PROMPT_NAME));
-        List<MCPCompletionCandidate> actualCandidates = new ArrayList<>(actual.getCandidates());
+        Collection<MCPCompletionCandidate> actualCandidates = actual.getCandidates();
         assertThat(actualCandidates.size(), is(1));
-        assertThat(actualCandidates.getFirst().getValue(), is("VALUE_MATCH"));
-        assertThat(actualCandidates.getFirst().getLabel(), is("Value match shadow algorithm"));
-        assertThat(actualCandidates.getFirst().getSource(), is("shadow-algorithm"));
+        MCPCompletionCandidate actualCandidate = actualCandidates.iterator().next();
+        assertThat(actualCandidate.getValue(), is("VALUE_MATCH"));
+        assertThat(actualCandidate.getLabel(), is("Value match shadow algorithm"));
+        assertThat(actualCandidate.getSource(), is("shadow-algorithm"));
     }
     
     @Test

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/completion/ShardingAlgorithmCompletionProviderTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/completion/ShardingAlgorithmCompletionProviderTest.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -69,11 +69,12 @@ class ShardingAlgorithmCompletionProviderTest {
                 Map.of("type", "")));
         MCPCompletionProviderResult actual = new ShardingAlgorithmCompletionProvider().complete(createHandlerContext(queryFacade),
                 createRequestContext(ShardingFeatureDefinition.ALGORITHM_PLUGINS_RESOURCE_URI, "algorithm_type"));
-        List<MCPCompletionCandidate> actualCandidates = new ArrayList<>(actual.getCandidates());
+        Collection<MCPCompletionCandidate> actualCandidates = actual.getCandidates();
         assertThat(actualCandidates.size(), is(1));
-        assertThat(actualCandidates.getFirst().getValue(), is("INLINE"));
-        assertThat(actualCandidates.getFirst().getLabel(), is("Inline sharding algorithm"));
-        assertThat(actualCandidates.getFirst().getSource(), is("sharding-algorithm"));
+        MCPCompletionCandidate actualCandidate = actualCandidates.iterator().next();
+        assertThat(actualCandidate.getValue(), is("INLINE"));
+        assertThat(actualCandidate.getLabel(), is("Inline sharding algorithm"));
+        assertThat(actualCandidate.getSource(), is("sharding-algorithm"));
     }
     
     @Test
@@ -83,10 +84,11 @@ class ShardingAlgorithmCompletionProviderTest {
                 Map.of("type", "SNOWFLAKE", "description", "Snowflake key generator")));
         MCPCompletionProviderResult actual = new ShardingAlgorithmCompletionProvider().complete(createHandlerContext(queryFacade),
                 createRequestContext(ShardingFeatureDefinition.KEY_GENERATE_ALGORITHM_PLUGINS_RESOURCE_URI, "key_generator_type"));
-        List<MCPCompletionCandidate> actualCandidates = new ArrayList<>(actual.getCandidates());
+        Collection<MCPCompletionCandidate> actualCandidates = actual.getCandidates();
         assertThat(actualCandidates.size(), is(1));
-        assertThat(actualCandidates.getFirst().getValue(), is("SNOWFLAKE"));
-        assertThat(actualCandidates.getFirst().getSource(), is("sharding-key-generate-algorithm"));
+        MCPCompletionCandidate actualCandidate = actualCandidates.iterator().next();
+        assertThat(actualCandidate.getValue(), is("SNOWFLAKE"));
+        assertThat(actualCandidate.getSource(), is("sharding-key-generate-algorithm"));
     }
     
     @Test

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidator.java
@@ -365,7 +365,7 @@ final class MCPDescriptorCatalogValidator {
     private static void validatePromptTemplate(final MCPPromptDescriptor descriptor, final MCPPromptTemplateBinding binding) {
         String template = MCPPromptTemplateLoader.load(binding.getTemplateResource());
         validateNoUnsupportedModelFacingPlaceholders(binding, template);
-        Set<String> declaredArguments = new HashSet<>(descriptor.getArguments().stream().map(MCPPromptArgumentDescriptor::getName).toList());
+        Set<String> declaredArguments = descriptor.getArguments().stream().map(MCPPromptArgumentDescriptor::getName).collect(Collectors.toSet());
         Set<String> renderedArguments = MCPPromptTemplateLoader.extractPlaceholders(template);
         for (String each : renderedArguments) {
             ShardingSpherePreconditions.checkState(declaredArguments.contains(each),


### PR DESCRIPTION
Avoid temporary collection copies in MCP descriptor validation and completion provider tests. Collect prompt argument names directly into a set and read singleton completion candidates from the returned collection after asserting the expected size.

For #35294