### PR TITLE
Refine MCP E2E fixture boundaries

### DIFF
--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
@@ -41,8 +41,6 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
     
     private static final String PLAN_PROMPT_NAME = "plan_mask_rule";
     
-    private static final String APPLY_TOOL_NAME = WorkflowToolDescriptors.APPLY_TOOL_NAME;
-    
     private static final String VALIDATE_TOOL_NAME = WorkflowToolDescriptors.VALIDATE_TOOL_NAME;
     
     private static final String ALGORITHMS_RESOURCE_URI = "shardingsphere://features/mask/algorithms";
@@ -140,26 +138,6 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
             assertValidationPassed(actualValidationResponse);
             assertThat(String.valueOf(getMapList(getMap(actualValidationResponse.get("rule_validation")).get("evidence")).getFirst().get("algorithm_type")).toUpperCase(Locale.ENGLISH),
                     is("MASK_FROM_X_TO_Y"));
-        }
-    }
-    
-    @Test
-    void assertApplySupportsApprovedStepsThroughProxy() throws IOException, InterruptedException {
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actualPlanResponse = interactionClient.call(PLAN_TOOL_NAME,
-                    Map.of("database", getLogicalDatabaseName(), "table", "orders", "column", "status",
-                            "operation_type", "create", "algorithm_type", "KEEP_FIRST_N_LAST_M",
-                            "primary_algorithm_properties", Map.of("first-n", "1", "last-m", "1", "replace-char", "*")));
-            assertThat(String.valueOf(actualPlanResponse.get("status")), is("planned"));
-            String planId = String.valueOf(actualPlanResponse.get("plan_id"));
-            Map<String, Object> actualPreviewResponse = previewWorkflow(interactionClient, planId);
-            assertThat(getMapList(actualPreviewResponse.get("preview_artifacts")).stream().map(each -> String.valueOf(each.get("approval_step"))).distinct().toList(),
-                    is(List.of("rule_distsql")));
-            Map<String, Object> actualRuleApplyResponse = interactionClient.call(APPLY_TOOL_NAME, createReviewThenExecuteArguments(planId, List.of("rule_distsql")));
-            assertThat(String.valueOf(actualRuleApplyResponse.get("status")), is("completed"));
-            assertThat(getStringList(actualRuleApplyResponse.get("executed_distsql")).size(), is(1));
-            assertThat(getStringList(actualRuleApplyResponse.get("skipped_artifacts")).size(), is(0));
-            assertValidationPassed(interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId)));
         }
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLReadOnlySQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLReadOnlySQLRuntimeE2ETest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.mcp.runtime.production;
+
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.apache.shardingsphere.test.e2e.mcp.support.runtime.RuntimeTransport;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPPayloadAssertions;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.client.MCPInteractionClient;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIf("isEnabled")
+class ProductionMySQLReadOnlySQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2ETest {
+    
+    @Override
+    protected boolean useSharedRuntimeFixture() {
+        return true;
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertExecuteSelectWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT status FROM orders ORDER BY order_id", "max_rows", 10));
+            assertThat(String.valueOf(actual.get("result_kind")), is("result_set"));
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertExecuteSelectWithTruncationWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT order_id, status FROM orders ORDER BY order_id", "max_rows", 1));
+            assertThat(String.valueOf(actual.get("result_kind")), is("result_set"));
+            assertThat(((List<?>) actual.get("rows")).size(), is(1));
+            assertThat(String.valueOf(actual.get("truncated")), is("true"));
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertExecuteExplainAnalyzeSelectWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "EXPLAIN ANALYZE SELECT * FROM orders WHERE order_id = 1", "max_rows", 10));
+            assertThat(String.valueOf(actual.get("result_kind")), is("result_set"));
+            assertThat(String.valueOf(actual.get("statement_type")), is("EXPLAIN ANALYZE"));
+            assertFalse(((List<?>) actual.get("rows")).isEmpty());
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertExecuteQueryTimeoutWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT SLEEP(2)", "timeout_ms", 1));
+            assertRecoveryResponse(actual);
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertRejectExecuteMultiStatementWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT 1; SELECT 2"));
+            assertRecoveryResponse(actual, "Only one SQL statement is allowed.", "multiple_sql_statements");
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertRejectExplainAnalyzeUpdateFromReadOnlyToolWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql",
+                            "EXPLAIN ANALYZE UPDATE orders SET status = 'DONE' WHERE order_id = 1"));
+            assertRecoveryResponse(actual,
+                    "database_gateway_execute_query only supports classifier-approved QUERY and EXPLAIN_ANALYZE statements. Use database_gateway_execute_update for side-effecting SQL.",
+                    "unsafe_sql_attempted");
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertRejectLockingReadFromReadOnlyToolWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT * FROM orders FOR UPDATE"));
+            assertRecoveryResponse(actual, "Locking read statements such as SELECT ... FOR UPDATE are not supported by the MCP read-only contract.");
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertRejectLockingReadFromUpdateToolWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_update",
+                    createExecuteUpdateArguments("SELECT * FROM orders FOR UPDATE"));
+            assertRecoveryResponse(actual, "Locking read statements such as SELECT ... FOR UPDATE are not supported by the MCP read-only contract.");
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("dualTransports")
+    void assertElicitMaskPlanningWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException {
+        useTransport(transport);
+        List<McpSchema.ElicitRequest> actualElicitationRequests = new CopyOnWriteArrayList<>();
+        try (McpSyncClient client = createElicitationClient(transport, actualElicitationRequests)) {
+            client.initialize();
+            McpSchema.CallToolResult actual = client.callTool(new McpSchema.CallToolRequest(MASK_PLAN_TOOL_NAME, Map.of(
+                    "database", LOGICAL_DATABASE_NAME,
+                    "schema", LOGICAL_DATABASE_NAME,
+                    "table", "orders",
+                    "column", "status",
+                    "operation_type", "create",
+                    "algorithm_type", "MASK_FROM_X_TO_Y")));
+            Map<String, Object> actualPayload = castStructuredContent(actual.structuredContent());
+            if (RuntimeTransport.HTTP == transport) {
+                assertThat(String.valueOf(actualPayload.get("status")), is("clarifying"));
+                assertThat(String.valueOf(actualPayload.get("fallback_reason")), is("remote_identity_required"));
+                assertTrue(actualElicitationRequests.isEmpty());
+                return;
+            }
+            assertThat(String.valueOf(actualPayload.get("status")), is("planned"));
+            assertThat(String.valueOf(actualPayload.get("current_step")), is("review"));
+            assertThat(String.valueOf(castToMap(castToMap(actualPayload.get("masked_property_preview")).get("primary")).get("from-x")), is("1"));
+            assertThat(String.valueOf(castToMap(castToMap(actualPayload.get("masked_property_preview")).get("primary")).get("to-y")), is("3"));
+            assertElicitationRequest(actualElicitationRequests);
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertRejectSequenceResourceWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.readResource(
+                    String.format("shardingsphere://databases/%s/schemas/%s/sequences", LOGICAL_DATABASE_NAME, LOGICAL_DATABASE_NAME));
+            assertThat(String.valueOf(actual.get("error_code")), is("json_rpc_error"));
+            assertThat(String.valueOf(actual.get("message")), is("Sequence resources are not supported for the current database."));
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertAiNativeDeterministicInteractionLoopWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            assertAiNativeCapabilities(interactionClient.readResource("shardingsphere://capabilities"));
+            assertAiNativeDiscovery(interactionClient);
+            Map<String, Object> searchMetadataPayload = interactionClient.call("database_gateway_search_metadata",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "query", "orders", "object_types", List.of("table")));
+            Map<String, Object> tableHit = MCPPayloadAssertions.findItem(searchMetadataPayload, "name", "orders");
+            String tableResourceUri = String.valueOf(getMap(tableHit.get("resource")).get("uri"));
+            assertThat(tableResourceUri, is("shardingsphere://databases/logic_db/schemas/logic_db/tables/orders"));
+            assertFalse(getMapList(tableHit.get("next_resources")).isEmpty());
+            MCPPayloadAssertions.assertSingleItemValue(interactionClient.readResource(tableResourceUri), "table", "orders");
+            assertAiNativeSqlPreview(interactionClient);
+            assertAiNativeSqlResult(interactionClient);
+        }
+    }
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLSQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLSQLRuntimeE2ETest.java
@@ -17,8 +17,6 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.runtime.production;
 
