### PR TITLE
Refine MCP collection copy rules and usages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,13 +87,21 @@ This guide is written **for AI coding agents only**. Follow it literally; improv
       `Collections.unmodifiableList`, `Collections.unmodifiableSet`, `Collections.unmodifiableMap`,
       `Collectors.toUnmodifiableList`, `Collectors.toUnmodifiableSet`, `Collectors.toUnmodifiableMap`,
       Guava `ImmutableList` / `ImmutableSet` / `ImmutableMap`, or similar explicit immutable copy/wrapper APIs
-      when the only reason is defensive programming.
+      when the only reason is defensive programming, possible mutability, or possible ordering.
+    - Do not create semantics-free collection copies.
+      Before adding `new ArrayList<>(...)`, `new LinkedList<>(...)`, `new HashSet<>(...)`, `new LinkedHashSet<>(...)`, `new HashMap<>(...)`, or `new LinkedHashMap<>(...)`,
+      verify the concrete semantic reason.
+      Without such a reason, forbidden patterns include `new LinkedHashSet<>(List.of(...))`, `new LinkedList<>(List.of(...))`, `new LinkedHashMap<>(Map.of(...))`,
+      copying the fresh result of a loader, builder, parser, or factory that already returns an owned collection,
+      copying a local collection freshly created in the same method only to update its element contents,
+      or creating `new HashSet<>(values)` only for `contains` when an existing set already contains the same values.
     - Ordinary collection literals or direct transformation results are allowed when they express data construction or transformation.
       Do not flag `List.of`, `Set.of`, `Map.of`, or `Stream.toList()` by default, and do not replace `Stream.toList()` with a mutable collector
       unless the code has a concrete mutability requirement.
     - Explicit collection copies or wrappers are allowed only with a concrete semantic reason, such as enforcing a documented public API contract,
       preserving a snapshot across shared ownership or asynchronous execution, protecting cached/global state from mutation,
       isolating later local mutation, or satisfying an external API requirement.
+      In tests, wrap `List.of`, `Set.of`, or `Map.of` in a mutable implementation only when that exact instance is mutated or when mutability is the scenario under test.
       Record the reason in the plan, review note, final response, or nearby code rationale.
 - **Complete Implementation**: no MVPs/placeholders/TODOs—deliver fully runnable solutions.
 
@@ -117,29 +125,6 @@ This guide is written **for AI coding agents only**. Follow it literally; improv
 - **Parameterized tests naming**: all parameterized tests must set an explicit `name` and use the `"{0}"` template for display names.
 - **Mocking Rule**: default to mocks; see Mocking & SPI Guidance for static/constructor mocking and spy avoidance details.
 - **Reflection Rule**: when tests must touch fields or methods via reflection, use `Plugins.getMemberAccessor()`—direct reflection APIs are forbidden.
-
-## Tool Usage Guide
-
-### Exa - Web Search
-**Purpose**: fetch the latest web information, official links, or announcements.
-**When to Trigger**
-- Needing current events, announcements, or security advisories.
-- Looking up official website entry points.
-- Verifying external information sources.
-**Key Parameters**
-- Keywords: ≤ 12.
-- `web_search_exa`: moderate.
-
-### mcp-deepwiki
-- Deep knowledge aggregation.
-  **Purpose**: deep semantic document retrieval, knowledge aggregation, and multi-source summarization.
-  **When to Trigger**
-    - Explaining technical concepts or contrasting standards.
-    - Describing algorithm principles.
-    - Integrating multiple official sources.
-      **Key Parameters**
-    - `topic`: technical topic or concept (e.g., "adaptive servo control").
-    - `depth`: 1-3 to control semantic layers.
 
 ## Dangerous Operation Confirmation Mechanism
 
@@ -296,90 +281,12 @@ Dangerous operation detected! Operation type: [specific action] Scope of impact:
 - For utilities with multiple return paths, record the branch list and update it if the code changes.
 - Use Jacoco to confirm expectations when coverage is in question; document any unreachable code instead of adding redundant tests.
 
