### PR TITLE
Refine MCP elicitation wording and CI feature coverage

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -52,7 +52,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          MCP_MODULES=mcp/api,mcp/support,mcp/core,mcp/features/encrypt,mcp/features/mask
+          MCP_MODULES=mcp/api,mcp/support,mcp/core,mcp/features/broadcast,mcp/features/encrypt,mcp/features/mask
+          MCP_MODULES="${MCP_MODULES},mcp/features/readwrite-splitting,mcp/features/shadow,mcp/features/sharding"
           MCP_MODULES="${MCP_MODULES},mcp/bootstrap,mcp/registry"
           ./mvnw -pl "${MCP_MODULES}" -am install \
             -DskipITs -Dspotless.skip=true \

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPToolElicitationFallbackResponseFactory.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPToolElicitationFallbackResponseFactory.java
@@ -91,7 +91,7 @@ public final class MCPToolElicitationFallbackResponseFactory {
         result.put("order", 1);
         result.put("type", "terminal");
         result.put("title", "Collect sensitive inputs through configured secure channels.");
-        result.put(MCPPayloadFieldNames.REASON, "MCP form elicitation is limited to non-sensitive STDIO continuations; URL mode is not implemented in this release.");
+        result.put(MCPPayloadFieldNames.REASON, "MCP form elicitation is limited to non-sensitive STDIO continuations; URL mode is not implemented by the MCP runtime.");
         return List.of(result);
     }
     

--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPToolElicitationFallbackResponseFactoryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/transport/capability/tool/MCPToolElicitationFallbackResponseFactoryTest.java
@@ -66,7 +66,10 @@ class MCPToolElicitationFallbackResponseFactoryTest extends AbstractMCPToolSpeci
         assertTrue((boolean) actualQuestion.get(MCPPayloadFieldNames.SECRET));
         assertThat(actualQuestion.get(MCPPayloadFieldNames.MESSAGE), is("Sensitive input must be provided through configured secure channels before continuing the same planner."));
         assertFalse(actualQuestion.containsKey(MCPPayloadFieldNames.DISPLAY_MESSAGE));
-        assertThat(((Map<?, ?>) ((List<?>) actualPayload.get(MCPPayloadFieldNames.NEXT_ACTIONS)).get(0)).get("type"), is("terminal"));
+        Map<?, ?> actualNextAction = (Map<?, ?>) ((List<?>) actualPayload.get(MCPPayloadFieldNames.NEXT_ACTIONS)).get(0);
+        assertThat(actualNextAction.get("type"), is("terminal"));
+        assertThat(actualNextAction.get(MCPPayloadFieldNames.REASON),
+                is("MCP form elicitation is limited to non-sensitive STDIO continuations; URL mode is not implemented by the MCP runtime."));
         assertFalse(String.valueOf(actualPayload).contains("Provide access token."));
     }
     


### PR DESCRIPTION
Stabilize the model-facing elicitation fallback reason by removing release-scoped wording and add a focused assertion for the emitted next action reason.

Expand the MCP CI module list so all MCP feature modules run in the pull request unit-test workflow.