-import io.modelcontextprotocol.client.McpSyncClient;
-import io.modelcontextprotocol.spec.McpSchema;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.MySQLRuntimeTestSupport;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.RuntimeTransport;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPPayloadAssertions;
@@ -31,7 +29,6 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
@@ -41,130 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIf("isEnabled")
 class ProductionMySQLSQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2ETest {
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertExecuteSelectWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT status FROM orders ORDER BY order_id", "max_rows", 10));
-            assertThat(String.valueOf(actual.get("result_kind")), is("result_set"));
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertExecuteSelectWithTruncationWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT order_id, status FROM orders ORDER BY order_id", "max_rows", 1));
-            assertThat(String.valueOf(actual.get("result_kind")), is("result_set"));
-            assertThat(((List<?>) actual.get("rows")).size(), is(1));
-            assertThat(String.valueOf(actual.get("truncated")), is("true"));
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertExecuteExplainAnalyzeSelectWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "EXPLAIN ANALYZE SELECT * FROM orders WHERE order_id = 1", "max_rows", 10));
-            assertThat(String.valueOf(actual.get("result_kind")), is("result_set"));
-            assertThat(String.valueOf(actual.get("statement_type")), is("EXPLAIN ANALYZE"));
-            assertFalse(((List<?>) actual.get("rows")).isEmpty());
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertExecuteQueryTimeoutWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT SLEEP(2)", "timeout_ms", 1));
-            assertRecoveryResponse(actual);
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertRejectExecuteMultiStatementWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT 1; SELECT 2"));
-            assertRecoveryResponse(actual, "Only one SQL statement is allowed.", "multiple_sql_statements");
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertRejectExplainAnalyzeUpdateFromReadOnlyToolWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql",
-                            "EXPLAIN ANALYZE UPDATE orders SET status = 'DONE' WHERE order_id = 1"));
-            assertRecoveryResponse(actual,
-                    "database_gateway_execute_query only supports classifier-approved QUERY and EXPLAIN_ANALYZE statements. Use database_gateway_execute_update for side-effecting SQL.",
-                    "unsafe_sql_attempted");
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertRejectLockingReadFromReadOnlyToolWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT * FROM orders FOR UPDATE"));
-            assertRecoveryResponse(actual, "Locking read statements such as SELECT ... FOR UPDATE are not supported by the MCP read-only contract.");
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertRejectLockingReadFromUpdateToolWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_update",
-                    createExecuteUpdateArguments("SELECT * FROM orders FOR UPDATE"));
-            assertRecoveryResponse(actual, "Locking read statements such as SELECT ... FOR UPDATE are not supported by the MCP read-only contract.");
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("dualTransports")
-    void assertElicitMaskPlanningWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException {
-        useTransport(transport);
-        List<McpSchema.ElicitRequest> actualElicitationRequests = new CopyOnWriteArrayList<>();
-        try (McpSyncClient client = createElicitationClient(transport, actualElicitationRequests)) {
-            client.initialize();
-            McpSchema.CallToolResult actual = client.callTool(new McpSchema.CallToolRequest(MASK_PLAN_TOOL_NAME, Map.of(
-                    "database", LOGICAL_DATABASE_NAME,
-                    "schema", LOGICAL_DATABASE_NAME,
-                    "table", "orders",
-                    "column", "status",
-                    "operation_type", "create",
-                    "algorithm_type", "MASK_FROM_X_TO_Y")));
-            Map<String, Object> actualPayload = castStructuredContent(actual.structuredContent());
-            if (RuntimeTransport.HTTP == transport) {
-                assertThat(String.valueOf(actualPayload.get("status")), is("clarifying"));
-                assertThat(String.valueOf(actualPayload.get("fallback_reason")), is("remote_identity_required"));
-                assertTrue(actualElicitationRequests.isEmpty());
-                return;
-            }
-            assertThat(String.valueOf(actualPayload.get("status")), is("planned"));
-            assertThat(String.valueOf(actualPayload.get("current_step")), is("review"));
-            assertThat(String.valueOf(castToMap(castToMap(actualPayload.get("masked_property_preview")).get("primary")).get("from-x")), is("1"));
-            assertThat(String.valueOf(castToMap(castToMap(actualPayload.get("masked_property_preview")).get("primary")).get("to-y")), is("3"));
-            assertElicitationRequest(actualElicitationRequests);
-        }
-    }
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("semanticPrimaryTransport")
@@ -188,18 +61,6 @@ class ProductionMySQLSQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2E
                     createExecuteUpdateArguments("UPDATE orders SET status = status WHERE order_id = -1"));
             assertThat(String.valueOf(actual.get("result_kind")), is("update_count"));
             assertThat(String.valueOf(actual.get("affected_rows")), is("0"));
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertRejectSequenceResourceWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.readResource(
-                    String.format("shardingsphere://databases/%s/schemas/%s/sequences", LOGICAL_DATABASE_NAME, LOGICAL_DATABASE_NAME));
-            assertThat(String.valueOf(actual.get("error_code")), is("json_rpc_error"));
-            assertThat(String.valueOf(actual.get("message")), is("Sequence resources are not supported for the current database."));
         }
     }
     