-## Response Style
-
-### Language and Tone
-- **Language Consistency**: respond in the same language as the user; if the user explicitly specifies a language, prioritize that language.
-- **Friendly and Natural**: interact like a professional peer; avoid stiff formal language.
-- **No Emojis or Symbols**: do not use emojis or decorative graphic symbols in any reply.
-- **Hit the Point Fast**: start with a sentence that captures the core idea, especially for complex problems.
-
-### Content Organization
-- **Hierarchical**: separate sections with headings/subheadings; split long content into sections.
-- **Focused Bullets**: break long paragraphs into short sentences or bullets, each covering a single idea.
-- **Logical Flow**: use ordered lists for multi-step work (1. 2. 3.) and unordered lists for peers (- or *).
-- **Proper Spacing**: keep blank lines or `---` between blocks to boost readability.
-> Avoid complex tables in the terminal (especially for long, code-heavy, or narrative content).
-
-### Visual & Layout Optimization
-- **Keep It Simple**: limit each line length to ≤200 characters.
-- **Leave White Space**: use blank lines wisely to avoid cramped output.
-- **Align Consistently**: stick to one indentation and bullet style (use `-` instead of mixing symbols).
-- **Emphasize Key Points**: highlight critical items with **bold** or *italics*.
-
-### Technical Content Guidelines
-
-#### Code & Data Presentation
-- **Code Blocks**: wrap multi-line code/config/logs inside Markdown fences with language hints (e.g., a fenced Java block).
-- **Focus on the Core**: trim unrelated snippets (like imports) to spotlight essential logic.
-- **Diff Markers**: show changes with `+` / `-` for quick scanning.
-- **Line Numbers**: add them when needed (e.g., debugging scenarios).
-
-#### Structured Data
-- **Prefer Lists**: use lists over tables in most cases.
-- **Tables Sparingly**: only use Markdown tables when strict alignment is required (e.g., parameter comparisons).
-
-### Interaction & User Experience
-- **Immediate Feedback**: respond quickly; avoid long silent periods.
-- **Visible Status**: surface progress for important actions (e.g., “Processing...”).
-- **Friendly Errors**: clearly explain failures and suggest actionable fixes.
-
-### Ending Suggestions
-- Append a **short summary** after complex content to reiterate the core points.
-- **Guide the Next Step**: close with actionable advice, instructions, or an invitation for follow-up questions.
-
-### Brevity & Signal
-- Prefer tables/bullets over prose walls; cite file paths (`kernel/src/...`) directly.
-- Eliminate repeated wording; reference prior sections instead of restating.
-- Default to ASCII; only mirror existing non-ASCII content when necessary.
-
 ## Governance Basics
 - Follow the instruction order from Core Principle #7 and surface conflicts with rationale when they arise.
 - Technical choices must satisfy ASF transparency: include license headers, document intent, and keep rationales visible to reviewers.
 - Default to the smallest safe change: monthly feature trains plus weekly patch windows reward incremental fixes unless the product requires deeper refactors.
 - Secure approvals for structural changes (new modules, configs, knobs); localized doc or code tweaks may land after self-review when you surface the evidence reviewers expect (tests, configs, reproduction steps).
 - Maintain deterministic builds, measurable coverage, and clear rollback notes; avoid speculative work without a benefit statement.
