### PR TITLE
Refactor MCP model-facing payload contract

### DIFF
--- a/docs/document/content/dev-manual/mcp.cn.md
+++ b/docs/document/content/dev-manual/mcp.cn.md
@@ -67,13 +67,15 @@ MCP 子链路按 `api + support + features + core + bootstrap` 分层组织：
 - 实现 `MCPToolHandler<T extends MCPHandlerContext>`。
 - 声明 context type。
 - 声明 canonical tool name。
+- `handle(...)` 只返回成功的 `MCPResponse`；参数非法、资源不存在、查询失败、超时、不支持等受控失败应抛出 `ShardingSphereMCPException` 子类或明确的运行时异常，由 runtime 转换为 MCP tool 错误结果。
 - 在 descriptor 中维护 input schema、output schema、annotations、相关 resources、follow-up tools 和副作用说明。
 
 对外新增 resource：
 
 - 实现 `MCPResourceHandler<T extends MCPHandlerContext>`。
 - 声明 context type。
-- 声明 canonical URI template。
+- 声明 canonical resource URI template。固定 URI 也是没有变量的 URI template。
+- `handle(...)` 只返回成功的 `MCPResponse`；失败不要在 handler 中手工构造错误 response，由 runtime 转换为 MCP resource 读取错误。
 - 在 descriptor 中维护 URI 参数含义、对象范围、MIME type、title、description、annotations 和关系元数据。
 
 运行时代码需要 descriptor 时，应使用 canonical tool name 或 resource URI template，通过 `MCPDescriptorCatalogIndex` 从 catalog 解析。

--- a/docs/document/content/dev-manual/mcp.en.md
+++ b/docs/document/content/dev-manual/mcp.en.md
@@ -67,13 +67,15 @@ When adding a public tool:
 - Implement `MCPToolHandler<T extends MCPHandlerContext>`.
 - Declare the context type.
 - Declare the canonical tool name.
+- `handle(...)` returns only a successful `MCPResponse`. For controlled failures such as invalid arguments, missing resources, query failure, timeout, or unsupported operations, throw a `ShardingSphereMCPException` subclass or a clear runtime exception and let runtime convert it to an MCP tool error result.
 - Maintain input schema, output schema, annotations, related resources, follow-up tools, and side-effect notes in the descriptor.
 
 When adding a public resource:
 
 - Implement `MCPResourceHandler<T extends MCPHandlerContext>`.
 - Declare the context type.
-- Declare the canonical URI template.
+- Declare the canonical resource URI template. A fixed URI is also a URI template without variables.
+- `handle(...)` returns only a successful `MCPResponse`. Do not build error responses in handlers; runtime converts failures to MCP resource read errors.
 - Maintain URI parameter meaning, object scope, MIME type, title, description, annotations, and relationship metadata in the descriptor.
 
 When runtime code needs the descriptor for a handler, resolve it from `MCPDescriptorCatalogIndex` by canonical tool name or resource URI template.

--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/protocol/response/MCPResponse.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/protocol/response/MCPResponse.java
@@ -17,10 +17,15 @@
 
 package org.apache.shardingsphere.mcp.api.protocol.response;
 
+import org.apache.shardingsphere.mcp.api.protocol.exception.ShardingSphereMCPException;
+
 import java.util.Map;
 
 /**
  * MCP response.
+ *
+ * <p>Tool and resource handlers return this type for successful calls. Controlled failures should be reported by throwing
+ * {@link ShardingSphereMCPException}; runtime converts those failures to the protocol-specific MCP error surface.</p>
  */
 @FunctionalInterface
 public interface MCPResponse {

--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/resource/MCPResourceHandler.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/resource/MCPResourceHandler.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mcp.api.resource;
 
 import org.apache.shardingsphere.mcp.api.MCPHandlerContext;
+import org.apache.shardingsphere.mcp.api.protocol.exception.ShardingSphereMCPException;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 
 /**
@@ -35,18 +36,21 @@ public interface MCPResourceHandler<T extends MCPHandlerContext> {
     Class<T> getContextType();
     
     /**
-     * Get resource URI or resource template URI template.
+     * Get canonical resource URI template.
      *
-     * @return resource URI or resource template URI template
+     * <p>A fixed resource URI is represented as a URI template without variables.</p>
+     *
+     * @return canonical resource URI template
      */
-    String getResourceUriOrTemplate();
+    String getResourceUriTemplate();
     
     /**
      * Handle one resource request.
      *
      * @param handlerContext handler context
      * @param uriVariables URI variables
-     * @return resource response
+     * @return successful resource response
+     * @throws ShardingSphereMCPException controlled failure to be converted by runtime
      */
     MCPResponse handle(T handlerContext, MCPUriVariables uriVariables);
 }