@@ -287,25 +148,6 @@ class ProductionMySQLSQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2E
                     createExecuteUpdateArguments("UPDATE orders SET status = 'PENDING' WHERE order_id = 1"));
             interactionClient.close();
             assertThat(MySQLRuntimeTestSupport.querySingleString(getContainer(), String.format("SELECT status FROM %s.orders WHERE order_id = 1", getPhysicalSchemaName())), is("NEW"));
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertAiNativeDeterministicInteractionLoopWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            assertAiNativeCapabilities(interactionClient.readResource("shardingsphere://capabilities"));
-            assertAiNativeDiscovery(interactionClient);
-            Map<String, Object> searchMetadataPayload = interactionClient.call("database_gateway_search_metadata",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "query", "orders", "object_types", List.of("table")));
-            Map<String, Object> tableHit = MCPPayloadAssertions.findItem(searchMetadataPayload, "name", "orders");
-            String tableResourceUri = String.valueOf(getMap(tableHit.get("resource")).get("uri"));
-            assertThat(tableResourceUri, is("shardingsphere://databases/logic_db/schemas/logic_db/tables/orders"));
-            assertFalse(getMapList(tableHit.get("next_resources")).isEmpty());
-            MCPPayloadAssertions.assertSingleItemValue(interactionClient.readResource(tableResourceUri), "table", "orders");
-            assertAiNativeSqlPreview(interactionClient);
-            assertAiNativeSqlResult(interactionClient);
         }
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/ExecuteQueryReadOnlyE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/ExecuteQueryReadOnlyE2ETest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.mcp.runtime.programmatic;
+
+import org.apache.shardingsphere.test.e2e.mcp.env.MCPE2ECondition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@EnabledIf("isEnabled")
+class ExecuteQueryReadOnlyE2ETest extends AbstractSharedHttpProgrammaticRuntimeE2ETest {
+    
+    private static boolean isEnabled() {
+        return MCPE2ECondition.isDockerEnabled();
+    }
+    
+    @Test
+    void assertExecuteSelectOverHttpSession() throws IOException, InterruptedException {
+        launchHttpTransport();
+        HttpClient httpClient = HttpClient.newHttpClient();
+        String sessionId = initializeSession(httpClient);
+        HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_query",
+                Map.of("database", "logic_db", "schema", "logic_db", "sql", "SELECT * FROM orders", "max_rows", 10));
+        assertThat(actual.statusCode(), is(200));
+        Map<String, Object> payload = getStructuredContent(actual.body());
+        assertThat(String.valueOf(payload.get("result_kind")), is("result_set"));
+    }
+    
+    @Test
+    void assertExecuteReadOnlyCommonTableExpression() throws IOException, InterruptedException {
+        launchHttpTransport();
+        HttpClient httpClient = HttpClient.newHttpClient();
+        String sessionId = initializeSession(httpClient);
+        HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_query",
+                Map.of("database", "logic_db", "schema", "logic_db", "sql", "WITH foo_orders AS (SELECT * FROM orders) SELECT * FROM foo_orders"));
+        assertThat(actual.statusCode(), is(200));
+        Map<String, Object> payload = getStructuredContent(actual.body());
+        assertThat(String.valueOf(payload.get("result_kind")), is("result_set"));
+        assertThat(String.valueOf(payload.get("statement_class")), is("query"));
+    }
+    
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/ExecuteQueryTransactionE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/ExecuteQueryTransactionE2ETest.java
@@ -38,31 +38,6 @@ class ExecuteQueryTransactionE2ETest extends AbstractHttpProgrammaticRuntimeE2ET
     }
     
     @Test
