### PR TITLE
Improve MCP tool argument validation and HTTP contract coverage

### DIFF
--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServlet.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServlet.java
@@ -61,6 +61,8 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
     
     private static final String JSON_CONTENT_TYPE = "application/json";
     
+    private static final String EVENT_STREAM_CONTENT_TYPE = "text/event-stream";
+    
     private final HttpServletStreamableServerTransportProvider delegate;
     
     private final McpJsonMapper jsonMapper;
@@ -135,8 +137,25 @@ final class StreamableHttpMCPServlet extends HttpServlet implements McpStreamabl
     }
     
     @Override
-    protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {
-        serviceRequest(request, response);
+    protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+        setUtf8Encoding(request, response);
+        if (!isEventStreamAccepted(request)) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Accept must include text/event-stream.");
+            return;
+        }
+        if (validateTransportSecurity(request, response)) {
+            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "HTTP GET event streams are not supported.");
+        }
+    }
+    
+    private boolean isEventStreamAccepted(final HttpServletRequest request) {
+        String acceptHeader = Objects.toString(request.getHeader(HttpHeaders.ACCEPT), "");
+        for (String each : acceptHeader.split(",")) {
+            if (EVENT_STREAM_CONTENT_TYPE.equalsIgnoreCase(each.split(";", 2)[0].trim())) {
+                return true;
+            }
+        }
+        return false;
     }
     
     private void serviceWithApplicationClassLoader(final HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServletTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/StreamableHttpMCPServletTest.java
@@ -182,22 +182,15 @@ class StreamableHttpMCPServletTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
         when(delegate.closeGracefully()).thenReturn(Mono.empty());
         StreamableHttpMCPServlet actual = createServlet(delegate, mock(MCPSessionManager.class), mock(MCPSessionExecutionCoordinator.class));
-        doAnswer(invocation -> assertDelegatedRequest(invocation.getArgument(0), invocation.getArgument(1), request, response))
-                .when(delegate).service(any(HttpServletRequest.class), any(HttpServletResponse.class));
         actual.service(request, response);
         verify(request).setCharacterEncoding("UTF-8");
         verify(response).setCharacterEncoding("UTF-8");
-    }
-    
-    private Object assertDelegatedRequest(final HttpServletRequest actualRequest, final HttpServletResponse actualResponse, final HttpServletRequest request, final HttpServletResponse response) {
-        assertThat(actualRequest, is(request));
-        assertThat(actualResponse, is(response));
-        assertThat(Thread.currentThread().getContextClassLoader(), is(StreamableHttpMCPServlet.class.getClassLoader()));
-        return null;
+        verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST, "Accept must include text/event-stream.");
+        verify(delegate, never()).service(any(HttpServletRequest.class), any(HttpServletResponse.class));
     }
     
     @Test