--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/resource/descriptor/MCPResourceDescriptor.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/resource/descriptor/MCPResourceDescriptor.java
@@ -24,12 +24,14 @@ import java.util.Map;
 
 /**
  * MCP resource descriptor.
+ *
+ * <p>The URI template is the canonical resource identifier. A fixed resource URI is a URI template without variables.</p>
  */
 @RequiredArgsConstructor
 @Getter
 public final class MCPResourceDescriptor {
     
-    private final String uriOrTemplate;
+    private final String uriTemplate;
     
     private final String name;
     
@@ -44,11 +46,11 @@ public final class MCPResourceDescriptor {
     private final Map<String, Object> meta;
     
     /**
-     * Judge whether the resource is a URI template.
+     * Judge whether the resource URI template contains variables.
      *
-     * @return true if the resource is a URI template
+     * @return true if the resource URI template contains variables
      */
     public boolean isTemplated() {
-        return null != uriOrTemplate && uriOrTemplate.contains("{");
+        return null != uriTemplate && uriTemplate.contains("{");
     }
 }

--- a/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/tool/MCPToolHandler.java
+++ b/mcp/api/src/main/java/org/apache/shardingsphere/mcp/api/tool/MCPToolHandler.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mcp.api.tool;
 
 import org.apache.shardingsphere.mcp.api.MCPHandlerContext;
+import org.apache.shardingsphere.mcp.api.protocol.exception.ShardingSphereMCPException;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 
 /**
@@ -35,9 +36,9 @@ public interface MCPToolHandler<T extends MCPHandlerContext> {
     Class<T> getContextType();
     
     /**
-     * Get tool name.
+     * Get canonical tool name.
      *
-     * @return tool name
+     * @return canonical tool name
      */
     String getToolName();
     
@@ -46,7 +47,8 @@ public interface MCPToolHandler<T extends MCPHandlerContext> {
      *
      * @param handlerContext handler context
      * @param toolCall tool call
-     * @return tool response
+     * @return successful tool response
+     * @throws ShardingSphereMCPException controlled failure to be converted by runtime
      */
     MCPResponse handle(T handlerContext, MCPToolCall toolCall);
 }

--- a/mcp/api/src/test/java/org/apache/shardingsphere/mcp/api/resource/descriptor/MCPResourceDescriptorTest.java
+++ b/mcp/api/src/test/java/org/apache/shardingsphere/mcp/api/resource/descriptor/MCPResourceDescriptorTest.java
@@ -33,7 +33,7 @@ class MCPResourceDescriptorTest {
     void assertGetUriTemplateForFixedResource() {
         MCPResourceDescriptor actual = new MCPResourceDescriptor("shardingsphere://databases", "databases", "Databases", "List databases.", "application/json",
                 MCPResourceAnnotations.EMPTY, Collections.emptyMap());
-        assertThat(actual.getUriOrTemplate(), is("shardingsphere://databases"));
+        assertThat(actual.getUriTemplate(), is("shardingsphere://databases"));
         assertFalse(actual.isTemplated());
     }
     
@@ -41,7 +41,7 @@ class MCPResourceDescriptorTest {
     void assertGetUriTemplateForResourceTemplate() {
         MCPResourceDescriptor actual = new MCPResourceDescriptor("shardingsphere://databases/{database}", "database", "Database",
                 "Read one database.", "application/json", MCPResourceAnnotations.EMPTY, Collections.emptyMap());
-        assertThat(actual.getUriOrTemplate(), is("shardingsphere://databases/{database}"));
+        assertThat(actual.getUriTemplate(), is("shardingsphere://databases/{database}"));
         assertTrue(actual.isTemplated());
     }
     

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/resource/MCPResourceSpecificationFactory.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/resource/MCPResourceSpecificationFactory.java
@@ -23,14 +23,12 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
 import org.apache.shardingsphere.infra.util.json.JsonUtils;
-import org.apache.shardingsphere.mcp.api.protocol.exception.ShardingSphereMCPException;
 import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceAnnotations;
 import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceDescriptor;
 import org.apache.shardingsphere.mcp.bootstrap.transport.MCPTransportErrorFactory;
 import org.apache.shardingsphere.mcp.core.context.MCPRuntimeContext;
 import org.apache.shardingsphere.mcp.core.resource.MCPResourceController;
 import org.apache.shardingsphere.mcp.core.resource.handler.ResourceDefinitionRegistry;
-import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConnectionException;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -67,7 +65,7 @@ public final class MCPResourceSpecificationFactory {
     
     private McpSchema.Resource createResource(final MCPResourceDescriptor descriptor) {
         McpSchema.Resource.Builder result = McpSchema.Resource.builder()
-                .uri(descriptor.getUriOrTemplate())
+                .uri(descriptor.getUriTemplate())
                 .name(descriptor.getName())
                 .title(descriptor.getTitle())
                 .description(descriptor.getDescription())
@@ -94,7 +92,7 @@ public final class MCPResourceSpecificationFactory {
     
     private McpSchema.ResourceTemplate createResourceTemplate(final MCPResourceDescriptor descriptor) {
         McpSchema.ResourceTemplate.Builder result = McpSchema.ResourceTemplate.builder()
-                .uriTemplate(descriptor.getUriOrTemplate())
+                .uriTemplate(descriptor.getUriTemplate())
                 .name(descriptor.getName())
                 .title(descriptor.getTitle())
                 .description(descriptor.getDescription())
@@ -117,7 +115,9 @@ public final class MCPResourceSpecificationFactory {
         try {
             Map<String, Object> payload = controller.handle(request.uri()).toPayload();
             return new ReadResourceResult(Collections.singletonList(new TextResourceContents(request.uri(), JSON_CONTENT_TYPE, JsonUtils.toJsonString(payload))));
-        } catch (final ShardingSphereMCPException | RuntimeDatabaseConnectionException | IllegalArgumentException | IllegalStateException | UnsupportedOperationException ex) {
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
             throw MCPTransportErrorFactory.createError(ex);
         }
     }

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/resource/MCPResourceSpecificationFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/resource/MCPResourceSpecificationFactoryTest.java
@@ -25,22 +25,32 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
+import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceAnnotations;
+import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceDescriptor;
+import org.apache.shardingsphere.mcp.core.context.MCPRequestScope;
 import org.apache.shardingsphere.mcp.core.context.MCPRuntimeContext;
+import org.apache.shardingsphere.mcp.core.resource.handler.ResourceDefinitionRegistry;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPShardingSphereMetadataKeys;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 class MCPResourceSpecificationFactoryTest {
@@ -51,7 +61,7 @@ class MCPResourceSpecificationFactoryTest {
         SyncResourceSpecification actualSpecification = findResourceSpecification(actual, "shardingsphere://capabilities");
         assertThat(actualSpecification.resource().name(), is("server-capability-catalog"));
         assertThat(actualSpecification.resource().title(), is("ShardingSphere MCP Capability Catalog"));
-        assertTrue(!actualSpecification.resource().description().isBlank());
+        assertFalse(actualSpecification.resource().description().isBlank());
         assertThat(actualSpecification.resource().mimeType(), is("application/json"));
         assertThat(actualSpecification.resource().meta().get(MCPShardingSphereMetadataKeys.RESOURCE_KIND), is("capability-catalog"));
         assertNotNull(actualSpecification.readHandler());
@@ -88,6 +98,22 @@ class MCPResourceSpecificationFactoryTest {
         @SuppressWarnings("unchecked")
         Map<String, Object> actualData = (Map<String, Object>) actual.getJsonRpcError().data();
         assertThat(actualData.get("message"), is("Unsupported resource URI `shardingsphere://unknown`."));
+    }
+    
+    @Test
+    void assertReadResourceConvertsRuntimeFailure() {
+        MCPResourceDescriptor descriptor = new MCPResourceDescriptor("shardingsphere://runtime-error", "runtime-error", "Runtime Error", "Read runtime error.", "application/json",
+                MCPResourceAnnotations.EMPTY, Map.of());
+        try (MockedStatic<ResourceDefinitionRegistry> mocked = mockStatic(ResourceDefinitionRegistry.class)) {
+            mocked.when(ResourceDefinitionRegistry::getSupportedResourceDescriptors).thenReturn(List.of(descriptor));
+            mocked.when(() -> ResourceDefinitionRegistry.dispatch(any(MCPRequestScope.class), eq("shardingsphere://runtime-error"))).thenThrow(new RuntimeException("runtime failure"));
+            SyncResourceSpecification actualSpecification = findResourceSpecification(
+                    new MCPResourceSpecificationFactory(createRuntimeContext()).createResourceSpecifications(), "shardingsphere://runtime-error");
+            McpError actual = assertThrows(McpError.class,
+                    () -> actualSpecification.readHandler().apply(mock(McpSyncServerExchange.class), new ReadResourceRequest("shardingsphere://runtime-error")));
+            assertThat(actual.getJsonRpcError().code(), is(McpSchema.ErrorCodes.INTERNAL_ERROR));
+            assertThat(actual.getJsonRpcError().message(), is("runtime failure"));
+        }
     }
     
     @Test

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/ResourceDefinitionRegistry.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/ResourceDefinitionRegistry.java
@@ -61,11 +61,11 @@ public final class ResourceDefinitionRegistry {
         ShardingSpherePreconditions.checkNotEmpty(handlers, () -> new IllegalStateException("No resource handlers are registered."));
         Map<MCPUriPattern, MCPResourceHandler<?>> result = new LinkedHashMap<>(handlers.size(), 1F);
         for (MCPResourceHandler<?> each : handlers) {
-            String uriOrTemplate = each.getResourceUriOrTemplate();
-            ShardingSpherePreconditions.checkState(null != uriOrTemplate && !uriOrTemplate.isBlank(),
-                    () -> new IllegalArgumentException(String.format("Resource URI or URI template is required for `%s`.", each.getClass().getName())));
+            String uriTemplate = each.getResourceUriTemplate();
+            ShardingSpherePreconditions.checkState(null != uriTemplate && !uriTemplate.isBlank(),
+                    () -> new IllegalArgumentException(String.format("Resource URI template is required for `%s`.", each.getClass().getName())));
             MCPHandlerContexts.validateContextType(each.getContextType(), each.getClass());
-            result.put(new MCPUriPattern(uriOrTemplate), each);
+            result.put(new MCPUriPattern(uriTemplate), each);
         }
         return result;
     }
@@ -96,19 +96,19 @@ public final class ResourceDefinitionRegistry {
     }
     
     private static MCPResourceDefinition createResourceDefinition(final MCPUriPattern uriPattern, final MCPResourceHandler<?> handler) {
-        return new MCPResourceDefinition(uriPattern, MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(handler.getResourceUriOrTemplate()), handler);
+        return new MCPResourceDefinition(uriPattern, MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(handler.getResourceUriTemplate()), handler);
     }
     
     private static void validateRegisteredResourceDescriptors() {
         for (MCPResourceDescriptor each : MCPDescriptorCatalogIndex.getResourceDescriptors()) {
             ShardingSpherePreconditions.checkState(isRegisteredResourceDescriptor(each),
-                    () -> new IllegalStateException(String.format("MCP resource descriptor `%s` has no registered handler.", each.getUriOrTemplate())));
+                    () -> new IllegalStateException(String.format("MCP resource descriptor `%s` has no registered handler.", each.getUriTemplate())));
         }
     }
     
     private static boolean isRegisteredResourceDescriptor(final MCPResourceDescriptor descriptor) {
         for (MCPResourceDefinition each : REGISTERED_RESOURCE_DEFINITIONS) {
-            if (descriptor.getUriOrTemplate().equals(each.getUriPattern().getPattern())) {
+            if (descriptor.getUriTemplate().equals(each.getUriPattern().getPattern())) {
                 return true;
             }
         }

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/DatabaseCapabilitiesHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/DatabaseCapabilitiesHandler.java
@@ -37,7 +37,7 @@ public final class DatabaseCapabilitiesHandler implements MCPResourceHandler<MCP
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return URI_PATTERN;
     }
     

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/RuntimeStatusHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/RuntimeStatusHandler.java
@@ -50,7 +50,7 @@ public final class RuntimeStatusHandler implements MCPResourceHandler<MCPDatabas
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return URI_PATTERN;
     }
     

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandler.java
@@ -42,7 +42,7 @@ public final class ServerCapabilitiesHandler implements MCPResourceHandler<MCPSe
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return URI_PATTERN;
     }
     

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerGuidanceHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerGuidanceHandler.java
@@ -37,7 +37,7 @@ public final class ServerGuidanceHandler implements MCPResourceHandler<MCPServic
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return URI_PATTERN;
     }
     

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourceHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourceHandler.java
@@ -60,7 +60,7 @@ public final class MetadataResourceHandler implements MCPResourceHandler<MCPData
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return uriTemplate;
     }
     
@@ -68,7 +68,7 @@ public final class MetadataResourceHandler implements MCPResourceHandler<MCPData
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         List<?> items = metadataLoader.apply(databaseContext, uriVariables);
         MCPResourceDescriptor descriptor = MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(uriTemplate);
-        ShardingSphereMCPResourceMetadata metadata = MCPDescriptorCatalogIndex.getRequiredShardingSphereResourceMetadata(descriptor.getUriOrTemplate());
+        ShardingSphereMCPResourceMetadata metadata = MCPDescriptorCatalogIndex.getRequiredShardingSphereResourceMetadata(descriptor.getUriTemplate());
         Map<String, Object> navigationPayload = createNavigationPayload(descriptor, uriVariables);
         if (isDetailResource(metadata)) {
             if (items.isEmpty()) {
@@ -271,15 +271,15 @@ public final class MetadataResourceHandler implements MCPResourceHandler<MCPData
     
     private Map<String, Object> createNavigationPayload(final MCPResourceDescriptor descriptor, final MCPUriVariables uriVariables) {
         Map<String, Object> result = new LinkedHashMap<>(3, 1F);
-        String uriOrTemplate = descriptor.getUriOrTemplate();
-        Optional<String> selfUri = new MCPUriTemplate(uriOrTemplate).expandIfComplete(uriVariables);
+        String uriTemplate = descriptor.getUriTemplate();
+        Optional<String> selfUri = new MCPUriTemplate(uriTemplate).expandIfComplete(uriVariables);
         selfUri.ifPresent(optional -> result.put("self_uri", optional));
         String parentUri = createParentUri(selfUri.orElse(""));
         if (!parentUri.isEmpty()) {
             result.put(MCPPayloadFieldNames.PARENT_RESOURCE, MCPResourceHintUtils.create(parentUri, resolveResourceKind(parentUri), "inspect_parent",
                     "Read the parent metadata resource before broadening or correcting the request.", MCPPayloadFieldNames.PARENT_RESOURCE));
         }
-        List<Map<String, Object>> nextResources = MCPDescriptorCatalogIndex.getResourceNavigationDescriptors(uriOrTemplate).stream()
+        List<Map<String, Object>> nextResources = MCPDescriptorCatalogIndex.getResourceNavigationDescriptors(uriTemplate).stream()
                 .filter(each -> each.getTo().startsWith("shardingsphere://"))
                 .map(each -> createNextResourceHint(each.getTo(), each.getDescription(), uriVariables)).flatMap(Optional::stream).toList();
         if (!nextResources.isEmpty()) {

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/workflow/WorkflowPlanHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/resource/handler/workflow/WorkflowPlanHandler.java
@@ -39,7 +39,7 @@ public final class WorkflowPlanHandler implements MCPResourceHandler<MCPWorkflow
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return URI_PATTERN;
     }
     

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/handler/core/CoreHandlerProviderTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/handler/core/CoreHandlerProviderTest.java
@@ -42,7 +42,7 @@ class CoreHandlerProviderTest {
     void assertGetResourceHandlers() {
         Collection<MCPResourceHandler<?>> actual = new CoreHandlerProvider().getResourceHandlers();
         assertThat(actual.size(), is(27));
-        List<String> actualUris = actual.stream().map(MCPResourceHandler::getResourceUriOrTemplate).toList();
+        List<String> actualUris = actual.stream().map(MCPResourceHandler::getResourceUriTemplate).toList();
         assertTrue(actualUris.contains("shardingsphere://capabilities"));
         assertTrue(actualUris.contains("shardingsphere://guidance"));
         assertTrue(actualUris.contains("shardingsphere://runtime"));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/CoreResourceHandlerSurfaceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/CoreResourceHandlerSurfaceTest.java
@@ -68,8 +68,8 @@ class CoreResourceHandlerSurfaceTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("handlerCases")
     void assertGetResourceDescriptor(final HandlerCase handlerCase) {
-        MCPResourceDescriptor actual = MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(handlerCase.getHandler().getResourceUriOrTemplate());
-        assertThat(actual.getUriOrTemplate(), is(handlerCase.getExpectedUriOrTemplate()));
+        MCPResourceDescriptor actual = MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(handlerCase.getHandler().getResourceUriTemplate());
+        assertThat(actual.getUriTemplate(), is(handlerCase.getExpectedUriTemplate()));
         assertFalse(actual.getDescription().isBlank());
     }
     
@@ -77,7 +77,7 @@ class CoreResourceHandlerSurfaceTest {
     @MethodSource("handlerCases")
     void assertHandle(final HandlerCase handlerCase) {
         try (MCPRequestScope requestContext = new MCPRequestScope(runtimeContext)) {
-            MCPResponse actual = handle(handlerCase.getHandler(), requestContext, parseUriVariables(handlerCase.getExpectedUriOrTemplate(), handlerCase.getResourceUri()));
+            MCPResponse actual = handle(handlerCase.getHandler(), requestContext, parseUriVariables(handlerCase.getExpectedUriTemplate(), handlerCase.getResourceUri()));
             Map<String, Object> actualPayload = actual.toPayload();
             if (HandlerResultType.DATABASE_CAPABILITY == handlerCase.getExpectedType()) {
                 assertThat(actual, isA(MCPDatabaseCapabilityResponse.class));
@@ -148,8 +148,8 @@ class CoreResourceHandlerSurfaceTest {
         }
     }
     
-    private MCPUriVariables parseUriVariables(final String uriOrTemplate, final String resourceUri) {
-        return new MCPUriPattern(uriOrTemplate).parse(resourceUri).orElseThrow();
+    private MCPUriVariables parseUriVariables(final String uriTemplate, final String resourceUri) {
+        return new MCPUriPattern(uriTemplate).parse(resourceUri).orElseThrow();
     }
     
     private <T extends MCPHandlerContext> MCPResponse handle(final MCPResourceHandler<T> handler, final MCPRequestScope requestContext, final MCPUriVariables uriVariables) {
@@ -394,7 +394,7 @@ class CoreResourceHandlerSurfaceTest {
         
         private final MCPResourceHandler<?> handler;
         
-        private final String expectedUriOrTemplate;
+        private final String expectedUriTemplate;
         
         private final String resourceUri;
         
@@ -408,8 +408,8 @@ class CoreResourceHandlerSurfaceTest {
             return handler;
         }
         
-        private String getExpectedUriOrTemplate() {
-            return expectedUriOrTemplate;
+        private String getExpectedUriTemplate() {
+            return expectedUriTemplate;
         }
         
         private String getResourceUri() {

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/ResourceDefinitionRegistryTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/ResourceDefinitionRegistryTest.java
@@ -117,7 +117,7 @@ class ResourceDefinitionRegistryTest {
     
     @Test
     void assertGetSupportedResourceDescriptors() {
-        Collection<String> actual = ResourceDefinitionRegistry.getSupportedResourceDescriptors().stream().map(MCPResourceDescriptor::getUriOrTemplate).toList();
+        Collection<String> actual = ResourceDefinitionRegistry.getSupportedResourceDescriptors().stream().map(MCPResourceDescriptor::getUriTemplate).toList();
         assertThat(actual, is(ResourceDefinitionRegistry.getSupportedResources()));
     }
     
@@ -150,14 +150,14 @@ class ResourceDefinitionRegistryTest {
     private static MCPResourceHandler<?> createResourceHandler(final String uriTemplate) {
         MCPResourceHandler<MCPServiceHandlerContext> result = mock(MCPResourceHandler.class);
         when(result.getContextType()).thenReturn(MCPServiceHandlerContext.class);
-        when(result.getResourceUriOrTemplate()).thenReturn(uriTemplate);
+        when(result.getResourceUriTemplate()).thenReturn(uriTemplate);
         return result;
     }
     
     private static MCPResourceHandler<?> createUnsupportedResourceHandler() {
         MCPResourceHandler<MCPHandlerContext> result = mock(MCPResourceHandler.class);
         when(result.getContextType()).thenReturn(MCPHandlerContext.class);
-        when(result.getResourceUriOrTemplate()).thenReturn("shardingsphere://unsupported");
+        when(result.getResourceUriTemplate()).thenReturn("shardingsphere://unsupported");
         return result;
     }
     
@@ -204,7 +204,7 @@ class ResourceDefinitionRegistryTest {
     
     private static String getRequiredUriMessage() {
         MCPResourceHandler<?> handler = createResourceHandler(null);
-        return String.format("Resource URI or URI template is required for `%s`.", handler.getClass().getName());
+        return String.format("Resource URI template is required for `%s`.", handler.getClass().getName());
     }
     
     private static String getDuplicateUriTemplateMessage() {

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourceHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/metadata/MetadataResourceHandlerTest.java
@@ -43,8 +43,8 @@ class MetadataResourceHandlerTest {
     @Test
     void assertGetResourceDescriptor() {
         MetadataResourceHandler handler = new MetadataResourceHandler("shardingsphere://databases", (requestContext, uriVariables) -> List.of());
-        MCPResourceDescriptor actual = MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(handler.getResourceUriOrTemplate());
-        assertThat(actual.getUriOrTemplate(), is("shardingsphere://databases"));
+        MCPResourceDescriptor actual = MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(handler.getResourceUriTemplate());
+        assertThat(actual.getUriTemplate(), is("shardingsphere://databases"));
         assertThat(actual.getTitle(), is("Logical Databases"));
     }
     

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRuleCountHandler.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRuleCountHandler.java
@@ -48,7 +48,7 @@ public final class BroadcastRuleCountHandler implements MCPResourceHandler<MCPDa
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return BroadcastFeatureDefinition.RULE_COUNT_RESOURCE_URI;
     }
     
@@ -56,6 +56,6 @@ public final class BroadcastRuleCountHandler implements MCPResourceHandler<MCPDa
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(ruleInspectionService.queryBroadcastRuleCount(databaseContext.getQueryFacade(), uriVariables.getValue("database")),
                 MCPResourceNavigationPayloadBuilder.create(
-                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables, BroadcastFeatureDefinition.RULES_RESOURCE_URI));
+                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables, BroadcastFeatureDefinition.RULES_RESOURCE_URI));
     }
 }

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRulesHandler.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRulesHandler.java
@@ -48,13 +48,13 @@ public final class BroadcastRulesHandler implements MCPResourceHandler<MCPDataba
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return BroadcastFeatureDefinition.RULES_RESOURCE_URI;
     }
     
     @Override
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(ruleInspectionService.queryBroadcastRules(databaseContext.getQueryFacade(), uriVariables.getValue("database")),
-                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables));
+                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables));
     }
 }

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastTableRuleHandler.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastTableRuleHandler.java
@@ -53,7 +53,7 @@ public final class BroadcastTableRuleHandler implements MCPResourceHandler<MCPDa
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return BroadcastFeatureDefinition.TABLE_RULE_RESOURCE_URI;
     }
     
@@ -65,6 +65,6 @@ public final class BroadcastTableRuleHandler implements MCPResourceHandler<MCPDa
         List<Map<String, Object>> items = ruleInspectionService.queryBroadcastRules(databaseContext.getQueryFacade(), database).stream()
                 .filter(each -> WorkflowSQLUtils.isSameIdentifier(databaseType, table, WorkflowRuleValueUtils.getRuleValue(each, "broadcast_table"))).toList();
         return new MCPItemsResponse(items, MCPResourceNavigationPayloadBuilder.create(
-                MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables, BroadcastFeatureDefinition.RULES_RESOURCE_URI));
+                MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables, BroadcastFeatureDefinition.RULES_RESOURCE_URI));
     }
 }

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/BroadcastMCPHandlerProviderTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/BroadcastMCPHandlerProviderTest.java
@@ -38,7 +38,7 @@ class BroadcastMCPHandlerProviderTest {
     @Test
     void assertGetResourceHandlers() {
         Collection<MCPResourceHandler<?>> actual = new BroadcastMCPHandlerProvider().getResourceHandlers();
-        assertThat(actual.stream().map(MCPResourceHandler::getResourceUriOrTemplate).toList(), is(List.of(
+        assertThat(actual.stream().map(MCPResourceHandler::getResourceUriTemplate).toList(), is(List.of(
                 BroadcastFeatureDefinition.RULES_RESOURCE_URI,
                 BroadcastFeatureDefinition.TABLE_RULE_RESOURCE_URI,
                 BroadcastFeatureDefinition.RULE_COUNT_RESOURCE_URI)));

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRuleCountHandlerTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRuleCountHandlerTest.java
@@ -44,7 +44,7 @@ class BroadcastRuleCountHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new BroadcastRuleCountHandler().getResourceUriOrTemplate(), is(BroadcastFeatureDefinition.RULE_COUNT_RESOURCE_URI));
+        assertThat(new BroadcastRuleCountHandler().getResourceUriTemplate(), is(BroadcastFeatureDefinition.RULE_COUNT_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRulesHandlerTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRulesHandlerTest.java
@@ -44,7 +44,7 @@ class BroadcastRulesHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new BroadcastRulesHandler().getResourceUriOrTemplate(), is(BroadcastFeatureDefinition.RULES_RESOURCE_URI));
+        assertThat(new BroadcastRulesHandler().getResourceUriTemplate(), is(BroadcastFeatureDefinition.RULES_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastTableRuleHandlerTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastTableRuleHandlerTest.java
@@ -43,7 +43,7 @@ class BroadcastTableRuleHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new BroadcastTableRuleHandler().getResourceUriOrTemplate(), is(BroadcastFeatureDefinition.TABLE_RULE_RESOURCE_URI));
+        assertThat(new BroadcastTableRuleHandler().getResourceUriTemplate(), is(BroadcastFeatureDefinition.TABLE_RULE_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptAlgorithmsHandler.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptAlgorithmsHandler.java
@@ -40,13 +40,13 @@ public final class EncryptAlgorithmsHandler implements MCPResourceHandler<MCPDat
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return EncryptFeatureDefinition.ALGORITHMS_RESOURCE_URI;
     }
     
     @Override
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(ruleInspectionService.queryEncryptAlgorithms(databaseContext.getQueryFacade()),
-                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables));
+                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables));
     }
 }

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptRuleHandler.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptRuleHandler.java
@@ -40,7 +40,7 @@ public final class EncryptRuleHandler implements MCPResourceHandler<MCPDatabaseH
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return EncryptFeatureDefinition.RULE_RESOURCE_URI;
     }
     
@@ -48,6 +48,6 @@ public final class EncryptRuleHandler implements MCPResourceHandler<MCPDatabaseH
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(ruleInspectionService.queryEncryptRules(databaseContext.getQueryFacade(), uriVariables.getValue("database"), uriVariables.getValue("table")),
                 MCPResourceNavigationPayloadBuilder.create(
-                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables, EncryptFeatureDefinition.RULES_RESOURCE_URI));
+                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables, EncryptFeatureDefinition.RULES_RESOURCE_URI));
     }
 }

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptRulesHandler.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptRulesHandler.java
@@ -40,13 +40,13 @@ public final class EncryptRulesHandler implements MCPResourceHandler<MCPDatabase
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return EncryptFeatureDefinition.RULES_RESOURCE_URI;
     }
     
     @Override
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(ruleInspectionService.queryEncryptRules(databaseContext.getQueryFacade(), uriVariables.getValue("database")),
-                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables));
+                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables));
     }
 }

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptDescriptorContractTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptDescriptorContractTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.feature.encrypt;
+
+import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalog;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogLoader;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class EncryptDescriptorContractTest {
+    
+    @Test
+    void assertEncryptDistSQLExamples() {
+        assertEncryptDistSQLExampleValue(findToolDescriptor().getOutputSchema().get("examples"));
+    }
+    
+    private MCPToolDescriptor findToolDescriptor() {
+        MCPDescriptorCatalog catalog = MCPDescriptorCatalogLoader.load();
+        return catalog.getProtocolDescriptors().getToolDescriptors().stream()
+                .filter(each -> EncryptFeatureDefinition.PLAN_TOOL_NAME.equals(each.getName())).findFirst().orElseThrow();
+    }
+    
+    private void assertEncryptDistSQLExampleValue(final Object value) {
+        if (value instanceof Map) {
+            assertEncryptDistSQLExampleMap((Map<?, ?>) value);
+        } else if (value instanceof Collection) {
+            for (Object each : (Collection<?>) value) {
+                assertEncryptDistSQLExampleValue(each);
+            }
+        }
+    }
+    
+    private void assertEncryptDistSQLExampleMap(final Map<?, ?> value) {
+        Object sql = value.get("sql");
+        if (null != sql && isEncryptRuleDistSQL(sql.toString())) {
+            assertEncryptRuleDistSQL(sql.toString());
+        }
+        for (Object each : value.values()) {
+            assertEncryptDistSQLExampleValue(each);
+        }
+    }
+    
+    private boolean isEncryptRuleDistSQL(final String sql) {
+        String actualSQL = sql.toUpperCase(Locale.ENGLISH);
+        return actualSQL.contains("CREATE ENCRYPT RULE") || actualSQL.contains("ALTER ENCRYPT RULE");
+    }
+    
+    private void assertEncryptRuleDistSQL(final String sql) {
+        String actualSQL = sql.toLowerCase(Locale.ENGLISH);
+        assertFalse(actualSQL.contains("type(name=aes"));
+        assertFalse(actualSQL.contains("'aes-key-value'") && !actualSQL.contains("'digest-algorithm-name'"));
+    }
+}

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptMCPHandlerProviderTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptMCPHandlerProviderTest.java
@@ -38,7 +38,7 @@ class EncryptMCPHandlerProviderTest {
     @Test
     void assertGetResourceHandlers() {
         Collection<MCPResourceHandler<?>> actual = new EncryptMCPHandlerProvider().getResourceHandlers();
-        assertThat(actual.stream().map(MCPResourceHandler::getResourceUriOrTemplate).toList(), is(List.of(
+        assertThat(actual.stream().map(MCPResourceHandler::getResourceUriTemplate).toList(), is(List.of(
                 "shardingsphere://features/encrypt/algorithms",
                 "shardingsphere://features/encrypt/databases/{database}/rules",
                 "shardingsphere://features/encrypt/databases/{database}/tables/{table}/rules")));

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptAlgorithmsHandlerTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptAlgorithmsHandlerTest.java
@@ -45,7 +45,7 @@ class EncryptAlgorithmsHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new EncryptAlgorithmsHandler().getResourceUriOrTemplate(), is(EncryptFeatureDefinition.ALGORITHMS_RESOURCE_URI));
+        assertThat(new EncryptAlgorithmsHandler().getResourceUriTemplate(), is(EncryptFeatureDefinition.ALGORITHMS_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptRuleHandlerTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptRuleHandlerTest.java
@@ -45,7 +45,7 @@ class EncryptRuleHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new EncryptRuleHandler().getResourceUriOrTemplate(), is(EncryptFeatureDefinition.RULE_RESOURCE_URI));
+        assertThat(new EncryptRuleHandler().getResourceUriTemplate(), is(EncryptFeatureDefinition.RULE_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptRulesHandlerTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/resource/handler/EncryptRulesHandlerTest.java
@@ -45,7 +45,7 @@ class EncryptRulesHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new EncryptRulesHandler().getResourceUriOrTemplate(), is(EncryptFeatureDefinition.RULES_RESOURCE_URI));
+        assertThat(new EncryptRulesHandler().getResourceUriTemplate(), is(EncryptFeatureDefinition.RULES_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskAlgorithmsHandler.java
+++ b/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskAlgorithmsHandler.java
@@ -40,13 +40,13 @@ public final class MaskAlgorithmsHandler implements MCPResourceHandler<MCPDataba
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return MaskFeatureDefinition.ALGORITHMS_RESOURCE_URI;
     }
     
     @Override
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(ruleInspectionService.queryMaskAlgorithms(databaseContext.getQueryFacade()),
-                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables));
+                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables));
     }
 }

--- a/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskRuleHandler.java
+++ b/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskRuleHandler.java
@@ -40,7 +40,7 @@ public final class MaskRuleHandler implements MCPResourceHandler<MCPDatabaseHand
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return MaskFeatureDefinition.RULE_RESOURCE_URI;
     }
     
@@ -48,6 +48,6 @@ public final class MaskRuleHandler implements MCPResourceHandler<MCPDatabaseHand
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(ruleInspectionService.queryMaskRules(databaseContext.getQueryFacade(), uriVariables.getValue("database"), uriVariables.getValue("table")),
                 MCPResourceNavigationPayloadBuilder.create(
-                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables, MaskFeatureDefinition.RULES_RESOURCE_URI));
+                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables, MaskFeatureDefinition.RULES_RESOURCE_URI));
     }
 }