-    void assertExecuteSelectOverHttpSession() throws IOException, InterruptedException {
-        launchHttpTransport();
-        HttpClient httpClient = HttpClient.newHttpClient();
-        String sessionId = initializeSession(httpClient);
-        HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_query",
-                createExecuteQueryArguments("logic_db", "logic_db", "SELECT * FROM orders", 10));
-        assertThat(actual.statusCode(), is(200));
-        Map<String, Object> payload = getStructuredContent(actual.body());
-        assertThat(String.valueOf(payload.get("result_kind")), is("result_set"));
-    }
-    
-    @Test
-    void assertExecuteReadOnlyCommonTableExpression() throws IOException, InterruptedException {
-        launchHttpTransport();
-        HttpClient httpClient = HttpClient.newHttpClient();
-        String sessionId = initializeSession(httpClient);
-        HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_query",
-                createExecuteQueryArguments("logic_db", "logic_db", "WITH foo_orders AS (SELECT * FROM orders) SELECT * FROM foo_orders"));
-        assertThat(actual.statusCode(), is(200));
-        Map<String, Object> payload = getStructuredContent(actual.body());
-        assertThat(String.valueOf(payload.get("result_kind")), is("result_set"));
-        assertThat(String.valueOf(payload.get("statement_class")), is("query"));
-    }
-    
-    @Test
     void assertRejectCrossDatabaseTransactionSwitch() throws IOException, InterruptedException {
         launchHttpTransport();
         HttpClient httpClient = HttpClient.newHttpClient();
@@ -101,7 +76,7 @@ class ExecuteQueryTransactionE2ETest extends AbstractHttpProgrammaticRuntimeE2ET
         assertThat(sendDeleteRequest(httpClient, createSessionHeaders(sessionId)).statusCode(), is(200));
         String newSessionId = initializeSession(httpClient);
         HttpResponse<String> actual = sendToolCallRequest(httpClient, newSessionId, "database_gateway_execute_query",
-                createExecuteQueryArguments("logic_db", "logic_db", "SELECT status FROM orders WHERE order_id = 1"));
+                Map.of("database", "logic_db", "schema", "logic_db", "sql", "SELECT status FROM orders WHERE order_id = 1"));
         assertThat(actual.statusCode(), is(200));
         Map<String, Object> payload = getStructuredContent(actual.body());
         assertThat(String.valueOf(((List<?>) ((List<?>) payload.get("rows")).get(0)).get(0)), is("NEW"));
