### PR TITLE
Refactor MCP workflow guidance around descriptors

### DIFF
--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/handler/core/CoreResourceHandlers.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/handler/core/CoreResourceHandlers.java
@@ -44,10 +44,21 @@ final class CoreResourceHandlers {
     static Collection<MCPResourceHandler<?>> createHandlers() {
         Collection<MCPResourceHandler<?>> result = new LinkedList<>();
         GovernanceMetadataQueryService governanceMetadataQueryService = new GovernanceMetadataQueryService();
+        addTopLevelHandlers(result);
+        addDatabaseHandlers(result);
+        addGovernanceMetadataHandlers(result, governanceMetadataQueryService);
+        addSchemaMetadataHandlers(result);
+        return result;
+    }
+    
+    private static void addTopLevelHandlers(final Collection<MCPResourceHandler<?>> result) {
         result.add(new ServerCapabilitiesHandler());
         result.add(new RuntimeStatusHandler());
         result.add(new WorkflowPlanHandler());
         result.add(new DatabaseCapabilitiesHandler());
+    }
+    
+    private static void addDatabaseHandlers(final Collection<MCPResourceHandler<?>> result) {
         result.add(createMetadataResourceHandler(
                 "shardingsphere://databases",
                 (requestContext, uriVariables) -> requestContext.getMetadataQueryFacade().queryDatabases()));
@@ -55,6 +66,9 @@ final class CoreResourceHandlers {
                 "shardingsphere://databases/{database}",
                 (requestContext, uriVariables) -> requestContext.getMetadataQueryFacade().queryDatabase(uriVariables.getValue("database"))
                         .map(CoreResourceHandlers::createSingletonList).orElse(Collections.emptyList())));
+    }
+    
+    private static void addGovernanceMetadataHandlers(final Collection<MCPResourceHandler<?>> result, final GovernanceMetadataQueryService governanceMetadataQueryService) {
         result.add(createMetadataResourceHandler(
                 "shardingsphere://databases/{database}/storage-units",
                 (requestContext, uriVariables) -> governanceMetadataQueryService.queryStorageUnits(requestContext.getQueryFacade(), uriVariables.getValue("database"))));
@@ -76,6 +90,9 @@ final class CoreResourceHandlers {
         result.add(createMetadataResourceHandler(
                 "shardingsphere://databases/{database}/single-table/default-storage-unit",
                 (requestContext, uriVariables) -> governanceMetadataQueryService.queryDefaultSingleTableStorageUnit(requestContext.getQueryFacade(), uriVariables.getValue("database"))));
+    }
+    
+    private static void addSchemaMetadataHandlers(final Collection<MCPResourceHandler<?>> result) {
         result.add(createMetadataResourceHandler(
                 "shardingsphere://databases/{database}/schemas",
                 (requestContext, uriVariables) -> requestContext.getMetadataQueryFacade().querySchemas(uriVariables.getValue("database"))));
@@ -134,7 +151,6 @@ final class CoreResourceHandlers {
                 (requestContext, uriVariables) -> requestContext.getMetadataQueryFacade().queryIndex(
                         uriVariables.getValue("database"), uriVariables.getValue("schema"), uriVariables.getValue("table"), uriVariables.getValue("index"))
                         .map(CoreResourceHandlers::createSingletonList).orElse(Collections.emptyList())));
-        return result;
     }
     
     private static List<?> createSingletonList(final Object metadata) {

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPWorkflowRecoveryPayloadFactory.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/protocol/error/MCPWorkflowRecoveryPayloadFactory.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.mcp.core.protocol.exception.MCPInvalidExecution
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPWorkflowStateException;
 import org.apache.shardingsphere.mcp.support.protocol.MCPNextActionUtils;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowToolDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 
 import java.util.List;
@@ -37,11 +38,11 @@ import java.util.Map;
 final class MCPWorkflowRecoveryPayloadFactory {
     
     static Map<String, Object> createMissingExecutionModeRecovery(final MCPExecutionModeRequiredException cause) {
-        return "database_gateway_apply_workflow".equals(cause.getToolName()) ? createMissingWorkflowExecutionModeRecovery(cause) : createMissingUpdateExecutionModeRecovery(cause);
+        return WorkflowToolDescriptors.APPLY_TOOL_NAME.equals(cause.getToolName()) ? createMissingWorkflowExecutionModeRecovery(cause) : createMissingUpdateExecutionModeRecovery(cause);
     }
     
     static Map<String, Object> createInvalidExecutionModeRecovery(final MCPInvalidExecutionModeException cause) {
-        return "database_gateway_apply_workflow".equals(cause.getToolName()) ? createInvalidWorkflowExecutionModeRecovery(cause) : createInvalidUpdateExecutionModeRecovery(cause);
+        return WorkflowToolDescriptors.APPLY_TOOL_NAME.equals(cause.getToolName()) ? createInvalidWorkflowExecutionModeRecovery(cause) : createInvalidUpdateExecutionModeRecovery(cause);
     }
     
     static Map<String, Object> createInvalidApprovedStepsRecovery(final MCPInvalidApprovedStepsException cause) {
@@ -53,7 +54,7 @@ final class MCPWorkflowRecoveryPayloadFactory {
         result.put(MCPPayloadFieldNames.ALLOWED_VALUES, cause.getAllowedValues());
         result.put("suggested_arguments", suggestedArguments);
         result.put(MCPPayloadFieldNames.NEXT_ACTIONS, List.of(MCPNextActionUtils.callTool(
-                "database_gateway_apply_workflow", "Preview again, then copy only visible approval_step values into approved_steps.", suggestedArguments)));
+                WorkflowToolDescriptors.APPLY_TOOL_NAME, "Preview again, then copy only visible approval_step values into approved_steps.", suggestedArguments)));
         result.put("ask_user_when_uncertain", true);
         return result;
     }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/StatementClassifier.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/StatementClassifier.java