--- a/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskRulesHandler.java
+++ b/mcp/features/mask/src/main/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskRulesHandler.java
@@ -40,13 +40,13 @@ public final class MaskRulesHandler implements MCPResourceHandler<MCPDatabaseHan
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return MaskFeatureDefinition.RULES_RESOURCE_URI;
     }
     
     @Override
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(ruleInspectionService.queryMaskRules(databaseContext.getQueryFacade(), uriVariables.getValue("database")),
-                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables));
+                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables));
     }
 }

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/MaskMCPHandlerProviderTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/MaskMCPHandlerProviderTest.java
@@ -35,7 +35,7 @@ class MaskMCPHandlerProviderTest {
     @Test
     void assertGetResourceHandlers() {
         Collection<MCPResourceHandler<?>> actual = new MaskMCPHandlerProvider().getResourceHandlers();
-        assertThat(actual.stream().map(MCPResourceHandler::getResourceUriOrTemplate).toList(), is(List.of(
+        assertThat(actual.stream().map(MCPResourceHandler::getResourceUriTemplate).toList(), is(List.of(
                 "shardingsphere://features/mask/algorithms",
                 "shardingsphere://features/mask/databases/{database}/rules",
                 "shardingsphere://features/mask/databases/{database}/tables/{table}/rules")));

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskAlgorithmsHandlerTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskAlgorithmsHandlerTest.java
@@ -45,7 +45,7 @@ class MaskAlgorithmsHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new MaskAlgorithmsHandler().getResourceUriOrTemplate(), is(MaskFeatureDefinition.ALGORITHMS_RESOURCE_URI));
+        assertThat(new MaskAlgorithmsHandler().getResourceUriTemplate(), is(MaskFeatureDefinition.ALGORITHMS_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskRuleHandlerTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskRuleHandlerTest.java
@@ -45,7 +45,7 @@ class MaskRuleHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new MaskRuleHandler().getResourceUriOrTemplate(), is(MaskFeatureDefinition.RULE_RESOURCE_URI));
+        assertThat(new MaskRuleHandler().getResourceUriTemplate(), is(MaskFeatureDefinition.RULE_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskRulesHandlerTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/resource/handler/MaskRulesHandlerTest.java
@@ -45,7 +45,7 @@ class MaskRulesHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new MaskRulesHandler().getResourceUriOrTemplate(), is(MaskFeatureDefinition.RULES_RESOURCE_URI));
+        assertThat(new MaskRulesHandler().getResourceUriTemplate(), is(MaskFeatureDefinition.RULES_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/LoadBalanceAlgorithmPluginsHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/LoadBalanceAlgorithmPluginsHandler.java
@@ -48,13 +48,13 @@ public final class LoadBalanceAlgorithmPluginsHandler implements MCPResourceHand
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return ReadwriteSplittingFeatureDefinition.LOAD_BALANCE_ALGORITHM_PLUGINS_RESOURCE_URI;
     }
     
     @Override
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(inspectionService.queryLoadBalanceAlgorithmPlugins(databaseContext.getQueryFacade()),
-                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables));
+                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables));
     }
 }

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleCountHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleCountHandler.java
@@ -48,7 +48,7 @@ public final class ReadwriteSplittingRuleCountHandler implements MCPResourceHand
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return ReadwriteSplittingFeatureDefinition.RULE_COUNT_RESOURCE_URI;
     }
     
@@ -56,6 +56,6 @@ public final class ReadwriteSplittingRuleCountHandler implements MCPResourceHand
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(inspectionService.queryRuleCount(databaseContext.getQueryFacade(), uriVariables.getValue("database")),
                 MCPResourceNavigationPayloadBuilder.create(
-                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables, ReadwriteSplittingFeatureDefinition.RULES_RESOURCE_URI));
+                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables, ReadwriteSplittingFeatureDefinition.RULES_RESOURCE_URI));
     }
 }

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleHandler.java
@@ -48,7 +48,7 @@ public final class ReadwriteSplittingRuleHandler implements MCPResourceHandler<M
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return ReadwriteSplittingFeatureDefinition.RULE_RESOURCE_URI;
     }
     