@@ -118,13 +93,4 @@ class ExecuteQueryTransactionE2ETest extends AbstractHttpProgrammaticRuntimeE2ET
         assertThat(String.valueOf(getStructuredContent(actual.body()).get("message")), is(expectedMessage));
     }
     
-    private Map<String, Object> createExecuteQueryArguments(final String databaseName, final String schemaName, final String sql) {
-        return createExecuteQueryArguments(databaseName, schemaName, sql, -1);
-    }
-    
-    private Map<String, Object> createExecuteQueryArguments(final String databaseName, final String schemaName, final String sql, final int maxRows) {
-        return -1 == maxRows
-                ? Map.of("database", databaseName, "schema", schemaName, "sql", sql)
-                : Map.of("database", databaseName, "schema", schemaName, "sql", sql, "max_rows", maxRows);
-    }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportApprovalSafetyE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportApprovalSafetyE2ETest.java
@@ -72,6 +72,22 @@ class HttpTransportApprovalSafetyE2ETest extends AbstractSharedHttpProgrammaticR
     }
     
     @Test
+    void assertRejectWorkflowReviewThenExecuteWithInvisibleApprovedStep() throws IOException, InterruptedException {
+        launchHttpTransport();
+        HttpClient httpClient = HttpClient.newHttpClient();
+        String sessionId = initializeSession(httpClient);
+        String planId = createMaskRulePlan(httpClient, sessionId);
+        Map<String, Object> previewPayload = callApplyWorkflow(httpClient, sessionId, planId, Map.of("execution_mode", "preview"));
+        assertThat(String.valueOf(previewPayload.get("status")), is("preview"));
+        Map<String, Object> executionPayload = callApplyWorkflow(httpClient, sessionId, planId,
+                Map.of("execution_mode", "review-then-execute", "approved_steps", List.of("ddl")));
+        assertThat(String.valueOf(executionPayload.get("status")), is("failed"));
+        Map<?, ?> actualIssue = (Map<?, ?>) ((List<?>) executionPayload.get("issues")).getFirst();
+        assertThat(actualIssue.get("code"), is(WorkflowIssueCode.WORKFLOW_STATUS_INVALID));
+        assertModelFacingPayloadContract(executionPayload);
+    }
+    
+    @Test
     void assertRejectWorkflowExecutionFromOtherSession() throws IOException, InterruptedException {
         launchHttpTransport();
         HttpClient httpClient = HttpClient.newHttpClient();

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportCompletionE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportCompletionE2ETest.java
@@ -50,20 +50,16 @@ class HttpTransportCompletionE2ETest extends AbstractSharedHttpProgrammaticRunti
         HttpClient httpClient = HttpClient.newHttpClient();
         String sessionId = initializeSession(httpClient);
         Map<String, Object> promptReference = Map.of("type", "ref/prompt", "name", "inspect_metadata");
-        assertThat(completeValues(httpClient, sessionId, promptReference, "database", "logic", Map.of()), is(List.of("logic_db")));
-        assertThat(completeValues(httpClient, sessionId, promptReference, "schema", "logic", Map.of("database", "logic_db")), is(List.of("logic_db")));
-        assertThat(completeValues(httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/tables/{table}"),
-                "table", "ord", Map.of("database", "logic_db", "schema", "logic_db")),
-                is(List.of("order_items", "orders")));
-        assertThat(completeValues(httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns/{column}"),
-                "column", "sta", Map.of("database", "logic_db", "schema", "logic_db", "table", "orders")),
-                is(List.of("status")));
-        assertThat(completeValues(httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes/{index}"),
-                "index", "idx", Map.of("database", "logic_db", "schema", "logic_db", "table", "orders")),
-                is(List.of("idx_orders_status")));
-        assertThat(completeValues(httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/sequences/{sequence}"),
-                "sequence", "ord", Map.of("database", "logic_db", "schema", "logic_db")),
-                is(List.of()));
+        assertCompletionValues("database completion", httpClient, sessionId, promptReference, "database", "logic", Map.of(), List.of("logic_db"));
+        assertCompletionValues("schema completion", httpClient, sessionId, promptReference, "schema", "logic", Map.of("database", "logic_db"), List.of("logic_db"));
+        assertCompletionValues("table completion", httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/tables/{table}"),
+                "table", "ord", Map.of("database", "logic_db", "schema", "logic_db"), List.of("order_items", "orders"));
+        assertCompletionValues("column completion", httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns/{column}"),
+                "column", "sta", Map.of("database", "logic_db", "schema", "logic_db", "table", "orders"), List.of("status"));
+        assertCompletionValues("index completion", httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes/{index}"),
+                "index", "idx", Map.of("database", "logic_db", "schema", "logic_db", "table", "orders"), List.of("idx_orders_status"));
+        assertCompletionValues("sequence completion", httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/sequences/{sequence}"),
+                "sequence", "ord", Map.of("database", "logic_db", "schema", "logic_db"), List.of());
     }
     
     @Test
