### PR TITLE
Refine MCP HTTP auth boundary wording

### DIFF
--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/security/MCPClientSafetyPolicy.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/security/MCPClientSafetyPolicy.java
@@ -52,7 +52,7 @@ public final class MCPClientSafetyPolicy {
         result.put("identity_scope", "mcp_session");
         result.put("transport_scope",
                 "HTTP transport can bind trusted session attribution when configured; "
-                        + "authentication and authorization remain outside the runtime in this release. "
+                        + "the MCP runtime does not provide built-in authentication or authorization. "
                         + "STDIO inherits the local process boundary.");
         result.put("tool_call_limit", MCPRuntimeProtectionPolicy.createToolCallLimitPayload());
         result.put("runtime_protection", MCPRuntimeProtectionPolicy.createRuntimeProtectionPayload());

--- a/test/e2e/mcp/src/test/resources/baseline-contract/model-contract/guidance.yaml
+++ b/test/e2e/mcp/src/test/resources/baseline-contract/model-contract/guidance.yaml
@@ -207,7 +207,7 @@ security_hints:
   client_safety_policy:
     identity_scope: mcp_session
     transport_scope: HTTP transport can bind trusted session attribution when configured;
-      authentication and authorization remain outside the runtime in this release.
+      the MCP runtime does not provide built-in authentication or authorization.
       STDIO inherits the local process boundary.
     tool_call_limit: {scope: session, max_calls: 10000, property: shardingsphere.mcp.maxToolCallsPerSession,
       recovery: Close and recreate the MCP session after the quota is exhausted.}

--- a/test/e2e/mcp/src/test/resources/llm/evaluation/mcp-builder-evaluation.xml
+++ b/test/e2e/mcp/src/test/resources/llm/evaluation/mcp-builder-evaluation.xml
@@ -193,13 +193,13 @@
     </question>
     <answer>no_builtin_auth|origin_403|gateway_auth_boundary</answer>
     <expected_answer>
-      The built-in ShardingSphere MCP HTTP runtime does not provide authorization in this release; transport.type only selects the active
+      The built-in ShardingSphere MCP HTTP runtime does not provide authentication or authorization; transport.type only selects the active
       transport, and bindHost controls the listener address. Missing Origin is accepted for non-browser clients, but any present Origin on a
       non-loopback binding is rejected with 403. Authentication and authorization must be enforced by the trusted network, reverse proxy, or
       gateway, and the answer should not invent OAuth or token YAML fields.
     </expected_answer>
     <verification>
-      <step>Confirm the answer says built-in Streamable HTTP authorization is absent in this release.</step>
+      <step>Confirm the answer says built-in Streamable HTTP authentication and authorization are absent.</step>
       <step>Confirm the answer states present Origin headers are rejected for non-loopback bindings.</step>
       <step>Confirm the answer places authentication at a trusted gateway or network boundary.</step>
     </verification>


### PR DESCRIPTION
- remove release-bound phrasing from MCP client safety guidance
- keep baseline contract and LLM evaluation text aligned with the stable no-built-in-auth boundary