@@ -56,6 +56,6 @@ public final class ReadwriteSplittingRuleHandler implements MCPResourceHandler<M
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(inspectionService.queryRule(databaseContext.getQueryFacade(), uriVariables.getValue("database"), uriVariables.getValue("rule")),
                 MCPResourceNavigationPayloadBuilder.create(
-                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables, ReadwriteSplittingFeatureDefinition.RULES_RESOURCE_URI));
+                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables, ReadwriteSplittingFeatureDefinition.RULES_RESOURCE_URI));
     }
 }

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleStatusHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleStatusHandler.java
@@ -48,7 +48,7 @@ public final class ReadwriteSplittingRuleStatusHandler implements MCPResourceHan
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return ReadwriteSplittingFeatureDefinition.RULE_STATUS_RESOURCE_URI;
     }
     
@@ -56,6 +56,6 @@ public final class ReadwriteSplittingRuleStatusHandler implements MCPResourceHan
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(inspectionService.queryRuleStatus(databaseContext.getQueryFacade(), uriVariables.getValue("database"), uriVariables.getValue("rule")),
                 MCPResourceNavigationPayloadBuilder.create(
-                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables, ReadwriteSplittingFeatureDefinition.STATUS_RESOURCE_URI));
+                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables, ReadwriteSplittingFeatureDefinition.STATUS_RESOURCE_URI));
     }
 }

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRulesHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRulesHandler.java
@@ -48,13 +48,13 @@ public final class ReadwriteSplittingRulesHandler implements MCPResourceHandler<
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return ReadwriteSplittingFeatureDefinition.RULES_RESOURCE_URI;
     }
     
     @Override
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(inspectionService.queryRules(databaseContext.getQueryFacade(), uriVariables.getValue("database")),
-                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables));
+                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables));
     }
 }

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingStatusHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingStatusHandler.java
@@ -48,7 +48,7 @@ public final class ReadwriteSplittingStatusHandler implements MCPResourceHandler
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return ReadwriteSplittingFeatureDefinition.STATUS_RESOURCE_URI;
     }
     