@@ -81,19 +77,14 @@ class HttpTransportCompletionE2ETest extends AbstractSharedHttpProgrammaticRunti
         launchHttpTransport();
         HttpClient httpClient = HttpClient.newHttpClient();
         String sessionId = initializeSession(httpClient);
-        Map<String, Object> loadBalanceAlgorithmCompletion = complete(httpClient, sessionId, Map.of("type", "ref/prompt", "name", "plan_readwrite_splitting_rule"),
-                "load_balancer_type", "ROUND", Map.of());
-        List<String> loadBalanceAlgorithmValues = extractCompletionValues(loadBalanceAlgorithmCompletion);
-        assertTrue(loadBalanceAlgorithmValues.contains("ROUND_ROBIN"), loadBalanceAlgorithmCompletion::toString);
-        List<String> shadowAlgorithmValues = completeValues(httpClient, sessionId, Map.of("type", "ref/prompt", "name", "plan_shadow_rule"),
-                "algorithm_type", "VALUE", Map.of());
-        assertTrue(shadowAlgorithmValues.contains("VALUE_MATCH"), shadowAlgorithmValues::toString);
-        List<String> shardingAlgorithmValues = completeValues(httpClient, sessionId, Map.of("type", "ref/prompt", "name", "plan_sharding_table_rule"),
-                "algorithm_type", "INLINE", Map.of());
-        assertTrue(shardingAlgorithmValues.contains("INLINE"), shardingAlgorithmValues::toString);
-        List<String> keyGenerateAlgorithmValues = completeValues(httpClient, sessionId, Map.of("type", "ref/prompt", "name", "plan_sharding_key_generator"),
-                "key_generator_type", "SNOW", Map.of());
-        assertTrue(keyGenerateAlgorithmValues.contains("SNOWFLAKE"), keyGenerateAlgorithmValues::toString);
+        assertCompletionValuesContain("readwrite-splitting load balancer completion", httpClient, sessionId,
+                Map.of("type", "ref/prompt", "name", "plan_readwrite_splitting_rule"), "load_balancer_type", "ROUND", "ROUND_ROBIN");
+        assertCompletionValuesContain("shadow algorithm completion", httpClient, sessionId,
+                Map.of("type", "ref/prompt", "name", "plan_shadow_rule"), "algorithm_type", "VALUE", "VALUE_MATCH");
+        assertCompletionValuesContain("sharding algorithm completion", httpClient, sessionId,
+                Map.of("type", "ref/prompt", "name", "plan_sharding_table_rule"), "algorithm_type", "INLINE", "INLINE");
+        assertCompletionValuesContain("sharding key generator completion", httpClient, sessionId,
+                Map.of("type", "ref/prompt", "name", "plan_sharding_key_generator"), "key_generator_type", "SNOW", "SNOWFLAKE");
     }
     
     @Test