-
-## Platform Snapshot
-- ShardingSphere layers sharding, encryption, traffic governance, and observability on top of existing databases.
-- Module map summary:
-  - `infra`/`database`/`parser`/`kernel`/`mode`: shared infrastructure for SQL parsing, routing, and governance metadata.
-  - `jdbc`/`jdbc-dialect`/`proxy`: integration points for clients and protocols.
-  - `features`: sharding, read/write splitting, encryption, shadow, traffic control.
-  - `agent`: bytecode helpers; `examples`, `docs`, `distribution`: runnable demos and release assets.
-- Layout standard: `src/main/java` + `src/test/java`; anything under `target/` is generated and must not be edited.
-
-### Data Flow & Integration Map
-1. **Client request** enters via `jdbc` or `proxy`.
-2. **SQL parsing/rewriting** happens in `parser` plus `infra` dialect layers.
-3. **Routing & planning** runs inside `kernel` using metadata from `database` and hints from `mode`.
-4. **Feature hooks** (sharding/encryption/etc.) in `features` adjust routes or payloads.
-5. **Executor/adapters** send work to physical databases and gather results.
-6. **Observability & governance** loops feed metrics/traffic rules back through `mode`.
-Use this flow to justify design changes and to debug regressions.
-
-### Deployment Modes
-- **Proxy cluster + registry** (ZooKeeper/Etcd): clients speak MySQL/PostgreSQL to `proxy`; governance state resides in `mode`.
-- **JDBC embedded**: applications embed the `jdbc` driver with YAML/Spring configs describing sharding and encryption.
-- **Hybrid**: compute happens in applications while governance/observability leverage `mode`.
-Always state which topology, registry, and engine versions (e.g., MySQL 5.7 vs 8.0) your change targets.
-
-## Design Playbook
-- **Preferred styles:** elegant, minimal solutions that keep methods/tests lean, use guard clauses, and delete dead code immediately.
-- **Patterns to lean on:** builders/factories from `infra`, SPI-driven extensions, DTOs with explicit ownership contracts, explicit strategy enums.
-- **Anti-patterns:** duplicating parsing logic, bypassing metadata caches, silently accepting invalid configs, static singletons in shared modules, or overbuilt helpers.
-- **Known pitfalls:** routing regressions when shadow rules are skipped, timezone drift from poor time-mocking, forgetting standalone vs cluster (`mode`) validation, missing ASF headers, Mockito inline mocks breaking on JDKs that block self-attach.
-- **Success recipe:** explain why the change exists, cite the affected data-flow step, keep public APIs backward compatible, and record defaults/knobs alongside code changes.
 
 ## Verification & Commands
 - Core commands: `./mvnw clean install -B -T1C -Pcheck` (full build), `./mvnw test -pl <module>` (scoped unit tests),