@@ -56,6 +56,6 @@ public final class ReadwriteSplittingStatusHandler implements MCPResourceHandler
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(inspectionService.queryStatuses(databaseContext.getQueryFacade(), uriVariables.getValue("database")),
                 MCPResourceNavigationPayloadBuilder.create(
-                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables, ReadwriteSplittingFeatureDefinition.RULES_RESOURCE_URI));
+                        MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables, ReadwriteSplittingFeatureDefinition.RULES_RESOURCE_URI));
     }
 }

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/ReadwriteSplittingMCPHandlerProviderTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/ReadwriteSplittingMCPHandlerProviderTest.java
@@ -40,7 +40,7 @@ class ReadwriteSplittingMCPHandlerProviderTest {
     @Test
     void assertGetResourceHandlers() {
         Collection<MCPResourceHandler<?>> actual = new ReadwriteSplittingMCPHandlerProvider().getResourceHandlers();
-        assertThat(actual.stream().map(MCPResourceHandler::getResourceUriOrTemplate).toList(), containsInAnyOrder(
+        assertThat(actual.stream().map(MCPResourceHandler::getResourceUriTemplate).toList(), containsInAnyOrder(
                 ReadwriteSplittingFeatureDefinition.RULES_RESOURCE_URI,
                 ReadwriteSplittingFeatureDefinition.RULE_RESOURCE_URI,
                 ReadwriteSplittingFeatureDefinition.STATUS_RESOURCE_URI,

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/LoadBalanceAlgorithmPluginsHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/LoadBalanceAlgorithmPluginsHandlerTest.java
@@ -44,7 +44,7 @@ class LoadBalanceAlgorithmPluginsHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new LoadBalanceAlgorithmPluginsHandler().getResourceUriOrTemplate(), is(ReadwriteSplittingFeatureDefinition.LOAD_BALANCE_ALGORITHM_PLUGINS_RESOURCE_URI));
+        assertThat(new LoadBalanceAlgorithmPluginsHandler().getResourceUriTemplate(), is(ReadwriteSplittingFeatureDefinition.LOAD_BALANCE_ALGORITHM_PLUGINS_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleCountHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleCountHandlerTest.java
@@ -44,7 +44,7 @@ class ReadwriteSplittingRuleCountHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new ReadwriteSplittingRuleCountHandler().getResourceUriOrTemplate(), is(ReadwriteSplittingFeatureDefinition.RULE_COUNT_RESOURCE_URI));
+        assertThat(new ReadwriteSplittingRuleCountHandler().getResourceUriTemplate(), is(ReadwriteSplittingFeatureDefinition.RULE_COUNT_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleHandlerTest.java
@@ -44,7 +44,7 @@ class ReadwriteSplittingRuleHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new ReadwriteSplittingRuleHandler().getResourceUriOrTemplate(), is(ReadwriteSplittingFeatureDefinition.RULE_RESOURCE_URI));
+        assertThat(new ReadwriteSplittingRuleHandler().getResourceUriTemplate(), is(ReadwriteSplittingFeatureDefinition.RULE_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleStatusHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleStatusHandlerTest.java
@@ -44,7 +44,7 @@ class ReadwriteSplittingRuleStatusHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new ReadwriteSplittingRuleStatusHandler().getResourceUriOrTemplate(), is(ReadwriteSplittingFeatureDefinition.RULE_STATUS_RESOURCE_URI));
+        assertThat(new ReadwriteSplittingRuleStatusHandler().getResourceUriTemplate(), is(ReadwriteSplittingFeatureDefinition.RULE_STATUS_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRulesHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRulesHandlerTest.java
@@ -44,7 +44,7 @@ class ReadwriteSplittingRulesHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new ReadwriteSplittingRulesHandler().getResourceUriOrTemplate(), is(ReadwriteSplittingFeatureDefinition.RULES_RESOURCE_URI));
+        assertThat(new ReadwriteSplittingRulesHandler().getResourceUriTemplate(), is(ReadwriteSplittingFeatureDefinition.RULES_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingStatusHandlerTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingStatusHandlerTest.java
@@ -44,7 +44,7 @@ class ReadwriteSplittingStatusHandlerTest {
     
     @Test
     void assertGetResourceUriTemplate() {
-        assertThat(new ReadwriteSplittingStatusHandler().getResourceUriOrTemplate(), is(ReadwriteSplittingFeatureDefinition.STATUS_RESOURCE_URI));
+        assertThat(new ReadwriteSplittingStatusHandler().getResourceUriTemplate(), is(ReadwriteSplittingFeatureDefinition.STATUS_RESOURCE_URI));
     }
     
     @Test

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/resource/handler/ShadowResourceHandler.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/resource/handler/ShadowResourceHandler.java
@@ -129,14 +129,14 @@ public final class ShadowResourceHandler implements MCPResourceHandler<MCPDataba
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return resourceUriTemplate;
     }
     
     @Override
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(query(databaseContext, uriVariables),
-                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables));
+                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables));
     }
     
     private List<Map<String, Object>> query(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/AbstractShardingResourceHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/AbstractShardingResourceHandler.java
@@ -46,14 +46,14 @@ abstract class AbstractShardingResourceHandler implements MCPResourceHandler<MCP
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return resourceUriTemplate;
     }
     
     @Override
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(query(databaseContext, uriVariables),
-                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriOrTemplate()), uriVariables));
+                MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables));
     }
     
     protected ShardingInspectionService getInspectionService() {

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingMCPHandlerProviderTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingMCPHandlerProviderTest.java
@@ -41,8 +41,8 @@ class ShardingMCPHandlerProviderTest {
     void assertGetResourceHandlers() {
         Collection<MCPResourceHandler<?>> actual = new ShardingMCPHandlerProvider().getResourceHandlers();
         assertThat(actual.size(), is(22));
-        assertTrue(actual.stream().map(MCPResourceHandler::getResourceUriOrTemplate).toList().contains(ShardingFeatureDefinition.TABLE_RULES_RESOURCE_URI));
-        assertTrue(actual.stream().map(MCPResourceHandler::getResourceUriOrTemplate).toList().contains(ShardingFeatureDefinition.UNUSED_AUDITORS_RESOURCE_URI));
+        assertTrue(actual.stream().map(MCPResourceHandler::getResourceUriTemplate).toList().contains(ShardingFeatureDefinition.TABLE_RULES_RESOURCE_URI));
+        assertTrue(actual.stream().map(MCPResourceHandler::getResourceUriTemplate).toList().contains(ShardingFeatureDefinition.UNUSED_AUDITORS_RESOURCE_URI));
         assertTrue(actual.stream().anyMatch(each -> each instanceof ShardingAlgorithmResourceHandler));
         assertTrue(actual.stream().anyMatch(each -> each instanceof ShardingTableResourceHandler));
         assertTrue(actual.stream().anyMatch(each -> each instanceof ShardingStrategyResourceHandler));

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPCompletionTargetDescriptorValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPCompletionTargetDescriptorValidator.java
@@ -51,7 +51,7 @@ public final class MCPCompletionTargetDescriptorValidator {
         Map<String, Set<String>> promptArguments = prompts.stream().collect(Collectors.toMap(MCPPromptDescriptor::getName,
                 each -> each.getArguments().stream().map(MCPPromptArgumentDescriptor::getName).collect(Collectors.toSet())));
         Set<String> promptNames = promptArguments.keySet();
-        Map<String, MCPResourceDescriptor> resourceDescriptors = resources.stream().collect(Collectors.toMap(MCPResourceDescriptor::getUriOrTemplate, each -> each));
+        Map<String, MCPResourceDescriptor> resourceDescriptors = resources.stream().collect(Collectors.toMap(MCPResourceDescriptor::getUriTemplate, each -> each));
         Map<String, MCPCompletionTargetDescriptor> registered = new LinkedHashMap<>(descriptors.size(), 1F);
         for (MCPCompletionTargetDescriptor each : descriptors) {
             validateCompletionReference(each, promptNames, resourceDescriptors.keySet());
@@ -106,7 +106,7 @@ public final class MCPCompletionTargetDescriptorValidator {
         MCPResourceDescriptor resource = resources.get(descriptor.getReference());
         ShardingSpherePreconditions.checkState(resource.isTemplated(),
                 () -> new IllegalStateException(String.format("Completion target `resource:%s` must reference a resource template.", descriptor.getReference())));
-        Collection<String> templateVariables = new MCPUriTemplate(resource.getUriOrTemplate()).getVariableNames();
+        Collection<String> templateVariables = new MCPUriTemplate(resource.getUriTemplate()).getVariableNames();
         for (String each : descriptor.getArguments()) {
             ShardingSpherePreconditions.checkState(templateVariables.contains(each), () -> new IllegalStateException(
                     String.format("Completion target `resource:%s` argument `%s` is not a URI template variable.", descriptor.getReference(), each)));

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndex.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndex.java
@@ -61,17 +61,17 @@ public final class MCPDescriptorCatalogIndex {
         int expectedSize = CATALOG.getProtocolDescriptors().getResourceDescriptors().size() + CATALOG.getProtocolDescriptors().getResourceTemplateDescriptors().size();
         Map<String, MCPResourceDescriptor> result = new LinkedHashMap<>(expectedSize, 1F);
         for (MCPResourceDescriptor each : CATALOG.getProtocolDescriptors().getResourceDescriptors()) {
-            result.put(each.getUriOrTemplate(), each);
+            result.put(each.getUriTemplate(), each);
         }
         for (MCPResourceDescriptor each : CATALOG.getProtocolDescriptors().getResourceTemplateDescriptors()) {
-            result.put(each.getUriOrTemplate(), each);
+            result.put(each.getUriTemplate(), each);
         }
         return result;
     }
     
     private static Map<String, ShardingSphereMCPResourceMetadata> createShardingSphereResourceMetadata() {
         return CATALOG.getShardingSphereDescriptors().getResourceMetadata().stream()
-                .collect(Collectors.toMap(ShardingSphereMCPResourceMetadata::getUriOrTemplate, each -> each));
+                .collect(Collectors.toMap(ShardingSphereMCPResourceMetadata::getUriTemplate, each -> each));
     }
     
     private static Map<String, MCPToolDescriptor> createToolDescriptors() {
@@ -121,22 +121,22 @@ public final class MCPDescriptorCatalogIndex {
     /**
      * Get required resource descriptor.
      *
-     * @param uriOrTemplate resource URI or resource template URI template
+     * @param uriTemplate resource URI template
      * @return resource descriptor
      */
-    public static MCPResourceDescriptor getRequiredResourceDescriptor(final String uriOrTemplate) {
-        return Optional.ofNullable(RESOURCE_DESCRIPTORS.get(uriOrTemplate)).orElseThrow(() -> new IllegalStateException(String.format("MCP resource descriptor is required for `%s`.", uriOrTemplate)));
+    public static MCPResourceDescriptor getRequiredResourceDescriptor(final String uriTemplate) {
+        return Optional.ofNullable(RESOURCE_DESCRIPTORS.get(uriTemplate)).orElseThrow(() -> new IllegalStateException(String.format("MCP resource descriptor is required for `%s`.", uriTemplate)));
     }
     
     /**
      * Get required ShardingSphere MCP resource metadata descriptor.
      *
-     * @param uriOrTemplate resource URI or resource template URI template
+     * @param uriTemplate resource URI template
      * @return ShardingSphere MCP resource metadata descriptor
      */
-    public static ShardingSphereMCPResourceMetadata getRequiredShardingSphereResourceMetadata(final String uriOrTemplate) {
-        return Optional.ofNullable(SHARDINGSPHERE_RESOURCE_METADATA.get(uriOrTemplate)).orElseThrow(
-                () -> new IllegalStateException(String.format("ShardingSphere MCP resource metadata descriptor is required for `%s`.", uriOrTemplate)));
+    public static ShardingSphereMCPResourceMetadata getRequiredShardingSphereResourceMetadata(final String uriTemplate) {
+        return Optional.ofNullable(SHARDINGSPHERE_RESOURCE_METADATA.get(uriTemplate)).orElseThrow(
+                () -> new IllegalStateException(String.format("ShardingSphere MCP resource metadata descriptor is required for `%s`.", uriTemplate)));
     }
     
     /**

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilder.java
@@ -79,7 +79,7 @@ final class MCPDescriptorCatalogPayloadBuilder {
     
     private Map<String, Object> createResourcePayload(final MCPResourceDescriptor descriptor, final String uriFieldName) {
         Map<String, Object> result = new LinkedHashMap<>(8, 1F);
-        result.put(uriFieldName, descriptor.getUriOrTemplate());
+        result.put(uriFieldName, descriptor.getUriTemplate());
         result.put("name", descriptor.getName());
         result.put("title", descriptor.getTitle());
         result.put("description", descriptor.getDescription());
@@ -197,7 +197,7 @@ final class MCPDescriptorCatalogPayloadBuilder {
     }
     
     private String resolveReferenceType(final String reference) {
-        if (catalog.getProtocolDescriptors().getAllResourceDescriptors().stream().anyMatch(each -> each.getUriOrTemplate().equals(reference))) {
+        if (catalog.getProtocolDescriptors().getAllResourceDescriptors().stream().anyMatch(each -> each.getUriTemplate().equals(reference))) {
             return reference.contains("{") ? "resource_template" : "resource";
         }
         if (catalog.getProtocolDescriptors().getToolDescriptors().stream().anyMatch(each -> each.getName().equals(reference))) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogYamlSwapper.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogYamlSwapper.java
@@ -93,26 +93,26 @@ final class MCPDescriptorCatalogYamlSwapper {
         }
     }
     
-    private static ShardingSphereMCPResourceMetadata swapShardingSphereResourceMetadata(final String uriOrTemplate, final YamlShardingSphereMCPResourceMetadata yamlMetadata) {
+    private static ShardingSphereMCPResourceMetadata swapShardingSphereResourceMetadata(final String uriTemplate, final YamlShardingSphereMCPResourceMetadata yamlMetadata) {
         if (null == yamlMetadata) {
-            return new ShardingSphereMCPResourceMetadata(uriOrTemplate, List.of(), null, null, null, List.of(), List.of(), List.of());
+            return new ShardingSphereMCPResourceMetadata(uriTemplate, List.of(), null, null, null, List.of(), List.of(), List.of());
         }
-        return new ShardingSphereMCPResourceMetadata(uriOrTemplate, swapUriVariables(yamlMetadata.getUriVariables()), yamlMetadata.getResourceKind(), yamlMetadata.getObjectScope(),
+        return new ShardingSphereMCPResourceMetadata(uriTemplate, swapUriVariables(yamlMetadata.getUriVariables()), yamlMetadata.getResourceKind(), yamlMetadata.getObjectScope(),
                 yamlMetadata.getFeature(), emptyIfNull(yamlMetadata.getRelatedTools()), emptyIfNull(yamlMetadata.getRelatedResources()), emptyIfNull(yamlMetadata.getUseBefore()));
     }
     
-    private static Map<String, Object> createResourceMeta(final String uriOrTemplate, final Map<String, Object> rawMeta, final ShardingSphereMCPResourceMetadata metadata) {
-        validateNoTypedResourceMetadataKeys(uriOrTemplate, rawMeta);
+    private static Map<String, Object> createResourceMeta(final String uriTemplate, final Map<String, Object> rawMeta, final ShardingSphereMCPResourceMetadata metadata) {
+        validateNoTypedResourceMetadataKeys(uriTemplate, rawMeta);
         Map<String, Object> result = new LinkedHashMap<>(rawMeta.size() + MCPShardingSphereMetadataKeys.TYPED_RESOURCE_METADATA_KEYS.size(), 1F);
         result.putAll(rawMeta);
         result.putAll(metadata.toMeta());
         return result;
     }
     
-    private static void validateNoTypedResourceMetadataKeys(final String uriOrTemplate, final Map<String, Object> rawMeta) {
+    private static void validateNoTypedResourceMetadataKeys(final String uriTemplate, final Map<String, Object> rawMeta) {
         for (String each : MCPShardingSphereMetadataKeys.TYPED_RESOURCE_METADATA_KEYS) {
             if (rawMeta.containsKey(each)) {
-                throw new IllegalStateException(String.format("MCP resource descriptor `%s` raw meta must not define typed ShardingSphere resource metadata key `%s`.", uriOrTemplate, each));
+                throw new IllegalStateException(String.format("MCP resource descriptor `%s` raw meta must not define typed ShardingSphere resource metadata key `%s`.", uriTemplate, each));
             }
         }
     }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceDescriptorValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceDescriptorValidator.java
@@ -46,48 +46,48 @@ public final class MCPResourceDescriptorValidator {
         int expectedSize = catalog.getProtocolDescriptors().getResourceDescriptors().size() + catalog.getProtocolDescriptors().getResourceTemplateDescriptors().size();
         Map<String, MCPResourceDescriptor> registered = new LinkedHashMap<>(expectedSize, 1F);
         for (MCPResourceDescriptor each : catalog.getProtocolDescriptors().getResourceDescriptors()) {
-            checkNotBlank(each.getUriOrTemplate(), "Resource URI");
+            checkNotBlank(each.getUriTemplate(), "Resource URI");
             ShardingSpherePreconditions.checkState(!each.isTemplated(),
-                    () -> new IllegalStateException(String.format("Fixed resource `%s` must not contain template variables.", each.getUriOrTemplate())));
+                    () -> new IllegalStateException(String.format("Fixed resource `%s` must not contain template variables.", each.getUriTemplate())));
             validateResourceDescriptor(each, registered);
         }
         for (MCPResourceDescriptor each : catalog.getProtocolDescriptors().getResourceTemplateDescriptors()) {
-            checkNotBlank(each.getUriOrTemplate(), "Resource template URI template");
+            checkNotBlank(each.getUriTemplate(), "Resource template URI");
             ShardingSpherePreconditions.checkState(each.isTemplated(),
-                    () -> new IllegalStateException(String.format("Resource template `%s` must contain template variables.", each.getUriOrTemplate())));
+                    () -> new IllegalStateException(String.format("Resource template `%s` must contain template variables.", each.getUriTemplate())));
             validateResourceDescriptor(each, registered);
-            validateResourceVariables(each, findShardingSphereResourceMetadata(catalog, each.getUriOrTemplate()).map(ShardingSphereMCPResourceMetadata::getUriVariables).orElse(List.of()));
+            validateResourceVariables(each, findShardingSphereResourceMetadata(catalog, each.getUriTemplate()).map(ShardingSphereMCPResourceMetadata::getUriVariables).orElse(List.of()));
         }
     }
     
     private static void validateResourceDescriptor(final MCPResourceDescriptor descriptor, final Map<String, MCPResourceDescriptor> registered) {
-        ShardingSpherePreconditions.checkState(null == registered.putIfAbsent(descriptor.getUriOrTemplate(), descriptor),
-                () -> new IllegalStateException(String.format("Duplicate MCP resource descriptor `%s`.", descriptor.getUriOrTemplate())));
+        ShardingSpherePreconditions.checkState(null == registered.putIfAbsent(descriptor.getUriTemplate(), descriptor),
+                () -> new IllegalStateException(String.format("Duplicate MCP resource descriptor `%s`.", descriptor.getUriTemplate())));
     }
     
-    private static Optional<ShardingSphereMCPResourceMetadata> findShardingSphereResourceMetadata(final MCPDescriptorCatalog catalog, final String uriOrTemplate) {
-        return catalog.getShardingSphereDescriptors().getResourceMetadata().stream().filter(each -> uriOrTemplate.equals(each.getUriOrTemplate())).findFirst();
+    private static Optional<ShardingSphereMCPResourceMetadata> findShardingSphereResourceMetadata(final MCPDescriptorCatalog catalog, final String uriTemplate) {
+        return catalog.getShardingSphereDescriptors().getResourceMetadata().stream().filter(each -> uriTemplate.equals(each.getUriTemplate())).findFirst();
     }
     
     private static void validateResourceVariables(final MCPResourceDescriptor descriptor, final Collection<MCPUriVariableDescriptor> uriVariables) {
-        List<String> templateVariables = new MCPUriTemplate(descriptor.getUriOrTemplate()).getVariableNames();
+        List<String> templateVariables = new MCPUriTemplate(descriptor.getUriTemplate()).getVariableNames();
         Set<String> registeredTemplateVariables = new HashSet<>();
         for (String each : templateVariables) {
             ShardingSpherePreconditions.checkState(registeredTemplateVariables.add(each),
-                    () -> new IllegalStateException(String.format("Duplicate URI template variable `%s` in resource descriptor `%s`.", each, descriptor.getUriOrTemplate())));
+                    () -> new IllegalStateException(String.format("Duplicate URI template variable `%s` in resource descriptor `%s`.", each, descriptor.getUriTemplate())));
         }
         Map<String, MCPUriVariableDescriptor> declaredParameters = new LinkedHashMap<>(uriVariables.size(), 1F);
         for (MCPUriVariableDescriptor each : uriVariables) {
             ShardingSpherePreconditions.checkState(each.isRequired(), () -> new IllegalStateException(
-                    String.format("Resource parameter `%s.%s` must be required because URI template variables are required.", descriptor.getUriOrTemplate(), each.getName())));
+                    String.format("Resource parameter `%s.%s` must be required because URI template variables are required.", descriptor.getUriTemplate(), each.getName())));
             ShardingSpherePreconditions.checkState(registeredTemplateVariables.contains(each.getName()),
-                    () -> new IllegalStateException(String.format("Resource descriptor `%s` declares non-template parameter `%s`.", descriptor.getUriOrTemplate(), each.getName())));
+                    () -> new IllegalStateException(String.format("Resource descriptor `%s` declares non-template parameter `%s`.", descriptor.getUriTemplate(), each.getName())));
             ShardingSpherePreconditions.checkState(null == declaredParameters.putIfAbsent(each.getName(), each),
-                    () -> new IllegalStateException(String.format("Duplicate MCP resource parameter `%s.%s`.", descriptor.getUriOrTemplate(), each.getName())));
+                    () -> new IllegalStateException(String.format("Duplicate MCP resource parameter `%s.%s`.", descriptor.getUriTemplate(), each.getName())));
         }
         for (String variableName : templateVariables) {
             ShardingSpherePreconditions.checkState(declaredParameters.containsKey(variableName),
-                    () -> new IllegalStateException(String.format("Resource descriptor `%s` must describe URI template variable `%s`.", descriptor.getUriOrTemplate(), variableName)));
+                    () -> new IllegalStateException(String.format("Resource descriptor `%s` must describe URI template variable `%s`.", descriptor.getUriTemplate(), variableName)));
         }
     }
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceNavigationDescriptorValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceNavigationDescriptorValidator.java
@@ -55,7 +55,7 @@ public final class MCPResourceNavigationDescriptorValidator {
     
     private static Set<String> createPublicIdentifiers(final MCPDescriptorCatalog catalog) {
         Set<String> result = new HashSet<>();
-        catalog.getProtocolDescriptors().getAllResourceDescriptors().stream().map(MCPResourceDescriptor::getUriOrTemplate).forEach(result::add);
+        catalog.getProtocolDescriptors().getAllResourceDescriptors().stream().map(MCPResourceDescriptor::getUriTemplate).forEach(result::add);
         catalog.getProtocolDescriptors().getToolDescriptors().stream().map(MCPToolDescriptor::getName).forEach(result::add);
         catalog.getProtocolDescriptors().getPromptDescriptors().stream().map(MCPPromptDescriptor::getName).forEach(result::add);
         return result;

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceNavigationPayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceNavigationPayloadBuilder.java
@@ -56,7 +56,7 @@ public final class MCPResourceNavigationPayloadBuilder {
      */
     public static Map<String, Object> create(final MCPResourceDescriptor descriptor, final MCPUriVariables uriVariables, final String parentUriTemplate) {
         Map<String, Object> result = new LinkedHashMap<>(2, 1F);
-        new MCPUriTemplate(descriptor.getUriOrTemplate()).expandIfComplete(uriVariables).ifPresent(optional -> result.put("self_uri", optional));
+        new MCPUriTemplate(descriptor.getUriTemplate()).expandIfComplete(uriVariables).ifPresent(optional -> result.put("self_uri", optional));
         Optional<String> parentUri = new MCPUriTemplate(parentUriTemplate).expandIfComplete(uriVariables);
         parentUri.filter(optional -> !optional.isEmpty()).ifPresent(optional -> result.put(MCPPayloadFieldNames.PARENT_RESOURCE, createParentResourceHint(optional)));
         return result;

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorCatalogValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorCatalogValidator.java
@@ -64,9 +64,9 @@ public final class MCPToolDescriptorCatalogValidator {
         Map<String, MCPToolDescriptor> registered = new LinkedHashMap<>(descriptors.size(), 1F);
         Map<String, MCPToolRuntimeDescriptor> runtimes = runtimeDescriptors.stream()
                 .collect(Collectors.toMap(MCPToolRuntimeDescriptor::getToolName, each -> each));
-        Set<String> resourceIdentifiers = catalog.getProtocolDescriptors().getAllResourceDescriptors().stream().map(MCPResourceDescriptor::getUriOrTemplate).collect(Collectors.toSet());
+        Set<String> resourceIdentifiers = catalog.getProtocolDescriptors().getAllResourceDescriptors().stream().map(MCPResourceDescriptor::getUriTemplate).collect(Collectors.toSet());
         Set<String> shardingSphereResourceIdentifiers = catalog.getShardingSphereDescriptors().getResourceMetadata().stream()
-                .map(ShardingSphereMCPResourceMetadata::getUriOrTemplate).collect(Collectors.toSet());
+                .map(ShardingSphereMCPResourceMetadata::getUriTemplate).collect(Collectors.toSet());
         for (MCPToolDescriptor each : descriptors) {
             ShardingSpherePreconditions.checkState(null == registered.putIfAbsent(each.getName(), each),
                     () -> new IllegalStateException(String.format("Duplicate MCP tool descriptor `%s`.", each.getName())));

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorCatalogValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorCatalogValidator.java
@@ -27,7 +27,6 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -224,49 +223,6 @@ public final class MCPToolDescriptorCatalogValidator {
             MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanOutputFields(descriptor);
         }
         MCPToolDescriptorValidationUtils.validateRequiredWorkflowPlanMetaFields(descriptor);
-        validateEncryptDistSQLExamples(descriptor);
-    }
-    
-    private static void validateEncryptDistSQLExamples(final MCPToolDescriptor descriptor) {
-        Object examples = descriptor.getOutputSchema().get("examples");
-        if (examples instanceof Collection) {
-            for (Object each : (Collection<?>) examples) {
-                validateEncryptDistSQLExample(descriptor, each);
-            }
-        }
-    }
-    
-    private static void validateEncryptDistSQLExample(final MCPToolDescriptor descriptor, final Object value) {
-        if (value instanceof Map) {
-            validateEncryptDistSQLExampleMap(descriptor, (Map<?, ?>) value);
-        } else if (value instanceof Collection) {
-            for (Object each : (Collection<?>) value) {
-                validateEncryptDistSQLExample(descriptor, each);
-            }
-        }
-    }
-    
-    private static void validateEncryptDistSQLExampleMap(final MCPToolDescriptor descriptor, final Map<?, ?> value) {
-        Object sql = value.get("sql");
-        if (null != sql && isEncryptRuleDistSQL(sql.toString())) {
-            validateEncryptRuleDistSQL(descriptor, sql.toString());
-        }
-        for (Object each : value.values()) {
-            validateEncryptDistSQLExample(descriptor, each);
-        }
-    }
-    
-    private static boolean isEncryptRuleDistSQL(final String sql) {
-        String actualSQL = sql.toUpperCase(Locale.ENGLISH);
-        return actualSQL.contains("CREATE ENCRYPT RULE") || actualSQL.contains("ALTER ENCRYPT RULE");
-    }
-    
-    private static void validateEncryptRuleDistSQL(final MCPToolDescriptor descriptor, final String sql) {
-        String actualSQL = sql.toLowerCase(Locale.ENGLISH);
-        ShardingSpherePreconditions.checkState(!actualSQL.contains("type(name=aes"),
-                () -> new IllegalStateException(String.format("Tool `%s` output example executable encrypt DistSQL must quote algorithm type as a string literal.", descriptor.getName())));
-        ShardingSpherePreconditions.checkState(!actualSQL.contains("'aes-key-value'") || actualSQL.contains("'digest-algorithm-name'"),
-                () -> new IllegalStateException(String.format("Tool `%s` output example executable AES DistSQL must include `digest-algorithm-name`.", descriptor.getName())));
     }
     
     private static void validateRelatedResourceUris(final MCPToolDescriptor descriptor, final Set<String> resourceIdentifiers, final Set<String> shardingSphereResourceIdentifiers) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolOutputSchemaValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolOutputSchemaValidator.java
@@ -19,35 +19,19 @@ package org.apache.shardingsphere.mcp.support.descriptor;
 
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
+import org.apache.shardingsphere.mcp.support.protocol.MCPModelFacingPayloadContract;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
 import org.apache.shardingsphere.mcp.support.protocol.MCPResponseMode;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 /**
  * Validator for model-facing MCP tool output schema contracts.
  */
 public final class MCPToolOutputSchemaValidator {
-    
-    private static final Collection<String> REMOVED_MODEL_FACING_FIELDS = Set.of(
-            "target_tool", "target_resource", "required_arguments", "action_kind", "suggested_next_tool", "suggested_next_tools", "recommended_next_tool",
-            "recommended_recovery", "suggested_next_action", "approved_by_user", "requires_user_approval", "approval_required", "user_overrides");
-    
-    private static final Map<String, Collection<String>> NEXT_ACTION_ALLOWED_FIELDS = createNextActionAllowedFields();
-    
-    private static final Map<String, Collection<String>> NEXT_ACTION_REQUIRED_FIELDS = createNextActionRequiredFields();
-    
-    private static final Collection<String> NEXT_ACTION_SCHEMA_ALLOWED_FIELDS = createNextActionSchemaAllowedFields();
-    
-    private static final Collection<String> MODEL_CRITICAL_HINT_FIELDS = List.of(
-            MCPPayloadFieldNames.NEXT_ACTIONS, MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.RESOURCE, MCPPayloadFieldNames.PARENT_RESOURCE,
-            MCPPayloadFieldNames.NEXT_RESOURCES, "manual_artifact_summary", "manual_follow_up", "empty_state", "ambiguity_state", MCPPayloadFieldNames.RECOVERY, "recovery_guidance",
-            "remediation");
     
     private static final Collection<String> CONTINUATION_MODES = List.of("none", "pagination", "metadata_search");
     
@@ -55,32 +39,6 @@ public final class MCPToolOutputSchemaValidator {
             "unsupported_target", "invalid_enum", "unsafe_sql", "stale_workflow", "unavailable_runtime", "terminal_operator_action");
     
     private MCPToolOutputSchemaValidator() {
-    }
-    
-    private static Map<String, Collection<String>> createNextActionAllowedFields() {
-        return Map.of(
-                "resource_read", Set.of("order", "type", "title", "resource_uri", "reason", "depends_on"),
-                "tool_call", Set.of("order", "type", "title", "tool_name", "arguments", "reason", "depends_on"),
-                "completion", Set.of("order", "type", "title", "ref", "argument", "context", "missing_context_arguments", "resume_ref", "resume_arguments", "reason", "depends_on"),
-                "ask_user", Set.of("order", "type", "title", "question", "required_inputs", "reason", "depends_on"),
-                "terminal", Set.of("order", "type", "title", "reason", "depends_on"));
-    }
-    
-    private static Map<String, Collection<String>> createNextActionRequiredFields() {
-        return Map.of(
-                "resource_read", Set.of("order", "type", "title", "resource_uri"),
-                "tool_call", Set.of("order", "type", "title", "tool_name", "arguments"),
-                "completion", Set.of("order", "type", "title", "ref", "argument"),
-                "ask_user", Set.of("order", "type", "title", "question"),
-                "terminal", Set.of("order", "type", "title"));
-    }
-    
-    private static Collection<String> createNextActionSchemaAllowedFields() {
-        Set<String> result = new HashSet<>();
-        for (Collection<String> each : NEXT_ACTION_ALLOWED_FIELDS.values()) {
-            result.addAll(each);
-        }
-        return result;
     }
     
     /**
@@ -191,7 +149,7 @@ public final class MCPToolOutputSchemaValidator {
     }
     
     private static void validateNoRemovedModelFacingField(final MCPToolDescriptor descriptor, final String fieldName) {
-        ShardingSpherePreconditions.checkState(!REMOVED_MODEL_FACING_FIELDS.contains(fieldName),
+        ShardingSpherePreconditions.checkState(!MCPModelFacingPayloadContract.isRemovedFieldName(fieldName),
                 () -> new IllegalStateException(String.format("Tool `%s` model-facing contract must use canonical fields instead of removed `%s`.", descriptor.getName(), fieldName)));
     }
     
@@ -207,10 +165,10 @@ public final class MCPToolOutputSchemaValidator {
     
     private static void validateConcreteNextAction(final MCPToolDescriptor descriptor, final Map<?, ?> action) {
         String type = String.valueOf(action.get("type"));
-        Collection<String> allowedFields = NEXT_ACTION_ALLOWED_FIELDS.get(type);
-        ShardingSpherePreconditions.checkState(null != allowedFields,
+        Collection<String> allowedFields = MCPModelFacingPayloadContract.getNextActionAllowedFields(type);
+        ShardingSpherePreconditions.checkState(!allowedFields.isEmpty(),
                 () -> new IllegalStateException(String.format("Tool `%s` next_actions example uses unknown type `%s`.", descriptor.getName(), type)));
-        for (String each : NEXT_ACTION_REQUIRED_FIELDS.get(type)) {
+        for (String each : MCPModelFacingPayloadContract.getNextActionRequiredFields(type)) {
             ShardingSpherePreconditions.checkState(action.containsKey(each),
                     () -> new IllegalStateException(String.format("Tool `%s` next_actions example `%s` must contain `%s`.", descriptor.getName(), type, each)));
         }
@@ -224,7 +182,7 @@ public final class MCPToolOutputSchemaValidator {
     private static void validateModelCriticalOutputHints(final MCPToolDescriptor descriptor, final Map<?, ?> properties) {
         for (Entry<?, ?> entry : properties.entrySet()) {
             String fieldName = String.valueOf(entry.getKey());
-            if (MODEL_CRITICAL_HINT_FIELDS.contains(fieldName)) {
+            if (MCPModelFacingPayloadContract.getModelCriticalFieldNames().contains(fieldName)) {
                 validateModelCriticalOutputHint(descriptor, fieldName, entry.getValue());
             }
             validateNestedModelCriticalOutputHints(descriptor, entry.getValue());
@@ -273,7 +231,7 @@ public final class MCPToolOutputSchemaValidator {
         }
         for (Object each : ((Map<?, ?>) properties).keySet()) {
             String fieldName = String.valueOf(each);
-            ShardingSpherePreconditions.checkState(NEXT_ACTION_SCHEMA_ALLOWED_FIELDS.contains(fieldName),
+            ShardingSpherePreconditions.checkState(MCPModelFacingPayloadContract.getNextActionSchemaAllowedFields().contains(fieldName),
                     () -> new IllegalStateException(String.format("Tool `%s` next_actions item contains unsupported field `%s`.", descriptor.getName(), fieldName)));
         }
     }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/ShardingSphereMCPResourceMetadata.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/ShardingSphereMCPResourceMetadata.java
@@ -31,7 +31,7 @@ import java.util.Map;
 @Getter
 public final class ShardingSphereMCPResourceMetadata {
     
-    private final String uriOrTemplate;
+    private final String uriTemplate;
     
     private final Collection<MCPUriVariableDescriptor> uriVariables;
     

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/protocol/MCPModelFacingPayloadContract.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/protocol/MCPModelFacingPayloadContract.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.protocol;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * MCP model-facing payload contract.
+ */
+public final class MCPModelFacingPayloadContract {
+    
+    private static final Collection<String> REMOVED_MODEL_FACING_FIELDS = Set.of(
+            "target_tool", "target_resource", "required_arguments", "action_kind", "suggested_next_tool", "suggested_next_tools", "recommended_next_tool",
+            "recommended_recovery", "suggested_next_action", "approved_by_user", "requires_user_approval", "approval_required", "user_overrides");
+    
+    private static final Map<String, Collection<String>> NEXT_ACTION_REQUIRED_FIELDS = Map.of(
+            "resource_read", Set.of("order", "type", "title", "resource_uri"),
+            "tool_call", Set.of("order", "type", "title", "tool_name", "arguments"),
+            "completion", Set.of("order", "type", "title", "ref", "argument"),
+            "ask_user", Set.of("order", "type", "title", "question"),
+            "terminal", Set.of("order", "type", "title"));
+    
+    private static final Map<String, Collection<String>> NEXT_ACTION_ALLOWED_FIELDS = Map.of(
+            "resource_read", Set.of("order", "type", "title", "resource_uri", "reason", "depends_on"),
+            "tool_call", Set.of("order", "type", "title", "tool_name", "arguments", "reason", "depends_on"),
+            "completion", Set.of("order", "type", "title", "ref", "argument", "context", "missing_context_arguments", "resume_ref", "resume_arguments", "reason", "depends_on"),
+            "ask_user", Set.of("order", "type", "title", "question", "required_inputs", "reason", "depends_on"),
+            "terminal", Set.of("order", "type", "title", "reason", "depends_on"));
+    
+    private static final Collection<String> NEXT_ACTION_SCHEMA_ALLOWED_FIELDS = createNextActionSchemaAllowedFields();
+    
+    private static final Collection<String> MODEL_CRITICAL_FIELD_NAMES = List.of(
+            MCPPayloadFieldNames.NEXT_ACTIONS, MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.RESOURCE, MCPPayloadFieldNames.PARENT_RESOURCE,
+            MCPPayloadFieldNames.NEXT_RESOURCES, "manual_artifact_summary", "manual_follow_up", "empty_state", "ambiguity_state", MCPPayloadFieldNames.RECOVERY, "recovery_guidance",
+            "remediation");
+    
+    private MCPModelFacingPayloadContract() {
+    }
+    
+    private static Collection<String> createNextActionSchemaAllowedFields() {
+        Set<String> result = new LinkedHashSet<>();
+        for (Collection<String> each : NEXT_ACTION_ALLOWED_FIELDS.values()) {
+            result.addAll(each);
+        }
+        return Collections.unmodifiableSet(result);
+    }
+    
+    /**
+     * Check whether a field name is a removed model-facing alias.
+     *
+     * @param fieldName field name
+     * @return true if removed, otherwise false
+     */
+    public static boolean isRemovedFieldName(final String fieldName) {
+        return REMOVED_MODEL_FACING_FIELDS.contains(fieldName);
+    }
+    
+    /**
+     * Get required fields for a canonical next_actions item type.
+     *
+     * @param actionType action type
+     * @return required field names
+     */
+    public static Collection<String> getNextActionRequiredFields(final String actionType) {
+        return NEXT_ACTION_REQUIRED_FIELDS.getOrDefault(actionType, List.of());
+    }
+    
+    /**
+     * Get allowed fields for a canonical next_actions item type.
+     *
+     * @param actionType action type
+     * @return allowed field names
+     */
+    public static Collection<String> getNextActionAllowedFields(final String actionType) {
+        return NEXT_ACTION_ALLOWED_FIELDS.getOrDefault(actionType, List.of());
+    }
+    
+    /**
+     * Get fields allowed by the next_actions item output schema.
+     *
+     * @return allowed schema field names
+     */
+    public static Collection<String> getNextActionSchemaAllowedFields() {
+        return NEXT_ACTION_SCHEMA_ALLOWED_FIELDS;
+    }
+    
+    /**
+     * Get model-critical field names that must stay visible to MCP clients and E2E model prompts.
+     *
+     * @return model-critical field names
+     */
+    public static Collection<String> getModelCriticalFieldNames() {
+        return MODEL_CRITICAL_FIELD_NAMES;
+    }
+}

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndexTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogIndexTest.java
@@ -37,7 +37,7 @@ class MCPDescriptorCatalogIndexTest {
     @Test
     void assertGetResourceDescriptors() {
         Collection<MCPResourceDescriptor> actualDescriptors = MCPDescriptorCatalogIndex.getResourceDescriptors();
-        assertTrue(actualDescriptors.stream().anyMatch(each -> "shardingsphere://workflows/{plan_id}".equals(each.getUriOrTemplate())));
+        assertTrue(actualDescriptors.stream().anyMatch(each -> "shardingsphere://workflows/{plan_id}".equals(each.getUriTemplate())));
     }
     
     @Test

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogLoaderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogLoaderTest.java
@@ -106,7 +106,7 @@ class MCPDescriptorCatalogLoaderTest {
     }
     
     private MCPResourceDescriptor findResource(final MCPDescriptorCatalog catalog, final String uriTemplate) {
-        return catalog.getProtocolDescriptors().getAllResourceDescriptors().stream().filter(each -> uriTemplate.equals(each.getUriOrTemplate())).findFirst().orElseThrow();
+        return catalog.getProtocolDescriptors().getAllResourceDescriptors().stream().filter(each -> uriTemplate.equals(each.getUriTemplate())).findFirst().orElseThrow();
     }
     
     private MCPResourceDescriptor createResourceTemplateDescriptor() {
@@ -131,7 +131,7 @@ class MCPDescriptorCatalogLoaderTest {
     }
     
     private ShardingSphereMCPResourceMetadata findShardingSphereResourceMetadata(final MCPDescriptorCatalog catalog, final String uriTemplate) {
-        return catalog.getShardingSphereDescriptors().getResourceMetadata().stream().filter(each -> uriTemplate.equals(each.getUriOrTemplate())).findFirst().orElseThrow();
+        return catalog.getShardingSphereDescriptors().getResourceMetadata().stream().filter(each -> uriTemplate.equals(each.getUriTemplate())).findFirst().orElseThrow();
     }
     
     private Map<?, ?> findInputProperty(final MCPToolDescriptor toolDescriptor, final String fieldName) {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPProtocolDescriptorCatalogTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/descriptor/MCPProtocolDescriptorCatalogTest.java
@@ -69,8 +69,8 @@ class MCPProtocolDescriptorCatalogTest {
         assertThat(actual.getAllResourceDescriptors(), is(List.of(resourceDescriptor, resourceTemplateDescriptor)));
     }
     
-    private MCPResourceDescriptor createResourceDescriptor(final String uriOrTemplate) {
-        return new MCPResourceDescriptor(uriOrTemplate, "test-resource", "Test Resource", "Read a test resource.", "application/json", MCPResourceAnnotations.EMPTY, Map.of());
+    private MCPResourceDescriptor createResourceDescriptor(final String uriTemplate) {
+        return new MCPResourceDescriptor(uriTemplate, "test-resource", "Test Resource", "Read a test resource.", "application/json", MCPResourceAnnotations.EMPTY, Map.of());
     }
     
     private MCPToolDescriptor createToolDescriptor() {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/protocol/MCPModelFacingPayloadContractTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/protocol/MCPModelFacingPayloadContractTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mcp.support.protocol;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MCPModelFacingPayloadContractTest {
+    
+    @Test
+    void assertIsRemovedFieldNameWithRemovedAlias() {
+        assertTrue(MCPModelFacingPayloadContract.isRemovedFieldName("target_tool"));
+    }
+    
+    @Test
+    void assertIsRemovedFieldNameWithCanonicalField() {
+        assertFalse(MCPModelFacingPayloadContract.isRemovedFieldName(MCPPayloadFieldNames.NEXT_ACTIONS));
+    }
+    
+    @Test
+    void assertGetNextActionRequiredFields() {
+        assertThat(MCPModelFacingPayloadContract.getNextActionRequiredFields("tool_call"), is(Set.of("order", "type", "title", "tool_name", "arguments")));
+    }
+    
+    @Test
+    void assertGetNextActionAllowedFields() {
+        assertThat(MCPModelFacingPayloadContract.getNextActionAllowedFields("completion"),
+                is(Set.of("order", "type", "title", "ref", "argument", "context", "missing_context_arguments", "resume_ref", "resume_arguments", "reason", "depends_on")));
+    }
+    
+    @Test
+    void assertGetNextActionSchemaAllowedFields() {
+        Collection<String> actual = MCPModelFacingPayloadContract.getNextActionSchemaAllowedFields();
+        assertTrue(actual.contains("resource_uri"));
+        assertFalse(actual.contains("target_tool"));
+    }
+    
+    @Test
+    void assertGetModelCriticalFieldNames() {
+        Collection<String> actual = MCPModelFacingPayloadContract.getModelCriticalFieldNames();
+        assertTrue(actual.contains(MCPPayloadFieldNames.NEXT_ACTIONS));
+        assertTrue(actual.contains("manual_follow_up"));
+    }
+}

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationTurnPlanner.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationTurnPlanner.java
@@ -17,20 +17,46 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.llm.conversation;
 
+import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
+import org.apache.shardingsphere.mcp.core.tool.handler.ToolDefinitionRegistry;
 import org.apache.shardingsphere.test.e2e.mcp.llm.scenario.LLME2EScenario;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionActionNames;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionTraceRecord;
 
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 final class LLMMCPConversationTurnPlanner {
     
     private final LLMMCPConversationInstructionFactory instructionFactory;
     
+    private final Set<String> readOnlyToolNames;
+    
     LLMMCPConversationTurnPlanner(final LLMMCPConversationInstructionFactory instructionFactory) {
+        this(instructionFactory, createReadOnlyToolNames());
+    }
+    
+    LLMMCPConversationTurnPlanner(final LLMMCPConversationInstructionFactory instructionFactory, final Set<String> readOnlyToolNames) {
         this.instructionFactory = instructionFactory;
+        this.readOnlyToolNames = readOnlyToolNames;
+    }
+    
+    private static Set<String> createReadOnlyToolNames() {
+        Set<String> result = new LinkedHashSet<>();
+        result.add(MCPInteractionActionNames.LIST_RESOURCES);
+        result.add(MCPInteractionActionNames.READ_RESOURCE);
+        result.add(MCPInteractionActionNames.LIST_PROMPTS);
+        result.add(MCPInteractionActionNames.GET_PROMPT);
+        result.add(MCPInteractionActionNames.COMPLETE);
+        for (MCPToolDescriptor each : ToolDefinitionRegistry.getSupportedToolDescriptors()) {
+            if (each.getAnnotations().isReadOnlyHint()) {
+                result.add(each.getName());
+            }
+        }
+        return result;
     }
     
     List<String> createTurnToolNames(final LLME2EScenario scenario, final List<MCPInteractionTraceRecord> interactionTrace) {
@@ -39,9 +65,9 @@ final class LLMMCPConversationTurnPlanner {
             return immediateActionToolNames;
         }
         if (instructionFactory.hasSideEffectExecutionNextAction(interactionTrace)) {
-            List<String> readOnlyToolNames = findMissingReadOnlyToolNames(scenario, interactionTrace);
-            if (!readOnlyToolNames.isEmpty()) {
-                return List.of(readOnlyToolNames.getFirst());
+            List<String> missingReadOnlyToolNames = findMissingReadOnlyToolNames(scenario, interactionTrace);
+            if (!missingReadOnlyToolNames.isEmpty()) {
+                return List.of(missingReadOnlyToolNames.getFirst());
             }
         }
         List<String> missingToolNames = findMissingAllowedToolNames(scenario, interactionTrace);
@@ -79,12 +105,6 @@ final class LLMMCPConversationTurnPlanner {
     }
     
     private boolean isReadOnlyToolName(final String toolName) {
-        return MCPInteractionActionNames.LIST_RESOURCES.equals(toolName)
-                || MCPInteractionActionNames.READ_RESOURCE.equals(toolName)
-                || MCPInteractionActionNames.LIST_PROMPTS.equals(toolName)
-                || MCPInteractionActionNames.GET_PROMPT.equals(toolName)
-                || MCPInteractionActionNames.COMPLETE.equals(toolName)
-                || "database_gateway_search_metadata".equals(toolName)
-                || "database_gateway_execute_query".equals(toolName);
+        return readOnlyToolNames.contains(toolName);
     }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationTurnPlannerTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationTurnPlannerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -34,7 +35,7 @@ class LLMMCPConversationTurnPlannerTest {
     @Test
     void assertCreateTurnToolNamesWithImmediateResourceAction() {
         LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
-        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory);
+        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory, Set.of());
         List<String> actual = planner.createTurnToolNames(createScenario(List.of(MCPInteractionActionNames.READ_RESOURCE, "database_gateway_execute_query"),
                 List.of(MCPInteractionActionNames.READ_RESOURCE, "database_gateway_execute_query")),
                 List.of(createTraceRecord("database_gateway_plan_mask_rule",
@@ -45,7 +46,7 @@ class LLMMCPConversationTurnPlannerTest {
     @Test
     void assertCreateTurnToolNamesWithImmediateCompletionAction() {
         LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
-        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory);
+        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory, Set.of());
         List<String> actual = planner.createTurnToolNames(createScenario(List.of("database_gateway_plan_mask_rule", "database_gateway_execute_query"),
                 List.of("database_gateway_plan_mask_rule", "database_gateway_execute_query")),
                 List.of(createTraceRecord("database_gateway_plan_mask_rule",
@@ -56,7 +57,7 @@ class LLMMCPConversationTurnPlannerTest {
     @Test
     void assertCreateTurnToolNamesPrefersReadOnlyAfterSideEffectNextAction() {
         LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
-        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory);
+        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory, Set.of("database_gateway_execute_query"));
         Map<String, Object> nextAction = Map.of("type", "tool_call", "tool_name", "database_gateway_execute_update", "arguments", Map.of("execution_mode", "execute"));
         List<String> actual = planner.createTurnToolNames(createScenario(List.of("database_gateway_execute_update", "database_gateway_execute_query"),
                 List.of("database_gateway_execute_update", "database_gateway_execute_query")),
@@ -65,16 +66,27 @@ class LLMMCPConversationTurnPlannerTest {
     }
     
     @Test
-    void assertCreateToolChoiceWithMissingCoverage() {
+    void assertCreateTurnToolNamesPrefersDescriptorReadOnlyToolAfterSideEffectNextAction() {
         LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
         LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory);
+        Map<String, Object> nextAction = Map.of("type", "tool_call", "tool_name", "database_gateway_execute_update", "arguments", Map.of("execution_mode", "execute"));
+        List<String> actual = planner.createTurnToolNames(createScenario(List.of("database_gateway_execute_update", "database_gateway_validate_runtime_database"),
+                List.of("database_gateway_execute_update", "database_gateway_validate_runtime_database")),
+                List.of(createTraceRecord("database_gateway_execute_update", Map.of("next_actions", List.of(nextAction)))));
+        assertThat(actual, is(List.of("database_gateway_validate_runtime_database")));
+    }
+    
+    @Test
+    void assertCreateToolChoiceWithMissingCoverage() {
+        LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
+        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory, Set.of());
         assertThat(planner.createToolChoice(createScenario(List.of("database_gateway_execute_query"), List.of("database_gateway_execute_query")), List.of(), false), is("required"));
     }
     
     @Test
     void assertCreateToolChoiceWithCoveredRequiredTools() {
         LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
-        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory);
+        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory, Set.of());
         assertThat(planner.createToolChoice(createScenario(List.of("database_gateway_execute_query"), List.of("database_gateway_execute_query")),
                 List.of(createTraceRecord("database_gateway_execute_query", Map.of("row_objects", List.of()))), false), is("auto"));
     }
@@ -82,7 +94,7 @@ class LLMMCPConversationTurnPlannerTest {
     @Test
     void assertCreateToolChoiceWithFinalAnswer() {
         LLMMCPConversationInstructionFactory instructionFactory = new LLMMCPConversationInstructionFactory();
-        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory);
+        LLMMCPConversationTurnPlanner planner = new LLMMCPConversationTurnPlanner(instructionFactory, Set.of());
         assertThat(planner.createToolChoice(createScenario(List.of("database_gateway_execute_query"), List.of("database_gateway_execute_query")), List.of(), true), is("none"));
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPModelFacingToolResponseFormatter.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPModelFacingToolResponseFormatter.java
@@ -20,6 +20,8 @@ package org.apache.shardingsphere.test.e2e.mcp.llm.conversation;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.util.json.JsonUtils;
+import org.apache.shardingsphere.mcp.support.protocol.MCPModelFacingPayloadContract;
+import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -33,17 +35,17 @@ final class LLMMCPModelFacingToolResponseFormatter {
     
     private static final List<String> GENERAL_FIELD_NAMES = List.of(
             "response_mode", "error_code", "message", "recovery_category", "result_kind", "status", "statement_type", "normalized_sql", "rows", "row_objects",
-            "returned_row_count", "plan_id", "workflow_resource", "manual_artifact_summary", "manual_follow_up");
+            "returned_row_count", "plan_id", "workflow_resource");
     
     private static final List<String> POST_ACTION_FIELD_NAMES = List.of(
-            "completion", "count", "has_more", "total_match_count", "returned_count", "truncated", "large_result_guidance", "search_context", "ambiguity_state");
+            "completion", "count", "has_more", "total_match_count", "returned_count", "truncated", "large_result_guidance", "search_context");
     
     static String format(final Map<String, Object> response) {
         Map<String, Object> result = new LinkedHashMap<>(16, 1F);
         copyFields(response, result, GENERAL_FIELD_NAMES);
         copyCompactArtifactList(response, result, "manual_artifacts");
         copyCompactArtifactList(response, result, "exported_artifacts");
-        copyIfPresent(response, result, "resources_to_read");
+        copyModelCriticalFields(response, result);
         copyModelFacingNextActions(response, result);
         copyFields(response, result, POST_ACTION_FIELD_NAMES);
         List<Map<String, Object>> resources = LLMMCPJsonValues.castToList(response.get("resources"));
@@ -75,6 +77,14 @@ final class LLMMCPModelFacingToolResponseFormatter {
     private static void copyIfPresent(final Map<String, Object> source, final Map<String, Object> target, final String fieldName) {
         if (source.containsKey(fieldName)) {
             target.put(fieldName, source.get(fieldName));
+        }
+    }
+    
+    private static void copyModelCriticalFields(final Map<String, Object> source, final Map<String, Object> target) {
+        for (String each : MCPModelFacingPayloadContract.getModelCriticalFieldNames()) {
+            if (!MCPPayloadFieldNames.NEXT_ACTIONS.equals(each) && !MCPPayloadFieldNames.RECOVERY.equals(each)) {
+                copyIfPresent(source, target, each);
+            }
         }
     }
     
@@ -164,13 +174,13 @@ final class LLMMCPModelFacingToolResponseFormatter {
         copyIfPresent(recovery, compactRecovery, "plan_id");
         copyIfPresent(recovery, compactRecovery, "completion_first");
         copyIfPresent(recovery, compactRecovery, "suggested_arguments");
-        copyIfPresent(recovery, compactRecovery, "resources_to_read");
+        copyModelCriticalFields(recovery, compactRecovery);
         copyModelFacingNextActions(recovery, compactRecovery);
         target.put("recovery", compactRecovery);
     }
     
     private static void copyModelFacingNextActions(final Map<String, Object> source, final Map<String, Object> target) {
-        List<Map<String, Object>> nextActions = LLMMCPJsonValues.castToList(source.get("next_actions"));
+        List<Map<String, Object>> nextActions = LLMMCPJsonValues.castToList(source.get(MCPPayloadFieldNames.NEXT_ACTIONS));
         if (nextActions.isEmpty()) {
             return;
         }
@@ -181,7 +191,7 @@ final class LLMMCPModelFacingToolResponseFormatter {
             }
         }
         if (!result.isEmpty()) {
-            target.put("next_actions", result);
+            target.put(MCPPayloadFieldNames.NEXT_ACTIONS, result);
         }
     }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPModelFacingToolResponseFormatterTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPModelFacingToolResponseFormatterTest.java
@@ -89,6 +89,31 @@ class LLMMCPModelFacingToolResponseFormatterTest {
     }
     
     @Test
+    void assertFormatWithModelCriticalFields() {
+        Map<String, Object> actual = format(Map.of(
+                "resources_to_read", List.of(Map.of("uri", "shardingsphere://capabilities")),
+                "resource", Map.of("uri", "shardingsphere://databases"),
+                "parent_resource", Map.of("uri", "shardingsphere://databases"),
+                "next_resources", List.of(Map.of("uri", "shardingsphere://databases/logic_db/schemas")),
+                "manual_artifact_summary", "Review DistSQL.",
+                "manual_follow_up", "Validate runtime state.",
+                "empty_state", Map.of("state", "no_match"),
+                "recovery_guidance", "Read metadata before retrying.",
+                "remediation", "Fix the mismatch.",
+                "ignored", "value"));
+        assertThat(actual, is(Map.of(
+                "resources_to_read", List.of(Map.of("uri", "shardingsphere://capabilities")),
+                "resource", Map.of("uri", "shardingsphere://databases"),
+                "parent_resource", Map.of("uri", "shardingsphere://databases"),
+                "next_resources", List.of(Map.of("uri", "shardingsphere://databases/logic_db/schemas")),
+                "manual_artifact_summary", "Review DistSQL.",
+                "manual_follow_up", "Validate runtime state.",
+                "empty_state", Map.of("state", "no_match"),
+                "recovery_guidance", "Read metadata before retrying.",
+                "remediation", "Fix the mismatch.")));
+    }
+    
+    @Test
     void assertFormatWithRecoveryAndNextActions() {
         Map<String, Object> actual = format(Map.of(
                 "next_actions", List.of(
@@ -102,6 +127,9 @@ class LLMMCPModelFacingToolResponseFormatterTest {
                         "next_actions", List.of(
                                 Map.of("type", "tool_call", "tool_name", "database_gateway_execute_update", "arguments", Map.of("execution_mode", "execute")),
                                 Map.of("type", "resource_read", "resource_uri", "shardingsphere://databases")),
+                        "resources_to_read", List.of(Map.of("uri", "shardingsphere://databases")),
+                        "recovery_guidance", "Read metadata.",
+                        "remediation", "Fix the request.",
                         "ignored", "value")));
         assertThat(actual, is(Map.of(
                 "next_actions", List.of(
@@ -110,6 +138,9 @@ class LLMMCPModelFacingToolResponseFormatterTest {
                         "recovery_category", "missing_context",
                         "model_action", "retry",
                         "suggested_arguments", Map.of("database", "logic_db"),
+                        "resources_to_read", List.of(Map.of("uri", "shardingsphere://databases")),
+                        "recovery_guidance", "Read metadata.",
+                        "remediation", "Fix the request.",
                         "next_actions", List.of(Map.of("type", "resource_read", "resource_uri", "shardingsphere://databases"))))));
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPModelContractAssertions.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPModelContractAssertions.java
@@ -17,9 +17,11 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.support.assertion;
 
+import org.apache.shardingsphere.mcp.support.protocol.MCPModelFacingPayloadContract;
+import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
+
 import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,24 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Assertions for model-facing MCP contracts.
  */
 public final class MCPModelContractAssertions {
-    
-    private static final Set<String> REMOVED_MODEL_FACING_FIELDS = Set.of(
-            "target_tool", "target_resource", "required_arguments", "action_kind", "suggested_next_tool", "suggested_next_tools", "recommended_next_tool",
-            "recommended_recovery", "suggested_next_action", "approved_by_user", "requires_user_approval", "approval_required", "user_overrides");
-    
-    private static final Map<String, Set<String>> NEXT_ACTION_REQUIRED_FIELDS = Map.of(
-            "resource_read", Set.of("order", "type", "title", "resource_uri"),
-            "tool_call", Set.of("order", "type", "title", "tool_name", "arguments"),
-            "completion", Set.of("order", "type", "title", "ref", "argument"),
-            "ask_user", Set.of("order", "type", "title", "question"),
-            "terminal", Set.of("order", "type", "title"));
-    
-    private static final Map<String, Set<String>> NEXT_ACTION_ALLOWED_FIELDS = Map.of(
-            "resource_read", Set.of("order", "type", "title", "resource_uri", "reason", "depends_on"),
-            "tool_call", Set.of("order", "type", "title", "tool_name", "arguments", "reason", "depends_on"),
-            "completion", Set.of("order", "type", "title", "ref", "argument", "context", "missing_context_arguments", "resume_ref", "resume_arguments", "reason", "depends_on"),
-            "ask_user", Set.of("order", "type", "title", "question", "required_inputs", "reason", "depends_on"),
-            "terminal", Set.of("order", "type", "title", "reason", "depends_on"));
     
     private MCPModelContractAssertions() {
     }
@@ -67,8 +51,8 @@ public final class MCPModelContractAssertions {
     
     private static void assertCanonicalNextActionListMap(final Map<?, ?> value) {
         assertNoRemovedModelFacingFields(value);
-        if (value.containsKey("next_actions") && !isNextActionsSchema(value.get("next_actions"))) {
-            assertNextActions(value.get("next_actions"));
+        if (value.containsKey(MCPPayloadFieldNames.NEXT_ACTIONS) && !isNextActionsSchema(value.get(MCPPayloadFieldNames.NEXT_ACTIONS))) {
+            assertNextActions(value.get(MCPPayloadFieldNames.NEXT_ACTIONS));
         }
         for (Object each : value.values()) {
             assertCanonicalNextActionLists(each);
@@ -77,7 +61,7 @@ public final class MCPModelContractAssertions {
     
     private static void assertNoRemovedModelFacingFields(final Map<?, ?> value) {
         for (Object each : value.keySet()) {
-            assertFalse(REMOVED_MODEL_FACING_FIELDS.contains(String.valueOf(each)), () -> "Removed model-facing field returned: " + each);
+            assertFalse(MCPModelFacingPayloadContract.isRemovedFieldName(String.valueOf(each)), () -> "Removed model-facing field returned: " + each);
         }
     }
     
@@ -95,12 +79,14 @@ public final class MCPModelContractAssertions {
     
     private static void assertNextAction(final Map<?, ?> action) {
         String type = String.valueOf(action.get("type"));
-        assertTrue(NEXT_ACTION_REQUIRED_FIELDS.containsKey(type), () -> "Unknown next_actions type: " + type);
-        for (String each : NEXT_ACTION_REQUIRED_FIELDS.get(type)) {
+        Collection<String> requiredFields = MCPModelFacingPayloadContract.getNextActionRequiredFields(type);
+        assertFalse(requiredFields.isEmpty(), () -> "Unknown next_actions type: " + type);
+        for (String each : requiredFields) {
             assertTrue(action.containsKey(each), () -> String.format("next_actions `%s` must contain `%s`.", type, each));
         }
         for (Object each : action.keySet()) {
-            assertTrue(NEXT_ACTION_ALLOWED_FIELDS.get(type).contains(String.valueOf(each)), () -> String.format("next_actions `%s` contains unsupported field `%s`.", type, each));
+            assertTrue(MCPModelFacingPayloadContract.getNextActionAllowedFields(type).contains(String.valueOf(each)),
+                    () -> String.format("next_actions `%s` contains unsupported field `%s`.", type, each));
         }
     }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/fixture/plugin/PluginFixtureStatusResourceHandler.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/fixture/plugin/PluginFixtureStatusResourceHandler.java
@@ -39,7 +39,7 @@ public final class PluginFixtureStatusResourceHandler implements MCPResourceHand
     }
     
     @Override
-    public String getResourceUriOrTemplate() {
+    public String getResourceUriTemplate() {
         return URI_PATTERN;
     }
     

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/fixture/plugin/PluginFixtureStatusResourceHandlerTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/fixture/plugin/PluginFixtureStatusResourceHandlerTest.java
@@ -35,8 +35,8 @@ class PluginFixtureStatusResourceHandlerTest {
     }
     
     @Test
-    void assertGetResourceUriOrTemplate() {
-        assertThat(new PluginFixtureStatusResourceHandler().getResourceUriOrTemplate(), is("shardingsphere://features/test-fixture/status"));
+    void assertGetResourceUriTemplate() {
+        assertThat(new PluginFixtureStatusResourceHandler().getResourceUriTemplate(), is("shardingsphere://features/test-fixture/status"));
     }
     
     @Test


### PR DESCRIPTION
- Add shared MCP model-facing payload contract for canonical fields and next_actions
- Reuse the contract in descriptor validation and MCP E2E assertions
- Move encrypt DistSQL descriptor checks into the encrypt feature test
- Derive MCP E2E read-only tool planning from descriptor annotations
- Preserve model-critical payload fields in E2E response formatting