-    void assertServiceGetWithExistingAcceptHeader() throws ServletException, IOException, ReflectiveOperationException {
+    void assertRejectUnsupportedEventStreamGet() throws ServletException, IOException, ReflectiveOperationException {
         HttpServletStreamableServerTransportProvider delegate = mock(HttpServletStreamableServerTransportProvider.class);
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getMethod()).thenReturn("GET");
@@ -205,14 +198,11 @@ class StreamableHttpMCPServletTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
         when(delegate.closeGracefully()).thenReturn(Mono.empty());
         StreamableHttpMCPServlet actual = createServlet(delegate, mock(MCPSessionManager.class), mock(MCPSessionExecutionCoordinator.class));
-        doAnswer(invocation -> {
-            assertThat(invocation.getArgument(0), is(request));
-            assertThat(((HttpServletRequest) invocation.getArgument(0)).getHeader(HttpHeaders.ACCEPT), is("text/event-stream"));
-            return null;
-        }).when(delegate).service(any(HttpServletRequest.class), any(HttpServletResponse.class));
         actual.service(request, response);
         verify(request).setCharacterEncoding("UTF-8");
         verify(response).setCharacterEncoding("UTF-8");
+        verify(response).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "HTTP GET event streams are not supported.");
+        verify(delegate, never()).service(any(HttpServletRequest.class), any(HttpServletResponse.class));
     }
     
     @Test

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/completion/provider/MetadataCompletionProvider.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/completion/provider/MetadataCompletionProvider.java
@@ -47,6 +47,8 @@ import java.util.stream.Stream;
  */
 public final class MetadataCompletionProvider implements MCPCompletionProvider<MCPDatabaseHandlerContext> {
     
+    private static final Set<String> STORAGE_UNIT_ARGUMENTS = Set.of("storageUnit", "storage_unit", "write_storage_unit", "source_storage_unit", "shadow_storage_unit");
+    
     private static final Set<String> SUPPORTED_ARGUMENTS = Set.of("database", "schema", "table", "column", "index", "sequence", "storageUnit");
     
     private final GovernanceMetadataQueryService governanceMetadataQueryService = new GovernanceMetadataQueryService();
@@ -58,18 +60,23 @@ public final class MetadataCompletionProvider implements MCPCompletionProvider<M
     
     @Override
     public boolean supports(final MCPCompletionRequestContext requestContext) {
-        return SUPPORTED_ARGUMENTS.contains(requestContext.getArgumentName());
+        return SUPPORTED_ARGUMENTS.contains(canonicalizeArgumentName(requestContext.getArgumentName()));
     }
     
     @Override
     public MCPCompletionProviderResult complete(final MCPDatabaseHandlerContext handlerContext, final MCPCompletionRequestContext requestContext) {
+        String argumentName = canonicalizeArgumentName(requestContext.getArgumentName());
         Map<String, String> contextArguments = new LinkedHashMap<>(requestContext.getContextArguments());
-        Map<String, Object> inferredContextArguments = applyContextDefaults(handlerContext, requestContext.getArgumentName(), contextArguments);
-        Collection<String> missingContextArguments = createMissingContextArguments(requestContext.getArgumentName(), contextArguments);
+        Map<String, Object> inferredContextArguments = applyContextDefaults(handlerContext, argumentName, contextArguments);
+        Collection<String> missingContextArguments = createMissingContextArguments(argumentName, contextArguments);
         String nearestResourceUri = createNearestResourceUri(
-                missingContextArguments.isEmpty() ? requestContext.getArgumentName() : missingContextArguments.iterator().next(), contextArguments);
+                missingContextArguments.isEmpty() ? argumentName : missingContextArguments.iterator().next(), contextArguments);
         return new MCPCompletionProviderResult(
-                completeMetadata(handlerContext, requestContext.getArgumentName(), contextArguments), inferredContextArguments, missingContextArguments, nearestResourceUri);
+                completeMetadata(handlerContext, argumentName, contextArguments), inferredContextArguments, missingContextArguments, nearestResourceUri);
+    }
+    
+    private String canonicalizeArgumentName(final String argumentName) {
+        return STORAGE_UNIT_ARGUMENTS.contains(argumentName) ? "storageUnit" : argumentName;
     }
     
     private Map<String, Object> applyContextDefaults(final MCPDatabaseHandlerContext handlerContext, final String argumentName, final Map<String, String> contextArguments) {

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/MCPToolArgumentContract.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/MCPToolArgumentContract.java
@@ -20,9 +20,11 @@ package org.apache.shardingsphere.mcp.core.tool.handler;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
+import org.apache.shardingsphere.mcp.api.protocol.exception.MCPInvalidRequestException;
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPExecutionModeRequiredException;
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPInvalidApprovedStepsException;
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPInvalidExecutionModeException;
+import org.apache.shardingsphere.mcp.core.protocol.exception.MCPInvalidToolArgumentException;
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPMissingToolArgumentException;
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPToolArgumentContractViolationException;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
@@ -52,6 +54,12 @@ final class MCPToolArgumentContract {
     
     private static final String ENUM = "enum";
     
+    private static final String MINIMUM = "minimum";
+    
+    private static final String MAXIMUM = "maximum";
+    
+    private static final String DEFAULT_VALUE = "default";
+    
     private static final String STRING = "string";
     
     private static final String INTEGER = "integer";
@@ -74,13 +82,9 @@ final class MCPToolArgumentContract {
     
     private void validateObject(final Map<?, ?> arguments, final Map<?, ?> schema, final String path, final Map<String, Object> rootArguments) {
         validateRequiredArguments(arguments, schema, path, rootArguments);
-        validateUnknownArguments(arguments, schema, path, rootArguments);
         for (Entry<?, ?> entry : arguments.entrySet()) {
             String argumentName = Objects.toString(entry.getKey(), "");
-            Map<?, ?> property = findProperty(schema, argumentName);
-            if (!property.isEmpty()) {
-                validateArgument(entry.getValue(), property, appendPath(path, argumentName), rootArguments);
-            }
+            validatePropertyArgument(entry.getValue(), schema, appendPath(path, argumentName), rootArguments, argumentName);
         }
     }
     
@@ -107,15 +111,18 @@ final class MCPToolArgumentContract {
         ShardingSpherePreconditions.checkState(!actualValue.isEmpty(), () -> createMissingArgumentException(rootArguments, path));
     }
     
-    private void validateUnknownArguments(final Map<?, ?> arguments, final Map<?, ?> schema, final String path, final Map<String, Object> rootArguments) {
-        if (!Boolean.FALSE.equals(schema.get(ADDITIONAL_PROPERTIES))) {
+    private void validatePropertyArgument(final Object value, final Map<?, ?> schema, final String argumentPath, final Map<String, Object> rootArguments, final String argumentName) {
+        Map<?, ?> property = findProperty(schema, argumentName);
+        if (!property.isEmpty()) {
+            validateArgument(value, property, argumentPath, rootArguments);
             return;
         }
-        for (Object each : arguments.keySet()) {
-            String argumentName = Objects.toString(each, "");
-            if (findProperty(schema, argumentName).isEmpty()) {
-                throw createContractViolationException(rootArguments, appendPath(path, argumentName), "unknown_argument", "", List.of());
-            }
+        Object additionalProperties = schema.get(ADDITIONAL_PROPERTIES);
+        if (Boolean.FALSE.equals(additionalProperties)) {
+            throw createContractViolationException(rootArguments, argumentPath, "unknown_argument", "", List.of());
+        }
+        if (additionalProperties instanceof Map<?, ?>) {
+            validateArgument(value, (Map<?, ?>) additionalProperties, argumentPath, rootArguments);
         }
     }
     
@@ -124,6 +131,9 @@ final class MCPToolArgumentContract {
         if (!expectedType.isEmpty()) {
             ShardingSpherePreconditions.checkState(isValidType(value, expectedType),
                     () -> createContractViolationException(rootArguments, path, "invalid_argument_type", expectedType, List.of()));
+        }
+        if (INTEGER.equals(expectedType)) {
+            validateIntegerRange(value, schema, path);
         }
         validateEnumValue(value, schema, path, rootArguments);
         if (ARRAY.equals(expectedType)) {
@@ -151,6 +161,47 @@ final class MCPToolArgumentContract {
             return value instanceof Collection<?>;
         }
         return !OBJECT.equals(expectedType) || value instanceof Map<?, ?>;
+    }
+    
+    private void validateIntegerRange(final Object value, final Map<?, ?> schema, final String path) {
+        if (!(schema.get(MINIMUM) instanceof Number) || !(schema.get(MAXIMUM) instanceof Number)) {
+            return;
+        }
+        BigInteger actualValue = toBigInteger(value);
+        BigInteger minimumValue = toBigInteger(schema.get(MINIMUM));
+        BigInteger maximumValue = toBigInteger(schema.get(MAXIMUM));
+        ShardingSpherePreconditions.checkState(isIntegerWithinRange(actualValue, minimumValue, maximumValue), () -> createInvalidIntegerArgumentException(value, schema, path));
+    }
+    
+    private RuntimeException createInvalidIntegerArgumentException(final Object value, final Map<?, ?> schema, final String path) {
+        int minimum = getIntegerSchemaValue(schema, MINIMUM);
+        int maximum = getIntegerSchemaValue(schema, MAXIMUM);
+        return new MCPInvalidToolArgumentException(toolName, toolName, path, minimum, maximum, getSuggestedIntegerValue(value, schema, minimum, maximum),
+                new MCPInvalidRequestException(String.format("%s is out of range.", path)));
+    }
+    
+    private BigInteger toBigInteger(final Object value) {
+        return value instanceof BigInteger ? (BigInteger) value : BigInteger.valueOf(((Number) value).longValue());
+    }
+    
+    private int getIntegerSchemaValue(final Map<?, ?> schema, final String key) {
+        return ((Number) schema.get(key)).intValue();
+    }
+    
+    private int getSuggestedIntegerValue(final Object value, final Map<?, ?> schema, final int minimumValue, final int maximumValue) {
+        Object defaultValue = schema.get(DEFAULT_VALUE);
+        if (isValidType(defaultValue, INTEGER) && isIntegerWithinRange(defaultValue, minimumValue, maximumValue)) {
+            return ((Number) defaultValue).intValue();
+        }
+        return toBigInteger(value).compareTo(BigInteger.valueOf(minimumValue)) < 0 ? minimumValue : maximumValue;
+    }
+    
+    private boolean isIntegerWithinRange(final Object value, final int minimumValue, final int maximumValue) {
+        return isIntegerWithinRange(toBigInteger(value), BigInteger.valueOf(minimumValue), BigInteger.valueOf(maximumValue));
+    }
+    
+    private boolean isIntegerWithinRange(final BigInteger value, final BigInteger minimumValue, final BigInteger maximumValue) {
+        return value.compareTo(minimumValue) >= 0 && value.compareTo(maximumValue) <= 0;
     }
     
     private void validateEnumValue(final Object value, final Map<?, ?> schema, final String path, final Map<String, Object> rootArguments) {

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/ExecuteUpdateToolHandler.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/ExecuteUpdateToolHandler.java
@@ -72,6 +72,7 @@ public final class ExecuteUpdateToolHandler implements MCPToolHandler<MCPDatabas
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPToolCall toolCall) {
         MCPToolArguments toolArguments = new MCPToolArguments(toolCall.getArguments());
         String executionMode = resolveExecutionMode(toolArguments);
+        SQLExecutionToolHandlerSupport.checkExecutionArguments(toolArguments, TOOL_NAME);
         String sql = toolArguments.getStringArgument("sql");
         ClassificationResult classificationResult = checkUpdateStatement(toolArguments, sql);
         if (EXECUTION_MODE_PREVIEW.equals(executionMode)) {

--- a/mcp/core/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-core.yaml
+++ b/mcp/core/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-core.yaml
@@ -1073,6 +1073,8 @@ tools:
           has_more: false
           continuation_mode: none
           total_match_count: 1
+          returned_count: 1
+          truncated: false
           search_context:
             query: orders
             database: logic_db
@@ -1381,7 +1383,7 @@ tools:
         - TRANSACTION_CONTROL
         - SAVEPOINT
   - name: database_gateway_execute_update
-    title: Execute Update SQL
+    title: Preview or Execute Side-Effecting SQL
     description: >-
       Execute or preview exactly one supported SQL statement that may mutate data, metadata, rules, or transaction state.
       Use execution_mode=preview first when the side-effect scope has not been reviewed. Preview is classification-only,
@@ -1599,7 +1601,7 @@ tools:
                 - 1
               reason: Execute only after reviewing normalized_sql and side_effect_scope; preview did not validate runtime executability.
     annotations:
-      title: Execute Update SQL
+      title: Preview or Execute Side-Effecting SQL
       readOnlyHint: false
       destructiveHint: true
       idempotentHint: false

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/completion/provider/MetadataCompletionProviderTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/completion/provider/MetadataCompletionProviderTest.java
@@ -67,6 +67,15 @@ class MetadataCompletionProviderTest {
     }
     
     @Test
+    void assertSupportsStorageUnitAliases() {
+        MetadataCompletionProvider provider = new MetadataCompletionProvider();
+        assertTrue(provider.supports(createRequestContext("storage_unit", Map.of())));
+        assertTrue(provider.supports(createRequestContext("write_storage_unit", Map.of())));
+        assertTrue(provider.supports(createRequestContext("source_storage_unit", Map.of())));
+        assertTrue(provider.supports(createRequestContext("shadow_storage_unit", Map.of())));
+    }
+    
+    @Test
     void assertSupportsWithUnknownArgument() {
         assertFalse(new MetadataCompletionProvider().supports(createRequestContext("foo_value", Map.of())));
     }
@@ -181,6 +190,17 @@ class MetadataCompletionProviderTest {
         when(queryFacade.query("logic_db", "", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of("name", "write_ds")));
         MCPCompletionProviderResult actual = new MetadataCompletionProvider().complete(createHandlerContext(mock(MCPMetadataQueryFacade.class), queryFacade),
                 createRequestContext("storageUnit", Map.of("database", "logic_db")));
+        assertCandidate(actual, "write_ds");
+        assertThat(actual.getMissingContextArguments(), is(List.of()));
+        assertThat(actual.getNearestResourceUri(), is("shardingsphere://databases/logic_db/storage-units"));
+    }
+    
+    @Test
+    void assertCompleteStorageUnitAlias() {
+        MCPFeatureQueryFacade queryFacade = mock(MCPFeatureQueryFacade.class);
+        when(queryFacade.query("logic_db", "", "SHOW STORAGE UNITS FROM logic_db")).thenReturn(List.of(Map.of("name", "write_ds")));
+        MCPCompletionProviderResult actual = new MetadataCompletionProvider().complete(createHandlerContext(mock(MCPMetadataQueryFacade.class), queryFacade),
+                createRequestContext("write_storage_unit", Map.of("database", "logic_db")));
         assertCandidate(actual, "write_ds");
         assertThat(actual.getMissingContextArguments(), is(List.of()));
         assertThat(actual.getNearestResourceUri(), is("shardingsphere://databases/logic_db/storage-units"));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/capability/ServerCapabilitiesHandlerTest.java
@@ -256,8 +256,9 @@ class ServerCapabilitiesHandlerTest {
         assertTrue(searchMetadataOutputProperties.containsKey("returned_count"));
         assertTrue(searchMetadataOutputProperties.containsKey("truncated"));
         assertTrue(searchMetadataOutputProperties.containsKey("large_result_guidance"));
+        assertThat(getInputFieldNames(searchMetadataTool), is(List.of("database", "schema", "query", "object_types")));
         Map<?, ?> objectTypesSchema = findInputSchema(searchMetadataTool, "object_types");
-        assertTrue(((List<?>) ((Map<?, ?>) objectTypesSchema.get("items")).get("enum")).containsAll(List.of("database", "schema", "table", "view", "column", "index", "sequence")));
+        assertTrue(((List<?>) ((Map<?, ?>) objectTypesSchema.get("items")).get("enum")).containsAll(List.of("database", "schema", "table", "view", "column", "index", "storage_unit", "sequence")));
         Map<?, ?> validateRuntimeDatabaseTool = findTool(capabilities, "database_gateway_validate_runtime_database");
         Map<?, ?> validateRuntimeDatabaseOutputProperties = (Map<?, ?>) ((Map<?, ?>) validateRuntimeDatabaseTool.get("outputSchema")).get("properties");
         assertThat(getInputFieldNames(validateRuntimeDatabaseTool), is(List.of("database")));
@@ -275,6 +276,7 @@ class ServerCapabilitiesHandlerTest {
         assertTrue(executeUpdateOutputProperties.containsKey("preview_semantics"));
         assertTrue(executeUpdateOutputProperties.containsKey("review_summary"));
         assertFalse(executeUpdateOutputProperties.containsKey("approval_summary"));
+        assertThat(executeUpdateTool.get("title"), is("Preview or Execute Side-Effecting SQL"));
         assertTrue(((String) executeUpdateTool.get("description")).contains("Preview is classification-only, not a database dry run."));
         assertThat(findInputSchema(executeUpdateTool, "execution_mode").get("description"),
                 is("Required safety gate. Use preview to classify side effects without execution; preview is not a database dry run. Use execute only after reviewing the preview."));

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/ToolDefinitionRegistryTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/ToolDefinitionRegistryTest.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.mcp.core.context.MCPRuntimeContext;
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPExecutionModeRequiredException;
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPInvalidApprovedStepsException;
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPInvalidExecutionModeException;
+import org.apache.shardingsphere.mcp.core.protocol.exception.MCPInvalidToolArgumentException;
 import org.apache.shardingsphere.mcp.core.protocol.exception.MCPToolArgumentContractViolationException;
 import org.apache.shardingsphere.mcp.core.protocol.exception.UnsupportedToolException;
 import org.apache.shardingsphere.mcp.core.resource.ResourceTestDataFactory;
@@ -140,6 +141,20 @@ class ToolDefinitionRegistryTest {
     }
     
     @Test
+    void assertDispatchWithIntegerAboveMaximum() {
+        MCPInvalidToolArgumentException actual = assertThrows(MCPInvalidToolArgumentException.class,
+                () -> dispatch("database_gateway_execute_update", Map.of("database", "logic_db", "sql", "UPDATE orders SET status = 'PAID' WHERE order_id = 1",
+                        "execution_mode", "preview", "max_rows", 5001)));
+        assertThat(actual.getMessage(), is("max_rows must be an integer between 0 and 5000."));
+        assertThat(actual.getSourceTool(), is("database_gateway_execute_update"));
+        assertThat(actual.getTargetTool(), is("database_gateway_execute_update"));
+        assertThat(actual.getArgumentPath(), is("max_rows"));
+        assertThat(actual.getMinimumValue(), is(0));
+        assertThat(actual.getMaximumValue(), is(5000));
+        assertThat(actual.getSuggestedValue(), is(100));
+    }
+    
+    @Test
     void assertDispatchWithInvalidEnumArgument() {
         MCPToolArgumentContractViolationException actual = assertThrows(MCPToolArgumentContractViolationException.class,
                 () -> dispatch("database_gateway_search_metadata", Map.of("query", "order", "object_types", List.of("TABLE"))));
@@ -201,6 +216,19 @@ class ToolDefinitionRegistryTest {
     }
     
     @Test
+    void assertValidateWithSchemaAdditionalProperties() {
+        MCPToolDescriptor descriptor = createAdditionalPropertiesFixtureToolDescriptor();
+        MCPToolArgumentContractViolationException actual = assertThrows(MCPToolArgumentContractViolationException.class,
+                () -> new MCPToolArgumentContract(descriptor.getName(), descriptor.getInputSchema()).validate(Map.of("options", Map.of("mode", 1))));
+        assertThat(actual.getMessage(), is("options.mode must be a string."));
+        assertThat(actual.getToolName(), is("fixture_tool"));
+        assertThat(actual.getArgumentPath(), is("options.mode"));
+        assertThat(actual.getCategory(), is("invalid_argument_type"));
+        assertThat(actual.getExpectedType(), is("string"));
+        assertThat(actual.getSuggestedArguments(), is(Map.of()));
+    }
+    
+    @Test
     void assertGetSupportedToolsWithNoToolHandlers() {
         try (MockedStatic<ShardingSphereServiceLoader> mocked = mockStatic(ShardingSphereServiceLoader.class)) {
             mocked.when(() -> ShardingSphereServiceLoader.getServiceInstances(MCPHandlerProvider.class)).thenReturn(Collections.emptyList());
@@ -220,6 +248,12 @@ class ToolDefinitionRegistryTest {
     
     private static MCPToolDescriptor createNestedFixtureToolDescriptor() {
         Map<String, Object> optionSchema = Map.of("type", "object", "properties", Map.of("mode", Map.of("type", "string")), "required", List.of(), "additionalProperties", false);
+        return new MCPToolDescriptor("fixture_tool", "Fixture Tool", "Fixture tool.", Map.of("type", "object", "properties", Map.of("options", optionSchema), "required", List.of(),
+                "additionalProperties", false), Collections.emptyMap(), new MCPToolAnnotations("Fixture Tool", true, false, true, true), Collections.emptyMap());
+    }
+    
+    private static MCPToolDescriptor createAdditionalPropertiesFixtureToolDescriptor() {
+        Map<String, Object> optionSchema = Map.of("type", "object", "additionalProperties", Map.of("type", "string"));
         return new MCPToolDescriptor("fixture_tool", "Fixture Tool", "Fixture tool.", Map.of("type", "object", "properties", Map.of("options", optionSchema), "required", List.of(),
                 "additionalProperties", false), Collections.emptyMap(), new MCPToolAnnotations("Fixture Tool", true, false, true, true), Collections.emptyMap());
     }

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/ExecuteUpdateToolHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/ExecuteUpdateToolHandlerTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.mcp.api.protocol.exception.MCPInvalidRequestExc
 import org.apache.shardingsphere.mcp.api.protocol.exception.MCPUnsupportedException;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
+import org.apache.shardingsphere.mcp.core.protocol.exception.MCPInvalidToolArgumentException;
 import org.apache.shardingsphere.mcp.support.database.MCPDatabaseHandlerContext;
 import org.apache.shardingsphere.mcp.support.database.capability.SupportedMCPStatement;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureExecutionFacade;
@@ -137,6 +138,19 @@ class ExecuteUpdateToolHandlerTest {
         assertThat(((Map<?, ?>) actualToolCallAction.get("arguments")).get("execution_mode"), is("execute"));
         assertThat(((Map<?, ?>) ((List<?>) actual.toPayload().get("resources_to_read")).getFirst()).get("uri"), is("shardingsphere://databases/logic_db/capabilities"));
         assertFalse(actual.toPayload().containsKey("ask_user_when_uncertain"));
+        verifyNoInteractions(executionFacade);
+    }
+    
+    @Test
+    void assertRejectPreviewWithInvalidTimeout() {
+        MCPFeatureExecutionFacade executionFacade = mock(MCPFeatureExecutionFacade.class);
+        MCPDatabaseHandlerContext databaseContext = mock(MCPDatabaseHandlerContext.class);
+        when(databaseContext.getExecutionFacade()).thenReturn(executionFacade);
+        MCPInvalidToolArgumentException actual = assertThrows(MCPInvalidToolArgumentException.class, () -> new ExecuteUpdateToolHandler().handle(databaseContext, new MCPToolCall("session-1",
+                Map.of("database", "logic_db", "schema", "public", "sql", "update orders set status = 'PAID'", "execution_mode", "preview", "timeout_ms", 300001))));
+        assertThat(actual.getMessage(), is("timeout_ms must be an integer between 0 and 300000."));
+        assertThat(actual.getArgumentPath(), is("timeout_ms"));
+        assertThat(actual.getSuggestedValue(), is(0));
         verifyNoInteractions(executionFacade);
     }
     

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/SearchMetadataToolHandlerTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/metadata/SearchMetadataToolHandlerTest.java
@@ -56,10 +56,10 @@ class SearchMetadataToolHandlerTest {
         MCPToolDescriptor actual = MCPDescriptorCatalogIndex.getRequiredToolDescriptor(new SearchMetadataToolHandler().getToolName());
         assertThat(actual.getName(), is("database_gateway_search_metadata"));
         assertThat(((Map<?, ?>) actual.getInputSchema().get("properties")).size(), is(4));
-        Map<?, ?> actualProperties = (Map<?, ?>) actual.getOutputSchema().get("properties");
         Map<?, ?> actualInputProperties = (Map<?, ?>) actual.getInputSchema().get("properties");
         Map<?, ?> actualObjectTypeItems = (Map<?, ?>) ((Map<?, ?>) actualInputProperties.get("object_types")).get("items");
         assertTrue(((List<?>) actualObjectTypeItems.get("enum")).contains("storage_unit"));
+        Map<?, ?> actualProperties = (Map<?, ?>) actual.getOutputSchema().get("properties");
         Map<?, ?> actualItems = (Map<?, ?>) ((Map<?, ?>) actualProperties.get("items")).get("items");
         Map<?, ?> actualItemProperties = (Map<?, ?>) actualItems.get("properties");
         assertTrue(actualItemProperties.containsKey("resource"));
@@ -170,6 +170,8 @@ class SearchMetadataToolHandlerTest {
             assertThat(actualPayload.get("total_match_count"), is(101));
             assertThat(actualPayload.get("returned_count"), is(100));
             assertTrue((Boolean) actualPayload.get("truncated"));
+            assertFalse((Boolean) actualPayload.get("has_more"));
+            assertThat(actualPayload.get("continuation_mode"), is("none"));
             Map<?, ?> actualLargeResultGuidance = (Map<?, ?>) actualPayload.get("large_result_guidance");
             assertThat(actualLargeResultGuidance.get("state"), is("metadata_search_result_truncated"));
             assertThat(actualLargeResultGuidance.get("threshold"), is(100));

--- a/mcp/features/broadcast/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-broadcast.yaml
+++ b/mcp/features/broadcast/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-broadcast.yaml
@@ -119,6 +119,8 @@ completionTargets:
     reference: plan_broadcast_rule
     arguments:
       - database
+      - table
+      - plan_id
     maxValues: 50
 
 resourceNavigation:

--- a/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/BroadcastFeatureDefinitionTest.java
+++ b/mcp/features/broadcast/src/test/java/org/apache/shardingsphere/mcp/feature/broadcast/BroadcastFeatureDefinitionTest.java
@@ -17,10 +17,15 @@
 
 package org.apache.shardingsphere.mcp.feature.broadcast;
 
+import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogLoader;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BroadcastFeatureDefinitionTest {
     
@@ -32,5 +37,12 @@ class BroadcastFeatureDefinitionTest {
         assertThat(BroadcastFeatureDefinition.TABLES_FIELD, is("tables"));
         assertThat(BroadcastFeatureDefinition.RULES_RESOURCE_URI, is("shardingsphere://features/broadcast/databases/{database}/rules"));
         assertThat(BroadcastFeatureDefinition.RULE_COUNT_RESOURCE_URI, is("shardingsphere://features/broadcast/databases/{database}/rule-count"));
+    }
+    
+    @Test
+    void assertPromptCompletionArguments() {
+        MCPCompletionTargetDescriptor actual = MCPDescriptorCatalogLoader.load().getShardingSphereDescriptors().getCompletionTargetDescriptors().stream()
+                .filter(each -> "prompt".equals(each.getReferenceType()) && BroadcastFeatureDefinition.PLAN_PROMPT_NAME.equals(each.getReference())).findFirst().orElseThrow();
+        assertTrue(actual.getArguments().containsAll(List.of("database", "table", "plan_id")));
     }
 }

--- a/mcp/features/encrypt/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-encrypt.yaml
+++ b/mcp/features/encrypt/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-encrypt.yaml
@@ -128,9 +128,14 @@ completionTargets:
   - referenceType: prompt
     reference: plan_encrypt_rule
     arguments:
+      - database
+      - schema
+      - table
+      - column
       - algorithm_type
       - assisted_query_algorithm_type
       - like_query_algorithm_type
+      - plan_id
     maxValues: 50
 resourceNavigation:
   - from: shardingsphere://features/encrypt/algorithms

--- a/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptDescriptorContractTest.java
+++ b/mcp/features/encrypt/src/test/java/org/apache/shardingsphere/mcp/feature/encrypt/EncryptDescriptorContractTest.java
@@ -18,11 +18,13 @@
 package org.apache.shardingsphere.mcp.feature.encrypt;
 
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalog;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogLoader;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -43,10 +45,21 @@ class EncryptDescriptorContractTest {
         assertTrue(actualProperties.containsKey("summary"));
     }
     
+    @Test
+    void assertPromptCompletionArguments() {
+        assertCompletionTargetArguments(EncryptFeatureDefinition.PLAN_PROMPT_NAME, "database", "schema", "table", "column", "plan_id");
+    }
+    
     private MCPToolDescriptor findToolDescriptor() {
         MCPDescriptorCatalog catalog = MCPDescriptorCatalogLoader.load();
         return catalog.getProtocolDescriptors().getToolDescriptors().stream()
                 .filter(each -> EncryptFeatureDefinition.PLAN_TOOL_NAME.equals(each.getName())).findFirst().orElseThrow();
+    }
+    
+    private void assertCompletionTargetArguments(final String promptName, final String... expectedArguments) {
+        MCPCompletionTargetDescriptor actual = MCPDescriptorCatalogLoader.load().getShardingSphereDescriptors().getCompletionTargetDescriptors().stream()
+                .filter(each -> "prompt".equals(each.getReferenceType()) && promptName.equals(each.getReference())).findFirst().orElseThrow();
+        assertTrue(actual.getArguments().containsAll(List.of(expectedArguments)));
     }
     
     private void assertEncryptDistSQLExampleValue(final Object value) {

--- a/mcp/features/mask/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-mask.yaml
+++ b/mcp/features/mask/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-mask.yaml
@@ -120,7 +120,12 @@ completionTargets:
   - referenceType: prompt
     reference: plan_mask_rule
     arguments:
+      - database
+      - schema
+      - table
+      - column
       - algorithm_type
+      - plan_id
     maxValues: 50
 resourceNavigation:
   - from: shardingsphere://features/mask/algorithms

--- a/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/MaskFeatureDefinitionTest.java
+++ b/mcp/features/mask/src/test/java/org/apache/shardingsphere/mcp/feature/mask/MaskFeatureDefinitionTest.java
@@ -17,10 +17,15 @@
 
 package org.apache.shardingsphere.mcp.feature.mask;
 
+import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogLoader;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MaskFeatureDefinitionTest {
     
@@ -32,5 +37,12 @@ class MaskFeatureDefinitionTest {
         assertThat(MaskFeatureDefinition.ALGORITHMS_RESOURCE_URI, is("shardingsphere://features/mask/algorithms"));
         assertThat(MaskFeatureDefinition.RULES_RESOURCE_URI, is("shardingsphere://features/mask/databases/{database}/rules"));
         assertThat(MaskFeatureDefinition.RULE_RESOURCE_URI, is("shardingsphere://features/mask/databases/{database}/tables/{table}/rules"));
+    }
+    
+    @Test
+    void assertPromptCompletionArguments() {
+        MCPCompletionTargetDescriptor actual = MCPDescriptorCatalogLoader.load().getShardingSphereDescriptors().getCompletionTargetDescriptors().stream()
+                .filter(each -> "prompt".equals(each.getReferenceType()) && MaskFeatureDefinition.PLAN_PROMPT_NAME.equals(each.getReference())).findFirst().orElseThrow();
+        assertTrue(actual.getArguments().containsAll(List.of("database", "schema", "table", "column", "plan_id")));
     }
 }

--- a/mcp/features/readwrite-splitting/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-readwrite-splitting.yaml
+++ b/mcp/features/readwrite-splitting/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-readwrite-splitting.yaml
@@ -221,12 +221,16 @@ completionTargets:
     reference: plan_readwrite_splitting_rule
     arguments:
       - database
+      - write_storage_unit
       - load_balancer_type
+      - plan_id
     maxValues: 50
   - referenceType: prompt
     reference: plan_readwrite_splitting_status
     arguments:
       - database
+      - storage_unit
+      - plan_id
     maxValues: 50
 resourceNavigation:
   - from: shardingsphere://features/readwrite-splitting/databases/{database}/rules

--- a/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/ReadwriteSplittingFeatureDefinitionTest.java
+++ b/mcp/features/readwrite-splitting/src/test/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/ReadwriteSplittingFeatureDefinitionTest.java
@@ -17,10 +17,16 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting;
 
+import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalog;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogLoader;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ReadwriteSplittingFeatureDefinitionTest {
     
@@ -28,5 +34,18 @@ class ReadwriteSplittingFeatureDefinitionTest {
     void assertWorkflowKinds() {
         assertThat(ReadwriteSplittingFeatureDefinition.RULE_WORKFLOW_KIND.getValue(), is("readwrite.rule"));
         assertThat(ReadwriteSplittingFeatureDefinition.STATUS_WORKFLOW_KIND.getValue(), is("readwrite.status"));
+    }
+    
+    @Test
+    void assertPromptCompletionArguments() {
+        MCPDescriptorCatalog catalog = MCPDescriptorCatalogLoader.load();
+        assertCompletionTargetArguments(catalog, ReadwriteSplittingFeatureDefinition.PLAN_RULE_PROMPT_NAME, "database", "write_storage_unit", "plan_id");
+        assertCompletionTargetArguments(catalog, ReadwriteSplittingFeatureDefinition.PLAN_STATUS_PROMPT_NAME, "database", "storage_unit", "plan_id");
+    }
+    
+    private void assertCompletionTargetArguments(final MCPDescriptorCatalog catalog, final String promptName, final String... expectedArguments) {
+        MCPCompletionTargetDescriptor actual = catalog.getShardingSphereDescriptors().getCompletionTargetDescriptors().stream()
+                .filter(each -> "prompt".equals(each.getReferenceType()) && promptName.equals(each.getReference())).findFirst().orElseThrow();
+        assertTrue(actual.getArguments().containsAll(List.of(expectedArguments)));
     }
 }

--- a/mcp/features/shadow/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-shadow.yaml
+++ b/mcp/features/shadow/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-shadow.yaml
@@ -290,18 +290,24 @@ completionTargets:
     reference: plan_shadow_rule
     arguments:
       - database
+      - source_storage_unit
+      - shadow_storage_unit
+      - table
       - algorithm_type
+      - plan_id
     maxValues: 50
   - referenceType: prompt
     reference: plan_default_shadow_algorithm
     arguments:
       - database
       - algorithm_type
+      - plan_id
     maxValues: 50
   - referenceType: prompt
     reference: plan_shadow_algorithm_cleanup
     arguments:
       - database
+      - plan_id
     maxValues: 50
 resourceNavigation:
   - from: shardingsphere://features/shadow/databases/{database}/rules

--- a/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/ShadowDescriptorContractTest.java
+++ b/mcp/features/shadow/src/test/java/org/apache/shardingsphere/mcp/feature/shadow/ShadowDescriptorContractTest.java
@@ -18,15 +18,18 @@
 package org.apache.shardingsphere.mcp.feature.shadow;
 
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalog;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogLoader;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ShadowDescriptorContractTest {
     
@@ -41,7 +44,21 @@ class ShadowDescriptorContractTest {
         }
     }
     
+    @Test
+    void assertPromptCompletionArguments() {
+        MCPDescriptorCatalog catalog = MCPDescriptorCatalogLoader.load();
+        assertCompletionTargetArguments(catalog, ShadowFeatureDefinition.PLAN_RULE_PROMPT_NAME, "database", "source_storage_unit", "shadow_storage_unit", "plan_id");
+        assertCompletionTargetArguments(catalog, ShadowFeatureDefinition.PLAN_DEFAULT_ALGORITHM_PROMPT_NAME, "database", "algorithm_type", "plan_id");
+        assertCompletionTargetArguments(catalog, ShadowFeatureDefinition.PLAN_ALGORITHM_CLEANUP_PROMPT_NAME, "database", "plan_id");
+    }
+    
     private MCPToolDescriptor findTool(final MCPDescriptorCatalog catalog, final String toolName) {
         return catalog.getProtocolDescriptors().getToolDescriptors().stream().filter(each -> toolName.equals(each.getName())).findFirst().orElseThrow();
+    }
+    
+    private void assertCompletionTargetArguments(final MCPDescriptorCatalog catalog, final String promptName, final String... expectedArguments) {
+        MCPCompletionTargetDescriptor actual = catalog.getShardingSphereDescriptors().getCompletionTargetDescriptors().stream()
+                .filter(each -> "prompt".equals(each.getReferenceType()) && promptName.equals(each.getReference())).findFirst().orElseThrow();
+        assertTrue(actual.getArguments().containsAll(List.of(expectedArguments)));
     }
 }

--- a/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-sharding.yaml
+++ b/mcp/features/sharding/src/main/resources/META-INF/shardingsphere-mcp/mcp-descriptors/mcp-descriptor-sharding.yaml
@@ -530,34 +530,40 @@ completionTargets:
     arguments:
       - database
       - algorithm_type
+      - plan_id
     maxValues: 50
   - referenceType: prompt
     reference: plan_sharding_table_reference_rule
     arguments:
       - database
+      - plan_id
     maxValues: 50
   - referenceType: prompt
     reference: plan_sharding_default_strategy
     arguments:
       - database
       - algorithm_type
+      - plan_id
     maxValues: 50
   - referenceType: prompt
     reference: plan_sharding_key_generator
     arguments:
       - database
       - key_generator_type
+      - plan_id
     maxValues: 50
   - referenceType: prompt
     reference: plan_sharding_key_generate_strategy
     arguments:
       - database
       - key_generator_type
+      - plan_id
     maxValues: 50
   - referenceType: prompt
     reference: plan_sharding_rule_component_cleanup
     arguments:
       - database
+      - plan_id
     maxValues: 50
 resourceNavigation:
   - from: shardingsphere://features/sharding/algorithm-plugins

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingDescriptorContractTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingDescriptorContractTest.java
@@ -18,15 +18,18 @@
 package org.apache.shardingsphere.mcp.feature.sharding;
 
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
+import org.apache.shardingsphere.mcp.support.descriptor.MCPCompletionTargetDescriptor;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalog;
 import org.apache.shardingsphere.mcp.support.descriptor.MCPDescriptorCatalogLoader;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ShardingDescriptorContractTest {
     
@@ -44,7 +47,24 @@ class ShardingDescriptorContractTest {
         }
     }
     
+    @Test
+    void assertPromptCompletionArguments() {
+        MCPDescriptorCatalog catalog = MCPDescriptorCatalogLoader.load();
+        assertCompletionTargetArguments(catalog, ShardingFeatureDefinition.PLAN_TABLE_RULE_PROMPT_NAME, "database", "algorithm_type", "plan_id");
+        assertCompletionTargetArguments(catalog, ShardingFeatureDefinition.PLAN_TABLE_REFERENCE_PROMPT_NAME, "database", "plan_id");
+        assertCompletionTargetArguments(catalog, ShardingFeatureDefinition.PLAN_DEFAULT_STRATEGY_PROMPT_NAME, "database", "algorithm_type", "plan_id");
+        assertCompletionTargetArguments(catalog, ShardingFeatureDefinition.PLAN_KEY_GENERATOR_PROMPT_NAME, "database", "key_generator_type", "plan_id");
+        assertCompletionTargetArguments(catalog, ShardingFeatureDefinition.PLAN_KEY_GENERATE_STRATEGY_PROMPT_NAME, "database", "key_generator_type", "plan_id");
+        assertCompletionTargetArguments(catalog, ShardingFeatureDefinition.PLAN_COMPONENT_CLEANUP_PROMPT_NAME, "database", "plan_id");
+    }
+    
     private MCPToolDescriptor findTool(final MCPDescriptorCatalog catalog, final String toolName) {
         return catalog.getProtocolDescriptors().getToolDescriptors().stream().filter(each -> toolName.equals(each.getName())).findFirst().orElseThrow();
+    }
+    
+    private void assertCompletionTargetArguments(final MCPDescriptorCatalog catalog, final String promptName, final String... expectedArguments) {
+        MCPCompletionTargetDescriptor actual = catalog.getShardingSphereDescriptors().getCompletionTargetDescriptors().stream()
+                .filter(each -> "prompt".equals(each.getReferenceType()) && promptName.equals(each.getReference())).findFirst().orElseThrow();
+        assertTrue(actual.getArguments().containsAll(List.of(expectedArguments)));
     }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/AbstractHttpProtocolOnlyE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/AbstractHttpProtocolOnlyE2ETest.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.test.e2e.mcp.support.transport.client.MCPHttpTr
 import org.junit.jupiter.api.AfterEach;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
@@ -92,6 +93,12 @@ abstract class AbstractHttpProtocolOnlyE2ETest {
         return MCPHttpTransportTestSupport.sendJsonRpcRequest(httpClient, getEndpointUri(), headers, "resource-1", "resources/read", Map.of("uri", "shardingsphere://capabilities"));
     }
     
+    protected final HttpResponse<String> sendToolCallRequest(final HttpClient httpClient, final String sessionId,
+                                                             final String toolName, final Map<String, Object> arguments) throws IOException, InterruptedException {
+        return MCPHttpTransportTestSupport.sendJsonRpcRequest(httpClient, getEndpointUri(), createSessionHeaders(sessionId), toolName + "-1", "tools/call",
+                Map.of("name", toolName, "arguments", arguments));
+    }
+    
     protected final HttpResponse<String> sendDeleteRequest(final HttpClient httpClient, final Map<String, String> headers) throws IOException, InterruptedException {
         return MCPHttpTransportTestSupport.sendDeleteRequest(httpClient, getEndpointUri(), headers);
     }
@@ -103,6 +110,10 @@ abstract class AbstractHttpProtocolOnlyE2ETest {
     
     protected final HttpResponse<String> openEventStream(final HttpClient httpClient, final Map<String, String> headers) throws IOException, InterruptedException {
         return MCPHttpTransportTestSupport.openEventStream(httpClient, getEndpointUri(), headers);
+    }
+    
+    protected final HttpResponse<InputStream> openEventStreamInputStream(final HttpClient httpClient, final Map<String, String> headers) throws IOException, InterruptedException {
+        return MCPHttpTransportTestSupport.openEventStreamInputStream(httpClient, getEndpointUri(), headers);
     }
     
     protected final Map<String, Object> parseJsonBody(final String responseBody) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportProtocolContractE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/HttpTransportProtocolContractE2ETest.java
@@ -17,10 +17,12 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.runtime.programmatic;
 
+import org.apache.shardingsphere.mcp.support.security.MCPClientSafetyPolicy;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.client.MCPHttpTransportTestSupport;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -85,6 +87,65 @@ class HttpTransportProtocolContractE2ETest extends AbstractHttpProtocolOnlyE2ETe
     }
     
     @Test
+    void assertRejectUnsupportedActiveEventStream() throws IOException, InterruptedException {
+        launchHttpTransport();
+        HttpClient httpClient = HttpClient.newHttpClient();
+        String sessionId = initializeSession(httpClient);
+        Map<String, String> headers = new LinkedHashMap<>(createSessionHeaders(sessionId));
+        headers.put("Accept", "text/event-stream");
+        HttpResponse<InputStream> actual = openEventStreamInputStream(httpClient, headers);
+        try (InputStream ignored = actual.body()) {
+            assertThat(actual.statusCode(), is(405));
+        }
+    }
+    
+    @Test
+    void assertReturnToolErrorForInvalidIntegerArgument() throws IOException, InterruptedException {
+        launchHttpTransport();
+        HttpClient httpClient = HttpClient.newHttpClient();
+        String sessionId = initializeSession(httpClient);
+        HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_update", createInvalidUpdateArguments());
+        Map<String, Object> actualRecovery = assertToolErrorRecovery(actual, "invalid_integer_argument");
+        assertThat(actualRecovery.get("argument_path"), is("max_rows"));
+        assertThat(actualRecovery.get("minimum_value"), is(0));
+        assertThat(actualRecovery.get("maximum_value"), is(5000));
+        assertThat(actualRecovery.get("suggested_value"), is(100));
+    }
+    
+    @Test
+    void assertReturnToolErrorForSchemaAdditionalProperties() throws IOException, InterruptedException {
+        launchHttpTransport();
+        HttpClient httpClient = HttpClient.newHttpClient();
+        String sessionId = initializeSession(httpClient);
+        HttpResponse<String> actual = sendToolCallRequest(httpClient, sessionId, "database_gateway_plan_readwrite_splitting_rule",
+                Map.of("load_balancer_properties", Map.of("weight", 1)));
+        Map<String, Object> actualRecovery = assertToolErrorRecovery(actual, "invalid_argument_type");
+        assertThat(actualRecovery.get("argument_path"), is("load_balancer_properties.weight"));
+        assertThat(actualRecovery.get("expected_type"), is("string"));
+    }
+    
+    @Test
+    void assertEnforceToolCallLimitPerSession() throws IOException, InterruptedException {
+        String propertyName = MCPClientSafetyPolicy.MAX_TOOL_CALLS_PER_SESSION_PROPERTY;
+        String originalValue = System.getProperty(propertyName);
+        System.setProperty(propertyName, "1");
+        try {
+            launchHttpTransport();
+            HttpClient httpClient = HttpClient.newHttpClient();
+            String sessionId = initializeSession(httpClient);
+            assertToolErrorRecovery(sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_update", createInvalidUpdateArguments()), "invalid_integer_argument");
+            Map<String, Object> actualRecovery = assertToolErrorRecovery(
+                    sendToolCallRequest(httpClient, sessionId, "database_gateway_execute_update", createInvalidUpdateArguments()), "tool_call_limit_exceeded");
+            assertThat(actualRecovery.get("session_id"), is(sessionId));
+            assertThat(actualRecovery.get("max_tool_calls_per_session"), is(1));
+            String otherSessionId = initializeSession(httpClient);
+            assertToolErrorRecovery(sendToolCallRequest(httpClient, otherSessionId, "database_gateway_execute_update", createInvalidUpdateArguments()), "invalid_integer_argument");
+        } finally {
+            restoreProperty(propertyName, originalValue);
+        }
+    }
+    
+    @Test
     void assertAcceptInitializeWithUnsupportedProtocolVersion() throws IOException, InterruptedException {
         launchHttpTransport();
         HttpClient httpClient = HttpClient.newHttpClient();
@@ -137,5 +198,28 @@ class HttpTransportProtocolContractE2ETest extends AbstractHttpProtocolOnlyE2ETe
         assertThat(deleteResponse.statusCode(), is(200));
         assertThat(actual.statusCode(), is(404));
         assertThat(String.valueOf(parseJsonBody(actual.body()).get("message")), is("Session not found: " + sessionId));
+    }
+    
+    private Map<String, Object> assertToolErrorRecovery(final HttpResponse<String> response, final String expectedCategory) {
+        assertThat(response.statusCode(), is(200));
+        Map<String, Object> result = castToMap(parseJsonBody(response.body()).get("result"));
+        assertTrue((boolean) result.get("isError"));
+        Map<String, Object> structuredContent = castToMap(result.get("structuredContent"));
+        assertThat(structuredContent.get("response_mode"), is("recovery"));
+        Map<String, Object> actualRecovery = castToMap(structuredContent.get("recovery"));
+        assertThat(actualRecovery.get("category"), is(expectedCategory));
+        return actualRecovery;
+    }
+    
+    private Map<String, Object> createInvalidUpdateArguments() {
+        return Map.of("database", "logic_db", "sql", "UPDATE orders SET status = 'PAID' WHERE order_id = 1", "execution_mode", "preview", "max_rows", 5001);
+    }
+    
+    private void restoreProperty(final String propertyName, final String originalValue) {
+        if (null == originalValue) {
+            System.clearProperty(propertyName);
+        } else {
+            System.setProperty(propertyName, originalValue);
+        }
     }
 }

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/MCPHttpTransportTestSupport.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/MCPHttpTransportTestSupport.java
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.MCPInteractionProtocolSupport;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -129,6 +130,23 @@ public final class MCPHttpTransportTestSupport {
         HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(endpointUri).GET();
         applyHeaders(requestBuilder, headers);
         return httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+    
+    /**
+     * Open an event stream without waiting for the whole response body.
+     *
+     * @param httpClient HTTP client
+     * @param endpointUri MCP endpoint URI
+     * @param headers request headers
+     * @return HTTP response
+     * @throws IOException I/O exception
+     * @throws InterruptedException interrupted exception
+     */
+    public static HttpResponse<InputStream> openEventStreamInputStream(final HttpClient httpClient, final URI endpointUri,
+                                                                       final Map<String, String> headers) throws IOException, InterruptedException {
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(endpointUri).GET();
+        applyHeaders(requestBuilder, headers);
+        return httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
     }
     
     /**


### PR DESCRIPTION
- Validate integer bounds and schema-valued additionalProperties in MCP tool arguments
- Apply execution argument validation to execute_update preview mode
- Return explicit 405 for unsupported Streamable HTTP GET event streams
- Add focused unit and E2E coverage for tool errors, rate limits, and HTTP transport contracts