@@ -418,28 +325,11 @@ Always state which topology, registry, and engine versions (e.g., MySQL 5.7 vs 8
 - Mention observability or agent impacts (metrics exporters, tracing hooks) whenever touched.
 - Capture performance guardrails—baseline vs new latency/QPS, CPU, memory observations—when runtime paths change.
 
-## Collaboration Patterns & Rituals
-- **Response focus:** for change requests list goal/constraints/suspected files/validation plan; for code reviews highlight issues + risks + suggested fixes; for status updates summarize completed work + verification + risks/TODOs; for failures/blockers share attempted command, reason for failure, and what you need next.
-- **Anti-patterns:** do not accept vague orders (“optimize stuff”); always clarify module + expected result.
-- **Hand-off checklist:** intent, edited files, rationale, executed commands (with exit codes), open risks, related issues/PRs.
-- **Release & rollback:** (1) restate why the release needs the change and cite affected modules/configs, (2) after implementation capture tests/perf smokes and document Spotless/Jacoco/static results plus translation/backport tasks, (3) outline rollback steps (disable knob, revert YAML/module) and how to confirm success, (4) prep release-note snippets or anchor updates for reviewers.
-- **Escalation etiquette:** commit messages use `module: intent`, reviews prioritize regression risks, approval requests follow “Command → Purpose → Sandbox limitation → Expected output,” and halt for guidance whenever sandbox limits conflict with `CODE_OF_CONDUCT.md`.
-
-## Prompt & Reference Snapshot
-- **Parser / dialect:** include target database version, sample SQL, expected AST deltas, and downstream modules relying on the result.
-- **Kernel routing & features:** describe metadata shape (tables, binding, sharding/encryption rules), knob values, and which `features` hook processes the change.
-- **Proxy runtime & governance:** state startup command, `conf/server.yaml`, registry/mode config, relevant logs, and client protocol.
-- **Observability / agent:** mention metrics or tracing plugins touched plus expected signal format and dashboards affected.
-- **Docs / config updates:** specify audience (user/admin), file path, translation implications, and any screenshots/assets added.
-- **Process & releases:** cite commit/PR intent, release-train context, maturity level, and rollback plan.
-- **Compliance & conduct:** flag license-header risk, third-party code usage, and inclusive language considerations.
-
 ## Mocking & SPI Guidance
 - Favor Mockito over bespoke fixtures; only add new fixture classes when mocks cannot express the scenario.
 - Use marker interfaces when distinct rule/attribute types are needed; reuse SPI types such as `ShardingSphereRule` where possible.
 - Name tests after the production method under test; never probe private helpers directly—document unreachable branches instead.
 - Mock heavy dependencies (database/cache/registry/network) and prefer mocking over building deep object graphs.
-- For static/constructor mocking, use `@ExtendWith(AutoMockExtension.class)` with `@StaticMockSettings`; avoid hand-written `mockStatic`/`mockConstruction` unless you documented why the extension cannot be used.
 - When static methods or constructors need mocking, prefer `@ExtendWith(AutoMockExtension.class)` with `@StaticMockSettings` (or the extension's constructor-mocking support); when a class is listed in `@StaticMockSettings`, do not call `mockStatic`/`mockConstruction` directly—stub via `when(...)` instead. Only if `AutoMockExtension` cannot be used and the reason is documented in the plan may you fall back to `mockStatic`/`mockConstruction`, wrapped in try-with-resources.
 - Before coding tests, follow the Coverage & Branch Checklist to map inputs/branches to planned assertions.
 - When a component is available via SPI (e.g., `TypedSPILoader`, `DatabaseTypedSPILoader`, `PushDownMetaDataRefresher`), obtain the instance through SPI by default; note any exceptions in the plan.

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/completion/MCPCompletionServiceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/completion/MCPCompletionServiceTest.java
@@ -111,7 +111,7 @@ class MCPCompletionServiceTest {
     @Test
     void assertCompleteReplacesEmptyContextWithInferredContext() {
         MCPCompletionResult actual = complete(new InMemoryWorkflowSessionContext(), createDescriptor("inspect_metadata", "table", 50), "table", "t_",
-                new LinkedHashMap<>(Map.of("database", "logic_db", "schema", "")), List.of(new InferredContextCompletionProvider()));
+                Map.of("database", "logic_db", "schema", ""), List.of(new InferredContextCompletionProvider()));
         assertThat(actual.getValues(), is(List.of("t_order")));
         assertThat(((Map<?, ?>) actual.getMeta().get(MCPShardingSphereMetadataKeys.CONTEXT_ARGUMENTS)).get("schema"), is("public"));
         assertThat(actual.getMeta().get(MCPShardingSphereMetadataKeys.DIAGNOSTIC), is("ok"));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/SearchMetadataToolServiceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/SearchMetadataToolServiceTest.java
@@ -34,7 +34,6 @@ import org.apache.shardingsphere.mcp.support.database.metadata.model.MCPViewMeta
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.junit.jupiter.api.Test;
 
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -107,7 +106,7 @@ class SearchMetadataToolServiceTest {
     
     @Test
     void assertExecuteSearchWithCompleteResult() {
-        Set<SupportedMCPMetadataObjectType> objectTypes = new LinkedHashSet<>(List.of(SupportedMCPMetadataObjectType.TABLE, SupportedMCPMetadataObjectType.VIEW));
+        Set<SupportedMCPMetadataObjectType> objectTypes = Set.of(SupportedMCPMetadataObjectType.TABLE, SupportedMCPMetadataObjectType.VIEW);
         MetadataSearchResult actual = execute(createDatabaseMetadata(),
                 new MetadataSearchRequest("logic_db", "", "order", objectTypes));
         assertThat(actual.getItems().size(), is(4));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowProxyQueryServiceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/WorkflowProxyQueryServiceTest.java
@@ -33,7 +33,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -198,9 +197,8 @@ class WorkflowProxyQueryServiceTest {
         when(resultSetMetaData.getColumnLabel(1)).thenReturn("COLUMN_NAME");
         when(resultSet.next()).thenReturn(true, true, false);
         when(resultSet.getObject(1)).thenReturn("status_cipher", "status_assisted_query");
-        Set<String> columnNames = new LinkedHashSet<>(List.of("status_cipher", "status_assisted_query"));
         WorkflowProxyQueryService service = createService(Map.of("logic_db", runtimeDatabaseConfig));
-        Set<String> actual = service.queryInformationSchemaColumnNames("logic_db", "", "orders", columnNames);
+        Set<String> actual = service.queryInformationSchemaColumnNames("logic_db", "", "orders", List.of("status_cipher", "status_assisted_query"));
         assertThat(actual, is(Set.of("status_cipher", "status_assisted_query")));
     }
     
@@ -222,7 +220,7 @@ class WorkflowProxyQueryServiceTest {
         when(resultSet.next()).thenReturn(true, false);
         when(resultSet.getObject(1)).thenReturn("status_cipher");
         WorkflowProxyQueryService service = createService(Map.of("logic_db", runtimeDatabaseConfig), databaseType);
-        Set<String> actual = service.queryInformationSchemaColumnNames("logic_db", "public", "orders", new LinkedHashSet<>(List.of("status_cipher")));
+        Set<String> actual = service.queryInformationSchemaColumnNames("logic_db", "public", "orders", List.of("status_cipher"));
         assertThat(actual, is(Set.of("status_cipher")));
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseCapabilityProvider.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseCapabilityProvider.java
@@ -39,7 +39,7 @@ public final class MCPDatabaseCapabilityProvider implements MCPFeatureCapability
     private final Map<String, MCPDatabaseCapability> databaseCapabilities;
     
     public MCPDatabaseCapabilityProvider(final Map<String, RuntimeDatabaseConfiguration> runtimeDatabases) {
-        databaseProfiles = new LinkedHashMap<>(new MCPJdbcDatabaseProfileLoader().load(runtimeDatabases));
+        databaseProfiles = new MCPJdbcDatabaseProfileLoader().load(runtimeDatabases);
         databaseCapabilities = createDatabaseCapabilities(databaseProfiles);
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidator.java
@@ -125,12 +125,11 @@ final class MCPDescriptorCatalogValidator {
             ShardingSpherePreconditions.checkState(registeredTemplateVariables.add(each),
                     () -> new IllegalStateException(String.format("Duplicate URI template variable `%s` in resource descriptor `%s`.", each, descriptor.getUriTemplate())));
         }
-        Set<String> templateVariableSet = new HashSet<>(templateVariables);
         Map<String, MCPUriVariableDescriptor> declaredParameters = new LinkedHashMap<>(uriVariables.size(), 1F);
         for (MCPUriVariableDescriptor each : uriVariables) {
             ShardingSpherePreconditions.checkState(each.isRequired(), () -> new IllegalStateException(
                     String.format("Resource parameter `%s.%s` must be required because URI template variables are required.", descriptor.getUriTemplate(), each.getName())));
-            ShardingSpherePreconditions.checkState(templateVariableSet.contains(each.getName()),
+            ShardingSpherePreconditions.checkState(registeredTemplateVariables.contains(each.getName()),
                     () -> new IllegalStateException(String.format("Resource descriptor `%s` declares non-template parameter `%s`.", descriptor.getUriTemplate(), each.getName())));
             ShardingSpherePreconditions.checkState(null == declaredParameters.putIfAbsent(each.getName(), each),
                     () -> new IllegalStateException(String.format("Duplicate MCP resource parameter `%s.%s`.", descriptor.getUriTemplate(), each.getName())));
@@ -534,7 +533,7 @@ final class MCPDescriptorCatalogValidator {
         MCPResourceDescriptor resource = resources.get(descriptor.getReference());
         ShardingSpherePreconditions.checkState(resource.isTemplated(),
                 () -> new IllegalStateException(String.format("Completion target `resource:%s` must reference a resource template.", descriptor.getReference())));
-        Set<String> templateVariables = new HashSet<>(new MCPUriTemplate(resource.getUriTemplate()).getVariableNames());
+        Collection<String> templateVariables = new MCPUriTemplate(resource.getUriTemplate()).getVariableNames();
         for (String each : descriptor.getArguments()) {
             ShardingSpherePreconditions.checkState(templateVariables.contains(each), () -> new IllegalStateException(
                     String.format("Completion target `resource:%s` argument `%s` is not a URI template variable.", descriptor.getReference(), each)));

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidancePayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowGuidancePayloadBuilder.java
@@ -309,14 +309,13 @@ public final class WorkflowGuidancePayloadBuilder {
     }
     
     private static List<Map<String, Object>> addSequencing(final List<Map<String, Object>> nextActions) {
-        List<Map<String, Object>> result = new LinkedList<>(nextActions);
-        for (int index = 0; index < result.size(); index++) {
-            result.get(index).put("order", index + 1);
-            if (0 < index && "ask_user".equals(result.get(index - 1).get("type"))) {
-                result.get(index).put("depends_on", List.of(index));
+        for (int index = 0; index < nextActions.size(); index++) {
+            nextActions.get(index).put("order", index + 1);
+            if (0 < index && "ask_user".equals(nextActions.get(index - 1).get("type"))) {
+                nextActions.get(index).put("depends_on", List.of(index));
             }
         }
-        return result;
+        return nextActions;
     }
     
     private static String resolvePlanningTool(final WorkflowContextSnapshot snapshot) {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/model/WorkflowContextSnapshotTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/workflow/model/WorkflowContextSnapshotTest.java
@@ -43,7 +43,7 @@ class WorkflowContextSnapshotTest {
         originalSnapshot.getClarifiedIntent().getUnresolvedFields().add("schema");
         originalSnapshot.getClarifiedIntent().getInferredValues().put("requires_decrypt", false);
         originalSnapshot.getFeatureData().getAlgorithmProperties("primary").put("mode", "changed");
-        originalSnapshot.getInteractionPlan().getValidationStrategy().put("layers", new LinkedList<>(List.of("rule")));
+        originalSnapshot.getInteractionPlan().getValidationStrategy().put("layers", List.of("rule"));
         getStringList(originalSnapshot.getIssues().get(0).getDetails(), "missing_fields").add("schema");
         getStringList(originalSnapshot.getValidationReport().getMismatches().get(0), "layers").add("rule");
         assertThat(actualSnapshot.getRequest().getTable(), is("orders"));
@@ -91,7 +91,7 @@ class WorkflowContextSnapshotTest {
         result.setFeatureData(featureData);
         InteractionPlan interactionPlan = new InteractionPlan();
         interactionPlan.setCurrentStep("review");
-        interactionPlan.getValidationStrategy().put("layers", new LinkedList<>(List.of("ddl")));
+        interactionPlan.getValidationStrategy().put("layers", List.of("ddl"));
         result.setInteractionPlan(interactionPlan);
         Map<String, Object> issueDetails = new LinkedHashMap<>(1, 1F);
         issueDetails.put("missing_fields", new LinkedList<>(List.of("column")));


### PR DESCRIPTION
- Remove redundant collection copies in MCP validators, capability provider, guidance payload builder, and tests
- Tighten AGENTS.md guidance against semantics-free collection copies
- Trim low-signal agent guidance sections

For #35294