@@ -117,6 +108,18 @@ class HttpTransportCompletionE2ETest extends AbstractSharedHttpProgrammaticRunti
                                         final String argumentName, final String argumentValue,
                                         final Map<String, String> contextArguments) throws IOException, InterruptedException {
         return extractCompletionValues(complete(httpClient, sessionId, reference, argumentName, argumentValue, contextArguments));
+    }
+    
+    private void assertCompletionValues(final String scenarioName, final HttpClient httpClient, final String sessionId, final Map<String, Object> reference,
+                                        final String argumentName, final String argumentValue, final Map<String, String> contextArguments,
+                                        final List<String> expectedValues) throws IOException, InterruptedException {
+        assertThat(scenarioName, completeValues(httpClient, sessionId, reference, argumentName, argumentValue, contextArguments), is(expectedValues));
+    }
+    
+    private void assertCompletionValuesContain(final String scenarioName, final HttpClient httpClient, final String sessionId, final Map<String, Object> reference,
+                                               final String argumentName, final String argumentValue, final String expectedValue) throws IOException, InterruptedException {
+        List<String> actualValues = completeValues(httpClient, sessionId, reference, argumentName, argumentValue, Map.of());
+        assertTrue(actualValues.contains(expectedValue), () -> scenarioName + ": " + actualValues);
     }
     
     private List<String> extractCompletionValues(final Map<String, Object> result) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportContractE2ETest.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.test.e2e.mcp.runtime.programmatic;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPShardingSphereMetadataKeys;
 import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowToolDescriptors;
 import org.apache.shardingsphere.test.e2e.mcp.env.MCPE2ECondition;