@@ -82,8 +82,10 @@ public final class StatementClassifier {
     private boolean isSavepointStatement(final String upperSql) {
         return "SAVEPOINT".equals(upperSql)
                 || upperSql.startsWith("SAVEPOINT ")
-                || upperSql.startsWith("ROLLBACK TO SAVEPOINT")
-                || upperSql.startsWith("RELEASE SAVEPOINT");
+                || "ROLLBACK TO".equals(upperSql)
+                || upperSql.startsWith("ROLLBACK TO ")
+                || "RELEASE SAVEPOINT".equals(upperSql)
+                || upperSql.startsWith("RELEASE SAVEPOINT ");
     }
     
     private String extractStatementType(final String upperSql) {
@@ -93,6 +95,9 @@ public final class StatementClassifier {
         if (upperSql.startsWith("ROLLBACK TO SAVEPOINT")) {
             return "ROLLBACK TO SAVEPOINT";
         }
+        if (upperSql.startsWith("ROLLBACK TO")) {
+            return "ROLLBACK TO";
+        }
         if (upperSql.startsWith("RELEASE SAVEPOINT")) {
             return "RELEASE SAVEPOINT";
         }
@@ -101,14 +106,19 @@ public final class StatementClassifier {
     
     private String extractSavepointName(final String sql) {
         String[] tokens = sql.split("\\s+");
-        if ("SAVEPOINT".equalsIgnoreCase(tokens[0]) && tokens.length >= 2) {
-            return tokens[tokens.length - 1];
+        if ("SAVEPOINT".equalsIgnoreCase(tokens[0]) && 2 == tokens.length) {
+            return tokens[1];
         }
-        if ("RELEASE".equalsIgnoreCase(tokens[0]) && tokens.length >= 3) {
-            return tokens[tokens.length - 1];
+        if ("RELEASE".equalsIgnoreCase(tokens[0]) && 3 == tokens.length && "SAVEPOINT".equalsIgnoreCase(tokens[1])) {
+            return tokens[2];
         }
-        if ("ROLLBACK".equalsIgnoreCase(tokens[0]) && tokens.length >= 4) {
-            return tokens[tokens.length - 1];
+        if ("ROLLBACK".equalsIgnoreCase(tokens[0]) && tokens.length >= 3 && "TO".equalsIgnoreCase(tokens[1])) {
+            if (3 == tokens.length && !"SAVEPOINT".equalsIgnoreCase(tokens[2])) {
+                return tokens[2];
+            }
+            if (4 == tokens.length && "SAVEPOINT".equalsIgnoreCase(tokens[2])) {
+                return tokens[3];
+            }
         }
         return "";
     }
@@ -117,7 +127,13 @@ public final class StatementClassifier {
         if (!savepointName.isEmpty()) {
             return;
         }
-        ShardingSpherePreconditions.checkState(!"SAVEPOINT".equals(statementType) && !"ROLLBACK TO SAVEPOINT".equals(statementType) && !"RELEASE SAVEPOINT".equals(statementType),
-                () -> new IllegalArgumentException("Savepoint name is required."));
+        ShardingSpherePreconditions.checkState(!isSavepointStatementType(statementType), () -> new IllegalArgumentException("Savepoint name is required."));
+    }
+    
+    private boolean isSavepointStatementType(final String statementType) {
+        return "SAVEPOINT".equals(statementType)
+                || "ROLLBACK TO".equals(statementType)
+                || "ROLLBACK TO SAVEPOINT".equals(statementType)
+                || "RELEASE SAVEPOINT".equals(statementType);
     }
 }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/workflow/WorkflowExecutionToolHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/workflow/WorkflowExecutionToolHandler.java
@@ -68,7 +68,7 @@ public final class WorkflowExecutionToolHandler implements MCPToolHandler<MCPWor
         MCPToolArguments toolArguments = new MCPToolArguments(toolCall.getArguments());
         String executionMode = toolArguments.getStringArgument(WorkflowFieldNames.EXECUTION_MODE);
         if (executionMode.isEmpty()) {
-            throw new MCPExecutionModeRequiredException("database_gateway_apply_workflow", List.of("preview", "review-then-execute", "manual-only"),
+            throw new MCPExecutionModeRequiredException(WorkflowToolDescriptors.APPLY_TOOL_NAME, List.of("preview", "review-then-execute", "manual-only"),
                     createPreviewSuggestedArguments(toolCall.getArguments()));
         }
         MCPDatabaseHandlerContext databaseContext = workflowContext.getDatabaseContext();

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyResponseBuilder.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowApplyResponseBuilder.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.mcp.support.protocol.MCPResponseMode;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowToolDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactBundle;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowArtifactPayloadUtils;
 import org.apache.shardingsphere.mcp.support.workflow.service.WorkflowGuidancePayloadBuilder;
@@ -166,12 +167,12 @@ public final class WorkflowApplyResponseBuilder {
             return MCPNextActionUtils.ordered(MCPNextActionUtils.stop("Preview has no artifacts to approve."));
         }
         if (EXECUTION_MODE_MANUAL_ONLY.equals(applyExecutionMode)) {
-            return MCPNextActionUtils.ordered(MCPNextActionUtils.callTool("database_gateway_apply_workflow",
+            return MCPNextActionUtils.ordered(MCPNextActionUtils.callTool(WorkflowToolDescriptors.APPLY_TOOL_NAME,
                     createPreviewNextActionReason(applyExecutionMode), createExecutionArguments(snapshot, applyExecutionMode)));
         }
         return MCPNextActionUtils.ordered(
                 MCPNextActionUtils.askUser(createPreviewNextActionReason(applyExecutionMode), List.of("approved_steps")),
-                MCPNextActionUtils.dependsOn(MCPNextActionUtils.callTool("database_gateway_apply_workflow",
+                MCPNextActionUtils.dependsOn(MCPNextActionUtils.callTool(WorkflowToolDescriptors.APPLY_TOOL_NAME,
                         "Apply reviewed workflow artifacts after merging approved_steps from action 1 into the arguments.",
                         createExecutionArguments(snapshot, applyExecutionMode)), 1));
     }
@@ -191,7 +192,7 @@ public final class WorkflowApplyResponseBuilder {
                 "confirmation_required", true,
                 "confirmation_field", "manual_artifacts_executed",
                 "validation_blocked_until", "manual_artifacts_executed",
-                "validation_tool_after_manual_execution", "database_gateway_validate_workflow",
+                "validation_tool_after_manual_execution", WorkflowToolDescriptors.VALIDATE_TOOL_NAME,
                 "safe_independent_read_only_checks", "database_gateway_execute_query may run before manual execution confirmation when the user asked for read-only verification.");
     }
     
@@ -211,7 +212,7 @@ public final class WorkflowApplyResponseBuilder {
         result.put("external_execution_required", true);
         result.put("requires_user_confirmation", true);
         result.put("validation_blocked_until", "manual_artifacts_executed");
-        result.put("validation_tool_after_manual_execution", "database_gateway_validate_workflow");
+        result.put("validation_tool_after_manual_execution", WorkflowToolDescriptors.VALIDATE_TOOL_NAME);
         result.put("validation_arguments_after_manual_execution", Map.of(WorkflowFieldNames.PLAN_ID, planId));
         return result;
     }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowExecutionService.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowExecutionService.java
@@ -30,6 +30,7 @@ import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
 import org.apache.shardingsphere.mcp.support.protocol.MCPResponseMode;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowPropertySource;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowToolDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowIssue;
@@ -127,11 +128,11 @@ public final class WorkflowExecutionService {
     
     private String requireExecutionMode(final WorkflowContextSnapshot snapshot, final String executionMode) {
         if (executionMode.isEmpty()) {
-            throw new MCPExecutionModeRequiredException("database_gateway_apply_workflow", EXECUTION_MODES, createPreviewSuggestedArguments(snapshot));
+            throw new MCPExecutionModeRequiredException(WorkflowToolDescriptors.APPLY_TOOL_NAME, EXECUTION_MODES, createPreviewSuggestedArguments(snapshot));
         }
         String result = executionMode.toLowerCase();
         if (!EXECUTION_MODES.contains(result)) {
-            throw new MCPInvalidExecutionModeException("database_gateway_apply_workflow", EXECUTION_MODES, createPreviewSuggestedArguments(snapshot));
+            throw new MCPInvalidExecutionModeException(WorkflowToolDescriptors.APPLY_TOOL_NAME, EXECUTION_MODES, createPreviewSuggestedArguments(snapshot));
         }
         return result;
     }

--- a/mcp/core/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-core.yaml
+++ b/mcp/core/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-core.yaml
@@ -548,12 +548,20 @@ completionTargets:
       - database
       - storageUnit
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        storageUnit:
+          - database
   - referenceType: resource
     reference: shardingsphere://databases/{database}/storage-units/{storageUnit}/used-by-rules
     arguments:
       - database
       - storageUnit
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        storageUnit:
+          - database
   - referenceType: resource
     reference: shardingsphere://databases/{database}/single-tables
     arguments:
@@ -565,6 +573,10 @@ completionTargets:
       - database
       - table
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        table:
+          - database
   - referenceType: resource
     reference: shardingsphere://databases/{database}/single-table/default-storage-unit
     arguments:
@@ -576,12 +588,20 @@ completionTargets:
       - database
       - schema
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        schema:
+          - database
   - referenceType: resource
     reference: shardingsphere://databases/{database}/schemas/{schema}/tables
     arguments:
       - database
       - schema
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        schema:
+          - database
   - referenceType: resource
     reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}
     arguments:
@@ -589,6 +609,13 @@ completionTargets:
       - schema
       - table
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        schema:
+          - database
+        table:
+          - database
+          - schema
   - referenceType: resource
     reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns
     arguments:
@@ -596,6 +623,13 @@ completionTargets:
       - schema
       - table
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        schema:
+          - database
+        table:
+          - database
+          - schema
   - referenceType: resource
     reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns/{column}
     arguments:
@@ -604,6 +638,17 @@ completionTargets:
       - table
       - column
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        schema:
+          - database
+        table:
+          - database
+          - schema
+        column:
+          - database
+          - schema
+          - table
   - referenceType: resource
     reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes
     arguments:
@@ -611,6 +656,13 @@ completionTargets:
       - schema
       - table
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        schema:
+          - database
+        table:
+          - database
+          - schema
   - referenceType: resource
     reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes/{index}
     arguments:
@@ -619,12 +671,27 @@ completionTargets:
       - table
       - index
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        schema:
+          - database
+        table:
+          - database
+          - schema
+        index:
+          - database
+          - schema
+          - table
   - referenceType: resource
     reference: shardingsphere://databases/{database}/schemas/{schema}/sequences
     arguments:
       - database
       - schema
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        schema:
+          - database
   - referenceType: resource
     reference: shardingsphere://databases/{database}/schemas/{schema}/sequences/{sequence}
     arguments:
@@ -632,6 +699,13 @@ completionTargets:
       - schema
       - sequence
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        schema:
+          - database
+        sequence:
+          - database
+          - schema
 resourceNavigation:
   - from: shardingsphere://capabilities
     to: shardingsphere://runtime

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/StatementClassifierTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/StatementClassifierTest.java
@@ -181,6 +181,8 @@ class StatementClassifierTest {
                         "RELEASE SAVEPOINT foo_sp_1", "", "foo_sp_1"),
                 Arguments.of("rollback to savepoint", "ROLLBACK TO SAVEPOINT foo_sp_1", SupportedMCPStatement.SAVEPOINT, "ROLLBACK TO SAVEPOINT",
                         "ROLLBACK TO SAVEPOINT foo_sp_1", "", "foo_sp_1"),
+                Arguments.of("rollback to savepoint name without optional keyword", "ROLLBACK TO foo_sp_1", SupportedMCPStatement.SAVEPOINT, "ROLLBACK TO",
+                        "ROLLBACK TO foo_sp_1", "", "foo_sp_1"),
                 Arguments.of("explain analyze", "EXPLAIN ANALYZE SELECT * FROM foo_orders", SupportedMCPStatement.EXPLAIN_ANALYZE, "EXPLAIN ANALYZE",
                         "EXPLAIN ANALYZE SELECT * FROM foo_orders", "foo_orders", ""));
     }
@@ -261,8 +263,12 @@ class StatementClassifierTest {
                 Arguments.of("blank sql", "   ", IllegalArgumentException.class, "sql cannot be empty."),
                 Arguments.of("multiple statements", "SELECT 1; SELECT 2", MCPMultipleSQLStatementsException.class, "Only one SQL statement is allowed."),
                 Arguments.of("savepoint without name", "SAVEPOINT", IllegalArgumentException.class, "Savepoint name is required."),
+                Arguments.of("savepoint with extra token", "SAVEPOINT foo_sp_1 extra", IllegalArgumentException.class, "Savepoint name is required."),
                 Arguments.of("release savepoint without name", "RELEASE SAVEPOINT", IllegalArgumentException.class, "Savepoint name is required."),
+                Arguments.of("release savepoint with extra token", "RELEASE SAVEPOINT foo_sp_1 extra", IllegalArgumentException.class, "Savepoint name is required."),
+                Arguments.of("rollback to without name", "ROLLBACK TO", IllegalArgumentException.class, "Savepoint name is required."),
                 Arguments.of("rollback to savepoint without name", "ROLLBACK TO SAVEPOINT", IllegalArgumentException.class, "Savepoint name is required."),
+                Arguments.of("rollback to savepoint with extra token", "ROLLBACK TO SAVEPOINT foo_sp_1 extra", IllegalArgumentException.class, "Savepoint name is required."),
                 Arguments.of("banned use", "USE foo_db", MCPBannedSQLStatementException.class, "Statement is banned by the MCP contract."),
                 Arguments.of("banned set", "SET search_path public", MCPBannedSQLStatementException.class, "Statement is banned by the MCP contract."),
                 Arguments.of("banned copy", "COPY foo_orders FROM '/tmp/foo.csv'", MCPBannedSQLStatementException.class, "Statement is banned by the MCP contract."),

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/BroadcastFeatureDefinition.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/BroadcastFeatureDefinition.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.mcp.feature.broadcast;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowKindDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 
 /**
@@ -31,7 +32,7 @@ public final class BroadcastFeatureDefinition {
     
     public static final String PLAN_PROMPT_NAME = "plan_broadcast_rule";
     
-    public static final WorkflowKind WORKFLOW_KIND = WorkflowKind.valueOf("broadcast.rule");
+    public static final WorkflowKind WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.BROADCAST_RULE);
     
     public static final String TABLES_FIELD = "tables";
     

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptFeatureDefinition.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptFeatureDefinition.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.mcp.feature.encrypt;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowKindDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 
 /**
@@ -31,7 +32,7 @@ public final class EncryptFeatureDefinition {
     
     public static final String PLAN_PROMPT_NAME = "plan_encrypt_rule";
     
-    public static final WorkflowKind WORKFLOW_KIND = WorkflowKind.valueOf("encrypt.rule");
+    public static final WorkflowKind WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.ENCRYPT_RULE);
     
     public static final String ALGORITHMS_RESOURCE_URI = "shardingsphere://features/encrypt/algorithms";
     

--- a/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/MaskFeatureDefinition.java
+++ b/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/MaskFeatureDefinition.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.mcp.feature.mask;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowKindDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 
 /**
@@ -31,7 +32,7 @@ public final class MaskFeatureDefinition {
     
     public static final String PLAN_PROMPT_NAME = "plan_mask_rule";
     
-    public static final WorkflowKind WORKFLOW_KIND = WorkflowKind.valueOf("mask.rule");
+    public static final WorkflowKind WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.MASK_RULE);
     
     public static final String ALGORITHMS_RESOURCE_URI = "shardingsphere://features/mask/algorithms";
     

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/ReadwriteSplittingFeatureDefinition.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/ReadwriteSplittingFeatureDefinition.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting;
 
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowKindDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 
 /**
@@ -32,9 +33,9 @@ public final class ReadwriteSplittingFeatureDefinition {
     
     public static final String PLAN_STATUS_PROMPT_NAME = "plan_readwrite_splitting_status";
     
-    public static final WorkflowKind RULE_WORKFLOW_KIND = WorkflowKind.valueOf("readwrite.rule");
+    public static final WorkflowKind RULE_WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.READWRITE_RULE);
     
-    public static final WorkflowKind STATUS_WORKFLOW_KIND = WorkflowKind.valueOf("readwrite.status");
+    public static final WorkflowKind STATUS_WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.READWRITE_STATUS);
     
     public static final String RULE_FIELD = "rule";
     

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/ShadowFeatureDefinition.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/ShadowFeatureDefinition.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mcp.feature.shadow;
 
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowKindDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 
 /**
@@ -36,11 +37,11 @@ public final class ShadowFeatureDefinition {
     
     public static final String PLAN_ALGORITHM_CLEANUP_PROMPT_NAME = "plan_shadow_algorithm_cleanup";
     
-    public static final WorkflowKind RULE_WORKFLOW_KIND = WorkflowKind.valueOf("shadow.rule");
+    public static final WorkflowKind RULE_WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.SHADOW_RULE);
     
-    public static final WorkflowKind DEFAULT_ALGORITHM_WORKFLOW_KIND = WorkflowKind.valueOf("shadow.default");
+    public static final WorkflowKind DEFAULT_ALGORITHM_WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.SHADOW_DEFAULT_ALGORITHM);
     
-    public static final WorkflowKind ALGORITHM_CLEANUP_WORKFLOW_KIND = WorkflowKind.valueOf("shadow.cleanup");
+    public static final WorkflowKind ALGORITHM_CLEANUP_WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.SHADOW_ALGORITHM_CLEANUP);
     
     public static final String RULE_FIELD = "rule";
     

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingFeatureDefinition.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingFeatureDefinition.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding;
 
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowKindDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 
 /**
@@ -24,17 +25,17 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
  */
 public final class ShardingFeatureDefinition {
     
-    public static final WorkflowKind TABLE_RULE_WORKFLOW_KIND = WorkflowKind.valueOf("sharding.table.rule");
+    public static final WorkflowKind TABLE_RULE_WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.SHARDING_TABLE_RULE);
     
-    public static final WorkflowKind TABLE_REFERENCE_WORKFLOW_KIND = WorkflowKind.valueOf("sharding.table.reference");
+    public static final WorkflowKind TABLE_REFERENCE_WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.SHARDING_TABLE_REFERENCE);
     
-    public static final WorkflowKind DEFAULT_STRATEGY_WORKFLOW_KIND = WorkflowKind.valueOf("sharding.default.strategy");
+    public static final WorkflowKind DEFAULT_STRATEGY_WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.SHARDING_DEFAULT_STRATEGY);
     
-    public static final WorkflowKind KEY_GENERATOR_WORKFLOW_KIND = WorkflowKind.valueOf("sharding.key.generator");
+    public static final WorkflowKind KEY_GENERATOR_WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.SHARDING_KEY_GENERATOR);
     
-    public static final WorkflowKind KEY_GENERATE_STRATEGY_WORKFLOW_KIND = WorkflowKind.valueOf("sharding.key.generate.strategy");
+    public static final WorkflowKind KEY_GENERATE_STRATEGY_WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.SHARDING_KEY_GENERATE_STRATEGY);
     
-    public static final WorkflowKind COMPONENT_CLEANUP_WORKFLOW_KIND = WorkflowKind.valueOf("sharding.component.cleanup");
+    public static final WorkflowKind COMPONENT_CLEANUP_WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.SHARDING_COMPONENT_CLEANUP);
     
     public static final String PLAN_TABLE_RULE_TOOL_NAME = "database_gateway_plan_sharding_table_rule";
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndex.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndex.java
@@ -55,6 +55,8 @@ public final class MCPDescriptorCatalogIndex {
     
     private static final Map<String, MCPToolRuntimeDescriptor> TOOL_RUNTIME_DESCRIPTORS = createToolRuntimeDescriptors();
     
+    private static final Map<String, String> PLANNING_TOOL_NAMES_BY_WORKFLOW_KIND = createPlanningToolNamesByWorkflowKind();
+    
     private static Map<String, MCPResourceDescriptor> createResourceDescriptors() {
         Map<String, MCPResourceDescriptor> result = new LinkedHashMap<>(CATALOG.getResourceDescriptors().size() + CATALOG.getResourceTemplateDescriptors().size(), 1F);
         for (MCPResourceDescriptor each : CATALOG.getResourceDescriptors()) {
@@ -90,6 +92,20 @@ public final class MCPDescriptorCatalogIndex {
     
     private static Map<String, MCPToolRuntimeDescriptor> createToolRuntimeDescriptors() {
         return CATALOG.getToolRuntimeDescriptors().stream().collect(Collectors.toMap(MCPToolRuntimeDescriptor::getToolName, each -> each));
+    }
+    
+    private static Map<String, String> createPlanningToolNamesByWorkflowKind() {
+        Map<String, String> result = new LinkedHashMap<>(CATALOG.getToolRuntimeDescriptors().size(), 1F);
+        for (MCPToolRuntimeDescriptor each : CATALOG.getToolRuntimeDescriptors()) {
+            if (!"plan".equals(each.getWorkflowRole())) {
+                continue;
+            }
+            MCPToolDescriptor toolDescriptor = TOOL_DESCRIPTORS.get(each.getToolName());
+            if (null != toolDescriptor && toolDescriptor.getMeta().containsKey(MCPShardingSphereMetadataKeys.WORKFLOW_KIND)) {
+                result.put(String.valueOf(toolDescriptor.getMeta().get(MCPShardingSphereMetadataKeys.WORKFLOW_KIND)), each.getToolName());
+            }
+        }
+        return result;
     }
     
     /**
@@ -169,6 +185,16 @@ public final class MCPDescriptorCatalogIndex {
      */
     public static Optional<MCPToolRuntimeDescriptor> findToolRuntimeDescriptor(final String toolName) {
         return Optional.ofNullable(TOOL_RUNTIME_DESCRIPTORS.get(toolName));
+    }
+    
+    /**
+     * Find planning tool name by workflow kind.
+     *
+     * @param workflowKind workflow kind
+     * @return found planning tool name
+     */
+    public static Optional<String> findPlanningToolNameByWorkflowKind(final String workflowKind) {
+        return Optional.ofNullable(PLANNING_TOOL_NAMES_BY_WORKFLOW_KIND.get(workflowKind));
     }
     
     /**

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilder.java
@@ -28,8 +28,10 @@ import org.apache.shardingsphere.mcp.support.protocol.MCPResponseMode;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 final class MCPDescriptorCatalogPayloadBuilder {
     
@@ -164,15 +166,16 @@ final class MCPDescriptorCatalogPayloadBuilder {
     }
     
     private Map<String, Object> createCompletionHint(final String argumentName) {
-        List<Map<String, Object>> references = catalog.getCompletionTargetDescriptors().stream()
-                .filter(each -> each.getArguments().contains(argumentName)).map(this::createCompletionReferenceHint).toList();
+        List<MCPCompletionTargetDescriptor> descriptors = catalog.getCompletionTargetDescriptors().stream()
+                .filter(each -> each.getArguments().contains(argumentName)).toList();
+        List<Map<String, Object>> references = descriptors.stream().map(this::createCompletionReferenceHint).toList();
         if (references.isEmpty()) {
             return Map.of();
         }
         Map<String, Object> result = new LinkedHashMap<>(3, 1F);
         result.put("available", true);
         result.put("references", references);
-        List<String> requiredContextArguments = createCompletionRequiredContextArguments(argumentName);
+        List<String> requiredContextArguments = createCompletionRequiredContextArguments(descriptors, argumentName);
         if (!requiredContextArguments.isEmpty()) {
             result.put("required_context_arguments", requiredContextArguments);
         }
@@ -187,17 +190,19 @@ final class MCPDescriptorCatalogPayloadBuilder {
         return result;
     }
     
-    private List<String> createCompletionRequiredContextArguments(final String argumentName) {
-        if ("schema".equals(argumentName)) {
-            return List.of("database");
+    private List<String> createCompletionRequiredContextArguments(final Collection<MCPCompletionTargetDescriptor> descriptors, final String argumentName) {
+        Set<String> result = new LinkedHashSet<>();
+        for (MCPCompletionTargetDescriptor each : descriptors) {
+            Object requiredContextArguments = each.getMeta().get(MCPShardingSphereMetadataKeys.REQUIRED_CONTEXT_ARGUMENTS);
+            if (!(requiredContextArguments instanceof Map)) {
+                continue;
+            }
+            Object arguments = ((Map<?, ?>) requiredContextArguments).get(argumentName);
+            if (arguments instanceof Collection) {
+                ((Collection<?>) arguments).stream().map(String::valueOf).forEach(result::add);
+            }
         }
-        if ("table".equals(argumentName) || "sequence".equals(argumentName)) {
-            return List.of("database", "schema");
-        }
-        if ("column".equals(argumentName) || "index".equals(argumentName)) {
-            return List.of("database", "schema", "table");
-        }
-        return List.of();
+        return result.stream().toList();
     }
     
     private String resolveReferenceType(final String reference) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidator.java
@@ -34,15 +34,17 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 final class MCPDescriptorCatalogValidator {
     
     private static final Collection<String> REMOVED_MODEL_FACING_FIELDS = Set.of(
             "target_tool", "target_resource", "required_arguments", "action_kind", "suggested_next_tool", "suggested_next_tools", "recommended_next_tool",
             "recommended_recovery", "suggested_next_action", "approved_by_user", "requires_user_approval", "approval_required", "user_overrides");
+    
+    private static final Collection<String> SUPPORTED_INPUT_SCHEMA_TOP_LEVEL_FIELDS = Set.of("type", "properties", "required", "additionalProperties");
     
     private static final Map<String, Collection<String>> NEXT_ACTION_ALLOWED_FIELDS = createNextActionAllowedFields();
     
@@ -84,7 +86,7 @@ final class MCPDescriptorCatalogValidator {
     
     static void validate(final MCPDescriptorCatalog catalog) {
         validateResourceDescriptors(catalog);
-        validateToolDescriptors(catalog.getToolDescriptors(), catalog.getToolRuntimeDescriptors());
+        validateToolDescriptors(catalog);
         validatePromptDescriptors(catalog.getPromptDescriptors(), catalog.getPromptTemplateBindings());
         validateCompletionTargetDescriptors(catalog.getCompletionTargetDescriptors(), catalog.getPromptDescriptors(), catalog.getAllResourceDescriptors());
         validateResourceNavigationDescriptors(catalog.getResourceNavigationDescriptors(), catalog);
@@ -139,11 +141,16 @@ final class MCPDescriptorCatalogValidator {
         }
     }
     
-    private static void validateToolDescriptors(final Collection<MCPToolDescriptor> descriptors, final Collection<MCPToolRuntimeDescriptor> runtimeDescriptors) {
+    private static void validateToolDescriptors(final MCPDescriptorCatalog catalog) {
+        Collection<MCPToolDescriptor> descriptors = catalog.getToolDescriptors();
+        Collection<MCPToolRuntimeDescriptor> runtimeDescriptors = catalog.getToolRuntimeDescriptors();
         Collection<MCPToolDescriptorValidator> descriptorValidators = MCPToolDescriptorValidatorLoader.load();
         Map<String, MCPToolDescriptor> registered = new LinkedHashMap<>(descriptors.size(), 1F);
         Map<String, MCPToolRuntimeDescriptor> runtimes = runtimeDescriptors.stream()
                 .collect(Collectors.toMap(MCPToolRuntimeDescriptor::getToolName, each -> each));
+        Set<String> resourceIdentifiers = catalog.getAllResourceDescriptors().stream().map(MCPResourceDescriptor::getUriTemplate).collect(Collectors.toSet());
+        Set<String> shardingSphereResourceIdentifiers = catalog.getShardingSphereResourceMetadata().stream()
+                .map(ShardingSphereMCPResourceMetadata::getUriOrTemplate).collect(Collectors.toSet());
         for (MCPToolDescriptor each : descriptors) {
             ShardingSpherePreconditions.checkState(null == registered.putIfAbsent(each.getName(), each),
                     () -> new IllegalStateException(String.format("Duplicate MCP tool descriptor `%s`.", each.getName())));
@@ -151,16 +158,58 @@ final class MCPDescriptorCatalogValidator {
             validateToolOutputSchema(each, descriptorValidators);
             validateDestructiveToolDescriptor(each, runtimes.get(each.getName()));
             validatePlanningExecutionMode(each);
+            validateRelatedResourceUris(each, resourceIdentifiers, shardingSphereResourceIdentifiers);
         }
+        validatePlanningToolRuntimeDescriptors(registered, runtimeDescriptors);
     }
     
     private static void validateToolInputSchema(final MCPToolDescriptor descriptor) {
         Map<String, Object> inputSchema = descriptor.getInputSchema();
+        for (String each : inputSchema.keySet()) {
+            ShardingSpherePreconditions.checkState(SUPPORTED_INPUT_SCHEMA_TOP_LEVEL_FIELDS.contains(each),
+                    () -> new IllegalStateException(String.format("Tool `%s` inputSchema contains unsupported top-level field `%s`.", descriptor.getName(), each)));
+        }
         ShardingSpherePreconditions.checkState("object".equals(inputSchema.get("type")),
                 () -> new IllegalStateException(String.format("Tool `%s` inputSchema must be an object.", descriptor.getName())));
         Object properties = inputSchema.get("properties");
         ShardingSpherePreconditions.checkState(properties instanceof Map, () -> new IllegalStateException(String.format("Tool `%s` inputSchema must declare properties.", descriptor.getName())));
         validateNoRemovedModelFacingFields(descriptor, inputSchema);
+    }
+    
+    private static void validateRelatedResourceUris(final MCPToolDescriptor descriptor, final Set<String> resourceIdentifiers, final Set<String> shardingSphereResourceIdentifiers) {
+        Object value = descriptor.getMeta().get(MCPShardingSphereMetadataKeys.RELATED_RESOURCE_URIS);
+        if (null == value) {
+            return;
+        }
+        ShardingSpherePreconditions.checkState(value instanceof Collection,
+                () -> new IllegalStateException(String.format("Tool `%s` metadata `%s` must be a list.", descriptor.getName(), MCPShardingSphereMetadataKeys.RELATED_RESOURCE_URIS)));
+        for (Object each : (Collection<?>) value) {
+            String uri = String.valueOf(each);
+            ShardingSpherePreconditions.checkState(resourceIdentifiers.contains(uri),
+                    () -> new IllegalStateException(String.format("Tool `%s` metadata `%s` references unknown resource `%s`.",
+                            descriptor.getName(), MCPShardingSphereMetadataKeys.RELATED_RESOURCE_URIS, uri)));
+            ShardingSpherePreconditions.checkState(shardingSphereResourceIdentifiers.contains(uri),
+                    () -> new IllegalStateException(String.format("Tool `%s` metadata `%s` references resource `%s` without ShardingSphere metadata.",
+                            descriptor.getName(), MCPShardingSphereMetadataKeys.RELATED_RESOURCE_URIS, uri)));
+        }
+    }
+    
+    private static void validatePlanningToolRuntimeDescriptors(final Map<String, MCPToolDescriptor> descriptors, final Collection<MCPToolRuntimeDescriptor> runtimeDescriptors) {
+        Map<String, String> workflowKinds = new LinkedHashMap<>(runtimeDescriptors.size(), 1F);
+        for (MCPToolRuntimeDescriptor each : runtimeDescriptors) {
+            if (!"plan".equals(each.getWorkflowRole())) {
+                continue;
+            }
+            MCPToolDescriptor descriptor = descriptors.get(each.getToolName());
+            ShardingSpherePreconditions.checkState(null != descriptor,
+                    () -> new IllegalStateException(String.format("Planning runtime tool `%s` must reference a registered tool descriptor.", each.getToolName())));
+            Object workflowKind = descriptor.getMeta().get(MCPShardingSphereMetadataKeys.WORKFLOW_KIND);
+            ShardingSpherePreconditions.checkState(null != workflowKind && !workflowKind.toString().isBlank(),
+                    () -> new IllegalStateException(String.format("Planning tool `%s` metadata must declare `%s`.", each.getToolName(), MCPShardingSphereMetadataKeys.WORKFLOW_KIND)));
+            String previousToolName = workflowKinds.putIfAbsent(workflowKind.toString(), each.getToolName());
+            ShardingSpherePreconditions.checkState(null == previousToolName, () -> new IllegalStateException(
+                    String.format("Planning workflow kind `%s` is used by both `%s` and `%s`.", workflowKind, previousToolName, each.getToolName())));
+        }
     }
     
     private static void validateToolOutputSchema(final MCPToolDescriptor descriptor, final Collection<MCPToolDescriptorValidator> descriptorValidators) {
@@ -436,8 +485,34 @@ final class MCPDescriptorCatalogValidator {
             validateCompletionReference(each, promptNames, resourceDescriptors.keySet());
             validatePromptCompletionArguments(each, promptArguments);
             validateResourceCompletionArguments(each, resourceDescriptors);
+            validateCompletionRequiredContextArguments(each);
             ShardingSpherePreconditions.checkState(null == registered.putIfAbsent(each.getReferenceType() + ":" + each.getReference(), each),
                     () -> new IllegalStateException(String.format("Duplicate MCP completion target `%s:%s`.", each.getReferenceType(), each.getReference())));
+        }
+    }
+    
+    private static void validateCompletionRequiredContextArguments(final MCPCompletionTargetDescriptor descriptor) {
+        Object value = descriptor.getMeta().get(MCPShardingSphereMetadataKeys.REQUIRED_CONTEXT_ARGUMENTS);
+        if (null == value) {
+            return;
+        }
+        ShardingSpherePreconditions.checkState(value instanceof Map,
+                () -> new IllegalStateException(String.format("Completion target `%s:%s` metadata `%s` must be an object.",
+                        descriptor.getReferenceType(), descriptor.getReference(), MCPShardingSphereMetadataKeys.REQUIRED_CONTEXT_ARGUMENTS)));
+        Set<String> argumentNames = new HashSet<>(descriptor.getArguments());
+        for (Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+            String argumentName = String.valueOf(entry.getKey());
+            ShardingSpherePreconditions.checkState(argumentNames.contains(argumentName),
+                    () -> new IllegalStateException(String.format("Completion target `%s:%s` required context argument `%s` is not declared by the target.",
+                            descriptor.getReferenceType(), descriptor.getReference(), argumentName)));
+            ShardingSpherePreconditions.checkState(entry.getValue() instanceof Collection,
+                    () -> new IllegalStateException(String.format("Completion target `%s:%s` required context for `%s` must be a list.",
+                            descriptor.getReferenceType(), descriptor.getReference(), argumentName)));
+            for (Object each : (Collection<?>) entry.getValue()) {
+                ShardingSpherePreconditions.checkState(argumentNames.contains(String.valueOf(each)),
+                        () -> new IllegalStateException(String.format("Completion target `%s:%s` context argument `%s` for `%s` is not declared by the target.",
+                                descriptor.getReferenceType(), descriptor.getReference(), each, argumentName)));
+            }
         }
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPModelFirstContractPayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPModelFirstContractPayloadBuilder.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
 import org.apache.shardingsphere.mcp.support.security.MCPClientSafetyPolicy;
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowToolDescriptors;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -91,7 +92,7 @@ final class MCPModelFirstContractPayloadBuilder {
         result.put("preflight_validation_tool", PREFLIGHT_TOOL_NAME);
         result.put("read_only_sql_tool", "database_gateway_execute_query");
         result.put("side_effect_sql_tool", "database_gateway_execute_update");
-        result.put("workflow_tools", List.of("database_gateway_apply_workflow", "database_gateway_validate_workflow"));
+        result.put("workflow_tools", List.of(WorkflowToolDescriptors.APPLY_TOOL_NAME, WorkflowToolDescriptors.VALIDATE_TOOL_NAME));
         result.put("side_effect_rule", "Preview first and continue only when the requested side effect is still intended.");
         result.put("completion_rule", "Use local completion hints on fields, prompts, and resources before guessing identifiers.");
         return result;
@@ -142,7 +143,7 @@ final class MCPModelFirstContractPayloadBuilder {
                         "call_tool database_gateway_apply_workflow execution_mode=review-then-execute approved_steps=<preview_artifacts.approval_step>",
                         "call_tool database_gateway_validate_workflow"),
                         "Reuse the same current-session plan_id and stop after validation succeeds.",
-                        List.of("database_gateway_apply_workflow", "database_gateway_validate_workflow"), List.of()),
+                        List.of(WorkflowToolDescriptors.APPLY_TOOL_NAME, WorkflowToolDescriptors.VALIDATE_TOOL_NAME), List.of()),
                 createCommonFlow("recover_from_error", List.of("follow recovery.next_actions", "prefer official list discovery methods when surface information is needed",
                         "read_resource shardingsphere://capabilities only when the server suggests the catalog resource", "ask_user only when uncertain"),
                         "Do not invent replacement calls while structured recovery actions are present.", List.of(), List.of(CATALOG_RESOURCE_URI)));
@@ -209,15 +210,15 @@ final class MCPModelFirstContractPayloadBuilder {
         Map<String, Object> result = new LinkedHashMap<>(4, 1F);
         result.put("planning_tools", catalog.getToolDescriptors().stream().map(MCPToolDescriptor::getName).filter(each -> each.startsWith(PLANNING_TOOL_NAME_PREFIX)).toList());
         Map<String, Object> previewTool = new LinkedHashMap<>(2, 1F);
-        previewTool.put("tool", "database_gateway_apply_workflow");
+        previewTool.put("tool", WorkflowToolDescriptors.APPLY_TOOL_NAME);
         previewTool.put(MCPPayloadFieldNames.EXECUTION_MODE, "preview");
         result.put("preview_tool", previewTool);
         Map<String, Object> executeTool = new LinkedHashMap<>(3, 1F);
-        executeTool.put("tool", "database_gateway_apply_workflow");
+        executeTool.put("tool", WorkflowToolDescriptors.APPLY_TOOL_NAME);
         executeTool.put(MCPPayloadFieldNames.EXECUTION_MODE, "review-then-execute");
         executeTool.put("execute_requires", "execution_mode=review-then-execute and explicit approved_steps copied from preview_artifacts.approval_step");
         result.put("execute_tool", executeTool);
-        result.put("validate_tool", "database_gateway_validate_workflow");
+        result.put("validate_tool", WorkflowToolDescriptors.VALIDATE_TOOL_NAME);
         return result;
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPModelFirstContractPayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPModelFirstContractPayloadBuilder.java
@@ -71,9 +71,10 @@ final class MCPModelFirstContractPayloadBuilder {
         result.put("optional_catalog_resource", CATALOG_RESOURCE_URI);
         result.put("metadata_first_resource", "shardingsphere://databases");
         result.put("preflight_rule", "Use database_gateway_validate_runtime_database with a configured database name before onboarding or troubleshooting runtime connectivity.");
-        result.put("sql_tool_selection", Map.of(
-                "read_only", "Use database_gateway_execute_query for one classifier-approved SELECT or EXPLAIN ANALYZE statement.",
-                "side_effecting", "Use database_gateway_execute_update with execution_mode=preview before execution."));
+        Map<String, Object> sqlToolSelection = new LinkedHashMap<>(2, 1F);
+        sqlToolSelection.put("read_only", "Use database_gateway_execute_query for one classifier-approved SELECT or EXPLAIN ANALYZE statement.");
+        sqlToolSelection.put("side_effecting", "Use database_gateway_execute_update with execution_mode=preview before execution.");
+        result.put("sql_tool_selection", sqlToolSelection);
         result.put("workflow_session_rule", "Reuse the current-session plan_id returned by a planning tool; re-plan when the plan is unavailable.");
         result.put("side_effect_rule", "Preview before side effects and continue only when the requested side effect is still intended.");
         result.put("next_action_rule", "Use canonical next_actions fields: type, tool_name, resource_uri, and arguments.");

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPShardingSphereMetadataKeys.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPShardingSphereMetadataKeys.java
@@ -37,15 +37,9 @@ public final class MCPShardingSphereMetadataKeys {
     
     public static final String FEATURE = PREFIX + "feature";
     
-    public static final String RUNTIME_VISIBILITY = PREFIX + "runtime-visibility";
-    
     public static final String URI_VARIABLES = PREFIX + "uri-variables";
     
     public static final String RELATED_TOOLS = PREFIX + "related-tools";
-    
-    public static final String FOLLOW_UP_TOOLS = PREFIX + "follow-up-tools";
-    
-    public static final String REJECTED_STATEMENT_CLASSES = PREFIX + "rejected-statement-classes";
     
     public static final String WORKFLOW_KIND = PREFIX + "workflow-kind";
     
@@ -86,6 +80,8 @@ public final class MCPShardingSphereMetadataKeys {
     public static final String MATCH_STRATEGY = PREFIX + "match-strategy";
     
     public static final String CONTEXT_ARGUMENTS = PREFIX + "context-arguments";
+    
+    public static final String REQUIRED_CONTEXT_ARGUMENTS = PREFIX + "required-context-arguments";
     
     public static final String CANDIDATE_COUNT = PREFIX + "candidate-count";
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/descriptor/WorkflowKindDescriptors.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/descriptor/WorkflowKindDescriptors.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.workflow.descriptor;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Shared workflow kind descriptors.
+ */
+public final class WorkflowKindDescriptors {
+    
+    public static final String ENCRYPT_RULE = "encrypt.rule";
+    
+    public static final String MASK_RULE = "mask.rule";
+    
+    public static final String BROADCAST_RULE = "broadcast.rule";
+    
+    public static final String READWRITE_RULE = "readwrite.rule";
+    
+    public static final String READWRITE_STATUS = "readwrite.status";
+    
+    public static final String SHADOW_RULE = "shadow.rule";
+    
+    public static final String SHADOW_DEFAULT_ALGORITHM = "shadow.default";
+    
+    public static final String SHADOW_ALGORITHM_CLEANUP = "shadow.cleanup";
+    
+    public static final String SHARDING_TABLE_RULE = "sharding.table.rule";
+    
+    public static final String SHARDING_TABLE_REFERENCE = "sharding.table.reference";
+    
+    public static final String SHARDING_DEFAULT_STRATEGY = "sharding.default.strategy";
+    
+    public static final String SHARDING_KEY_GENERATOR = "sharding.key.generator";
+    
+    public static final String SHARDING_KEY_GENERATE_STRATEGY = "sharding.key.generate.strategy";
+    
+    public static final String SHARDING_COMPONENT_CLEANUP = "sharding.component.cleanup";
+    
+    private static final Collection<String> RULE_DISTSQL_ONLY_WORKFLOW_KINDS = Set.of(ENCRYPT_RULE, MASK_RULE, BROADCAST_RULE, READWRITE_RULE, READWRITE_STATUS, SHADOW_RULE,
+            SHADOW_DEFAULT_ALGORITHM, SHADOW_ALGORITHM_CLEANUP, SHARDING_TABLE_RULE, SHARDING_TABLE_REFERENCE, SHARDING_DEFAULT_STRATEGY, SHARDING_KEY_GENERATOR,
+            SHARDING_KEY_GENERATE_STRATEGY, SHARDING_COMPONENT_CLEANUP);
+    
+    private WorkflowKindDescriptors() {
+    }
+    
+    /**
+     * Judge whether workflow must expose rule DistSQL artifacts only.
+     *
+     * @param workflowKind workflow kind
+     * @return whether workflow is rule DistSQL only
+     */
+    public static boolean isRuleDistSQLOnly(final String workflowKind) {
+        return RULE_DISTSQL_ONLY_WORKFLOW_KINDS.contains(workflowKind);
+    }
+}

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowArtifactPayloadUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowArtifactPayloadUtils.java
@@ -18,10 +18,10 @@
 package org.apache.shardingsphere.mcp.support.workflow.service;
 
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowPropertySource;
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowKindDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Workflow artifact payload utility methods.
@@ -45,39 +45,6 @@ public final class WorkflowArtifactPayloadUtils {
     public static final String STEP_INDEX_DDL = "index_ddl";
     
     public static final String STEP_RULE_DISTSQL = "rule_distsql";
-    
-    private static final String ENCRYPT_RULE_WORKFLOW_KIND = "encrypt.rule";
-    
-    private static final String MASK_RULE_WORKFLOW_KIND = "mask.rule";
-    
-    private static final String BROADCAST_RULE_WORKFLOW_KIND = "broadcast.rule";
-    
-    private static final String READWRITE_RULE_WORKFLOW_KIND = "readwrite.rule";
-    
-    private static final String READWRITE_STATUS_WORKFLOW_KIND = "readwrite.status";
-    
-    private static final String SHADOW_RULE_WORKFLOW_KIND = "shadow.rule";
-    
-    private static final String SHADOW_DEFAULT_ALGORITHM_WORKFLOW_KIND = "shadow.default";
-    
-    private static final String SHADOW_ALGORITHM_CLEANUP_WORKFLOW_KIND = "shadow.cleanup";
-    
-    private static final String SHARDING_TABLE_RULE_WORKFLOW_KIND = "sharding.table.rule";
-    
-    private static final String SHARDING_TABLE_REFERENCE_WORKFLOW_KIND = "sharding.table.reference";
-    
-    private static final String SHARDING_DEFAULT_STRATEGY_WORKFLOW_KIND = "sharding.default.strategy";
-    
-    private static final String SHARDING_KEY_GENERATOR_WORKFLOW_KIND = "sharding.key.generator";
-    
-    private static final String SHARDING_KEY_GENERATE_STRATEGY_WORKFLOW_KIND = "sharding.key.generate.strategy";
-    
-    private static final String SHARDING_COMPONENT_CLEANUP_WORKFLOW_KIND = "sharding.component.cleanup";
-    
-    private static final Set<String> RULE_DISTSQL_ONLY_WORKFLOW_KINDS = Set.of(ENCRYPT_RULE_WORKFLOW_KIND, MASK_RULE_WORKFLOW_KIND, BROADCAST_RULE_WORKFLOW_KIND, READWRITE_RULE_WORKFLOW_KIND,
-            READWRITE_STATUS_WORKFLOW_KIND, SHADOW_RULE_WORKFLOW_KIND, SHADOW_DEFAULT_ALGORITHM_WORKFLOW_KIND, SHADOW_ALGORITHM_CLEANUP_WORKFLOW_KIND, SHARDING_TABLE_RULE_WORKFLOW_KIND,
-            SHARDING_TABLE_REFERENCE_WORKFLOW_KIND, SHARDING_DEFAULT_STRATEGY_WORKFLOW_KIND, SHARDING_KEY_GENERATOR_WORKFLOW_KIND, SHARDING_KEY_GENERATE_STRATEGY_WORKFLOW_KIND,
-            SHARDING_COMPONENT_CLEANUP_WORKFLOW_KIND);
     
     private WorkflowArtifactPayloadUtils() {
     }
@@ -112,6 +79,6 @@ public final class WorkflowArtifactPayloadUtils {
      */
     public static boolean isRuleDistSQLOnlyWorkflow(final WorkflowContextSnapshot snapshot) {
         String workflowKind = null == snapshot.getWorkflowKind() ? "" : snapshot.getWorkflowKind().getValue();
-        return RULE_DISTSQL_ONLY_WORKFLOW_KINDS.contains(workflowKind);
+        return WorkflowKindDescriptors.isRuleDistSQLOnly(workflowKind);
     }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidancePayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidancePayloadBuilder.java
@@ -20,8 +20,10 @@ package org.apache.shardingsphere.mcp.support.workflow.service;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.support.diagnostic.MCPDiagnosticCategory;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogIndex;
 import org.apache.shardingsphere.mcp.support.protocol.MCPNextActionUtils;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowToolDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmPropertyRequirement;
 import org.apache.shardingsphere.mcp.support.workflow.model.ClarifiedIntent;
 import org.apache.shardingsphere.mcp.support.workflow.model.ValidationReport;
@@ -45,77 +47,9 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WorkflowGuidancePayloadBuilder {
     
-    private static final String APPLY_WORKFLOW = "database_gateway_apply_workflow";
-    
-    private static final String VALIDATE_WORKFLOW = "database_gateway_validate_workflow";
-    
     private static final String EXECUTION_MODE_PREVIEW = "preview";
     
     private static final String EXECUTION_MODE_MANUAL_ONLY = "manual-only";
-    
-    private static final String ENCRYPT_RULE_WORKFLOW_KIND = "encrypt.rule";
-    
-    private static final String MASK_RULE_WORKFLOW_KIND = "mask.rule";
-    
-    private static final String BROADCAST_RULE_WORKFLOW_KIND = "broadcast.rule";
-    
-    private static final String READWRITE_RULE_WORKFLOW_KIND = "readwrite.rule";
-    
-    private static final String READWRITE_STATUS_WORKFLOW_KIND = "readwrite.status";
-    
-    private static final String SHADOW_RULE_WORKFLOW_KIND = "shadow.rule";
-    
-    private static final String SHADOW_DEFAULT_ALGORITHM_WORKFLOW_KIND = "shadow.default";
-    
-    private static final String SHADOW_ALGORITHM_CLEANUP_WORKFLOW_KIND = "shadow.cleanup";
-    
-    private static final String SHARDING_TABLE_RULE_WORKFLOW_KIND = "sharding.table.rule";
-    
-    private static final String SHARDING_TABLE_REFERENCE_WORKFLOW_KIND = "sharding.table.reference";
-    
-    private static final String SHARDING_DEFAULT_STRATEGY_WORKFLOW_KIND = "sharding.default.strategy";
-    
-    private static final String SHARDING_KEY_GENERATOR_WORKFLOW_KIND = "sharding.key.generator";
-    
-    private static final String SHARDING_KEY_GENERATE_STRATEGY_WORKFLOW_KIND = "sharding.key.generate.strategy";
-    
-    private static final String SHARDING_COMPONENT_CLEANUP_WORKFLOW_KIND = "sharding.component.cleanup";
-    
-    private static final String PLAN_ENCRYPT_RULE = "database_gateway_plan_encrypt_rule";
-    
-    private static final String PLAN_MASK_RULE = "database_gateway_plan_mask_rule";
-    
-    private static final String PLAN_BROADCAST_RULE = "database_gateway_plan_broadcast_rule";
-    
-    private static final String PLAN_READWRITE_RULE = "database_gateway_plan_readwrite_splitting_rule";
-    
-    private static final String PLAN_READWRITE_STATUS = "database_gateway_plan_readwrite_splitting_status";
-    
-    private static final String PLAN_SHADOW_RULE = "database_gateway_plan_shadow_rule";
-    
-    private static final String PLAN_DEFAULT_SHADOW_ALGORITHM = "database_gateway_plan_default_shadow_algorithm";
-    
-    private static final String PLAN_SHADOW_ALGORITHM_CLEANUP = "database_gateway_plan_shadow_algorithm_cleanup";
-    
-    private static final String PLAN_SHARDING_TABLE_RULE = "database_gateway_plan_sharding_table_rule";
-    
-    private static final String PLAN_SHARDING_TABLE_REFERENCE_RULE = "database_gateway_plan_sharding_table_reference_rule";
-    
-    private static final String PLAN_SHARDING_DEFAULT_STRATEGY = "database_gateway_plan_sharding_default_strategy";
-    
-    private static final String PLAN_SHARDING_KEY_GENERATOR = "database_gateway_plan_sharding_key_generator";
-    
-    private static final String PLAN_SHARDING_KEY_GENERATE_STRATEGY = "database_gateway_plan_sharding_key_generate_strategy";
-    
-    private static final String PLAN_SHARDING_COMPONENT_CLEANUP = "database_gateway_plan_sharding_rule_component_cleanup";
-    
-    private static final Map<String, String> PLANNING_TOOLS = Map.ofEntries(Map.entry(ENCRYPT_RULE_WORKFLOW_KIND, PLAN_ENCRYPT_RULE), Map.entry(MASK_RULE_WORKFLOW_KIND, PLAN_MASK_RULE),
-            Map.entry(BROADCAST_RULE_WORKFLOW_KIND, PLAN_BROADCAST_RULE), Map.entry(READWRITE_RULE_WORKFLOW_KIND, PLAN_READWRITE_RULE),
-            Map.entry(READWRITE_STATUS_WORKFLOW_KIND, PLAN_READWRITE_STATUS), Map.entry(SHADOW_RULE_WORKFLOW_KIND, PLAN_SHADOW_RULE),
-            Map.entry(SHADOW_DEFAULT_ALGORITHM_WORKFLOW_KIND, PLAN_DEFAULT_SHADOW_ALGORITHM), Map.entry(SHADOW_ALGORITHM_CLEANUP_WORKFLOW_KIND, PLAN_SHADOW_ALGORITHM_CLEANUP),
-            Map.entry(SHARDING_TABLE_RULE_WORKFLOW_KIND, PLAN_SHARDING_TABLE_RULE), Map.entry(SHARDING_TABLE_REFERENCE_WORKFLOW_KIND, PLAN_SHARDING_TABLE_REFERENCE_RULE),
-            Map.entry(SHARDING_DEFAULT_STRATEGY_WORKFLOW_KIND, PLAN_SHARDING_DEFAULT_STRATEGY), Map.entry(SHARDING_KEY_GENERATOR_WORKFLOW_KIND, PLAN_SHARDING_KEY_GENERATOR),
-            Map.entry(SHARDING_KEY_GENERATE_STRATEGY_WORKFLOW_KIND, PLAN_SHARDING_KEY_GENERATE_STRATEGY), Map.entry(SHARDING_COMPONENT_CLEANUP_WORKFLOW_KIND, PLAN_SHARDING_COMPONENT_CLEANUP));
     
     /**
      * Append model-facing next action guidance to a planning response.
@@ -156,7 +90,7 @@ public final class WorkflowGuidancePayloadBuilder {
     public static void appendApplyGuidance(final Map<String, Object> payload, final String status) {
         List<Map<String, Object>> nextActions = new LinkedList<>();
         if (WorkflowLifecycle.STATUS_COMPLETED.equals(status)) {
-            nextActions.add(createToolAction(VALIDATE_WORKFLOW, "Validate the runtime state after workflow artifacts are applied or exported.",
+            nextActions.add(createToolAction(WorkflowToolDescriptors.VALIDATE_TOOL_NAME, "Validate the runtime state after workflow artifacts are applied or exported.",
                     Map.of(WorkflowFieldNames.PLAN_ID, Objects.toString(payload.get(WorkflowFieldNames.PLAN_ID), ""))));
         }
         if (WorkflowLifecycle.STATUS_AWAITING_MANUAL_EXECUTION.equals(status)) {
@@ -346,7 +280,7 @@ public final class WorkflowGuidancePayloadBuilder {
             return List.of(createUserAction("Ask for the missing inputs, then call the same planning tool with the existing plan_id.", missingRequiredInputs));
         }
         if (WorkflowLifecycle.STATUS_PLANNED.equals(snapshot.getStatus())) {
-            return List.of(createToolAction(APPLY_WORKFLOW, "Preview workflow artifacts before execution.",
+            return List.of(createToolAction(WorkflowToolDescriptors.APPLY_TOOL_NAME, "Preview workflow artifacts before execution.",
                     Map.of(WorkflowFieldNames.PLAN_ID, snapshot.getPlanId(), WorkflowFieldNames.EXECUTION_MODE, EXECUTION_MODE_PREVIEW)));
         }
         if (WorkflowLifecycle.STATUS_FAILED.equals(snapshot.getStatus())) {
@@ -386,7 +320,7 @@ public final class WorkflowGuidancePayloadBuilder {
     }
     
     private static String resolvePlanningTool(final WorkflowContextSnapshot snapshot) {
-        return PLANNING_TOOLS.getOrDefault(resolveWorkflowKind(snapshot), "");
+        return MCPDescriptorCatalogIndex.findPlanningToolNameByWorkflowKind(resolveWorkflowKind(snapshot)).orElse("");
     }
     
     private static String resolveWorkflowKind(final WorkflowContextSnapshot snapshot) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidanceResourceHintProvider.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidanceResourceHintProvider.java
@@ -17,9 +17,14 @@
 
 package org.apache.shardingsphere.mcp.support.workflow.service;
 
+import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogIndex;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPShardingSphereMetadataKeys;
+import org.apache.shardingsphere.mcp.support.descriptor.ShardingSphereMCPResourceMetadata;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
 import org.apache.shardingsphere.mcp.support.protocol.MCPResourceHintUtils;
 import org.apache.shardingsphere.mcp.support.resource.MCPUriPathSegmentUtils;
+import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowKindDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
@@ -28,39 +33,12 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Provides model-facing workflow resource read hints.
  */
 public final class WorkflowGuidanceResourceHintProvider {
-    
-    private static final String ENCRYPT_RULE_WORKFLOW_KIND = "encrypt.rule";
-    
-    private static final String MASK_RULE_WORKFLOW_KIND = "mask.rule";
-    
-    private static final String BROADCAST_RULE_WORKFLOW_KIND = "broadcast.rule";
-    
-    private static final String READWRITE_RULE_WORKFLOW_KIND = "readwrite.rule";
-    
-    private static final String READWRITE_STATUS_WORKFLOW_KIND = "readwrite.status";
-    
-    private static final String SHADOW_RULE_WORKFLOW_KIND = "shadow.rule";
-    
-    private static final String SHADOW_DEFAULT_ALGORITHM_WORKFLOW_KIND = "shadow.default";
-    
-    private static final String SHADOW_ALGORITHM_CLEANUP_WORKFLOW_KIND = "shadow.cleanup";
-    
-    private static final String SHARDING_TABLE_RULE_WORKFLOW_KIND = "sharding.table.rule";
-    
-    private static final String SHARDING_TABLE_REFERENCE_WORKFLOW_KIND = "sharding.table.reference";
-    
-    private static final String SHARDING_DEFAULT_STRATEGY_WORKFLOW_KIND = "sharding.default.strategy";
-    
-    private static final String SHARDING_KEY_GENERATOR_WORKFLOW_KIND = "sharding.key.generator";
-    
-    private static final String SHARDING_KEY_GENERATE_STRATEGY_WORKFLOW_KIND = "sharding.key.generate.strategy";
-    
-    private static final String SHARDING_COMPONENT_CLEANUP_WORKFLOW_KIND = "sharding.component.cleanup";
     
     /**
      * Create resource hints for a workflow planning response.
@@ -72,6 +50,7 @@ public final class WorkflowGuidanceResourceHintProvider {
         List<Map<String, Object>> result = new LinkedList<>();
         addFeatureResources(result, snapshot);
         WorkflowRequest request = snapshot.getRequest();
+        addDescriptorRelatedResources(result, snapshot, request);
         if (!request.getDatabase().isEmpty()) {
             addRuleResources(result, snapshot, request);
             addGovernanceMetadataResources(result, snapshot, request);
@@ -86,80 +65,105 @@ public final class WorkflowGuidanceResourceHintProvider {
     
     private void addFeatureResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot) {
         switch (resolveWorkflowKind(snapshot)) {
-            case ENCRYPT_RULE_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/encrypt/algorithms", "algorithm", "read_first",
-                    "Read encrypt algorithm metadata before choosing algorithm arguments.");
-            case MASK_RULE_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/mask/algorithms", "algorithm", "read_first",
-                    "Read mask algorithm metadata before choosing algorithm arguments.");
-            case READWRITE_RULE_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/readwrite-splitting/load-balance-algorithm-plugins", "algorithm", "read_first",
-                    "Read load-balance algorithm plugin metadata before choosing algorithm arguments.");
-            case SHADOW_RULE_WORKFLOW_KIND, SHADOW_DEFAULT_ALGORITHM_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/shadow/algorithm-plugins", "algorithm",
-                    "read_first", "Read shadow algorithm plugin metadata before choosing algorithm arguments.");
-            case SHARDING_TABLE_RULE_WORKFLOW_KIND, SHARDING_DEFAULT_STRATEGY_WORKFLOW_KIND -> addResourceHint(resourcesToRead, "shardingsphere://features/sharding/algorithm-plugins",
-                    "algorithm", "read_first", "Read sharding algorithm plugin metadata before choosing algorithm arguments.");
-            case SHARDING_KEY_GENERATOR_WORKFLOW_KIND, SHARDING_KEY_GENERATE_STRATEGY_WORKFLOW_KIND -> addResourceHint(resourcesToRead,
-                    "shardingsphere://features/sharding/key-generate-algorithm-plugins", "algorithm", "read_first",
-                    "Read key-generate algorithm plugin metadata before choosing generator arguments.");
-            default -> {
-            }
+            case WorkflowKindDescriptors.ENCRYPT_RULE:
+                addResourceHint(resourcesToRead, "shardingsphere://features/encrypt/algorithms", "algorithm", "read_first",
+                        "Read encrypt algorithm metadata before choosing algorithm arguments.");
+                break;
+            case WorkflowKindDescriptors.MASK_RULE:
+                addResourceHint(resourcesToRead, "shardingsphere://features/mask/algorithms", "algorithm", "read_first",
+                        "Read mask algorithm metadata before choosing algorithm arguments.");
+                break;
+            case WorkflowKindDescriptors.READWRITE_RULE:
+                addResourceHint(resourcesToRead, "shardingsphere://features/readwrite-splitting/load-balance-algorithm-plugins", "algorithm", "read_first",
+                        "Read load-balance algorithm plugin metadata before choosing algorithm arguments.");
+                break;
+            case WorkflowKindDescriptors.SHADOW_RULE:
+            case WorkflowKindDescriptors.SHADOW_DEFAULT_ALGORITHM:
+                addResourceHint(resourcesToRead, "shardingsphere://features/shadow/algorithm-plugins", "algorithm", "read_first",
+                        "Read shadow algorithm plugin metadata before choosing algorithm arguments.");
+                break;
+            case WorkflowKindDescriptors.SHARDING_TABLE_RULE:
+            case WorkflowKindDescriptors.SHARDING_DEFAULT_STRATEGY:
+                addResourceHint(resourcesToRead, "shardingsphere://features/sharding/algorithm-plugins", "algorithm", "read_first",
+                        "Read sharding algorithm plugin metadata before choosing algorithm arguments.");
+                break;
+            case WorkflowKindDescriptors.SHARDING_KEY_GENERATOR:
+            case WorkflowKindDescriptors.SHARDING_KEY_GENERATE_STRATEGY:
+                addResourceHint(resourcesToRead, "shardingsphere://features/sharding/key-generate-algorithm-plugins", "algorithm", "read_first",
+                        "Read key-generate algorithm plugin metadata before choosing generator arguments.");
+                break;
+            default:
+                break;
         }
     }
     
     private void addGovernanceMetadataResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot, final WorkflowRequest request) {
         String workflowKind = resolveWorkflowKind(snapshot);
         switch (workflowKind) {
-            case READWRITE_RULE_WORKFLOW_KIND, READWRITE_STATUS_WORKFLOW_KIND, SHADOW_RULE_WORKFLOW_KIND, SHARDING_TABLE_RULE_WORKFLOW_KIND -> addStorageUnitsResourceHint(resourcesToRead,
-                    request);
-            default -> {
-            }
+            case WorkflowKindDescriptors.READWRITE_RULE:
+            case WorkflowKindDescriptors.READWRITE_STATUS:
+            case WorkflowKindDescriptors.SHADOW_RULE:
+            case WorkflowKindDescriptors.SHARDING_TABLE_RULE:
+                addStorageUnitsResourceHint(resourcesToRead, request);
+                break;
+            default:
+                break;
         }
         switch (workflowKind) {
-            case SHADOW_RULE_WORKFLOW_KIND, SHARDING_TABLE_RULE_WORKFLOW_KIND -> {
+            case WorkflowKindDescriptors.SHADOW_RULE:
+            case WorkflowKindDescriptors.SHARDING_TABLE_RULE:
                 addSingleTablesResourceHint(resourcesToRead, request);
                 if (!request.getTable().isEmpty()) {
                     addSingleTableResourceHint(resourcesToRead, request);
                 }
-            }
-            default -> {
-            }
+                break;
+            default:
+                break;
         }
     }
     
     private void addFeatureTableRuleResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot, final WorkflowRequest request) {
         switch (resolveWorkflowKind(snapshot)) {
-            case ENCRYPT_RULE_WORKFLOW_KIND -> addTableResourceHint(resourcesToRead, request, "shardingsphere://features/encrypt/databases/%s/tables/%s/rules",
-                    "Inspect current encrypt table rule DistSQL state before planning changes.");
-            case MASK_RULE_WORKFLOW_KIND -> addTableResourceHint(resourcesToRead, request, "shardingsphere://features/mask/databases/%s/tables/%s/rules",
-                    "Inspect current mask table rule DistSQL state before planning changes.");
-            case SHADOW_RULE_WORKFLOW_KIND -> addTableResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/tables/%s/rules",
-                    "Inspect current shadow table rule DistSQL state before planning changes.");
-            case SHARDING_TABLE_RULE_WORKFLOW_KIND -> {
+            case WorkflowKindDescriptors.ENCRYPT_RULE:
+                addTableResourceHint(resourcesToRead, request, "shardingsphere://features/encrypt/databases/%s/tables/%s/rules",
+                        "Inspect current encrypt table rule DistSQL state before planning changes.");
+                break;
+            case WorkflowKindDescriptors.MASK_RULE:
+                addTableResourceHint(resourcesToRead, request, "shardingsphere://features/mask/databases/%s/tables/%s/rules",
+                        "Inspect current mask table rule DistSQL state before planning changes.");
+                break;
+            case WorkflowKindDescriptors.SHADOW_RULE:
+                addTableResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/tables/%s/rules",
+                        "Inspect current shadow table rule DistSQL state before planning changes.");
+                break;
+            case WorkflowKindDescriptors.SHARDING_TABLE_RULE:
                 addTableResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/tables/%s/table-rule",
                         "Inspect current sharding table rule DistSQL state before planning changes.");
                 addTableResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/tables/%s/nodes",
                         "Inspect current sharding table nodes before planning changes.");
-            }
-            default -> {
-            }
+                break;
+            default:
+                break;
         }
     }
     
     private void addRuleResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot, final WorkflowRequest request) {
         switch (resolveWorkflowKind(snapshot)) {
-            case ENCRYPT_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/encrypt/databases/%s/rules",
+            case WorkflowKindDescriptors.ENCRYPT_RULE -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/encrypt/databases/%s/rules",
                     "Inspect current encrypt rules before planning changes.");
-            case MASK_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/mask/databases/%s/rules",
+            case WorkflowKindDescriptors.MASK_RULE -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/mask/databases/%s/rules",
                     "Inspect current mask rules before planning changes.");
-            case BROADCAST_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/broadcast/databases/%s/rules",
+            case WorkflowKindDescriptors.BROADCAST_RULE -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/broadcast/databases/%s/rules",
                     "Inspect current broadcast rules before planning changes.");
-            case READWRITE_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/readwrite-splitting/databases/%s/rules",
+            case WorkflowKindDescriptors.READWRITE_RULE -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/readwrite-splitting/databases/%s/rules",
                     "Inspect current readwrite-splitting rules before planning changes.");
-            case READWRITE_STATUS_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/readwrite-splitting/databases/%s/status",
+            case WorkflowKindDescriptors.READWRITE_STATUS -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/readwrite-splitting/databases/%s/status",
                     "Inspect current readwrite-splitting status before planning changes.");
-            case SHADOW_RULE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/rules",
+            case WorkflowKindDescriptors.SHADOW_RULE -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/rules",
                     "Inspect current shadow rules before planning changes.");
-            case SHADOW_DEFAULT_ALGORITHM_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/default-algorithm",
+            case WorkflowKindDescriptors.SHADOW_DEFAULT_ALGORITHM -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/default-algorithm",
                     "Inspect current default shadow algorithm before planning changes.");
-            case SHADOW_ALGORITHM_CLEANUP_WORKFLOW_KIND -> {
+            case WorkflowKindDescriptors.SHADOW_ALGORITHM_CLEANUP -> {
                 addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/algorithms",
                         "Inspect configured shadow algorithms before planning cleanup.");
                 addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/table-rules",
@@ -167,17 +171,61 @@ public final class WorkflowGuidanceResourceHintProvider {
                 addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/shadow/databases/%s/default-algorithm",
                         "Inspect default shadow algorithm references before planning cleanup.");
             }
-            case SHARDING_TABLE_RULE_WORKFLOW_KIND -> addShardingTableRuleResources(resourcesToRead, request);
-            case SHARDING_TABLE_REFERENCE_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/table-reference-rules",
+            case WorkflowKindDescriptors.SHARDING_TABLE_RULE -> addShardingTableRuleResources(resourcesToRead, request);
+            case WorkflowKindDescriptors.SHARDING_TABLE_REFERENCE -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/table-reference-rules",
                     "Inspect current sharding table reference rules before planning changes.");
-            case SHARDING_DEFAULT_STRATEGY_WORKFLOW_KIND -> addShardingDefaultStrategyResources(resourcesToRead, request);
-            case SHARDING_KEY_GENERATOR_WORKFLOW_KIND -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/key-generators",
+            case WorkflowKindDescriptors.SHARDING_DEFAULT_STRATEGY -> addShardingDefaultStrategyResources(resourcesToRead, request);
+            case WorkflowKindDescriptors.SHARDING_KEY_GENERATOR -> addDatabaseResourceHint(resourcesToRead, request, "shardingsphere://features/sharding/databases/%s/key-generators",
                     "Inspect current sharding key generators before planning changes.");
-            case SHARDING_KEY_GENERATE_STRATEGY_WORKFLOW_KIND -> addShardingKeyGenerateStrategyResources(resourcesToRead, request);
-            case SHARDING_COMPONENT_CLEANUP_WORKFLOW_KIND -> addShardingComponentCleanupResources(resourcesToRead, request);
+            case WorkflowKindDescriptors.SHARDING_KEY_GENERATE_STRATEGY -> addShardingKeyGenerateStrategyResources(resourcesToRead, request);
+            case WorkflowKindDescriptors.SHARDING_COMPONENT_CLEANUP -> addShardingComponentCleanupResources(resourcesToRead, request);
             default -> {
             }
         }
+    }
+    
+    private void addDescriptorRelatedResources(final Collection<Map<String, Object>> resourcesToRead, final WorkflowContextSnapshot snapshot, final WorkflowRequest request) {
+        Optional<String> planningToolName = MCPDescriptorCatalogIndex.findPlanningToolNameByWorkflowKind(resolveWorkflowKind(snapshot));
+        if (planningToolName.isEmpty()) {
+            return;
+        }
+        MCPToolDescriptor descriptor = MCPDescriptorCatalogIndex.getRequiredToolDescriptor(planningToolName.get());
+        Object relatedResourceUris = descriptor.getMeta().get(MCPShardingSphereMetadataKeys.RELATED_RESOURCE_URIS);
+        if (!(relatedResourceUris instanceof Collection)) {
+            return;
+        }
+        for (Object each : (Collection<?>) relatedResourceUris) {
+            String uriTemplate = String.valueOf(each);
+            createConcreteResourceUri(uriTemplate, request).ifPresent(uri -> addResourceHint(resourcesToRead, uri, resolveResourceKind(uriTemplate), "inspect_detail",
+                    "Read descriptor-related resource before planning workflow artifacts."));
+        }
+    }
+    
+    private Optional<String> createConcreteResourceUri(final String uriTemplate, final WorkflowRequest request) {
+        Optional<String> result = replaceRequiredVariable(uriTemplate, "database", request.getDatabase());
+        if (result.isEmpty()) {
+            return result;
+        }
+        result = replaceRequiredVariable(result.get(), "schema", request.getSchema());
+        if (result.isEmpty()) {
+            return result;
+        }
+        result = replaceRequiredVariable(result.get(), "table", request.getTable());
+        return result.filter(each -> !each.contains("{"));
+    }
+    
+    private Optional<String> replaceRequiredVariable(final String uriTemplate, final String variableName, final String value) {
+        String placeholder = "{" + variableName + "}";
+        if (!uriTemplate.contains(placeholder)) {
+            return Optional.of(uriTemplate);
+        }
+        return value.isEmpty() ? Optional.empty() : Optional.of(uriTemplate.replace(placeholder, MCPUriPathSegmentUtils.encodePathSegment(value)));
+    }
+    
+    private String resolveResourceKind(final String uriTemplate) {
+        ShardingSphereMCPResourceMetadata metadata = MCPDescriptorCatalogIndex.getRequiredShardingSphereResourceMetadata(uriTemplate);
+        String result = metadata.getObjectScope();
+        return null == result ? metadata.getResourceKind() : result;
     }
     
     private void addDatabaseResourceHint(final Collection<Map<String, Object>> resourcesToRead, final WorkflowRequest request, final String uriTemplate, final String reason) {
@@ -206,6 +254,9 @@ public final class WorkflowGuidanceResourceHintProvider {
     }
     
     private void addResourceHint(final Collection<Map<String, Object>> resourcesToRead, final String uri, final String resourceKind, final String action, final String reason) {
+        if (resourcesToRead.stream().anyMatch(each -> uri.equals(each.get("uri")))) {
+            return;
+        }
         resourcesToRead.add(MCPResourceHintUtils.create(uri, resourceKind, action, reason, MCPPayloadFieldNames.RESOURCES_TO_READ));
     }
     

--- a/mcp/support/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-support.yaml
+++ b/mcp/support/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-support.yaml
@@ -140,12 +140,20 @@ completionTargets:
       - database
       - schema
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        schema:
+          - database
   - referenceType: prompt
     reference: safe_sql_execution
     arguments:
       - database
       - schema
     maxValues: 50
+    meta:
+      org.apache.shardingsphere/required-context-arguments:
+        schema:
+          - database
   - referenceType: prompt
     reference: recover_workflow
     arguments:

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndexTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndexTest.java
@@ -98,6 +98,16 @@ class MCPDescriptorCatalogIndexTest {
     }
     
     @Test
+    void assertFindPlanningToolNameByWorkflowKind() {
+        assertThat(MCPDescriptorCatalogIndex.findPlanningToolNameByWorkflowKind("encrypt.rule").orElseThrow(), is("database_gateway_plan_encrypt_rule"));
+    }
+    
+    @Test
+    void assertFindPlanningToolNameByUnknownWorkflowKind() {
+        assertFalse(MCPDescriptorCatalogIndex.findPlanningToolNameByWorkflowKind("unknown.rule").isPresent());
+    }
+    
+    @Test
     void assertGetCompletionTargetDescriptors() {
         Collection<MCPCompletionTargetDescriptor> actualDescriptors = MCPDescriptorCatalogIndex.getCompletionTargetDescriptors();
         assertTrue(actualDescriptors.stream().anyMatch(each -> "prompt".equals(each.getReferenceType()) && "inspect_metadata".equals(each.getReference())));

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilderTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
+import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptArgumentDescriptor;
+import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptDescriptor;
 import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceAnnotations;
 import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceDescriptor;
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolAnnotations;
@@ -93,6 +95,21 @@ class MCPDescriptorCatalogPayloadBuilderTest {
                 "destructiveHint", true,
                 "idempotentHint", false,
                 "openWorldHint", true)));
+    }
+    
+    @Test
+    @SuppressWarnings("unchecked")
+    void assertBuildPromptCompletionRequiredContextFromDescriptorMeta() {
+        MCPPromptDescriptor prompt = new MCPPromptDescriptor("test_prompt", "Test Prompt", "Guide a test prompt.", List.of(
+                new MCPPromptArgumentDescriptor("database", "Database", "Logical database.", false),
+                new MCPPromptArgumentDescriptor("schema", "Schema", "Schema.", false)), Map.of());
+        MCPCompletionTargetDescriptor completionTarget = new MCPCompletionTargetDescriptor("prompt", "test_prompt", List.of("database", "schema"), 50,
+                Map.of(MCPShardingSphereMetadataKeys.REQUIRED_CONTEXT_ARGUMENTS, Map.of("schema", List.of("database"))));
+        MCPDescriptorCatalog catalog = new MCPDescriptorCatalog(List.of(), List.of(), List.of(), List.of(), List.of(prompt), List.of(), List.of(completionTarget), List.of(), List.of());
+        Map<String, Object> payload = MCPDescriptorCatalogPayloadBuilder.build(catalog, List.of(), List.of(), List.of());
+        Map<String, Object> actualPrompt = ((List<Map<String, Object>>) payload.get("prompts")).get(0);
+        Map<String, Object> actualSchemaArgument = ((List<Map<String, Object>>) actualPrompt.get("arguments")).get(1);
+        assertThat(((Map<String, Object>) actualSchemaArgument.get("completion")).get("required_context_arguments"), is(List.of("database")));
     }
     
     private MCPDescriptorCatalog createCatalog(final List<MCPResourceDescriptor> resourceDescriptors, final List<MCPToolDescriptor> toolDescriptors) {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidatorTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidatorTest.java
@@ -78,6 +78,45 @@ class MCPDescriptorCatalogValidatorTest {
     }
     
     @Test
+    void assertValidateRejectsUnsupportedInputSchemaTopLevelField() {
+        Map<String, Object> inputSchema = new LinkedHashMap<>(createInputSchema());
+        inputSchema.put("oneOf", List.of(Map.of("required", List.of("query"))));
+        assertValidationError(createCatalog(List.of(), List.of(new MCPToolDescriptor(
+                "database_gateway_test_tool", "Test Tool", "Run a test tool.", inputSchema,
+                createOutputSchema(), new MCPToolAnnotations("Test Tool", true, false, true, true), Map.of()))),
+                "Tool `database_gateway_test_tool` inputSchema contains unsupported top-level field `oneOf`.");
+    }
+    
+    @Test
+    void assertValidateRejectsUnknownRelatedResourceUri() {
+        assertValidationError(createCatalog(List.of(), List.of(new MCPToolDescriptor(
+                "database_gateway_test_tool", "Test Tool", "Run a test tool.", createInputSchema(),
+                createOutputSchema(), new MCPToolAnnotations("Test Tool", true, false, true, true),
+                Map.of(MCPShardingSphereMetadataKeys.RELATED_RESOURCE_URIS, List.of("shardingsphere://unknown"))))),
+                "Tool `database_gateway_test_tool` metadata `org.apache.shardingsphere/related-resource-uris` references unknown resource `shardingsphere://unknown`.");
+    }
+    
+    @Test
+    void assertValidateRejectsPlanningRuntimeWithoutWorkflowKind() {
+        String toolName = "database_gateway_test_plan_rule";
+        assertValidationError(createToolRuntimeCatalog(List.of(), List.of(createToolDescriptor(toolName, new MCPToolAnnotations("Test Tool", true, false, true, true), createOutputSchema())),
+                List.of(new MCPToolRuntimeDescriptor(toolName, "plan", List.of()))),
+                "Planning tool `database_gateway_test_plan_rule` metadata must declare `org.apache.shardingsphere/workflow-kind`.");
+    }
+    
+    @Test
+    void assertValidateRejectsDuplicatePlanningWorkflowKind() {
+        MCPToolDescriptor firstTool = createToolDescriptor("database_gateway_test_plan_rule", new MCPToolAnnotations("Test Tool", true, false, true, true), createOutputSchema(),
+                Map.of(MCPShardingSphereMetadataKeys.WORKFLOW_KIND, "test.rule"));
+        MCPToolDescriptor secondTool = createToolDescriptor("database_gateway_test_plan_rule_again", new MCPToolAnnotations("Test Tool", true, false, true, true), createOutputSchema(),
+                Map.of(MCPShardingSphereMetadataKeys.WORKFLOW_KIND, "test.rule"));
+        assertValidationError(createToolRuntimeCatalog(List.of(), List.of(firstTool, secondTool), List.of(
+                new MCPToolRuntimeDescriptor(firstTool.getName(), "plan", List.of()),
+                new MCPToolRuntimeDescriptor(secondTool.getName(), "plan", List.of()))),
+                "Planning workflow kind `test.rule` is used by both `database_gateway_test_plan_rule` and `database_gateway_test_plan_rule_again`.");
+    }
+    
+    @Test
     void assertValidateRejectsUnsupportedNextActionSchemaField() {
         assertValidationError(createCatalog(List.of(), List.of(createToolDescriptor(
                 "database_gateway_test_tool", new MCPToolAnnotations("Test Tool", true, false, true, true),
@@ -154,6 +193,20 @@ class MCPDescriptorCatalogValidatorTest {
                 List.of(new MCPPromptTemplateBinding("test_prompt", "META-INF/shardingsphere-mcp/prompts/fixture-uri-template.md")))));
     }
     
+    @Test
+    void assertValidateRejectsUnknownCompletionRequiredContextArgument() {
+        MCPPromptDescriptor prompt = createPromptDescriptor("test_prompt", List.of(
+                new MCPPromptArgumentDescriptor("database", "Database", "Logical database.", false),
+                new MCPPromptArgumentDescriptor("schema", "Schema", "Schema.", false)),
+                Map.of("org.apache.shardingsphere/client-form-only-arguments", List.of("database", "schema")));
+        MCPCompletionTargetDescriptor completion = new MCPCompletionTargetDescriptor("prompt", "test_prompt", List.of("database", "schema"), 50,
+                Map.of(MCPShardingSphereMetadataKeys.REQUIRED_CONTEXT_ARGUMENTS, Map.of("schema", List.of("tenant"))));
+        assertValidationError(new MCPDescriptorCatalog(List.of(), List.of(), List.of(), List.of(), List.of(prompt),
+                List.of(new MCPPromptTemplateBinding("test_prompt", "META-INF/shardingsphere-mcp/prompts/fixture-uri-template.md")),
+                List.of(completion), List.of(), List.of()),
+                "Completion target `prompt:test_prompt` context argument `tenant` for `schema` is not declared by the target.");
+    }
+    
     private void assertValidationError(final MCPDescriptorCatalog catalog, final String expectedMessage) {
         IllegalStateException actual = assertThrows(IllegalStateException.class, () -> MCPDescriptorCatalogValidator.validate(catalog));
         assertThat(actual.getMessage(), is(expectedMessage));
@@ -166,6 +219,11 @@ class MCPDescriptorCatalogValidatorTest {
     private MCPDescriptorCatalog createCatalog(final List<MCPResourceDescriptor> resourceDescriptors, final List<MCPResourceDescriptor> resourceTemplateDescriptors,
                                                final List<MCPToolDescriptor> toolDescriptors) {
         return new MCPDescriptorCatalog(resourceDescriptors, resourceTemplateDescriptors, List.of(), toolDescriptors, List.of(), List.of(), List.of(), List.of(), List.of());
+    }
+    
+    private MCPDescriptorCatalog createToolRuntimeCatalog(final List<MCPResourceDescriptor> resourceDescriptors, final List<MCPToolDescriptor> toolDescriptors,
+                                                          final List<MCPToolRuntimeDescriptor> runtimeDescriptors) {
+        return new MCPDescriptorCatalog(resourceDescriptors, List.of(), List.of(), toolDescriptors, List.of(), List.of(), List.of(), List.of(), runtimeDescriptors);
     }
     
     private MCPDescriptorCatalog createPromptCatalog(final List<MCPPromptDescriptor> promptDescriptors, final List<MCPPromptTemplateBinding> promptTemplateBindings) {
@@ -190,7 +248,11 @@ class MCPDescriptorCatalogValidatorTest {
     }
     
     private MCPToolDescriptor createToolDescriptor(final String toolName, final MCPToolAnnotations annotations, final Map<String, Object> outputSchema) {
-        return new MCPToolDescriptor(toolName, "Test Tool", "Run a test tool.", createInputSchema(), outputSchema, annotations, Map.of());
+        return createToolDescriptor(toolName, annotations, outputSchema, Map.of());
+    }
+    
+    private MCPToolDescriptor createToolDescriptor(final String toolName, final MCPToolAnnotations annotations, final Map<String, Object> outputSchema, final Map<String, Object> meta) {
+        return new MCPToolDescriptor(toolName, "Test Tool", "Run a test tool.", createInputSchema(), outputSchema, annotations, meta);
     }
     
     private Map<String, Object> createInputSchema() {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPModelFirstContractPayloadBuilderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPModelFirstContractPayloadBuilderTest.java
@@ -60,6 +60,7 @@ class MCPModelFirstContractPayloadBuilderTest {
         assertThat(actual.get("optional_catalog_resource"), is("shardingsphere://capabilities"));
         assertThat(actual.get("metadata_first_resource"), is("shardingsphere://databases"));
         assertTrue(String.valueOf(actual.get("preflight_rule")).contains("database_gateway_validate_runtime_database"));
+        assertThat(castToMap(actual.get("sql_tool_selection")).keySet().stream().toList(), is(List.of("read_only", "side_effecting")));
         assertThat(actual.get("side_effect_rule"), is("Preview before side effects and continue only when the requested side effect is still intended."));
         assertThat(actual.get("detail_resource_rule"), is("Use resource descriptors, outputSchema, and returned payload keys before assuming detail fields."));
     }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/descriptor/WorkflowKindDescriptorsTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/descriptor/WorkflowKindDescriptorsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.workflow.descriptor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WorkflowKindDescriptorsTest {
+    
+    @Test
+    void assertIsRuleDistSQLOnly() {
+        assertTrue(WorkflowKindDescriptors.isRuleDistSQLOnly(WorkflowKindDescriptors.ENCRYPT_RULE));
+        assertTrue(WorkflowKindDescriptors.isRuleDistSQLOnly(WorkflowKindDescriptors.SHARDING_COMPONENT_CLEANUP));
+        assertFalse(WorkflowKindDescriptors.isRuleDistSQLOnly("encrypt.table"));
+    }
+}

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidanceResourceHintProviderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidanceResourceHintProviderTest.java
@@ -54,6 +54,12 @@ class WorkflowGuidanceResourceHintProviderTest {
     }
     
     @Test
+    void assertCreateResourcesToReadWithDescriptorResources() {
+        List<String> actual = extractResourceUris(new WorkflowGuidanceResourceHintProvider().createResourcesToRead(createSnapshot("encrypt.rule", "logic_db", "", "t_order")));
+        assertTrue(actual.contains("shardingsphere://workflow/test-resource"));
+    }
+    
+    @Test
     void assertCreateResourcesToReadWithShardingComponentCleanup() {
         List<String> actual = extractResourceUris(new WorkflowGuidanceResourceHintProvider().createResourcesToRead(createSnapshot("sharding.component.cleanup", "logic_db", "", "")));
         assertThat(actual, is(List.of(

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanPayloadBuilderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowPlanPayloadBuilderTest.java
@@ -31,8 +31,6 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.List;
 import java.util.Map;
@@ -341,19 +339,11 @@ class WorkflowPlanPayloadBuilderTest {
         assertThat(actualNextAction.get("tool_name"), is("database_gateway_plan_encrypt_rule"));
     }
     
-    @ParameterizedTest(name = "{0}")
-    @CsvSource({
-            "table rule,sharding.table.rule,database_gateway_plan_sharding_table_rule",
-            "table reference,sharding.table.reference,database_gateway_plan_sharding_table_reference_rule",
-            "default strategy,sharding.default.strategy,database_gateway_plan_sharding_default_strategy",
-            "key generator,sharding.key.generator,database_gateway_plan_sharding_key_generator",
-            "key generate strategy,sharding.key.generate.strategy,database_gateway_plan_sharding_key_generate_strategy",
-            "component cleanup,sharding.component.cleanup,database_gateway_plan_sharding_rule_component_cleanup"
-    })
-    void assertBuildRecommendsShardingPlanningToolAfterFailure(final String displayName, final String workflowKind, final String expectedToolName) {
+    @Test
+    void assertBuildAsksUserWhenPlanningToolIsNotInCatalogAfterFailure() {
         WorkflowContextSnapshot snapshot = new WorkflowContextSnapshot();
         snapshot.setPlanId("plan-1");
-        snapshot.setWorkflowKind(WorkflowKind.valueOf(workflowKind));
+        snapshot.setWorkflowKind(WorkflowKind.valueOf("sharding.table.rule"));
         snapshot.setStatus(WorkflowLifecycle.STATUS_FAILED);
         snapshot.setClarifiedIntent(new ClarifiedIntent());
         WorkflowRequest request = new WorkflowRequest();
@@ -361,7 +351,8 @@ class WorkflowPlanPayloadBuilderTest {
         snapshot.setInteractionPlan(InteractionPlan.create("plan-1", request, "Sharding workflow plan.", List.of("Review"), List.of("rules")));
         Map<String, Object> actual = WorkflowPlanPayloadBuilder.build(snapshot);
         Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actual.get("next_actions")).getFirst();
-        assertThat(actualNextAction.get("tool_name"), is(expectedToolName));
+        assertThat(actualNextAction.get("type"), is("ask_user"));
+        assertThat(actualNextAction.get("required_inputs"), is(List.of("workflow_kind", "issues")));
     }
     
     private List<String> extractResourceUris(final List<?> resources) {

--- a/mcp/support/src/test/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-test-planning.yaml
+++ b/mcp/support/src/test/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-test-planning.yaml
@@ -142,3 +142,9 @@ tools:
       destructiveHint: false
       idempotentHint: false
       openWorldHint: true
+    runtime:
+      workflowRole: plan
+    meta:
+      org.apache.shardingsphere/workflow-kind: encrypt.rule
+      org.apache.shardingsphere/related-resource-uris:
+        - shardingsphere://workflow/test-resource

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/HttpProductionProxyMaskWorkflowE2ETest.java
@@ -41,8 +41,6 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
     
     private static final String PLAN_PROMPT_NAME = "plan_mask_rule";
     
-    private static final String APPLY_TOOL_NAME = WorkflowToolDescriptors.APPLY_TOOL_NAME;
-    
     private static final String VALIDATE_TOOL_NAME = WorkflowToolDescriptors.VALIDATE_TOOL_NAME;
     
     private static final String ALGORITHMS_RESOURCE_URI = "shardingsphere://features/mask/algorithms";
@@ -140,26 +138,6 @@ class HttpProductionProxyMaskWorkflowE2ETest extends AbstractProductionProxyWork
             assertValidationPassed(actualValidationResponse);
             assertThat(String.valueOf(getMapList(getMap(actualValidationResponse.get("rule_validation")).get("evidence")).getFirst().get("algorithm_type")).toUpperCase(Locale.ENGLISH),
                     is("MASK_FROM_X_TO_Y"));
-        }
-    }
-    
-    @Test
-    void assertApplySupportsApprovedStepsThroughProxy() throws IOException, InterruptedException {
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actualPlanResponse = interactionClient.call(PLAN_TOOL_NAME,
-                    Map.of("database", getLogicalDatabaseName(), "table", "orders", "column", "status",
-                            "operation_type", "create", "algorithm_type", "KEEP_FIRST_N_LAST_M",
-                            "primary_algorithm_properties", Map.of("first-n", "1", "last-m", "1", "replace-char", "*")));
-            assertThat(String.valueOf(actualPlanResponse.get("status")), is("planned"));
-            String planId = String.valueOf(actualPlanResponse.get("plan_id"));
-            Map<String, Object> actualPreviewResponse = previewWorkflow(interactionClient, planId);
-            assertThat(getMapList(actualPreviewResponse.get("preview_artifacts")).stream().map(each -> String.valueOf(each.get("approval_step"))).distinct().toList(),
-                    is(List.of("rule_distsql")));
-            Map<String, Object> actualRuleApplyResponse = interactionClient.call(APPLY_TOOL_NAME, createReviewThenExecuteArguments(planId, List.of("rule_distsql")));
-            assertThat(String.valueOf(actualRuleApplyResponse.get("status")), is("completed"));
-            assertThat(getStringList(actualRuleApplyResponse.get("executed_distsql")).size(), is(1));
-            assertThat(getStringList(actualRuleApplyResponse.get("skipped_artifacts")).size(), is(0));
-            assertValidationPassed(interactionClient.call(VALIDATE_TOOL_NAME, Map.of("plan_id", planId)));
         }
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLReadOnlySQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLReadOnlySQLRuntimeE2ETest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.mcp.runtime.production;
+
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.apache.shardingsphere.test.e2e.mcp.support.runtime.RuntimeTransport;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPPayloadAssertions;
+import org.apache.shardingsphere.test.e2e.mcp.support.transport.client.MCPInteractionClient;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIf("isEnabled")
+class ProductionMySQLReadOnlySQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2ETest {
+    
+    @Override
+    protected boolean useSharedRuntimeFixture() {
+        return true;
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertExecuteSelectWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT status FROM orders ORDER BY order_id", "max_rows", 10));
+            assertThat(String.valueOf(actual.get("result_kind")), is("result_set"));
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertExecuteSelectWithTruncationWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT order_id, status FROM orders ORDER BY order_id", "max_rows", 1));
+            assertThat(String.valueOf(actual.get("result_kind")), is("result_set"));
+            assertThat(((List<?>) actual.get("rows")).size(), is(1));
+            assertThat(String.valueOf(actual.get("truncated")), is("true"));
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertExecuteExplainAnalyzeSelectWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "EXPLAIN ANALYZE SELECT * FROM orders WHERE order_id = 1", "max_rows", 10));
+            assertThat(String.valueOf(actual.get("result_kind")), is("result_set"));
+            assertThat(String.valueOf(actual.get("statement_type")), is("EXPLAIN ANALYZE"));
+            assertFalse(((List<?>) actual.get("rows")).isEmpty());
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertExecuteQueryTimeoutWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT SLEEP(2)", "timeout_ms", 1));
+            assertRecoveryResponse(actual);
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertRejectExecuteMultiStatementWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT 1; SELECT 2"));
+            assertRecoveryResponse(actual, "Only one SQL statement is allowed.", "multiple_sql_statements");
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertRejectExplainAnalyzeUpdateFromReadOnlyToolWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql",
+                            "EXPLAIN ANALYZE UPDATE orders SET status = 'DONE' WHERE order_id = 1"));
+            assertRecoveryResponse(actual,
+                    "database_gateway_execute_query only supports classifier-approved QUERY and EXPLAIN_ANALYZE statements. Use database_gateway_execute_update for side-effecting SQL.",
+                    "unsafe_sql_attempted");
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertRejectLockingReadFromReadOnlyToolWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT * FROM orders FOR UPDATE"));
+            assertRecoveryResponse(actual, "Locking read statements such as SELECT ... FOR UPDATE are not supported by the MCP read-only contract.");
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertRejectLockingReadFromUpdateToolWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.call("database_gateway_execute_update",
+                    createExecuteUpdateArguments("SELECT * FROM orders FOR UPDATE"));
+            assertRecoveryResponse(actual, "Locking read statements such as SELECT ... FOR UPDATE are not supported by the MCP read-only contract.");
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("dualTransports")
+    void assertElicitMaskPlanningWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException {
+        useTransport(transport);
+        List<McpSchema.ElicitRequest> actualElicitationRequests = new CopyOnWriteArrayList<>();
+        try (McpSyncClient client = createElicitationClient(transport, actualElicitationRequests)) {
+            client.initialize();
+            McpSchema.CallToolResult actual = client.callTool(new McpSchema.CallToolRequest(MASK_PLAN_TOOL_NAME, Map.of(
+                    "database", LOGICAL_DATABASE_NAME,
+                    "schema", LOGICAL_DATABASE_NAME,
+                    "table", "orders",
+                    "column", "status",
+                    "operation_type", "create",
+                    "algorithm_type", "MASK_FROM_X_TO_Y")));
+            Map<String, Object> actualPayload = castStructuredContent(actual.structuredContent());
+            if (RuntimeTransport.HTTP == transport) {
+                assertThat(String.valueOf(actualPayload.get("status")), is("clarifying"));
+                assertThat(String.valueOf(actualPayload.get("fallback_reason")), is("remote_identity_required"));
+                assertTrue(actualElicitationRequests.isEmpty());
+                return;
+            }
+            assertThat(String.valueOf(actualPayload.get("status")), is("planned"));
+            assertThat(String.valueOf(actualPayload.get("current_step")), is("review"));
+            assertThat(String.valueOf(castToMap(castToMap(actualPayload.get("masked_property_preview")).get("primary")).get("from-x")), is("1"));
+            assertThat(String.valueOf(castToMap(castToMap(actualPayload.get("masked_property_preview")).get("primary")).get("to-y")), is("3"));
+            assertElicitationRequest(actualElicitationRequests);
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertRejectSequenceResourceWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            Map<String, Object> actual = interactionClient.readResource(
+                    String.format("shardingsphere://databases/%s/schemas/%s/sequences", LOGICAL_DATABASE_NAME, LOGICAL_DATABASE_NAME));
+            assertThat(String.valueOf(actual.get("error_code")), is("json_rpc_error"));
+            assertThat(String.valueOf(actual.get("message")), is("Sequence resources are not supported for the current database."));
+        }
+    }
+    
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("semanticPrimaryTransport")
+    void assertAiNativeDeterministicInteractionLoopWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
+        useTransport(transport);
+        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
+            assertAiNativeCapabilities(interactionClient.readResource("shardingsphere://capabilities"));
+            assertAiNativeDiscovery(interactionClient);
+            Map<String, Object> searchMetadataPayload = interactionClient.call("database_gateway_search_metadata",
+                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "query", "orders", "object_types", List.of("table")));
+            Map<String, Object> tableHit = MCPPayloadAssertions.findItem(searchMetadataPayload, "name", "orders");
+            String tableResourceUri = String.valueOf(getMap(tableHit.get("resource")).get("uri"));
+            assertThat(tableResourceUri, is("shardingsphere://databases/logic_db/schemas/logic_db/tables/orders"));
+            assertFalse(getMapList(tableHit.get("next_resources")).isEmpty());
+            MCPPayloadAssertions.assertSingleItemValue(interactionClient.readResource(tableResourceUri), "table", "orders");
+            assertAiNativeSqlPreview(interactionClient);
+            assertAiNativeSqlResult(interactionClient);
+        }
+    }
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLSQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMySQLSQLRuntimeE2ETest.java
@@ -17,8 +17,6 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.runtime.production;
 
-import io.modelcontextprotocol.client.McpSyncClient;
-import io.modelcontextprotocol.spec.McpSchema;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.MySQLRuntimeTestSupport;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.RuntimeTransport;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPPayloadAssertions;
@@ -31,7 +29,6 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
@@ -41,130 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIf("isEnabled")
 class ProductionMySQLSQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2ETest {
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertExecuteSelectWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT status FROM orders ORDER BY order_id", "max_rows", 10));
-            assertThat(String.valueOf(actual.get("result_kind")), is("result_set"));
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertExecuteSelectWithTruncationWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT order_id, status FROM orders ORDER BY order_id", "max_rows", 1));
-            assertThat(String.valueOf(actual.get("result_kind")), is("result_set"));
-            assertThat(((List<?>) actual.get("rows")).size(), is(1));
-            assertThat(String.valueOf(actual.get("truncated")), is("true"));
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertExecuteExplainAnalyzeSelectWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "EXPLAIN ANALYZE SELECT * FROM orders WHERE order_id = 1", "max_rows", 10));
-            assertThat(String.valueOf(actual.get("result_kind")), is("result_set"));
-            assertThat(String.valueOf(actual.get("statement_type")), is("EXPLAIN ANALYZE"));
-            assertFalse(((List<?>) actual.get("rows")).isEmpty());
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertExecuteQueryTimeoutWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT SLEEP(2)", "timeout_ms", 1));
-            assertRecoveryResponse(actual);
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertRejectExecuteMultiStatementWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT 1; SELECT 2"));
-            assertRecoveryResponse(actual, "Only one SQL statement is allowed.", "multiple_sql_statements");
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertRejectExplainAnalyzeUpdateFromReadOnlyToolWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql",
-                            "EXPLAIN ANALYZE UPDATE orders SET status = 'DONE' WHERE order_id = 1"));
-            assertRecoveryResponse(actual,
-                    "database_gateway_execute_query only supports classifier-approved QUERY and EXPLAIN_ANALYZE statements. Use database_gateway_execute_update for side-effecting SQL.",
-                    "unsafe_sql_attempted");
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertRejectLockingReadFromReadOnlyToolWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_query",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "sql", "SELECT * FROM orders FOR UPDATE"));
-            assertRecoveryResponse(actual, "Locking read statements such as SELECT ... FOR UPDATE are not supported by the MCP read-only contract.");
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertRejectLockingReadFromUpdateToolWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.call("database_gateway_execute_update",
-                    createExecuteUpdateArguments("SELECT * FROM orders FOR UPDATE"));
-            assertRecoveryResponse(actual, "Locking read statements such as SELECT ... FOR UPDATE are not supported by the MCP read-only contract.");
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("dualTransports")
-    void assertElicitMaskPlanningWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException {
-        useTransport(transport);
-        List<McpSchema.ElicitRequest> actualElicitationRequests = new CopyOnWriteArrayList<>();
-        try (McpSyncClient client = createElicitationClient(transport, actualElicitationRequests)) {
-            client.initialize();
-            McpSchema.CallToolResult actual = client.callTool(new McpSchema.CallToolRequest(MASK_PLAN_TOOL_NAME, Map.of(
-                    "database", LOGICAL_DATABASE_NAME,
-                    "schema", LOGICAL_DATABASE_NAME,
-                    "table", "orders",
-                    "column", "status",
-                    "operation_type", "create",
-                    "algorithm_type", "MASK_FROM_X_TO_Y")));
-            Map<String, Object> actualPayload = castStructuredContent(actual.structuredContent());
-            if (RuntimeTransport.HTTP == transport) {
-                assertThat(String.valueOf(actualPayload.get("status")), is("clarifying"));
-                assertThat(String.valueOf(actualPayload.get("fallback_reason")), is("remote_identity_required"));
-                assertTrue(actualElicitationRequests.isEmpty());
-                return;
-            }
-            assertThat(String.valueOf(actualPayload.get("status")), is("planned"));
-            assertThat(String.valueOf(actualPayload.get("current_step")), is("review"));
-            assertThat(String.valueOf(castToMap(castToMap(actualPayload.get("masked_property_preview")).get("primary")).get("from-x")), is("1"));
-            assertThat(String.valueOf(castToMap(castToMap(actualPayload.get("masked_property_preview")).get("primary")).get("to-y")), is("3"));
-            assertElicitationRequest(actualElicitationRequests);
-        }
-    }
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("semanticPrimaryTransport")
@@ -188,18 +61,6 @@ class ProductionMySQLSQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2E
                     createExecuteUpdateArguments("UPDATE orders SET status = status WHERE order_id = -1"));
             assertThat(String.valueOf(actual.get("result_kind")), is("update_count"));
             assertThat(String.valueOf(actual.get("affected_rows")), is("0"));
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertRejectSequenceResourceWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            Map<String, Object> actual = interactionClient.readResource(
-                    String.format("shardingsphere://databases/%s/schemas/%s/sequences", LOGICAL_DATABASE_NAME, LOGICAL_DATABASE_NAME));
-            assertThat(String.valueOf(actual.get("error_code")), is("json_rpc_error"));
-            assertThat(String.valueOf(actual.get("message")), is("Sequence resources are not supported for the current database."));
         }
     }
     
@@ -287,25 +148,6 @@ class ProductionMySQLSQLRuntimeE2ETest extends AbstractProductionMySQLRuntimeE2E
                     createExecuteUpdateArguments("UPDATE orders SET status = 'PENDING' WHERE order_id = 1"));
             interactionClient.close();
             assertThat(MySQLRuntimeTestSupport.querySingleString(getContainer(), String.format("SELECT status FROM %s.orders WHERE order_id = 1", getPhysicalSchemaName())), is("NEW"));
-        }
-    }
-    
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("semanticPrimaryTransport")
-    void assertAiNativeDeterministicInteractionLoopWithActualMySQLBackend(final String name, final RuntimeTransport transport) throws IOException, InterruptedException {
-        useTransport(transport);
-        try (MCPInteractionClient interactionClient = createOpenedInteractionClient()) {
-            assertAiNativeCapabilities(interactionClient.readResource("shardingsphere://capabilities"));
-            assertAiNativeDiscovery(interactionClient);
-            Map<String, Object> searchMetadataPayload = interactionClient.call("database_gateway_search_metadata",
-                    Map.of("database", LOGICAL_DATABASE_NAME, "schema", LOGICAL_DATABASE_NAME, "query", "orders", "object_types", List.of("table")));
-            Map<String, Object> tableHit = MCPPayloadAssertions.findItem(searchMetadataPayload, "name", "orders");
-            String tableResourceUri = String.valueOf(getMap(tableHit.get("resource")).get("uri"));
-            assertThat(tableResourceUri, is("shardingsphere://databases/logic_db/schemas/logic_db/tables/orders"));
-            assertFalse(getMapList(tableHit.get("next_resources")).isEmpty());
-            MCPPayloadAssertions.assertSingleItemValue(interactionClient.readResource(tableResourceUri), "table", "orders");
-            assertAiNativeSqlPreview(interactionClient);
-            assertAiNativeSqlResult(interactionClient);
         }
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/ExecuteQueryReadOnlyE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/ExecuteQueryReadOnlyE2ETest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.mcp.runtime.programmatic;
+
+import org.apache.shardingsphere.test.e2e.mcp.env.MCPE2ECondition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@EnabledIf("isEnabled")
+class ExecuteQueryReadOnlyE2ETest extends AbstractSharedHttpProgrammaticRuntimeE2ETest {
+    
+    private static boolean isEnabled() {
+        return MCPE2ECondition.isDockerEnabled();
+    }
+    
+    @Test
+    void assertExecuteSelectOverHttpSession() throws IOException, InterruptedException {
+        launchHttpTransport();
+        HttpClient httpClient = HttpClient.newHttpClient();
+        String sessionId = initializeSession(httpClient);
+        HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_query",
+                Map.of("database", "logic_db", "schema", "logic_db", "sql", "SELECT * FROM orders", "max_rows", 10));
+        assertThat(actual.statusCode(), is(200));
+        Map<String, Object> payload = getStructuredContent(actual.body());
+        assertThat(String.valueOf(payload.get("result_kind")), is("result_set"));
+    }
+    
+    @Test
+    void assertExecuteReadOnlyCommonTableExpression() throws IOException, InterruptedException {
+        launchHttpTransport();
+        HttpClient httpClient = HttpClient.newHttpClient();
+        String sessionId = initializeSession(httpClient);
+        HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_query",
+                Map.of("database", "logic_db", "schema", "logic_db", "sql", "WITH foo_orders AS (SELECT * FROM orders) SELECT * FROM foo_orders"));
+        assertThat(actual.statusCode(), is(200));
+        Map<String, Object> payload = getStructuredContent(actual.body());
+        assertThat(String.valueOf(payload.get("result_kind")), is("result_set"));
+        assertThat(String.valueOf(payload.get("statement_class")), is("query"));
+    }
+    
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/ExecuteQueryTransactionE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/ExecuteQueryTransactionE2ETest.java
@@ -38,31 +38,6 @@ class ExecuteQueryTransactionE2ETest extends AbstractHttpProgrammaticRuntimeE2ET
     }
     
     @Test
-    void assertExecuteSelectOverHttpSession() throws IOException, InterruptedException {
-        launchHttpTransport();
-        HttpClient httpClient = HttpClient.newHttpClient();
-        String sessionId = initializeSession(httpClient);
-        HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_query",
-                createExecuteQueryArguments("logic_db", "logic_db", "SELECT * FROM orders", 10));
-        assertThat(actual.statusCode(), is(200));
-        Map<String, Object> payload = getStructuredContent(actual.body());
-        assertThat(String.valueOf(payload.get("result_kind")), is("result_set"));
-    }
-    
-    @Test
-    void assertExecuteReadOnlyCommonTableExpression() throws IOException, InterruptedException {
-        launchHttpTransport();
-        HttpClient httpClient = HttpClient.newHttpClient();
-        String sessionId = initializeSession(httpClient);
-        HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_query",
-                createExecuteQueryArguments("logic_db", "logic_db", "WITH foo_orders AS (SELECT * FROM orders) SELECT * FROM foo_orders"));
-        assertThat(actual.statusCode(), is(200));
-        Map<String, Object> payload = getStructuredContent(actual.body());
-        assertThat(String.valueOf(payload.get("result_kind")), is("result_set"));
-        assertThat(String.valueOf(payload.get("statement_class")), is("query"));
-    }
-    
-    @Test
     void assertRejectCrossDatabaseTransactionSwitch() throws IOException, InterruptedException {
         launchHttpTransport();
         HttpClient httpClient = HttpClient.newHttpClient();
@@ -101,7 +76,7 @@ class ExecuteQueryTransactionE2ETest extends AbstractHttpProgrammaticRuntimeE2ET
         assertThat(sendDeleteRequest(httpClient, createSessionHeaders(sessionId)).statusCode(), is(200));
         String newSessionId = initializeSession(httpClient);
         HttpResponse<String> actual = sendToolCallRequest(httpClient, newSessionId, "database_gateway_execute_query",
-                createExecuteQueryArguments("logic_db", "logic_db", "SELECT status FROM orders WHERE order_id = 1"));
+                Map.of("database", "logic_db", "schema", "logic_db", "sql", "SELECT status FROM orders WHERE order_id = 1"));
         assertThat(actual.statusCode(), is(200));
         Map<String, Object> payload = getStructuredContent(actual.body());
         assertThat(String.valueOf(((List<?>) ((List<?>) payload.get("rows")).get(0)).get(0)), is("NEW"));
@@ -118,13 +93,4 @@ class ExecuteQueryTransactionE2ETest extends AbstractHttpProgrammaticRuntimeE2ET
         assertThat(String.valueOf(getStructuredContent(actual.body()).get("message")), is(expectedMessage));
     }
     
-    private Map<String, Object> createExecuteQueryArguments(final String databaseName, final String schemaName, final String sql) {
-        return createExecuteQueryArguments(databaseName, schemaName, sql, -1);
-    }
-    
-    private Map<String, Object> createExecuteQueryArguments(final String databaseName, final String schemaName, final String sql, final int maxRows) {
-        return -1 == maxRows
-                ? Map.of("database", databaseName, "schema", schemaName, "sql", sql)
-                : Map.of("database", databaseName, "schema", schemaName, "sql", sql, "max_rows", maxRows);
-    }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportApprovalSafetyE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportApprovalSafetyE2ETest.java
@@ -72,6 +72,22 @@ class HttpTransportApprovalSafetyE2ETest extends AbstractSharedHttpProgrammaticR
     }
     
     @Test
+    void assertRejectWorkflowReviewThenExecuteWithInvisibleApprovedStep() throws IOException, InterruptedException {
+        launchHttpTransport();
+        HttpClient httpClient = HttpClient.newHttpClient();
+        String sessionId = initializeSession(httpClient);
+        String planId = createMaskRulePlan(httpClient, sessionId);
+        Map<String, Object> previewPayload = callApplyWorkflow(httpClient, sessionId, planId, Map.of("execution_mode", "preview"));
+        assertThat(String.valueOf(previewPayload.get("status")), is("preview"));
+        Map<String, Object> executionPayload = callApplyWorkflow(httpClient, sessionId, planId,
+                Map.of("execution_mode", "review-then-execute", "approved_steps", List.of("ddl")));
+        assertThat(String.valueOf(executionPayload.get("status")), is("failed"));
+        Map<?, ?> actualIssue = (Map<?, ?>) ((List<?>) executionPayload.get("issues")).getFirst();
+        assertThat(actualIssue.get("code"), is(WorkflowIssueCode.WORKFLOW_STATUS_INVALID));
+        assertModelFacingPayloadContract(executionPayload);
+    }
+    
+    @Test
     void assertRejectWorkflowExecutionFromOtherSession() throws IOException, InterruptedException {
         launchHttpTransport();
         HttpClient httpClient = HttpClient.newHttpClient();

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportCompletionE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportCompletionE2ETest.java
@@ -50,20 +50,16 @@ class HttpTransportCompletionE2ETest extends AbstractSharedHttpProgrammaticRunti
         HttpClient httpClient = HttpClient.newHttpClient();
         String sessionId = initializeSession(httpClient);
         Map<String, Object> promptReference = Map.of("type", "ref/prompt", "name", "inspect_metadata");
-        assertThat(completeValues(httpClient, sessionId, promptReference, "database", "logic", Map.of()), is(List.of("logic_db")));
-        assertThat(completeValues(httpClient, sessionId, promptReference, "schema", "logic", Map.of("database", "logic_db")), is(List.of("logic_db")));
-        assertThat(completeValues(httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/tables/{table}"),
-                "table", "ord", Map.of("database", "logic_db", "schema", "logic_db")),
-                is(List.of("order_items", "orders")));
-        assertThat(completeValues(httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns/{column}"),
-                "column", "sta", Map.of("database", "logic_db", "schema", "logic_db", "table", "orders")),
-                is(List.of("status")));
-        assertThat(completeValues(httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes/{index}"),
-                "index", "idx", Map.of("database", "logic_db", "schema", "logic_db", "table", "orders")),
-                is(List.of("idx_orders_status")));
-        assertThat(completeValues(httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/sequences/{sequence}"),
-                "sequence", "ord", Map.of("database", "logic_db", "schema", "logic_db")),
-                is(List.of()));
+        assertCompletionValues("database completion", httpClient, sessionId, promptReference, "database", "logic", Map.of(), List.of("logic_db"));
+        assertCompletionValues("schema completion", httpClient, sessionId, promptReference, "schema", "logic", Map.of("database", "logic_db"), List.of("logic_db"));
+        assertCompletionValues("table completion", httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/tables/{table}"),
+                "table", "ord", Map.of("database", "logic_db", "schema", "logic_db"), List.of("order_items", "orders"));
+        assertCompletionValues("column completion", httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns/{column}"),
+                "column", "sta", Map.of("database", "logic_db", "schema", "logic_db", "table", "orders"), List.of("status"));
+        assertCompletionValues("index completion", httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes/{index}"),
+                "index", "idx", Map.of("database", "logic_db", "schema", "logic_db", "table", "orders"), List.of("idx_orders_status"));
+        assertCompletionValues("sequence completion", httpClient, sessionId, createResourceReference("shardingsphere://databases/{database}/schemas/{schema}/sequences/{sequence}"),
+                "sequence", "ord", Map.of("database", "logic_db", "schema", "logic_db"), List.of());
     }
     
     @Test
@@ -81,19 +77,14 @@ class HttpTransportCompletionE2ETest extends AbstractSharedHttpProgrammaticRunti
         launchHttpTransport();
         HttpClient httpClient = HttpClient.newHttpClient();
         String sessionId = initializeSession(httpClient);
-        Map<String, Object> loadBalanceAlgorithmCompletion = complete(httpClient, sessionId, Map.of("type", "ref/prompt", "name", "plan_readwrite_splitting_rule"),
-                "load_balancer_type", "ROUND", Map.of());
-        List<String> loadBalanceAlgorithmValues = extractCompletionValues(loadBalanceAlgorithmCompletion);
-        assertTrue(loadBalanceAlgorithmValues.contains("ROUND_ROBIN"), loadBalanceAlgorithmCompletion::toString);
-        List<String> shadowAlgorithmValues = completeValues(httpClient, sessionId, Map.of("type", "ref/prompt", "name", "plan_shadow_rule"),
-                "algorithm_type", "VALUE", Map.of());
-        assertTrue(shadowAlgorithmValues.contains("VALUE_MATCH"), shadowAlgorithmValues::toString);
-        List<String> shardingAlgorithmValues = completeValues(httpClient, sessionId, Map.of("type", "ref/prompt", "name", "plan_sharding_table_rule"),
-                "algorithm_type", "INLINE", Map.of());
-        assertTrue(shardingAlgorithmValues.contains("INLINE"), shardingAlgorithmValues::toString);
-        List<String> keyGenerateAlgorithmValues = completeValues(httpClient, sessionId, Map.of("type", "ref/prompt", "name", "plan_sharding_key_generator"),
-                "key_generator_type", "SNOW", Map.of());
-        assertTrue(keyGenerateAlgorithmValues.contains("SNOWFLAKE"), keyGenerateAlgorithmValues::toString);
+        assertCompletionValuesContain("readwrite-splitting load balancer completion", httpClient, sessionId,
+                Map.of("type", "ref/prompt", "name", "plan_readwrite_splitting_rule"), "load_balancer_type", "ROUND", "ROUND_ROBIN");
+        assertCompletionValuesContain("shadow algorithm completion", httpClient, sessionId,
+                Map.of("type", "ref/prompt", "name", "plan_shadow_rule"), "algorithm_type", "VALUE", "VALUE_MATCH");
+        assertCompletionValuesContain("sharding algorithm completion", httpClient, sessionId,
+                Map.of("type", "ref/prompt", "name", "plan_sharding_table_rule"), "algorithm_type", "INLINE", "INLINE");
+        assertCompletionValuesContain("sharding key generator completion", httpClient, sessionId,
+                Map.of("type", "ref/prompt", "name", "plan_sharding_key_generator"), "key_generator_type", "SNOW", "SNOWFLAKE");
     }
     
     @Test
@@ -117,6 +108,18 @@ class HttpTransportCompletionE2ETest extends AbstractSharedHttpProgrammaticRunti
                                         final String argumentName, final String argumentValue,
                                         final Map<String, String> contextArguments) throws IOException, InterruptedException {
         return extractCompletionValues(complete(httpClient, sessionId, reference, argumentName, argumentValue, contextArguments));
+    }
+    
+    private void assertCompletionValues(final String scenarioName, final HttpClient httpClient, final String sessionId, final Map<String, Object> reference,
+                                        final String argumentName, final String argumentValue, final Map<String, String> contextArguments,
+                                        final List<String> expectedValues) throws IOException, InterruptedException {
+        assertThat(scenarioName, completeValues(httpClient, sessionId, reference, argumentName, argumentValue, contextArguments), is(expectedValues));
+    }
+    
+    private void assertCompletionValuesContain(final String scenarioName, final HttpClient httpClient, final String sessionId, final Map<String, Object> reference,
+                                               final String argumentName, final String argumentValue, final String expectedValue) throws IOException, InterruptedException {
+        List<String> actualValues = completeValues(httpClient, sessionId, reference, argumentName, argumentValue, Map.of());
+        assertTrue(actualValues.contains(expectedValue), () -> scenarioName + ": " + actualValues);
     }
     
     private List<String> extractCompletionValues(final Map<String, Object> result) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportContractE2ETest.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.test.e2e.mcp.runtime.programmatic;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPShardingSphereMetadataKeys;
 import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowToolDescriptors;
 import org.apache.shardingsphere.test.e2e.mcp.env.MCPE2ECondition;
-import org.apache.shardingsphere.test.e2e.mcp.support.OfficialMCPToolNames;
 import org.apache.shardingsphere.test.e2e.mcp.support.assertion.MCPModelContractAssertions;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.client.MCPHttpTransportTestSupport;
 import org.junit.jupiter.api.Test;
@@ -35,15 +34,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIf("isEnabled")
 class HttpTransportContractE2ETest extends AbstractSharedHttpProgrammaticRuntimeE2ETest {
-    
-    private static final List<String> OFFICIAL_TOOL_NAMES = OfficialMCPToolNames.getAll();
     
     private static final String PLAN_MASK_TOOL_NAME = "database_gateway_plan_mask_rule";
     
@@ -65,16 +61,7 @@ class HttpTransportContractE2ETest extends AbstractSharedHttpProgrammaticRuntime
         HttpResponse<String> actual = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         assertThat(actual.statusCode(), is(200));
         Map<String, Object> actualCapabilities = getFirstResourcePayload(actual.body());
-        assertThat(((List<?>) actualCapabilities.get("supportedTools")).stream().map(String::valueOf).toList(), containsInAnyOrder(OFFICIAL_TOOL_NAMES.toArray()));
-        assertTrue(((List<?>) actualCapabilities.get("prompts")).stream().map(String::valueOf).anyMatch(each -> each.contains("inspect_metadata")));
-        assertTrue(((List<?>) actualCapabilities.get("completionTargets")).stream().map(String::valueOf).anyMatch(each -> each.contains("inspect_metadata")));
-        assertTrue(((List<?>) actualCapabilities.get("resourceNavigation")).stream().map(String::valueOf).anyMatch(each -> each.contains("database_gateway_apply_workflow")));
-        assertFalse(actualCapabilities.containsKey("fingerprints"));
-        Map<String, Object> actualProtocolAvailability = castToMap(actualCapabilities.get("protocolAvailability"));
-        assertTrue((Boolean) actualProtocolAvailability.get("prompts"));
-        assertTrue((Boolean) actualProtocolAvailability.get("completions"));
-        assertTrue((Boolean) actualProtocolAvailability.get("resourceNavigation"));
-        assertModelFacingPayloadContract(actualCapabilities);
+        assertThat(actualCapabilities.get("response_mode"), is("catalog"));
     }
     
     @Test

--- a/test/e2e/mcp/src/test/resources/baseline-contract/model-contract/capabilities.yaml
+++ b/test/e2e/mcp/src/test/resources/baseline-contract/model-contract/capabilities.yaml
@@ -916,10 +916,16 @@ completionTargets:
   reference: shardingsphere://databases/{database}/storage-units/{storageUnit}
   arguments: [database, storageUnit]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      storageUnit: [database]
 - referenceType: resource
   reference: shardingsphere://databases/{database}/storage-units/{storageUnit}/used-by-rules
   arguments: [database, storageUnit]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      storageUnit: [database]
 - referenceType: resource
   reference: shardingsphere://databases/{database}/single-tables
   arguments: [database]
@@ -928,6 +934,9 @@ completionTargets:
   reference: shardingsphere://databases/{database}/single-tables/{table}
   arguments: [database, table]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      table: [database]
 - referenceType: resource
   reference: shardingsphere://databases/{database}/single-table/default-storage-unit
   arguments: [database]
@@ -936,38 +945,73 @@ completionTargets:
   reference: shardingsphere://databases/{database}/schemas/{schema}
   arguments: [database, schema]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      schema: [database]
 - referenceType: resource
   reference: shardingsphere://databases/{database}/schemas/{schema}/tables
   arguments: [database, schema]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      schema: [database]
 - referenceType: resource
   reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}
   arguments: [database, schema, table]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      schema: [database]
+      table: [database, schema]
 - referenceType: resource
   reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns
   arguments: [database, schema, table]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      schema: [database]
+      table: [database, schema]
 - referenceType: resource
   reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/columns/{column}
   arguments: [database, schema, table, column]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      schema: [database]
+      table: [database, schema]
+      column: [database, schema, table]
 - referenceType: resource
   reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes
   arguments: [database, schema, table]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      schema: [database]
+      table: [database, schema]
 - referenceType: resource
   reference: shardingsphere://databases/{database}/schemas/{schema}/tables/{table}/indexes/{index}
   arguments: [database, schema, table, index]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      schema: [database]
+      table: [database, schema]
+      index: [database, schema, table]
 - referenceType: resource
   reference: shardingsphere://databases/{database}/schemas/{schema}/sequences
   arguments: [database, schema]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      schema: [database]
 - referenceType: resource
   reference: shardingsphere://databases/{database}/schemas/{schema}/sequences/{sequence}
   arguments: [database, schema, sequence]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      schema: [database]
+      sequence: [database, schema]
 - referenceType: prompt
   reference: plan_encrypt_rule
   arguments: [algorithm_type, assisted_query_algorithm_type, like_query_algorithm_type]
@@ -1024,10 +1068,16 @@ completionTargets:
   reference: inspect_metadata
   arguments: [database, schema]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      schema: [database]
 - referenceType: prompt
   reference: safe_sql_execution
   arguments: [database, schema]
   maxValues: 50
+  meta:
+    org.apache.shardingsphere/required-context-arguments:
+      schema: [database]
 - referenceType: prompt
   reference: recover_workflow
   arguments: [plan_id]


### PR DESCRIPTION
Derive planning tool lookup, workflow kind reuse, and completion context
requirements from MCP descriptors instead of scattered Java mappings.

Add descriptor validation for supported input schema fields, planning
workflow-kind uniqueness, related resource metadata, and completion context
arguments. Tighten savepoint statement parsing and lightly organize core
resource handler registration without changing behavior.

For #35294