### PR TITLE
Use Lombok for boilerplate accessors

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierIndex.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierIndex.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.infra.metadata.identifier;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
@@ -325,6 +327,7 @@ public final class IdentifierIndex<T> {
         return snapshot.getExactValues().toString();
     }
     
+    @Getter(AccessLevel.PRIVATE)
     private static final class Snapshot<T> {
         
         private static final Snapshot<?> EMPTY = new Snapshot<>(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
@@ -345,32 +348,25 @@ public final class IdentifierIndex<T> {
         private static <T> Snapshot<T> empty() {
             return (Snapshot<T>) EMPTY;
         }
-        
-        private Map<String, T> getExactValues() {
-            return exactValues;
-        }
-        
-        private Map<String, Collection<String>> getNormalizedIdentifierNames() {
-            return normalizedIdentifierNames;
-        }
-        
-        private Map<String, NormalizedBucket<T>> getNormalizedBuckets() {
-            return normalizedBuckets;
-        }
     }
     
     private static final class NormalizedBucket<T> {
         
+        @Getter(AccessLevel.PRIVATE)
         private final String singleIdentifier;
         
+        @Getter(AccessLevel.PRIVATE)
         private final T singleValue;
         
+        @Getter(AccessLevel.PRIVATE)
         private final Collection<String> identifiers;
         
         private final String singleUnquotedIdentifier;
         
+        @Getter(AccessLevel.PRIVATE)
         private final T singleUnquotedValue;
         
+        @Getter(AccessLevel.PRIVATE)
         private final Collection<String> unquotedIdentifiers;
         
         private NormalizedBucket(final String singleIdentifier, final T singleValue, final Collection<String> identifiers,
@@ -387,32 +383,12 @@ public final class IdentifierIndex<T> {
             return null != singleIdentifier;
         }
         
-        private String getSingleIdentifier() {
-            return singleIdentifier;
-        }
-        
-        private T getSingleValue() {
-            return singleValue;
-        }
-        
-        private Collection<String> getIdentifiers() {
-            return identifiers;
-        }
-        
         private boolean hasUnquotedIdentifier() {
             return null != singleUnquotedIdentifier;
         }
         
         private boolean hasSingleUnquotedIdentifier() {
             return null == unquotedIdentifiers && null != singleUnquotedIdentifier;
-        }
-        
-        private T getSingleUnquotedValue() {
-            return singleUnquotedValue;
-        }
-        
-        private Collection<String> getUnquotedIdentifiers() {
-            return unquotedIdentifiers;
         }
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/rule/builder/fixture/ToggleFixtureDatabaseRuleConfiguration.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/rule/builder/fixture/ToggleFixtureDatabaseRuleConfiguration.java
@@ -17,18 +17,16 @@
 
 package org.apache.shardingsphere.infra.rule.builder.fixture;
 
+import lombok.Getter;
 import org.apache.shardingsphere.infra.config.rule.scope.DatabaseRuleConfiguration;
 import org.apache.shardingsphere.infra.config.rule.function.EnhancedRuleConfiguration;
 
 public final class ToggleFixtureDatabaseRuleConfiguration implements DatabaseRuleConfiguration, EnhancedRuleConfiguration {
     
+    @Getter
     private final boolean empty;
     
     public ToggleFixtureDatabaseRuleConfiguration(final boolean empty) {
         this.empty = empty;
-    }
-    
-    public boolean isEmpty() {
-        return empty;
     }
 }

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/CoreResourceHandlerSurfaceTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/resource/handler/CoreResourceHandlerSurfaceTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mcp.core.resource.handler;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.api.MCPHandlerContext;
 import org.apache.shardingsphere.mcp.api.protocol.exception.MCPUnsupportedException;
@@ -392,41 +393,23 @@ class CoreResourceHandlerSurfaceTest {
         
         private final String description;
         
+        @Getter(AccessLevel.PRIVATE)
         private final MCPResourceHandler<?> handler;
         
+        @Getter(AccessLevel.PRIVATE)
         private final String expectedUriTemplate;
         
+        @Getter(AccessLevel.PRIVATE)
         private final String resourceUri;
         
+        @Getter(AccessLevel.PRIVATE)
         private final HandlerResultType expectedType;
         
+        @Getter(AccessLevel.PRIVATE)
         private final String expectedDatabase;
         
+        @Getter(AccessLevel.PRIVATE)
         private final List<String> expectedObjectNames;
-        
-        private MCPResourceHandler<?> getHandler() {
-            return handler;
-        }
-        
-        private String getExpectedUriTemplate() {
-            return expectedUriTemplate;
-        }
-        
-        private String getResourceUri() {
-            return resourceUri;
-        }
-        
-        private HandlerResultType getExpectedType() {
-            return expectedType;
-        }
-        
-        private String getExpectedDatabase() {
-            return expectedDatabase;
-        }
-        
-        private List<String> getExpectedObjectNames() {
-            return expectedObjectNames;
-        }
         
         @Override
         public String toString() {

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/AbstractShardingResourceHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/AbstractShardingResourceHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.resource.handler;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
@@ -33,6 +35,7 @@ abstract class AbstractShardingResourceHandler implements MCPResourceHandler<MCP
     
     private final String resourceUriTemplate;
     
+    @Getter(AccessLevel.PROTECTED)
     private final ShardingInspectionService inspectionService;
     
     AbstractShardingResourceHandler(final String resourceUriTemplate, final ShardingInspectionService inspectionService) {
@@ -54,10 +57,6 @@ abstract class AbstractShardingResourceHandler implements MCPResourceHandler<MCP
     public MCPResponse handle(final MCPDatabaseHandlerContext databaseContext, final MCPUriVariables uriVariables) {
         return new MCPItemsResponse(query(databaseContext, uriVariables),
                 MCPResourceNavigationPayloadBuilder.create(MCPDescriptorCatalogIndex.getRequiredResourceDescriptor(getResourceUriTemplate()), uriVariables));
-    }
-    
-    protected ShardingInspectionService getInspectionService() {
-        return inspectionService;
     }
     
     protected abstract List<Map<String, Object>> query(MCPDatabaseHandlerContext databaseContext, MCPUriVariables uriVariables);

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowLifecycleSpec.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingWorkflowLifecycleSpec.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.workflow.model.RuleArtifact;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
@@ -25,6 +27,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+@Getter(AccessLevel.PACKAGE)
 final class ShardingWorkflowLifecycleSpec {
     
     private final WorkflowKind workflowKind;
@@ -54,31 +57,4 @@ final class ShardingWorkflowLifecycleSpec {
         this.artifactSupplier = artifactSupplier;
     }
     
-    WorkflowKind getWorkflowKind() {
-        return workflowKind;
-    }
-    
-    String getDefaultOperationType() {
-        return defaultOperationType;
-    }
-    
-    String getSummary() {
-        return summary;
-    }
-    
-    Function<ShardingWorkflowRequest, Boolean> getExistsSupplier() {
-        return existsSupplier;
-    }
-    
-    Function<ShardingWorkflowRequest, Boolean> getRequiredInputSupplier() {
-        return requiredInputSupplier;
-    }
-    
-    BiFunction<ShardingWorkflowRequest, WorkflowContextSnapshot, Boolean> getAlgorithmPlanSupplier() {
-        return algorithmPlanSupplier;
-    }
-    
-    Function<ShardingWorkflowRequest, RuleArtifact> getArtifactSupplier() {
-        return artifactSupplier;
-    }
 }

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/AbstractMCPJdbcMetadataLoaderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/AbstractMCPJdbcMetadataLoaderTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mcp.support.database.metadata.jdbc;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory;
 import org.apache.shardingsphere.mcp.support.database.capability.SupportedMCPMetadataObjectType;
@@ -373,16 +374,13 @@ abstract class AbstractMCPJdbcMetadataLoaderTest {
     }
     
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter(AccessLevel.PROTECTED)
     protected static final class LoadedMetadataCatalog {
         
         private final Map<String, MCPDatabaseMetadata> databaseMetadataMap;
         
         protected Optional<MCPDatabaseMetadata> findMetadata(final String databaseName) {
             return Optional.ofNullable(databaseMetadataMap.get(databaseName));
-        }
-        
-        protected Map<String, MCPDatabaseMetadata> getDatabaseMetadataMap() {
-            return databaseMetadataMap;
         }
     }
     

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/CreateViewPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/CreateViewPushDownMetaDataRefresherTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mode.metadata.refresher.pushdown.type.view;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
@@ -242,10 +244,13 @@ class CreateViewPushDownMetaDataRefresherTest {
     
     private static final class RecordingMetaDataManagerPersistService implements MetaDataManagerPersistService {
         
+        @Getter(AccessLevel.PRIVATE)
         private boolean alterSingleRuleConfigurationCalled;
         
+        @Getter(AccessLevel.PRIVATE)
         private ShardingSphereDatabase alterSingleRuleConfigurationDatabase;
         
+        @Getter(AccessLevel.PRIVATE)
         private RuleMetaData alterSingleRuleConfigurationRuleMetaData;
         
         @Override
@@ -341,18 +346,6 @@ class CreateViewPushDownMetaDataRefresherTest {
         @Override
         public void alterProperties(final Properties props) {
             throw new UnsupportedOperationException();
-        }
-        
-        private boolean isAlterSingleRuleConfigurationCalled() {
-            return alterSingleRuleConfigurationCalled;
-        }
-        
-        private ShardingSphereDatabase getAlterSingleRuleConfigurationDatabase() {
-            return alterSingleRuleConfigurationDatabase;
-        }
-        
-        private RuleMetaData getAlterSingleRuleConfigurationRuleMetaData() {
-            return alterSingleRuleConfigurationRuleMetaData;
         }
     }
 }

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/ddl/partition/AddPartitionDefinitionSegment.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/ddl/partition/AddPartitionDefinitionSegment.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.partitio
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dal.PartitionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.AlterDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.property.PropertiesSegment;
@@ -31,6 +32,7 @@ import java.util.Optional;
  */
 @RequiredArgsConstructor
 @Getter
+@Setter
 public final class AddPartitionDefinitionSegment implements AlterDefinitionSegment {
     
     private final int startIndex;
@@ -48,30 +50,12 @@ public final class AddPartitionDefinitionSegment implements AlterDefinitionSegme
     private Integer buckets;
     
     /**
-     * Set partition values.
-     *
-     * @param partitionValues partition values
-     */
-    public void setPartitionValues(final PartitionValuesSegment partitionValues) {
-        this.partitionValues = partitionValues;
-    }
-    
-    /**
      * Get partition values.
      *
      * @return partition values
      */
     public Optional<PartitionValuesSegment> getPartitionValues() {
         return Optional.ofNullable(partitionValues);
-    }
-    
-    /**
-     * Set properties.
-     *
-     * @param properties properties
-     */
-    public void setProperties(final PropertiesSegment properties) {
-        this.properties = properties;
     }
     
     /**
@@ -84,30 +68,12 @@ public final class AddPartitionDefinitionSegment implements AlterDefinitionSegme
     }
     
     /**
-     * Set distributed column.
-     *
-     * @param distributedColumn distributed column
-     */
-    public void setDistributedColumn(final ColumnSegment distributedColumn) {
-        this.distributedColumn = distributedColumn;
-    }
-    
-    /**
      * Get distributed column.
      *
      * @return distributed column
      */
     public Optional<ColumnSegment> getDistributedColumn() {
         return Optional.ofNullable(distributedColumn);
-    }
-    
-    /**
-     * Set buckets.
-     *
-     * @param buckets buckets
-     */
-    public void setBuckets(final Integer buckets) {
-        this.buckets = buckets;
     }
     
     /**

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/value/literal/impl/DateTimeLiteralValue.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/value/literal/impl/DateTimeLiteralValue.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sql.parser.statement.core.value.literal.impl;
 
+import lombok.Getter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.sql.parser.statement.core.value.literal.LiteralValue;
 
@@ -27,6 +28,7 @@ public final class DateTimeLiteralValue implements LiteralValue<String> {
     
     private final String dateTimeType;
     
+    @Getter
     private final String dateTimeValue;
     
     private final QuoteCharacter quoteCharacter;
@@ -46,12 +48,4 @@ public final class DateTimeLiteralValue implements LiteralValue<String> {
         return containsBrace ? "{" + dateTimeType + " " + quotedDateTimeValue + "}" : dateTimeType + " " + quotedDateTimeValue;
     }
     
-    /**
-     * Get date time value.
-     *
-     * @return date time value
-     */
-    public String getDateTimeValue() {
-        return dateTimeValue;
-    }
 }

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/upload/FirebirdBlobUpload.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/upload/FirebirdBlobUpload.java
@@ -56,10 +56,6 @@ public final class FirebirdBlobUpload {
         return buffer.toByteArray();
     }
     
-    public boolean isClosed() {
-        return closed;
-    }
-    
     /**
      * Mark this BLOB upload as closed.
      */

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationArtifacts.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationArtifacts.java
@@ -18,7 +18,9 @@
 package org.apache.shardingsphere.test.e2e.mcp.llm.conversation;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.apache.shardingsphere.test.e2e.mcp.llm.conversation.artifact.LLME2EArtifactBundle;
 import org.apache.shardingsphere.test.e2e.mcp.llm.conversation.artifact.LLME2EAssertionReport;
 import org.apache.shardingsphere.test.e2e.mcp.llm.scenario.LLME2EScenario;
@@ -36,10 +38,13 @@ final class LLMMCPConversationArtifacts {
     
     private final List<String> rawModelOutputs = new LinkedList<>();
     
+    @Getter(AccessLevel.PACKAGE)
     private final List<MCPInteractionTraceRecord> interactionTrace = new LinkedList<>();
     
     private final List<String> mcpRuntimeLogLines = new LinkedList<>();
     
+    @Getter(AccessLevel.PACKAGE)
+    @Setter(AccessLevel.PACKAGE)
     private String finalAnswerJson = "";
     
     void addRawModelOutput(final String rawModelOutput) {
@@ -54,20 +59,8 @@ final class LLMMCPConversationArtifacts {
         mcpRuntimeLogLines.add(runtimeLogLine);
     }
     
-    List<MCPInteractionTraceRecord> getInteractionTrace() {
-        return interactionTrace;
-    }
-    
     int nextSequence() {
         return interactionTrace.size() + 1;
-    }
-    
-    String getFinalAnswerJson() {
-        return finalAnswerJson;
-    }
-    
-    void setFinalAnswerJson(final String finalAnswerJson) {
-        this.finalAnswerJson = finalAnswerJson;
     }
     
     LLME2EArtifactBundle createArtifactBundle(final LLME2EScenario scenario, final LLME2EAssertionReport assertionReport) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionMySQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionMySQLRuntimeE2ETest.java
@@ -20,6 +20,8 @@ package org.apache.shardingsphere.test.e2e.mcp.runtime.production;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
 import org.apache.shardingsphere.test.e2e.mcp.env.MCPE2ECondition;
 import org.apache.shardingsphere.test.e2e.mcp.support.OfficialMCPToolNames;
@@ -59,19 +61,13 @@ abstract class AbstractProductionMySQLRuntimeE2ETest extends AbstractTransportPa
     
     protected static final String MASK_PLAN_TOOL_NAME = "database_gateway_plan_mask_rule";
     
+    @Getter(AccessLevel.PROTECTED)
     private GenericContainer<?> container;
     
+    @Getter(AccessLevel.PROTECTED)
     private String physicalSchemaName;
     
     private MySQLRuntimeFixture sharedRuntimeFixture;
-    
-    protected GenericContainer<?> getContainer() {
-        return container;
-    }
-    
-    protected String getPhysicalSchemaName() {
-        return physicalSchemaName;
-    }
     
     @AfterEach
     void tearDownContainer() {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/runtime/ReadinessProbe.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/runtime/ReadinessProbe.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.test.e2e.mcp.support.runtime;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.function.LongSupplier;
@@ -162,6 +163,7 @@ public final class ReadinessProbe {
      * @param <T> ready value type
      */
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter(AccessLevel.PRIVATE)
     public static final class ReadinessResult<T> {
         
         private final T value;
@@ -203,22 +205,6 @@ public final class ReadinessProbe {
          */
         public static <T> ReadinessResult<T> failed(final Exception failure) {
             return new ReadinessResult<>(null, failure, false, true);
-        }
-        
-        private T getValue() {
-            return value;
-        }
-        
-        private Exception getFailure() {
-            return failure;
-        }
-        
-        private boolean isReady() {
-            return ready;
-        }
-        
-        private boolean isFailed() {
-            return failed;
         }
     }
 }

--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/sql/env/DataSetEnvironmentManager.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/sql/env/DataSetEnvironmentManager.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.sql.env;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.sqlbatch.DialectSQLBatchOption;
@@ -308,35 +310,21 @@ public final class DataSetEnvironmentManager {
     }
     
     @RequiredArgsConstructor
+    @Getter(AccessLevel.PRIVATE)
     private static final class ResetPlan {
         
         private final Map<DataNode, InsertDataNodePlan> insertDataNodePlans;
         
         private final Map<String, Collection<String>> tableNamesByDataSourceName;
-        
-        private Map<DataNode, InsertDataNodePlan> getInsertDataNodePlans() {
-            return insertDataNodePlans;
-        }
-        
-        private Map<String, Collection<String>> getTableNamesByDataSourceName() {
-            return tableNamesByDataSourceName;
-        }
     }
     
     @RequiredArgsConstructor
+    @Getter(AccessLevel.PRIVATE)
     private static final class InsertDataNodePlan {
         
         private final Collection<DataSetColumn> columnMetaData;
         
         private final Collection<SQLValueGroup> sqlValueGroups = new LinkedList<>();
-        
-        private Collection<DataSetColumn> getColumnMetaData() {
-            return columnMetaData;
-        }
-        
-        private Collection<SQLValueGroup> getSqlValueGroups() {
-            return sqlValueGroups;
-        }
         
         private void addSQLValueGroup(final SQLValueGroup sqlValueGroup) {
             sqlValueGroups.add(sqlValueGroup);


### PR DESCRIPTION
Replace hand-written getter and setter methods with narrow Lombok annotations in non-agent modules. Keep the final session getter manual because Lombok cannot preserve its final method signature.