-import org.apache.shardingsphere.test.e2e.mcp.support.OfficialMCPToolNames;
 import org.apache.shardingsphere.test.e2e.mcp.support.assertion.MCPModelContractAssertions;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.client.MCPHttpTransportTestSupport;
 import org.junit.jupiter.api.Test;
@@ -35,15 +34,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIf("isEnabled")
 class HttpTransportContractE2ETest extends AbstractSharedHttpProgrammaticRuntimeE2ETest {
-    
-    private static final List<String> OFFICIAL_TOOL_NAMES = OfficialMCPToolNames.getAll();
     
     private static final String PLAN_MASK_TOOL_NAME = "database_gateway_plan_mask_rule";
     
@@ -65,16 +61,7 @@ class HttpTransportContractE2ETest extends AbstractSharedHttpProgrammaticRuntime
         HttpResponse<String> actual = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         assertThat(actual.statusCode(), is(200));
         Map<String, Object> actualCapabilities = getFirstResourcePayload(actual.body());
-        assertThat(((List<?>) actualCapabilities.get("supportedTools")).stream().map(String::valueOf).toList(), containsInAnyOrder(OFFICIAL_TOOL_NAMES.toArray()));
-        assertTrue(((List<?>) actualCapabilities.get("prompts")).stream().map(String::valueOf).anyMatch(each -> each.contains("inspect_metadata")));
-        assertTrue(((List<?>) actualCapabilities.get("completionTargets")).stream().map(String::valueOf).anyMatch(each -> each.contains("inspect_metadata")));
-        assertTrue(((List<?>) actualCapabilities.get("resourceNavigation")).stream().map(String::valueOf).anyMatch(each -> each.contains("database_gateway_apply_workflow")));
-        assertFalse(actualCapabilities.containsKey("fingerprints"));
-        Map<String, Object> actualProtocolAvailability = castToMap(actualCapabilities.get("protocolAvailability"));
-        assertTrue((Boolean) actualProtocolAvailability.get("prompts"));
-        assertTrue((Boolean) actualProtocolAvailability.get("completions"));
-        assertTrue((Boolean) actualProtocolAvailability.get("resourceNavigation"));
-        assertModelFacingPayloadContract(actualCapabilities);
+        assertThat(actualCapabilities.get("response_mode"), is("catalog"));
     }
     
     @Test


### PR DESCRIPTION
Split read-only MCP SQL and execute_query E2E scenarios onto shared fixtures. Narrow lowercase HTTP header coverage to the header contract and keep broad model contracts in dedicated tests. Deduplicate production Proxy approval coverage and add a programmatic invisible-approved-step safety check.

For #35294.
