### PR TITLE
Refactor constructors to use Lombok

### DIFF
--- a/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProviderTest.java
+++ b/database/connector/dialect/mysql/src/test/java/org/apache/shardingsphere/database/connector/mysql/metadata/identifier/MySQLIdentifierCasePolicyProviderTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.database.connector.mysql.metadata.identifier;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicyProvider;
@@ -63,7 +65,7 @@ class MySQLIdentifierCasePolicyProviderTest {
     }
     
     @Test
-    void assertProvideWithQuotedTableName() throws SQLException {
+    void assertProvideWithQuotedTableName() {
         IdentifierCasePolicy actual = provider.provide(new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FixtureDataSource(true, 1)))
                 .map(policySet -> policySet.getPolicy(IdentifierScope.TABLE)).orElseThrow(AssertionError::new);
         assertThat(actual.getLookupMode(QuoteCharacter.BACK_QUOTE), is(LookupMode.NORMALIZED));
@@ -86,7 +88,7 @@ class MySQLIdentifierCasePolicyProviderTest {
         }
     }
     
-    private static Stream<Arguments> provideArguments() throws SQLException {
+    private static Stream<Arguments> provideArguments() {
         return Stream.of(
                 Arguments.of("null_data_source", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, null), null, null, null),
                 Arguments.of("null_connection", new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new NullConnectionFixtureDataSource()), null, null, null),
@@ -101,7 +103,7 @@ class MySQLIdentifierCasePolicyProviderTest {
     }
     
     @Test
-    void assertProvideWithLowerCaseTableNamesZeroUsesScopedPolicies() throws SQLException {
+    void assertProvideWithLowerCaseTableNamesZeroUsesScopedPolicies() {
         IdentifierCasePolicyProviderContext context = new IdentifierCasePolicyProviderContext(DATABASE_TYPE, new FixtureDataSource(true, 0));
         IdentifierCasePolicySet actual = provider.provide(context).orElseThrow(AssertionError::new);
         assertThat(actual.getPolicy(IdentifierScope.SCHEMA).matches("foo_schema", "FOO_SCHEMA", QuoteCharacter.NONE), is(Boolean.TRUE));
@@ -142,16 +144,12 @@ class MySQLIdentifierCasePolicyProviderTest {
         return null;
     }
     
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class FixtureDataSource implements DataSource {
         
         private final boolean hasResultSetRow;
         
         private final int lowerCaseTableNames;
-        
-        private FixtureDataSource(final boolean hasResultSetRow, final int lowerCaseTableNames) {
-            this.hasResultSetRow = hasResultSetRow;
-            this.lowerCaseTableNames = lowerCaseTableNames;
-        }
         
         @Override
         public Connection getConnection() {

--- a/database/protocol/dialect/firebird/src/main/java/org/apache/shardingsphere/database/protocol/firebird/packet/command/query/batch/FirebirdBatchStatement.java
+++ b/database/protocol/dialect/firebird/src/main/java/org/apache/shardingsphere/database/protocol/firebird/packet/command/query/batch/FirebirdBatchStatement.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.database.protocol.firebird.packet.command.query.batch;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.List;
  * Firebird batch statement metadata.
  */
 @Getter
+@RequiredArgsConstructor
 public final class FirebirdBatchStatement {
     
     private final int statementHandle;
@@ -46,13 +48,6 @@ public final class FirebirdBatchStatement {
     
     public FirebirdBatchStatement(final int statementHandle, final List<FirebirdBatchColumnDescriptor> columnDescriptors, final long bufferSize) {
         this(statementHandle, columnDescriptors, bufferSize, false);
-    }
-    
-    public FirebirdBatchStatement(final int statementHandle, final List<FirebirdBatchColumnDescriptor> columnDescriptors, final long bufferSize, final boolean recordCounts) {
-        this.statementHandle = statementHandle;
-        this.columnDescriptors = columnDescriptors;
-        this.bufferSize = bufferSize;
-        this.recordCounts = recordCounts;
     }
     
     /**

--- a/database/protocol/dialect/firebird/src/main/java/org/apache/shardingsphere/database/protocol/firebird/packet/command/query/batch/FirebirdParseBatchBlr.java
+++ b/database/protocol/dialect/firebird/src/main/java/org/apache/shardingsphere/database/protocol/firebird/packet/command/query/batch/FirebirdParseBatchBlr.java
@@ -18,6 +18,8 @@
 package org.apache.shardingsphere.database.protocol.firebird.packet.command.query.batch;
 
 import io.netty.buffer.ByteBuf;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.database.protocol.firebird.exception.FirebirdProtocolException;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.FirebirdBinaryColumnType;
@@ -30,6 +32,7 @@ import java.util.List;
  * Firebird batch message format parser, port of {@code PARSE_msg_format} / {@code parse_format} from Firebird {@code parser.cpp}.
  */
 @Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public final class FirebirdParseBatchBlr {
     
     private static final int HEADER_LENGTH = 4;
@@ -39,12 +42,6 @@ public final class FirebirdParseBatchBlr {
     private final int messageLength;
     
     private final int netLength;
-    
-    private FirebirdParseBatchBlr(final List<FirebirdBatchColumnDescriptor> fields, final int messageLength, final int netLength) {
-        this.fields = fields;
-        this.messageLength = messageLength;
-        this.netLength = netLength;
-    }
     
     /**
      * Parse a BLR message buffer into its message format and validate that every field is supported.

--- a/database/protocol/dialect/firebird/src/main/java/org/apache/shardingsphere/database/protocol/firebird/packet/command/query/statement/FirebirdBlrRowMetadata.java
+++ b/database/protocol/dialect/firebird/src/main/java/org/apache/shardingsphere/database/protocol/firebird/packet/command/query/statement/FirebirdBlrRowMetadata.java
@@ -18,6 +18,8 @@
 package org.apache.shardingsphere.database.protocol.firebird.packet.command.query.statement;
 
 import io.netty.buffer.ByteBuf;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.database.protocol.firebird.packet.command.query.FirebirdBinaryColumnType;
 import org.firebirdsql.gds.BlrConstants;
@@ -29,6 +31,7 @@ import java.util.List;
  * Firebird BLR row metadata.
  */
 @Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public final class FirebirdBlrRowMetadata {
     
     private final ByteBuf blr;
@@ -36,12 +39,6 @@ public final class FirebirdBlrRowMetadata {
     private final int length;
     
     private final List<FirebirdBinaryColumnType> columnTypes;
-    
-    private FirebirdBlrRowMetadata(final ByteBuf blr, final int length, final List<FirebirdBinaryColumnType> columnTypes) {
-        this.blr = blr;
-        this.length = length;
-        this.columnTypes = columnTypes;
-    }
     
     /**
      * Parse FirebirdBlrRowMetadata from BLR buffer.

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/assignment/EncryptAssignmentTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/assignment/EncryptAssignmentTokenGenerator.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.token.generator.assignment;
 
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
@@ -51,6 +52,7 @@ import java.util.Optional;
  */
 @Slf4j
 @HighFrequencyInvocation
+@AllArgsConstructor
 public final class EncryptAssignmentTokenGenerator {
     
     private final EncryptRule rule;
@@ -58,12 +60,6 @@ public final class EncryptAssignmentTokenGenerator {
     private final ShardingSphereDatabase database;
     
     private final DatabaseType databaseType;
-    
-    public EncryptAssignmentTokenGenerator(final EncryptRule rule, final ShardingSphereDatabase database, final DatabaseType databaseType) {
-        this.rule = rule;
-        this.database = database;
-        this.databaseType = databaseType;
-    }
     
     /**
      * Generate SQL tokens.

--- a/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/segment/strategy/AbstractKeyGenerateStrategyDefinitionSegment.java
+++ b/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/segment/strategy/AbstractKeyGenerateStrategyDefinitionSegment.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.sharding.distsql.segment.strategy;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.distsql.segment.AlgorithmSegment;
 import org.apache.shardingsphere.distsql.segment.DistSQLSegment;
 
@@ -25,16 +27,12 @@ import java.util.Optional;
 /**
  * Abstract key generate strategy definition segment.
  */
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class AbstractKeyGenerateStrategyDefinitionSegment implements DistSQLSegment {
     
     private final String keyGeneratorName;
     
     private final AlgorithmSegment algorithmSegment;
-    
-    protected AbstractKeyGenerateStrategyDefinitionSegment(final String keyGeneratorName, final AlgorithmSegment algorithmSegment) {
-        this.keyGeneratorName = keyGeneratorName;
-        this.algorithmSegment = algorithmSegment;
-    }
     
     /**
      * Get key generator name.

--- a/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/segment/strategy/KeyGenerateStrategySegment.java
+++ b/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/segment/strategy/KeyGenerateStrategySegment.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sharding.distsql.segment.strategy;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.distsql.segment.AlgorithmSegment;
 import org.apache.shardingsphere.distsql.segment.DistSQLSegment;
@@ -27,6 +28,7 @@ import java.util.Optional;
  * Key generate strategy segment.
  */
 @Getter
+@AllArgsConstructor
 public final class KeyGenerateStrategySegment implements DistSQLSegment {
     
     private final String keyGenerateColumn;
@@ -41,12 +43,6 @@ public final class KeyGenerateStrategySegment implements DistSQLSegment {
     
     public KeyGenerateStrategySegment(final String keyGenerateColumn, final String keyGeneratorName) {
         this(keyGenerateColumn, null, keyGeneratorName);
-    }
-    
-    public KeyGenerateStrategySegment(final String keyGenerateColumn, final AlgorithmSegment keyGenerateAlgorithmSegment, final String keyGeneratorName) {
-        this.keyGenerateColumn = keyGenerateColumn;
-        this.keyGenerateAlgorithmSegment = keyGenerateAlgorithmSegment;
-        this.keyGeneratorName = keyGeneratorName;
     }
     
     /**

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContext.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.metadata.identifier;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicySet;
@@ -25,6 +26,7 @@ import org.apache.shardingsphere.database.connector.core.metadata.identifier.Ide
 /**
  * Database identifier context.
  */
+@AllArgsConstructor
 public final class DatabaseIdentifierContext {
     
     private volatile IdentifierCasePolicySet policySet;
@@ -34,11 +36,6 @@ public final class DatabaseIdentifierContext {
     
     public DatabaseIdentifierContext(final IdentifierCasePolicySet policySet) {
         this(policySet, false);
-    }
-    
-    public DatabaseIdentifierContext(final IdentifierCasePolicySet policySet, final boolean heterogeneousTableLookupEnabled) {
-        this.policySet = policySet;
-        this.heterogeneousTableLookupEnabled = heterogeneousTableLookupEnabled;
     }
     
     /**

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierIndex.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/identifier/IdentifierIndex.java
@@ -18,7 +18,9 @@
 package org.apache.shardingsphere.infra.metadata.identifier;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
@@ -41,6 +43,7 @@ import java.util.Optional;
  * @param <T> metadata object type
  */
 @Slf4j
+@RequiredArgsConstructor
 public final class IdentifierIndex<T> {
     
     private final DatabaseIdentifierContext databaseIdentifierContext;
@@ -48,11 +51,6 @@ public final class IdentifierIndex<T> {
     private final IdentifierScope identifierScope;
     
     private volatile Snapshot<T> snapshot = Snapshot.empty();
-    
-    public IdentifierIndex(final DatabaseIdentifierContext databaseIdentifierContext, final IdentifierScope identifierScope) {
-        this.databaseIdentifierContext = databaseIdentifierContext;
-        this.identifierScope = identifierScope;
-    }
     
     /**
      * Rebuild identifier index by actual names.
@@ -328,6 +326,7 @@ public final class IdentifierIndex<T> {
     }
     
     @Getter(AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class Snapshot<T> {
         
         private static final Snapshot<?> EMPTY = new Snapshot<>(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
@@ -338,18 +337,13 @@ public final class IdentifierIndex<T> {
         
         private final Map<String, NormalizedBucket<T>> normalizedBuckets;
         
-        private Snapshot(final Map<String, T> exactValues, final Map<String, Collection<String>> normalizedIdentifierNames, final Map<String, NormalizedBucket<T>> normalizedBuckets) {
-            this.exactValues = exactValues;
-            this.normalizedIdentifierNames = normalizedIdentifierNames;
-            this.normalizedBuckets = normalizedBuckets;
-        }
-        
         @SuppressWarnings("unchecked")
         private static <T> Snapshot<T> empty() {
             return (Snapshot<T>) EMPTY;
         }
     }
     
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class NormalizedBucket<T> {
         
         @Getter(AccessLevel.PRIVATE)
@@ -368,16 +362,6 @@ public final class IdentifierIndex<T> {
         
         @Getter(AccessLevel.PRIVATE)
         private final Collection<String> unquotedIdentifiers;
-        
-        private NormalizedBucket(final String singleIdentifier, final T singleValue, final Collection<String> identifiers,
-                                 final String singleUnquotedIdentifier, final T singleUnquotedValue, final Collection<String> unquotedIdentifiers) {
-            this.singleIdentifier = singleIdentifier;
-            this.singleValue = singleValue;
-            this.identifiers = identifiers;
-            this.singleUnquotedIdentifier = singleUnquotedIdentifier;
-            this.singleUnquotedValue = singleUnquotedValue;
-            this.unquotedIdentifiers = unquotedIdentifiers;
-        }
         
         private boolean hasSingleIdentifier() {
             return null != singleIdentifier;

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/identifier/DatabaseIdentifierContextFactoryTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.infra.metadata.identifier;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
@@ -664,10 +666,6 @@ class DatabaseIdentifierContextFactoryTest {
         return new IdentifierValue(quoted ? quoteCharacter + lookupName + quoteCharacter : lookupName);
     }
     
-    private static ResourceMetaData createResourceMetaDataWithFirstDataSource() {
-        return createResourceMetaDataWithStorageUrls("jdbc:mysql://localhost:3306/foo_db");
-    }
-    
     private static ResourceMetaData createResourceMetaDataWithMySQLLowerCaseTableNames(final int lowerCaseTableNames) {
         Map<String, StorageUnit> storageUnits = new LinkedHashMap<>(1, 1F);
         storageUnits.put("ds_0", createStorageUnit("ds_0", "jdbc:mysql://localhost:3306/foo_db", new LowerCaseTableNamesDataSource(lowerCaseTableNames)));
@@ -739,13 +737,10 @@ class DatabaseIdentifierContextFactoryTest {
         }
     }
     
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class LowerCaseTableNamesDataSource implements DataSource {
         
         private final int lowerCaseTableNames;
-        
-        private LowerCaseTableNamesDataSource(final int lowerCaseTableNames) {
-            this.lowerCaseTableNames = lowerCaseTableNames;
-        }
         
         @Override
         public Connection getConnection() {

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/rule/builder/fixture/ToggleFixtureDatabaseRuleConfiguration.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/rule/builder/fixture/ToggleFixtureDatabaseRuleConfiguration.java
@@ -17,16 +17,15 @@
 
 package org.apache.shardingsphere.infra.rule.builder.fixture;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.infra.config.rule.scope.DatabaseRuleConfiguration;
 import org.apache.shardingsphere.infra.config.rule.function.EnhancedRuleConfiguration;
 
+@AllArgsConstructor
 public final class ToggleFixtureDatabaseRuleConfiguration implements DatabaseRuleConfiguration, EnhancedRuleConfiguration {
     
     @Getter
     private final boolean empty;
     
-    public ToggleFixtureDatabaseRuleConfiguration(final boolean empty) {
-        this.empty = empty;
-    }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/rule/builder/fixture/ToggleFixtureRule.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/rule/builder/fixture/ToggleFixtureRule.java
@@ -17,16 +17,14 @@
 
 package org.apache.shardingsphere.infra.rule.builder.fixture;
 
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.rule.scope.DatabaseRule;
 
+@AllArgsConstructor
 public final class ToggleFixtureRule implements DatabaseRule {
     
     private final RuleConfiguration ruleConfig;
-    
-    public ToggleFixtureRule(final RuleConfiguration ruleConfig) {
-        this.ruleConfig = ruleConfig;
-    }
     
     @Override
     public RuleConfiguration getConfiguration() {

--- a/infra/distsql-handler/src/test/java/org/apache/shardingsphere/distsql/handler/engine/concurrent/fixture/FixtureDistSQLQueryStatement.java
+++ b/infra/distsql-handler/src/test/java/org/apache/shardingsphere/distsql/handler/engine/concurrent/fixture/FixtureDistSQLQueryStatement.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.distsql.handler.engine.concurrent.fixture;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.distsql.statement.DistSQLStatement;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
@@ -25,11 +26,9 @@ import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
  * Fixture DistSQL query statement.
  */
 @Getter
+@AllArgsConstructor
 public final class FixtureDistSQLQueryStatement extends DistSQLStatement {
     
     private final ShardingSphereRule expectedRule;
     
-    public FixtureDistSQLQueryStatement(final ShardingSphereRule expectedRule) {
-        this.expectedRule = expectedRule;
-    }
 }

--- a/infra/distsql-handler/src/test/java/org/apache/shardingsphere/distsql/handler/engine/concurrent/fixture/FixtureDistSQLUpdateStatement.java
+++ b/infra/distsql-handler/src/test/java/org/apache/shardingsphere/distsql/handler/engine/concurrent/fixture/FixtureDistSQLUpdateStatement.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.distsql.handler.engine.concurrent.fixture;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.distsql.statement.DistSQLStatement;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
@@ -25,11 +26,9 @@ import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
  * Fixture DistSQL update statement.
  */
 @Getter
+@AllArgsConstructor
 public final class FixtureDistSQLUpdateStatement extends DistSQLStatement {
     
     private final ShardingSphereRule expectedRule;
     
-    public FixtureDistSQLUpdateStatement(final ShardingSphereRule expectedRule) {
-        this.expectedRule = expectedRule;
-    }
 }

--- a/infra/spi/src/test/java/org/apache/shardingsphere/infra/spi/type/ordered/fixture/impl/ComparableOrderedInterfaceFixtureImpl.java
+++ b/infra/spi/src/test/java/org/apache/shardingsphere/infra/spi/type/ordered/fixture/impl/ComparableOrderedInterfaceFixtureImpl.java
@@ -17,17 +17,15 @@
 
 package org.apache.shardingsphere.infra.spi.type.ordered.fixture.impl;
 
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.infra.spi.type.ordered.fixture.OrderedInterfaceFixture;
 
 import java.util.Objects;
 
+@AllArgsConstructor
 public final class ComparableOrderedInterfaceFixtureImpl implements OrderedInterfaceFixture {
     
     private final String value;
-    
-    public ComparableOrderedInterfaceFixtureImpl(final String value) {
-        this.value = value;
-    }
     
     @Override
     public boolean equals(final Object obj) {

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/HttpTransportConfiguration.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/config/HttpTransportConfiguration.java
@@ -17,12 +17,14 @@
 
 package org.apache.shardingsphere.mcp.bootstrap.config;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
  * HTTP transport configuration.
  */
 @Getter
+@AllArgsConstructor
 public final class HttpTransportConfiguration {
     
     private final String bindHost;
@@ -37,10 +39,4 @@ public final class HttpTransportConfiguration {
         this(bindHost, port, endpointPath, null);
     }
     
-    public HttpTransportConfiguration(final String bindHost, final int port, final String endpointPath, final SessionAttributionSourceConfiguration sessionAttributionSource) {
-        this.bindHost = bindHost;
-        this.port = port;
-        this.endpointPath = endpointPath;
-        this.sessionAttributionSource = sessionAttributionSource;
-    }
 }

--- a/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolver.java
+++ b/mcp/bootstrap/src/main/java/org/apache/shardingsphere/mcp/bootstrap/transport/server/http/SessionAttributionResolver.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mcp.bootstrap.transport.server.http;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.mcp.api.session.MCPSessionIdentity;
 import org.apache.shardingsphere.mcp.bootstrap.config.SessionAttributionSourceConfiguration;
@@ -35,13 +36,10 @@ import java.util.Optional;
  * Session attribution resolver.
  */
 @Getter
+@AllArgsConstructor
 public final class SessionAttributionResolver {
     
     private final SessionAttributionSourceConfiguration config;
-    
-    public SessionAttributionResolver(final SessionAttributionSourceConfiguration config) {
-        this.config = config;
-    }
     
     /**
      * Resolve session identity from HTTP request.

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/MCPSQLExecutionFacade.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/MCPSQLExecutionFacade.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.core.tool.handler.execute;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mcp.api.protocol.exception.MCPInvalidRequestException;
 import org.apache.shardingsphere.mcp.api.protocol.exception.MCPUnsupportedException;
@@ -39,6 +41,7 @@ import java.util.Optional;
 /**
  * MCP SQL execution facade.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class MCPSQLExecutionFacade implements MCPFeatureExecutionFacade {
     
     private final MCPDatabaseCapabilityProvider databaseCapabilityProvider;
@@ -60,18 +63,6 @@ public final class MCPSQLExecutionFacade implements MCPFeatureExecutionFacade {
                 new MCPJdbcTransactionStatementExecutor(sessionManager),
                 new MCPJdbcStatementExecutor(sessionManager.getTransactionResourceManager().getRuntimeDatabases(), sessionManager.getTransactionResourceManager()),
                 new StatementClassifier(), new SQLStatementScanner(), new SQLExecutionTraceFactory());
-    }
-    
-    MCPSQLExecutionFacade(final MCPDatabaseCapabilityProvider databaseCapabilityProvider, final MCPSessionExecutionCoordinator sessionExecutionCoordinator,
-                          final MCPJdbcTransactionStatementExecutor transactionStatementExecutor, final MCPJdbcStatementExecutor statementExecutor,
-                          final StatementClassifier statementClassifier, final SQLStatementScanner scanner, final SQLExecutionTraceFactory sqlExecutionTraceFactory) {
-        this.databaseCapabilityProvider = databaseCapabilityProvider;
-        this.sessionExecutionCoordinator = sessionExecutionCoordinator;
-        this.transactionStatementExecutor = transactionStatementExecutor;
-        this.statementExecutor = statementExecutor;
-        this.statementClassifier = statementClassifier;
-        this.scanner = scanner;
-        this.sqlExecutionTraceFactory = sqlExecutionTraceFactory;
     }
     
     @Override

--- a/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/SQLStatementObjectName.java
+++ b/mcp/core/src/main/java/org/apache/shardingsphere/mcp/core/tool/handler/execute/SQLStatementObjectName.java
@@ -17,16 +17,15 @@
 
 package org.apache.shardingsphere.mcp.core.tool.handler.execute;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 final class SQLStatementObjectName {
     
     private final String objectName;
     
     private final int nextIndex;
-    
-    SQLStatementObjectName(final String objectName, final int nextIndex) {
-        this.objectName = objectName;
-        this.nextIndex = nextIndex;
-    }
     
     String objectName() {
         return objectName;

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/workflow/WorkflowHandlerTestFixture.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/tool/handler/workflow/WorkflowHandlerTestFixture.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.core.tool.handler.workflow;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.support.database.MCPDatabaseHandlerContext;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureExecutionFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
@@ -35,10 +37,8 @@ import java.util.Map;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class WorkflowHandlerTestFixture {
-    
-    private WorkflowHandlerTestFixture() {
-    }
     
     static Context createContext(final WorkflowContextSnapshot snapshot) {
         MCPWorkflowHandlerContext result = mock(MCPWorkflowHandlerContext.class);

--- a/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/InMemoryWorkflowSessionContextTest.java
+++ b/mcp/core/src/test/java/org/apache/shardingsphere/mcp/core/workflow/InMemoryWorkflowSessionContextTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.core.workflow;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.exception.MCPInvalidRequestException;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
 import org.apache.shardingsphere.mcp.support.workflow.model.InteractionPlan;
@@ -204,13 +206,10 @@ class InMemoryWorkflowSessionContextTest {
         }
     }
     
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class MutableClock extends Clock {
         
         private Instant currentInstant;
-        
-        private MutableClock(final Instant currentInstant) {
-            this.currentInstant = currentInstant;
-        }
         
         @Override
         public ZoneId getZone() {

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRuleCountHandler.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRuleCountHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.broadcast.resource.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
@@ -30,16 +32,13 @@ import org.apache.shardingsphere.mcp.support.protocol.response.MCPItemsResponse;
 /**
  * Broadcast rule count handler.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class BroadcastRuleCountHandler implements MCPResourceHandler<MCPDatabaseHandlerContext> {
     
     private final BroadcastRuleInspectionService ruleInspectionService;
     
     public BroadcastRuleCountHandler() {
         ruleInspectionService = new BroadcastRuleInspectionService();
-    }
-    
-    BroadcastRuleCountHandler(final BroadcastRuleInspectionService ruleInspectionService) {
-        this.ruleInspectionService = ruleInspectionService;
     }
     
     @Override

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRulesHandler.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastRulesHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.broadcast.resource.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
@@ -30,16 +32,13 @@ import org.apache.shardingsphere.mcp.support.protocol.response.MCPItemsResponse;
 /**
  * Broadcast rules handler.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class BroadcastRulesHandler implements MCPResourceHandler<MCPDatabaseHandlerContext> {
     
     private final BroadcastRuleInspectionService ruleInspectionService;
     
     public BroadcastRulesHandler() {
         ruleInspectionService = new BroadcastRuleInspectionService();
-    }
-    
-    BroadcastRulesHandler(final BroadcastRuleInspectionService ruleInspectionService) {
-        this.ruleInspectionService = ruleInspectionService;
     }
     
     @Override

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastTableRuleHandler.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/resource/handler/BroadcastTableRuleHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.broadcast.resource.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
@@ -35,16 +37,13 @@ import java.util.Map;
 /**
  * Broadcast table rule handler.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class BroadcastTableRuleHandler implements MCPResourceHandler<MCPDatabaseHandlerContext> {
     
     private final BroadcastRuleInspectionService ruleInspectionService;
     
     public BroadcastTableRuleHandler() {
         ruleInspectionService = new BroadcastRuleInspectionService();
-    }
-    
-    BroadcastTableRuleHandler(final BroadcastRuleInspectionService ruleInspectionService) {
-        this.ruleInspectionService = ruleInspectionService;
     }
     
     @Override

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/handler/PlanBroadcastRuleToolHandler.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/handler/PlanBroadcastRuleToolHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.broadcast.tool.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolHandler;
@@ -35,16 +37,13 @@ import java.util.Map;
 /**
  * Tool handler for broadcast workflow planning.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class PlanBroadcastRuleToolHandler implements MCPToolHandler<MCPWorkflowHandlerContext> {
     
     private final BroadcastWorkflowPlanningService planningService;
     
     public PlanBroadcastRuleToolHandler() {
         planningService = new BroadcastWorkflowPlanningService();
-    }
-    
-    PlanBroadcastRuleToolHandler(final BroadcastWorkflowPlanningService planningService) {
-        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowPlanningService.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowPlanningService.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.broadcast.tool.service;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.feature.broadcast.BroadcastFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.broadcast.tool.model.BroadcastWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
@@ -36,6 +38,7 @@ import java.util.Map;
 /**
  * Broadcast workflow planning service.
  */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public final class BroadcastWorkflowPlanningService {
     
     private static final List<String> INTERACTION_STEPS = List.of(
@@ -59,11 +62,6 @@ public final class BroadcastWorkflowPlanningService {
     public BroadcastWorkflowPlanningService() {
         ruleInspectionService = new BroadcastRuleInspectionService();
         ruleDistSQLPlanningService = new BroadcastRuleDistSQLPlanningService();
-    }
-    
-    BroadcastWorkflowPlanningService(final BroadcastRuleInspectionService ruleInspectionService, final BroadcastRuleDistSQLPlanningService ruleDistSQLPlanningService) {
-        this.ruleInspectionService = ruleInspectionService;
-        this.ruleDistSQLPlanningService = ruleDistSQLPlanningService;
     }
     
     /**

--- a/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowValidationService.java
+++ b/mcp/features/broadcast/src/main/java/org/apache/shardingsphere/mcp/feature/broadcast/tool/service/BroadcastWorkflowValidationService.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.broadcast.tool.service;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.feature.broadcast.tool.model.BroadcastWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureExecutionFacade;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
@@ -40,6 +42,7 @@ import java.util.Map;
 /**
  * Broadcast workflow validation service.
  */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public final class BroadcastWorkflowValidationService implements MCPWorkflowRuntimeHandler {
     
     private final WorkflowValidationSupport validationSupport = new WorkflowValidationSupport();
@@ -51,11 +54,6 @@ public final class BroadcastWorkflowValidationService implements MCPWorkflowRunt
     public BroadcastWorkflowValidationService() {
         ruleInspectionService = new BroadcastRuleInspectionService();
         workflowSynchronizationSupport = new WorkflowSynchronizationSupport();
-    }
-    
-    BroadcastWorkflowValidationService(final BroadcastRuleInspectionService ruleInspectionService, final WorkflowSynchronizationSupport workflowSynchronizationSupport) {
-        this.ruleInspectionService = ruleInspectionService;
-        this.workflowSynchronizationSupport = workflowSynchronizationSupport;
     }
     
     @Override

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/model/EncryptWorkflowState.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/model/EncryptWorkflowState.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mcp.feature.encrypt.tool.model;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFeatureData;
 
 import java.util.LinkedHashMap;
@@ -29,14 +30,12 @@ import java.util.Map;
  * Encrypt workflow state.
  */
 @Getter
+@NoArgsConstructor
 public final class EncryptWorkflowState implements WorkflowFeatureData {
     
     private final List<Map<String, Object>> beforeRules = new LinkedList<>();
     
     private final List<Map<String, Object>> expectedRules = new LinkedList<>();
-    
-    public EncryptWorkflowState() {
-    }
     
     public EncryptWorkflowState(final List<Map<String, Object>> beforeRules, final List<Map<String, Object>> expectedRules) {
         this.beforeRules.addAll(copyRules(beforeRules));

--- a/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptAlgorithmCatalog.java
+++ b/mcp/features/encrypt/src/main/java/org/apache/shardingsphere/mcp/feature/encrypt/tool/service/EncryptAlgorithmCatalog.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.encrypt.tool.service;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.feature.encrypt.EncryptFeatureDefinition;
 import org.apache.shardingsphere.mcp.support.workflow.model.AlgorithmPropertyRequirement;
 
@@ -30,12 +32,10 @@ import java.util.Objects;
 /**
  * Encrypt algorithm catalog.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class EncryptAlgorithmCatalog {
     
     private static final Map<String, EncryptAlgorithmDefinition> DEFINITIONS = createDefinitions();
-    
-    private EncryptAlgorithmCatalog() {
-    }
     
     /**
      * Find encrypt capability map.

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/ReadwriteSplittingFeatureDefinition.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/ReadwriteSplittingFeatureDefinition.java
@@ -17,12 +17,15 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowKindDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 
 /**
  * Readwrite-splitting MCP feature definition.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ReadwriteSplittingFeatureDefinition {
     
     public static final String PLAN_RULE_TOOL_NAME = "database_gateway_plan_readwrite_splitting_rule";
@@ -65,6 +68,4 @@ public final class ReadwriteSplittingFeatureDefinition {
     
     public static final String LOAD_BALANCE_ALGORITHM_PLUGINS_RESOURCE_URI = "shardingsphere://features/readwrite-splitting/load-balance-algorithm-plugins";
     
-    private ReadwriteSplittingFeatureDefinition() {
-    }
 }

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/LoadBalanceAlgorithmPluginsHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/LoadBalanceAlgorithmPluginsHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.resource.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
@@ -30,16 +32,13 @@ import org.apache.shardingsphere.mcp.support.protocol.response.MCPItemsResponse;
 /**
  * Load-balance algorithm plugin catalog handler.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class LoadBalanceAlgorithmPluginsHandler implements MCPResourceHandler<MCPDatabaseHandlerContext> {
     
     private final ReadwriteSplittingInspectionService inspectionService;
     
     public LoadBalanceAlgorithmPluginsHandler() {
         inspectionService = new ReadwriteSplittingInspectionService();
-    }
-    
-    LoadBalanceAlgorithmPluginsHandler(final ReadwriteSplittingInspectionService inspectionService) {
-        this.inspectionService = inspectionService;
     }
     
     @Override

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleCountHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleCountHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.resource.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
@@ -30,16 +32,13 @@ import org.apache.shardingsphere.mcp.support.protocol.response.MCPItemsResponse;
 /**
  * Readwrite-splitting rule count handler.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ReadwriteSplittingRuleCountHandler implements MCPResourceHandler<MCPDatabaseHandlerContext> {
     
     private final ReadwriteSplittingInspectionService inspectionService;
     
     public ReadwriteSplittingRuleCountHandler() {
         inspectionService = new ReadwriteSplittingInspectionService();
-    }
-    
-    ReadwriteSplittingRuleCountHandler(final ReadwriteSplittingInspectionService inspectionService) {
-        this.inspectionService = inspectionService;
     }
     
     @Override

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.resource.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
@@ -30,16 +32,13 @@ import org.apache.shardingsphere.mcp.support.protocol.response.MCPItemsResponse;
 /**
  * Readwrite-splitting single rule handler.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ReadwriteSplittingRuleHandler implements MCPResourceHandler<MCPDatabaseHandlerContext> {
     
     private final ReadwriteSplittingInspectionService inspectionService;
     
     public ReadwriteSplittingRuleHandler() {
         inspectionService = new ReadwriteSplittingInspectionService();
-    }
-    
-    ReadwriteSplittingRuleHandler(final ReadwriteSplittingInspectionService inspectionService) {
-        this.inspectionService = inspectionService;
     }
     
     @Override

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleStatusHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRuleStatusHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.resource.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
@@ -30,16 +32,13 @@ import org.apache.shardingsphere.mcp.support.protocol.response.MCPItemsResponse;
 /**
  * Readwrite-splitting single rule status handler.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ReadwriteSplittingRuleStatusHandler implements MCPResourceHandler<MCPDatabaseHandlerContext> {
     
     private final ReadwriteSplittingInspectionService inspectionService;
     
     public ReadwriteSplittingRuleStatusHandler() {
         inspectionService = new ReadwriteSplittingInspectionService();
-    }
-    
-    ReadwriteSplittingRuleStatusHandler(final ReadwriteSplittingInspectionService inspectionService) {
-        this.inspectionService = inspectionService;
     }
     
     @Override

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRulesHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingRulesHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.resource.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
@@ -30,16 +32,13 @@ import org.apache.shardingsphere.mcp.support.protocol.response.MCPItemsResponse;
 /**
  * Readwrite-splitting rules handler.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ReadwriteSplittingRulesHandler implements MCPResourceHandler<MCPDatabaseHandlerContext> {
     
     private final ReadwriteSplittingInspectionService inspectionService;
     
     public ReadwriteSplittingRulesHandler() {
         inspectionService = new ReadwriteSplittingInspectionService();
-    }
-    
-    ReadwriteSplittingRulesHandler(final ReadwriteSplittingInspectionService inspectionService) {
-        this.inspectionService = inspectionService;
     }
     
     @Override

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingStatusHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/resource/handler/ReadwriteSplittingStatusHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.resource.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
@@ -30,16 +32,13 @@ import org.apache.shardingsphere.mcp.support.protocol.response.MCPItemsResponse;
 /**
  * Readwrite-splitting status handler.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ReadwriteSplittingStatusHandler implements MCPResourceHandler<MCPDatabaseHandlerContext> {
     
     private final ReadwriteSplittingInspectionService inspectionService;
     
     public ReadwriteSplittingStatusHandler() {
         inspectionService = new ReadwriteSplittingInspectionService();
-    }
-    
-    ReadwriteSplittingStatusHandler(final ReadwriteSplittingInspectionService inspectionService) {
-        this.inspectionService = inspectionService;
     }
     
     @Override

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/handler/PlanReadwriteSplittingRuleToolHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/handler/PlanReadwriteSplittingRuleToolHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.tool.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolHandler;
@@ -39,16 +41,13 @@ import java.util.function.Consumer;
 /**
  * Tool handler for readwrite-splitting rule workflow planning.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class PlanReadwriteSplittingRuleToolHandler implements MCPToolHandler<MCPWorkflowHandlerContext> {
     
     private final ReadwriteSplittingRuleWorkflowPlanningService planningService;
     
     public PlanReadwriteSplittingRuleToolHandler() {
         planningService = new ReadwriteSplittingRuleWorkflowPlanningService();
-    }
-    
-    PlanReadwriteSplittingRuleToolHandler(final ReadwriteSplittingRuleWorkflowPlanningService planningService) {
-        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/handler/PlanReadwriteSplittingStatusToolHandler.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/handler/PlanReadwriteSplittingStatusToolHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.tool.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolHandler;
@@ -40,16 +42,13 @@ import java.util.function.Consumer;
 /**
  * Tool handler for readwrite-splitting storage-unit status workflow planning.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class PlanReadwriteSplittingStatusToolHandler implements MCPToolHandler<MCPWorkflowHandlerContext> {
     
     private final ReadwriteSplittingStatusWorkflowPlanningService planningService;
     
     public PlanReadwriteSplittingStatusToolHandler() {
         planningService = new ReadwriteSplittingStatusWorkflowPlanningService();
-    }
-    
-    PlanReadwriteSplittingStatusToolHandler(final ReadwriteSplittingStatusWorkflowPlanningService planningService) {
-        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingStatusWorkflowPlanningService.java
+++ b/mcp/features/readwrite-splitting/src/main/java/org/apache/shardingsphere/mcp/feature/readwritesplitting/tool/service/ReadwriteSplittingStatusWorkflowPlanningService.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.readwritesplitting.tool.service;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.feature.readwritesplitting.ReadwriteSplittingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.readwritesplitting.tool.model.ReadwriteSplittingStatusWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
@@ -37,6 +39,7 @@ import java.util.Map;
 /**
  * Readwrite-splitting status workflow planning service.
  */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ReadwriteSplittingStatusWorkflowPlanningService {
     
     private static final List<String> INTERACTION_STEPS = List.of(
@@ -60,12 +63,6 @@ public final class ReadwriteSplittingStatusWorkflowPlanningService {
     public ReadwriteSplittingStatusWorkflowPlanningService() {
         inspectionService = new ReadwriteSplittingInspectionService();
         distSQLPlanningService = new ReadwriteSplittingStatusDistSQLPlanningService();
-    }
-    
-    ReadwriteSplittingStatusWorkflowPlanningService(final ReadwriteSplittingInspectionService inspectionService,
-                                                    final ReadwriteSplittingStatusDistSQLPlanningService distSQLPlanningService) {
-        this.inspectionService = inspectionService;
-        this.distSQLPlanningService = distSQLPlanningService;
     }
     
     /**

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/ShadowFeatureDefinition.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/ShadowFeatureDefinition.java
@@ -17,12 +17,15 @@
 
 package org.apache.shardingsphere.mcp.feature.shadow;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowKindDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 
 /**
  * Shadow MCP feature definition.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ShadowFeatureDefinition {
     
     public static final String PLAN_RULE_TOOL_NAME = "database_gateway_plan_shadow_rule";
@@ -73,6 +76,4 @@ public final class ShadowFeatureDefinition {
     
     public static final String ALGORITHM_PLUGINS_RESOURCE_URI = "shardingsphere://features/shadow/algorithm-plugins";
     
-    private ShadowFeatureDefinition() {
-    }
 }

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/resource/handler/ShadowResourceHandler.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/resource/handler/ShadowResourceHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.shadow.resource.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
 import org.apache.shardingsphere.mcp.api.resource.MCPUriVariables;
@@ -33,6 +35,7 @@ import java.util.Map;
 /**
  * Shadow resource handler.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ShadowResourceHandler implements MCPResourceHandler<MCPDatabaseHandlerContext> {
     
     private final String resourceUriTemplate;
@@ -43,12 +46,6 @@ public final class ShadowResourceHandler implements MCPResourceHandler<MCPDataba
     
     private ShadowResourceHandler(final String resourceUriTemplate, final ResourceKind resourceKind) {
         this(resourceUriTemplate, resourceKind, new ShadowInspectionService());
-    }
-    
-    ShadowResourceHandler(final String resourceUriTemplate, final ResourceKind resourceKind, final ShadowInspectionService inspectionService) {
-        this.resourceUriTemplate = resourceUriTemplate;
-        this.resourceKind = resourceKind;
-        this.inspectionService = inspectionService;
     }
     
     /**

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/handler/PlanDefaultShadowAlgorithmToolHandler.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/handler/PlanDefaultShadowAlgorithmToolHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.shadow.tool.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolHandler;
@@ -38,16 +40,13 @@ import java.util.function.Consumer;
 /**
  * Tool handler for default shadow algorithm workflow planning.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class PlanDefaultShadowAlgorithmToolHandler implements MCPToolHandler<MCPWorkflowHandlerContext> {
     
     private final ShadowWorkflowPlanningService planningService;
     
     public PlanDefaultShadowAlgorithmToolHandler() {
         planningService = new ShadowWorkflowPlanningService();
-    }
-    
-    PlanDefaultShadowAlgorithmToolHandler(final ShadowWorkflowPlanningService planningService) {
-        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/handler/PlanShadowAlgorithmCleanupToolHandler.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/handler/PlanShadowAlgorithmCleanupToolHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.shadow.tool.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolHandler;
@@ -36,16 +38,13 @@ import java.util.function.Consumer;
 /**
  * Tool handler for shadow algorithm cleanup workflow planning.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class PlanShadowAlgorithmCleanupToolHandler implements MCPToolHandler<MCPWorkflowHandlerContext> {
     
     private final ShadowWorkflowPlanningService planningService;
     
     public PlanShadowAlgorithmCleanupToolHandler() {
         planningService = new ShadowWorkflowPlanningService();
-    }
-    
-    PlanShadowAlgorithmCleanupToolHandler(final ShadowWorkflowPlanningService planningService) {
-        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/handler/PlanShadowRuleToolHandler.java
+++ b/mcp/features/shadow/src/main/java/org/apache/shardingsphere/mcp/feature/shadow/tool/handler/PlanShadowRuleToolHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.shadow.tool.handler;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolHandler;
@@ -38,16 +40,13 @@ import java.util.function.Consumer;
 /**
  * Tool handler for shadow rule workflow planning.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class PlanShadowRuleToolHandler implements MCPToolHandler<MCPWorkflowHandlerContext> {
     
     private final ShadowWorkflowPlanningService planningService;
     
     public PlanShadowRuleToolHandler() {
         planningService = new ShadowWorkflowPlanningService();
-    }
-    
-    PlanShadowRuleToolHandler(final ShadowWorkflowPlanningService planningService) {
-        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingFeatureDefinition.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/ShardingFeatureDefinition.java
@@ -17,12 +17,15 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowKindDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 
 /**
  * Sharding MCP feature definition.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ShardingFeatureDefinition {
     
     public static final WorkflowKind TABLE_RULE_WORKFLOW_KIND = WorkflowKind.valueOf(WorkflowKindDescriptors.SHARDING_TABLE_RULE);
@@ -117,6 +120,4 @@ public final class ShardingFeatureDefinition {
     
     public static final String AUDITOR_FIELD = "auditor";
     
-    private ShardingFeatureDefinition() {
-    }
 }

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/AbstractShardingResourceHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/resource/handler/AbstractShardingResourceHandler.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mcp.feature.sharding.resource.handler;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.mcp.api.protocol.response.MCPResponse;
 import org.apache.shardingsphere.mcp.api.resource.MCPResourceHandler;
@@ -31,17 +32,13 @@ import org.apache.shardingsphere.mcp.support.protocol.response.MCPItemsResponse;
 import java.util.List;
 import java.util.Map;
 
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 abstract class AbstractShardingResourceHandler implements MCPResourceHandler<MCPDatabaseHandlerContext> {
     
     private final String resourceUriTemplate;
     
     @Getter(AccessLevel.PROTECTED)
     private final ShardingInspectionService inspectionService;
-    
-    AbstractShardingResourceHandler(final String resourceUriTemplate, final ShardingInspectionService inspectionService) {
-        this.resourceUriTemplate = resourceUriTemplate;
-        this.inspectionService = inspectionService;
-    }
     
     @Override
     public Class<MCPDatabaseHandlerContext> getContextType() {

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingDefaultStrategyToolHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingDefaultStrategyToolHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.handler;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingDefaultStrategyWorkflowRequest;
@@ -28,6 +30,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 /**
  * Tool handler for default sharding strategy planning.
  */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public final class PlanShardingDefaultStrategyToolHandler extends AbstractShardingPlanningToolHandler {
     
     private final ShardingPlanningRequestBinder requestBinder = new ShardingPlanningRequestBinder();
@@ -36,10 +39,6 @@ public final class PlanShardingDefaultStrategyToolHandler extends AbstractShardi
     
     public PlanShardingDefaultStrategyToolHandler() {
         planningService = new ShardingDefaultStrategyWorkflowPlanningService();
-    }
-    
-    PlanShardingDefaultStrategyToolHandler(final ShardingDefaultStrategyWorkflowPlanningService planningService) {
-        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingKeyGenerateStrategyToolHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingKeyGenerateStrategyToolHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.handler;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingKeyGenerateStrategyWorkflowRequest;
@@ -28,6 +30,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 /**
  * Tool handler for sharding key generate strategy planning.
  */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public final class PlanShardingKeyGenerateStrategyToolHandler extends AbstractShardingPlanningToolHandler {
     
     private final ShardingPlanningRequestBinder requestBinder = new ShardingPlanningRequestBinder();
@@ -36,10 +39,6 @@ public final class PlanShardingKeyGenerateStrategyToolHandler extends AbstractSh
     
     public PlanShardingKeyGenerateStrategyToolHandler() {
         planningService = new ShardingKeyGenerateStrategyWorkflowPlanningService();
-    }
-    
-    PlanShardingKeyGenerateStrategyToolHandler(final ShardingKeyGenerateStrategyWorkflowPlanningService planningService) {
-        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingKeyGeneratorToolHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingKeyGeneratorToolHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.handler;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingKeyGeneratorWorkflowRequest;
@@ -28,6 +30,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 /**
  * Tool handler for sharding key generator planning.
  */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public final class PlanShardingKeyGeneratorToolHandler extends AbstractShardingPlanningToolHandler {
     
     private final ShardingPlanningRequestBinder requestBinder = new ShardingPlanningRequestBinder();
@@ -36,10 +39,6 @@ public final class PlanShardingKeyGeneratorToolHandler extends AbstractShardingP
     
     public PlanShardingKeyGeneratorToolHandler() {
         planningService = new ShardingKeyGeneratorWorkflowPlanningService();
-    }
-    
-    PlanShardingKeyGeneratorToolHandler(final ShardingKeyGeneratorWorkflowPlanningService planningService) {
-        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingRuleComponentCleanupToolHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingRuleComponentCleanupToolHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.handler;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingRuleComponentCleanupWorkflowRequest;
@@ -28,6 +30,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 /**
  * Tool handler for sharding rule component cleanup planning.
  */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public final class PlanShardingRuleComponentCleanupToolHandler extends AbstractShardingPlanningToolHandler {
     
     private final ShardingPlanningRequestBinder requestBinder = new ShardingPlanningRequestBinder();
@@ -36,10 +39,6 @@ public final class PlanShardingRuleComponentCleanupToolHandler extends AbstractS
     
     public PlanShardingRuleComponentCleanupToolHandler() {
         planningService = new ShardingRuleComponentCleanupWorkflowPlanningService();
-    }
-    
-    PlanShardingRuleComponentCleanupToolHandler(final ShardingRuleComponentCleanupWorkflowPlanningService planningService) {
-        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingTableReferenceRuleToolHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingTableReferenceRuleToolHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.handler;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingTableReferenceRuleWorkflowRequest;
@@ -28,6 +30,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 /**
  * Tool handler for sharding table reference rule planning.
  */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public final class PlanShardingTableReferenceRuleToolHandler extends AbstractShardingPlanningToolHandler {
     
     private final ShardingPlanningRequestBinder requestBinder = new ShardingPlanningRequestBinder();
@@ -36,10 +39,6 @@ public final class PlanShardingTableReferenceRuleToolHandler extends AbstractSha
     
     public PlanShardingTableReferenceRuleToolHandler() {
         planningService = new ShardingTableReferenceRuleWorkflowPlanningService();
-    }
-    
-    PlanShardingTableReferenceRuleToolHandler(final ShardingTableReferenceRuleWorkflowPlanningService planningService) {
-        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingTableRuleToolHandler.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/handler/PlanShardingTableRuleToolHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.handler;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.api.tool.MCPToolCall;
 import org.apache.shardingsphere.mcp.feature.sharding.ShardingFeatureDefinition;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingTableRuleWorkflowRequest;
@@ -28,6 +30,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 /**
  * Tool handler for sharding table rule planning.
  */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public final class PlanShardingTableRuleToolHandler extends AbstractShardingPlanningToolHandler {
     
     private final ShardingPlanningRequestBinder requestBinder = new ShardingPlanningRequestBinder();
@@ -36,10 +39,6 @@ public final class PlanShardingTableRuleToolHandler extends AbstractShardingPlan
     
     public PlanShardingTableRuleToolHandler() {
         planningService = new ShardingTableRuleWorkflowPlanningService();
-    }
-    
-    PlanShardingTableRuleToolHandler(final ShardingTableRuleWorkflowPlanningService planningService) {
-        this.planningService = planningService;
     }
     
     @Override

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingDefaultStrategyWorkflowPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingDefaultStrategyWorkflowPlanningService.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingDefaultStrategyWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
@@ -25,16 +27,13 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 /**
  * Sharding default strategy workflow planning service.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ShardingDefaultStrategyWorkflowPlanningService {
     
     private final ShardingWorkflowPlanningKernel kernel;
     
     public ShardingDefaultStrategyWorkflowPlanningService() {
         this(new ShardingWorkflowPlanningKernel());
-    }
-    
-    ShardingDefaultStrategyWorkflowPlanningService(final ShardingWorkflowPlanningKernel kernel) {
-        this.kernel = kernel;
     }
     
     /**

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingKeyGenerateStrategyWorkflowPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingKeyGenerateStrategyWorkflowPlanningService.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingKeyGenerateStrategyWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
@@ -25,16 +27,13 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 /**
  * Sharding key generate strategy workflow planning service.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ShardingKeyGenerateStrategyWorkflowPlanningService {
     
     private final ShardingWorkflowPlanningKernel kernel;
     
     public ShardingKeyGenerateStrategyWorkflowPlanningService() {
         this(new ShardingWorkflowPlanningKernel());
-    }
-    
-    ShardingKeyGenerateStrategyWorkflowPlanningService(final ShardingWorkflowPlanningKernel kernel) {
-        this.kernel = kernel;
     }
     
     /**

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingKeyGeneratorWorkflowPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingKeyGeneratorWorkflowPlanningService.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingKeyGeneratorWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
@@ -25,16 +27,13 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 /**
  * Sharding key generator workflow planning service.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ShardingKeyGeneratorWorkflowPlanningService {
     
     private final ShardingWorkflowPlanningKernel kernel;
     
     public ShardingKeyGeneratorWorkflowPlanningService() {
         this(new ShardingWorkflowPlanningKernel());
-    }
-    
-    ShardingKeyGeneratorWorkflowPlanningService(final ShardingWorkflowPlanningKernel kernel) {
-        this.kernel = kernel;
     }
     
     /**

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingRuleComponentCleanupWorkflowPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingRuleComponentCleanupWorkflowPlanningService.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingRuleComponentCleanupWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
@@ -25,16 +27,13 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 /**
  * Sharding rule component cleanup workflow planning service.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ShardingRuleComponentCleanupWorkflowPlanningService {
     
     private final ShardingWorkflowPlanningKernel kernel;
     
     public ShardingRuleComponentCleanupWorkflowPlanningService() {
         this(new ShardingWorkflowPlanningKernel());
-    }
-    
-    ShardingRuleComponentCleanupWorkflowPlanningService(final ShardingWorkflowPlanningKernel kernel) {
-        this.kernel = kernel;
     }
     
     /**

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingTableReferenceRuleWorkflowPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingTableReferenceRuleWorkflowPlanningService.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingTableReferenceRuleWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
@@ -25,16 +27,13 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 /**
  * Sharding table reference rule workflow planning service.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ShardingTableReferenceRuleWorkflowPlanningService {
     
     private final ShardingWorkflowPlanningKernel kernel;
     
     public ShardingTableReferenceRuleWorkflowPlanningService() {
         this(new ShardingWorkflowPlanningKernel());
-    }
-    
-    ShardingTableReferenceRuleWorkflowPlanningService(final ShardingWorkflowPlanningKernel kernel) {
-        this.kernel = kernel;
     }
     
     /**

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingTableRuleWorkflowPlanningService.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/service/ShardingTableRuleWorkflowPlanningService.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.feature.sharding.tool.service;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.feature.sharding.tool.model.ShardingTableRuleWorkflowRequest;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowSessionContext;
@@ -25,16 +27,13 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnaps
 /**
  * Sharding table rule workflow planning service.
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class ShardingTableRuleWorkflowPlanningService {
     
     private final ShardingWorkflowPlanningKernel kernel;
     
     public ShardingTableRuleWorkflowPlanningService() {
         this(new ShardingWorkflowPlanningKernel());
-    }
-    
-    ShardingTableRuleWorkflowPlanningService(final ShardingWorkflowPlanningKernel kernel) {
-        this.kernel = kernel;
     }
     
     /**

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/context/RequestScopedMetadataContext.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/context/RequestScopedMetadataContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mcp.support.database.metadata.context;
 
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mcp.support.database.capability.MCPDatabaseCapabilityProvider;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.MCPJdbcMetadataLoader;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
@@ -30,6 +31,7 @@ import java.util.Optional;
 /**
  * Request-scoped metadata context.
  */
+@RequiredArgsConstructor
 public final class RequestScopedMetadataContext implements AutoCloseable {
     
     private final Map<String, RuntimeDatabaseConfiguration> runtimeDatabases;
@@ -39,11 +41,6 @@ public final class RequestScopedMetadataContext implements AutoCloseable {
     private final MCPJdbcMetadataLoader metadataLoader = new MCPJdbcMetadataLoader();
     
     private final Map<String, MCPDatabaseMetadata> loadedDatabaseMetadata = new LinkedHashMap<>(4, 1F);
-    
-    public RequestScopedMetadataContext(final Map<String, RuntimeDatabaseConfiguration> runtimeDatabases, final MCPDatabaseCapabilityProvider databaseCapabilityProvider) {
-        this.runtimeDatabases = runtimeDatabases;
-        this.databaseCapabilityProvider = databaseCapabilityProvider;
-    }
     
     /**
      * Load database metadata lazily within the current request.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/RuntimeDatabaseConfiguration.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/RuntimeDatabaseConfiguration.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mcp.support.database.metadata.jdbc;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.sql.Connection;
@@ -29,6 +30,7 @@ import java.util.Properties;
  * Runtime database configuration for one logical database binding.
  */
 @Getter
+@AllArgsConstructor
 public final class RuntimeDatabaseConfiguration {
     
     private final String jdbcUrl;
@@ -38,13 +40,6 @@ public final class RuntimeDatabaseConfiguration {
     private final String password;
     
     private final String driverClassName;
-    
-    public RuntimeDatabaseConfiguration(final String jdbcUrl, final String username, final String password, final String driverClassName) {
-        this.jdbcUrl = jdbcUrl;
-        this.username = username;
-        this.password = password;
-        this.driverClassName = driverClassName;
-    }
     
     /**
      * Open connection.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/tool/request/SQLExecutionRequest.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/tool/request/SQLExecutionRequest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mcp.support.database.tool.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
@@ -26,6 +27,7 @@ import lombok.Getter;
  * The optional schema field is a namespace hint for unqualified object names.</p>
  */
 @Getter
+@AllArgsConstructor
 public final class SQLExecutionRequest {
     
     private final String sessionId;
@@ -46,13 +48,4 @@ public final class SQLExecutionRequest {
         this(sessionId, database, schema, sql, maxRows, timeoutMs, false);
     }
     
-    public SQLExecutionRequest(final String sessionId, final String database, final String schema, final String sql, final int maxRows, final int timeoutMs, final boolean readOnlyExecution) {
-        this.sessionId = sessionId;
-        this.database = database;
-        this.schema = schema;
-        this.sql = sql;
-        this.maxRows = maxRows;
-        this.timeoutMs = timeoutMs;
-        this.readOnlyExecution = readOnlyExecution;
-    }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPCompletionTargetDescriptorValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPCompletionTargetDescriptorValidator.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptArgumentDescriptor;
 import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptDescriptor;
@@ -34,10 +36,8 @@ import java.util.stream.Collectors;
 /**
  * Validator for MCP completion targets.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPCompletionTargetDescriptorValidator {
-    
-    private MCPCompletionTargetDescriptorValidator() {
-    }
     
     /**
      * Validate completion targets against declared prompt and resource descriptors.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogPayloadBuilder.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptArgumentDescriptor;
 import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptDescriptor;
 import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceAnnotations;
@@ -33,13 +35,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 final class MCPDescriptorCatalogPayloadBuilder {
     
     private final MCPDescriptorCatalog catalog;
-    
-    private MCPDescriptorCatalogPayloadBuilder(final MCPDescriptorCatalog catalog) {
-        this.catalog = catalog;
-    }
     
     static Map<String, Object> build(final MCPDescriptorCatalog catalog, final Collection<String> supportedResources, final Collection<String> supportedTools,
                                      final Collection<?> supportedStatements) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogValidator.java
@@ -17,10 +17,11 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class MCPDescriptorCatalogValidator {
-    
-    private MCPDescriptorCatalogValidator() {
-    }
     
     static void validate(final MCPDescriptorCatalog catalog) {
         MCPResourceDescriptorValidator.validate(catalog);

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogYamlLoader.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogYamlLoader.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.util.directory.ClasspathResourceDirectoryReader;
 import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
 import org.apache.shardingsphere.mcp.support.descriptor.yaml.YamlMCPDescriptorCatalog;
@@ -26,12 +28,10 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.stream.Stream;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class MCPDescriptorCatalogYamlLoader {
     
     private static final String MCP_DESCRIPTOR_DIRECTORY = "META-INF/shardingsphere-mcp/mcp-descriptors";
-    
-    private MCPDescriptorCatalogYamlLoader() {
-    }
     
     static Collection<YamlMCPDescriptorCatalog> load() {
         try (Stream<String> resources = ClasspathResourceDirectoryReader.read(MCP_DESCRIPTOR_DIRECTORY)) {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogYamlSwapper.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogYamlSwapper.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptArgumentDescriptor;
 import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptDescriptor;
 import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceAnnotations;
@@ -44,10 +46,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class MCPDescriptorCatalogYamlSwapper {
-    
-    private MCPDescriptorCatalogYamlSwapper() {
-    }
     
     static MCPDescriptorCatalog swap(final Collection<YamlMCPDescriptorCatalog> yamlCatalogs) {
         Collection<MCPResourceDescriptor> resourceDescriptors = new LinkedList<>();

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPPromptDescriptorValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPPromptDescriptorValidator.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptArgumentDescriptor;
 import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptDescriptor;
@@ -32,14 +34,12 @@ import java.util.stream.Collectors;
 /**
  * Validator for MCP prompt descriptors and their internal templates.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPPromptDescriptorValidator {
     
     private static final String CLIENT_FORM_ONLY_ARGUMENTS = "org.apache.shardingsphere/client-form-only-arguments";
     
     private static final Pattern SINGLE_BRACE_PLACEHOLDER_PATTERN = Pattern.compile("(?<!\\{)\\{\\s*([a-zA-Z0-9_.-]+)\\s*}(?!})");
-    
-    private MCPPromptDescriptorValidator() {
-    }
     
     /**
      * Validate prompt descriptors against their internal templates.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceDescriptorValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceDescriptorValidator.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceDescriptor;
 import org.apache.shardingsphere.mcp.support.resource.MCPUriTemplate;
@@ -32,10 +34,8 @@ import java.util.Set;
 /**
  * Validator for MCP resource descriptors.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPResourceDescriptorValidator {
-    
-    private MCPResourceDescriptorValidator() {
-    }
     
     /**
      * Validate fixed and templated resources in one descriptor catalog.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceNavigationDescriptorValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPResourceNavigationDescriptorValidator.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mcp.api.prompt.descriptor.MCPPromptDescriptor;
 import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceDescriptor;
@@ -29,10 +31,8 @@ import java.util.Set;
 /**
  * Validator for MCP resource navigation descriptors.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPResourceNavigationDescriptorValidator {
-    
-    private MCPResourceNavigationDescriptorValidator() {
-    }
     
     /**
      * Validate resource navigation endpoints against public descriptor identifiers.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorCatalogValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorCatalogValidator.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mcp.api.resource.descriptor.MCPResourceDescriptor;
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
@@ -35,6 +37,7 @@ import java.util.stream.Collectors;
 /**
  * Validator for MCP tool descriptors and their runtime bindings.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPToolDescriptorCatalogValidator {
     
     private static final Collection<String> SUPPORTED_INPUT_SCHEMA_TOP_LEVEL_FIELDS = Set.of("type", "properties", "required", "additionalProperties");
@@ -48,9 +51,6 @@ public final class MCPToolDescriptorCatalogValidator {
     private static final String VALIDATE_RUNTIME_DATABASE = "database_gateway_validate_runtime_database";
     
     private static final Collection<String> SECRET_WORKFLOW_OUTPUT_FIELDS = List.of("masked_property_preview", "secret_reference_summary");
-    
-    private MCPToolDescriptorCatalogValidator() {
-    }
     
     /**
      * Validate tool descriptors in one descriptor catalog.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorValidationUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolDescriptorValidationUtils.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
@@ -31,6 +33,7 @@ import java.util.Optional;
 /**
  * MCP tool descriptor validation utilities.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPToolDescriptorValidationUtils {
     
     private static final Collection<String> REQUIRED_WORKFLOW_PLAN_OUTPUT_FIELDS = List.of(
@@ -42,9 +45,6 @@ public final class MCPToolDescriptorValidationUtils {
     private static final Collection<String> REQUIRED_WORKFLOW_PLAN_META_FIELDS = List.of(
             "org.apache.shardingsphere/workflow-kind", "org.apache.shardingsphere/artifact-categories", "org.apache.shardingsphere/side-effect-scope",
             "org.apache.shardingsphere/related-resource-uris", "org.apache.shardingsphere/follow-up-tools");
-    
-    private MCPToolDescriptorValidationUtils() {
-    }
     
     /**
      * Validate required workflow planning output fields.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolOutputSchemaValidator.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPToolOutputSchemaValidator.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.descriptor;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.support.protocol.MCPModelFacingPayloadContract;
@@ -31,15 +33,13 @@ import java.util.Map.Entry;
 /**
  * Validator for model-facing MCP tool output schema contracts.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPToolOutputSchemaValidator {
     
     private static final Collection<String> CONTINUATION_MODES = List.of("none", "pagination", "metadata_search");
     
     private static final Collection<String> RECOVERY_CATEGORIES = List.of("not_found", "ambiguous", "empty_scope", "missing_context", "validation", "terminal",
             "unsupported_target", "invalid_enum", "unsafe_sql", "stale_workflow", "unavailable_runtime", "terminal_operator_action");
-    
-    private MCPToolOutputSchemaValidator() {
-    }
     
     /**
      * Validate one tool output schema.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/protocol/MCPModelFacingPayloadContract.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/protocol/MCPModelFacingPayloadContract.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.protocol;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -27,6 +29,7 @@ import java.util.Set;
 /**
  * MCP model-facing payload contract.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPModelFacingPayloadContract {
     
     private static final Collection<String> REMOVED_MODEL_FACING_FIELDS = Set.of(
@@ -53,9 +56,6 @@ public final class MCPModelFacingPayloadContract {
             MCPPayloadFieldNames.SUMMARY, MCPPayloadFieldNames.NEXT_ACTIONS, MCPPayloadFieldNames.RESOURCES_TO_READ, MCPPayloadFieldNames.RESOURCE,
             MCPPayloadFieldNames.SELF_RESOURCE, MCPPayloadFieldNames.PARENT_RESOURCE, MCPPayloadFieldNames.NEXT_RESOURCES, "manual_artifact_summary", "manual_follow_up",
             "empty_state", "ambiguity_state", MCPPayloadFieldNames.RECOVERY, "recovery_guidance", "remediation");
-    
-    private MCPModelFacingPayloadContract() {
-    }
     
     private static Collection<String> createNextActionSchemaAllowedFields() {
         Set<String> result = new LinkedHashSet<>();

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/protocol/MCPPayloadFieldNames.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/protocol/MCPPayloadFieldNames.java
@@ -17,9 +17,13 @@
 
 package org.apache.shardingsphere.mcp.support.protocol;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 /**
  * MCP model-facing payload field names.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPPayloadFieldNames {
     
     public static final String ALLOWED_VALUES = "allowed_values";
@@ -66,6 +70,4 @@ public final class MCPPayloadFieldNames {
     
     public static final String URI = "uri";
     
-    private MCPPayloadFieldNames() {
-    }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/security/MCPRuntimeProtectionPolicy.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/security/MCPRuntimeProtectionPolicy.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.security;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
 
 import java.util.LinkedHashMap;
@@ -25,6 +27,7 @@ import java.util.Map;
 /**
  * MCP runtime protection policy.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPRuntimeProtectionPolicy {
     
     public static final int DEFAULT_MAX_TOOL_CALLS_PER_SESSION = 10000;
@@ -38,9 +41,6 @@ public final class MCPRuntimeProtectionPolicy {
     public static final int DEFAULT_TIMEOUT_MILLISECONDS = 0;
     
     public static final int MAX_TIMEOUT_MILLISECONDS = 300000;
-    
-    private MCPRuntimeProtectionPolicy() {
-    }
     
     /**
      * Get maximum tool calls per MCP session.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/descriptor/WorkflowKindDescriptors.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/descriptor/WorkflowKindDescriptors.java
@@ -17,12 +17,15 @@
 
 package org.apache.shardingsphere.mcp.support.workflow.descriptor;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import java.util.Collection;
 import java.util.Set;
 
 /**
  * Shared workflow kind descriptors.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WorkflowKindDescriptors {
     
     public static final String ENCRYPT_RULE = "encrypt.rule";
@@ -56,9 +59,6 @@ public final class WorkflowKindDescriptors {
     private static final Collection<String> RULE_DISTSQL_ONLY_WORKFLOW_KINDS = Set.of(ENCRYPT_RULE, MASK_RULE, BROADCAST_RULE, READWRITE_RULE, READWRITE_STATUS, SHADOW_RULE,
             SHADOW_DEFAULT_ALGORITHM, SHADOW_ALGORITHM_CLEANUP, SHARDING_TABLE_RULE, SHARDING_TABLE_REFERENCE, SHARDING_DEFAULT_STRATEGY, SHARDING_KEY_GENERATOR,
             SHARDING_KEY_GENERATE_STRATEGY, SHARDING_COMPONENT_CLEANUP);
-    
-    private WorkflowKindDescriptors() {
-    }
     
     /**
      * Judge whether workflow must expose rule DistSQL artifacts only.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/descriptor/WorkflowToolDescriptors.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/descriptor/WorkflowToolDescriptors.java
@@ -17,15 +17,17 @@
 
 package org.apache.shardingsphere.mcp.support.workflow.descriptor;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 /**
  * Shared workflow tool names.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WorkflowToolDescriptors {
     
     public static final String APPLY_TOOL_NAME = "database_gateway_apply_workflow";
     
     public static final String VALIDATE_TOOL_NAME = "database_gateway_validate_workflow";
     
-    private WorkflowToolDescriptors() {
-    }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/RuleWorkflowFeatureData.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/RuleWorkflowFeatureData.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mcp.support.workflow.model;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -28,14 +29,12 @@ import java.util.Map;
  * Rule workflow feature-scoped state.
  */
 @Getter
+@NoArgsConstructor
 public final class RuleWorkflowFeatureData implements WorkflowFeatureData {
     
     private final List<Map<String, Object>> beforeRules = new LinkedList<>();
     
     private final List<Map<String, Object>> expectedRules = new LinkedList<>();
-    
-    public RuleWorkflowFeatureData() {
-    }
     
     public RuleWorkflowFeatureData(final List<Map<String, Object>> beforeRules, final List<Map<String, Object>> expectedRules) {
         this.beforeRules.addAll(copyRules(beforeRules));

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/WorkflowFieldNames.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/WorkflowFieldNames.java
@@ -17,9 +17,13 @@
 
 package org.apache.shardingsphere.mcp.support.workflow.model;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 /**
  * Workflow MCP field names.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WorkflowFieldNames {
     
     public static final String ALGORITHM_TYPE = "algorithm_type";
@@ -68,6 +72,4 @@ public final class WorkflowFieldNames {
     
     public static final String TABLE = "table";
     
-    private WorkflowFieldNames() {
-    }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/WorkflowLifecycle.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/model/WorkflowLifecycle.java
@@ -17,9 +17,13 @@
 
 package org.apache.shardingsphere.mcp.support.workflow.model;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 /**
  * Workflow lifecycle vocabulary.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WorkflowLifecycle {
     
     public static final String STATUS_AWAITING_MANUAL_EXECUTION = "awaiting-manual-execution";
@@ -58,6 +62,4 @@ public final class WorkflowLifecycle {
     
     public static final String OPERATION_DROP = "drop";
     
-    private WorkflowLifecycle() {
-    }
 }

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowArtifactPayloadUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowArtifactPayloadUtils.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.workflow.service;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.support.workflow.WorkflowPropertySource;
 import org.apache.shardingsphere.mcp.support.workflow.descriptor.WorkflowKindDescriptors;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
@@ -26,6 +28,7 @@ import java.util.Map;
 /**
  * Workflow artifact payload utility methods.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WorkflowArtifactPayloadUtils {
     
     public static final String ARTIFACT_TYPE_CREATE_INDEX = "create-index";
@@ -45,9 +48,6 @@ public final class WorkflowArtifactPayloadUtils {
     public static final String STEP_INDEX_DDL = "index_ddl";
     
     public static final String STEP_RULE_DISTSQL = "rule_distsql";
-    
-    private WorkflowArtifactPayloadUtils() {
-    }
     
     /**
      * Create masked workflow artifact payload.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowDistSQLQueryUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowDistSQLQueryUtils.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.workflow.service;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.exception.MCPQueryFailedException;
 import org.apache.shardingsphere.mcp.support.database.spi.MCPFeatureQueryFacade;
 
@@ -29,10 +31,8 @@ import java.util.Objects;
 /**
  * DistSQL query utilities for workflow planning.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WorkflowDistSQLQueryUtils {
-    
-    private WorkflowDistSQLQueryUtils() {
-    }
     
     /**
      * Judge whether a query failed because the current backend cannot parse ShardingSphere DistSQL.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowLifecycleUtils.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowLifecycleUtils.java
@@ -17,16 +17,16 @@
 
 package org.apache.shardingsphere.mcp.support.workflow.service;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowContextSnapshot;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowLifecycle;
 
 /**
  * Workflow lifecycle utility methods.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WorkflowLifecycleUtils {
-    
-    private WorkflowLifecycleUtils() {
-    }
     
     /**
      * Check whether the workflow snapshot belongs to the current session.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowRequestBinder.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/service/WorkflowRequestBinder.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.workflow.service;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.api.protocol.exception.MCPInvalidRequestException;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowFieldNames;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowRequest;
@@ -29,10 +31,8 @@ import java.util.function.Supplier;
 /**
  * Workflow request binder.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WorkflowRequestBinder {
-    
-    private WorkflowRequestBinder() {
-    }
     
     /**
      * Bind workflow planning request from MCP arguments.

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/spi/WorkflowRuntimeDefinition.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/workflow/spi/WorkflowRuntimeDefinition.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mcp.support.workflow.spi;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
 
@@ -24,6 +25,7 @@ import org.apache.shardingsphere.mcp.support.workflow.model.WorkflowKind;
  * Workflow runtime definition.
  */
 @Getter
+@AllArgsConstructor
 public final class WorkflowRuntimeDefinition {
     
     private final WorkflowKind workflowKind;
@@ -37,14 +39,6 @@ public final class WorkflowRuntimeDefinition {
     public WorkflowRuntimeDefinition(final WorkflowKind workflowKind, final MCPWorkflowValidationHandler validationHandler,
                                      final MCPWorkflowApplySynchronizationHandler applySynchronizationHandler) {
         this(workflowKind, validationHandler, applySynchronizationHandler, MCPWorkflowApplyArtifactValidator.NO_OP);
-    }
-    
-    public WorkflowRuntimeDefinition(final WorkflowKind workflowKind, final MCPWorkflowValidationHandler validationHandler,
-                                     final MCPWorkflowApplySynchronizationHandler applySynchronizationHandler, final MCPWorkflowApplyArtifactValidator applyArtifactValidator) {
-        this.workflowKind = workflowKind;
-        this.validationHandler = validationHandler;
-        this.applySynchronizationHandler = applySynchronizationHandler;
-        this.applyArtifactValidator = applyArtifactValidator;
     }
     
     /**

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/AbstractMCPJdbcMetadataLoaderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/metadata/jdbc/AbstractMCPJdbcMetadataLoaderTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mcp.support.database.metadata.jdbc;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeFactory;
@@ -403,16 +404,12 @@ abstract class AbstractMCPJdbcMetadataLoaderTest {
         }
     }
     
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
     protected static final class MockDriver implements Driver {
         
         private final String jdbcUrl;
         
         private final Connection connection;
-        
-        protected MockDriver(final String jdbcUrl, final Connection connection) {
-            this.jdbcUrl = jdbcUrl;
-            this.connection = connection;
-        }
         
         @Override
         public Connection connect(final String url, final Properties info) {

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/markdown/MCPMarkdownResourceLoaderTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/markdown/MCPMarkdownResourceLoaderTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mcp.support.markdown;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -84,6 +86,7 @@ class MCPMarkdownResourceLoaderTest {
         }
     }
     
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class FixtureResourceClassLoader extends ClassLoader {
         
         private final String resourceName;
@@ -92,11 +95,6 @@ class MCPMarkdownResourceLoaderTest {
         
         private FixtureResourceClassLoader(final String resourceName) {
             this(resourceName, null);
-        }
-        
-        private FixtureResourceClassLoader(final String resourceName, final String content) {
-            this.resourceName = resourceName;
-            this.content = content;
         }
         
         @Override

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/FederationMetaDataRefreshEngine.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/FederationMetaDataRefreshEngine.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mode.metadata.refresher.federation;
 
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
@@ -34,15 +35,12 @@ import java.util.Optional;
 /**
  * Federation meta data refresh engine.
  */
+@AllArgsConstructor
 public final class FederationMetaDataRefreshEngine {
     
     private static final Collection<Class<?>> SUPPORTED_REFRESH_TYPES = new HashSet<>(Arrays.asList(CreateViewStatement.class, AlterViewStatement.class, DropViewStatement.class));
     
     private final SQLStatementContext sqlStatementContext;
-    
-    public FederationMetaDataRefreshEngine(final SQLStatementContext sqlStatementContext) {
-        this.sqlStatementContext = sqlStatementContext;
-    }
     
     /**
      * Whether to need refresh meta data.

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/CreateViewPushDownMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/CreateViewPushDownMetaDataRefresherTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.mode.metadata.refresher.pushdown.type.view;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
@@ -162,13 +163,10 @@ class CreateViewPushDownMetaDataRefresherTest {
         }
     }
     
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class SingleTableMutableDataNodeRuleAttribute implements MutableDataNodeRuleAttribute {
         
         private final DataNode dataNode;
-        
-        private SingleTableMutableDataNodeRuleAttribute(final DataNode dataNode) {
-            this.dataNode = dataNode;
-        }
         
         @Override
         public void put(final String dataSourceName, final String schemaName, final String tableName) {
@@ -218,13 +216,10 @@ class CreateViewPushDownMetaDataRefresherTest {
         }
     }
     
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class DistributedTableMapperRuleAttribute implements TableMapperRuleAttribute {
         
         private final String distributedTableName;
-        
-        private DistributedTableMapperRuleAttribute(final String distributedTableName) {
-            this.distributedTableName = distributedTableName;
-        }
         
         @Override
         public Collection<String> getLogicTableNames() {

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/SchemaRefreshUtilsTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/SchemaRefreshUtilsTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mode.metadata.refresher.util;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
@@ -98,16 +100,12 @@ class SchemaRefreshUtilsTest {
         return new FixtureSQLStatementContext(sqlStatement, tablesContext);
     }
     
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class FixtureSQLStatementContext implements SQLStatementContext {
         
         private final SQLStatement sqlStatement;
         
         private final TablesContext tablesContext;
-        
-        private FixtureSQLStatementContext(final SQLStatement sqlStatement, final TablesContext tablesContext) {
-            this.sqlStatement = sqlStatement;
-            this.tablesContext = tablesContext;
-        }
         
         @Override
         public SQLStatement getSqlStatement() {

--- a/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/exclusive/ClusterExclusiveOperatorContext.java
+++ b/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/exclusive/ClusterExclusiveOperatorContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.mode.manager.cluster.exclusive;
 
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mode.exclusive.ExclusiveLockHandle;
 import org.apache.shardingsphere.mode.exclusive.ExclusiveOperatorContext;
@@ -63,6 +64,7 @@ public final class ClusterExclusiveOperatorContext implements ExclusiveOperatorC
         return Math.max(0L, timeoutMillis - (System.currentTimeMillis() - startTimeMillis));
     }
     
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class ClusterExclusiveLockHandle implements ExclusiveLockHandle {
         
         private final String operationKey;
@@ -72,12 +74,6 @@ public final class ClusterExclusiveOperatorContext implements ExclusiveOperatorC
         private final Collection<String> exclusiveOperationKeys;
         
         private final AtomicBoolean closed = new AtomicBoolean();
-        
-        private ClusterExclusiveLockHandle(final String operationKey, final DistributedLock distributedLock, final Collection<String> exclusiveOperationKeys) {
-            this.operationKey = operationKey;
-            this.distributedLock = distributedLock;
-            this.exclusiveOperationKeys = exclusiveOperationKeys;
-        }
         
         @Override
         public void close() {

--- a/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/exclusive/ClusterExclusiveOperatorContextTest.java
+++ b/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/exclusive/ClusterExclusiveOperatorContextTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.mode.manager.cluster.exclusive;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstanceContext;
 import org.apache.shardingsphere.mode.exclusive.ExclusiveLockHandle;
 import org.apache.shardingsphere.mode.repository.cluster.exception.ClusterRepositoryPersistException;
@@ -255,13 +257,10 @@ class ClusterExclusiveOperatorContextTest {
         }
     }
     
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class FreshDistributedLock implements DistributedLock {
         
         private final SharedState sharedState;
-        
-        private FreshDistributedLock(final SharedState sharedState) {
-            this.sharedState = sharedState;
-        }
         
         @Override
         public boolean tryLock(final long timeoutMillis) {

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/ddl/partition/PartitionValuesSegment.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/ddl/partition/PartitionValuesSegment.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.partition;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.SQLSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
@@ -30,6 +31,7 @@ import java.util.LinkedList;
  */
 @Getter
 @Setter
+@RequiredArgsConstructor
 public final class PartitionValuesSegment implements SQLSegment {
     
     private final int startIndex;
@@ -41,12 +43,6 @@ public final class PartitionValuesSegment implements SQLSegment {
     private final Collection<ExpressionSegment> values = new LinkedList<>();
     
     private boolean isMaxValue;
-    
-    public PartitionValuesSegment(final int startIndex, final int stopIndex, final PartitionValuesType valuesType) {
-        this.startIndex = startIndex;
-        this.stopIndex = stopIndex;
-        this.valuesType = valuesType;
-    }
     
     /**
      * Partition values type.

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/metadata/FirebirdBlobColumnMetaDataResolver.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/metadata/FirebirdBlobColumnMetaDataResolver.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.metadata;
 
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.database.connector.firebird.metadata.data.FirebirdBlobInfoRegistry;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
@@ -27,13 +28,10 @@ import java.util.OptionalInt;
 /**
  * Resolver for Firebird BLOB column metadata.
  */
+@AllArgsConstructor
 public final class FirebirdBlobColumnMetaDataResolver {
     
     private final String databaseName;
-    
-    public FirebirdBlobColumnMetaDataResolver(final String databaseName) {
-        this.databaseName = databaseName;
-    }
     
     /**
      * Resolve BLOB-related metadata for the given table column.

--- a/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/upload/FirebirdBlobUpload.java
+++ b/proxy/frontend/dialect/firebird/src/main/java/org/apache/shardingsphere/proxy/frontend/firebird/command/query/blob/upload/FirebirdBlobUpload.java
@@ -18,11 +18,13 @@
 package org.apache.shardingsphere.proxy.frontend.firebird.command.query.blob.upload;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
 @Getter
+@RequiredArgsConstructor
 public final class FirebirdBlobUpload {
     
     private final int blobHandle;
@@ -32,11 +34,6 @@ public final class FirebirdBlobUpload {
     private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
     
     private boolean closed;
-    
-    public FirebirdBlobUpload(final int blobHandle, final long blobId) {
-        this.blobHandle = blobHandle;
-        this.blobId = blobId;
-    }
     
     /**
      * Append a BLOB data segment.

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationTurnPlanner.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/LLMMCPConversationTurnPlanner.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.llm.conversation;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.core.tool.handler.ToolDefinitionRegistry;
 import org.apache.shardingsphere.test.e2e.mcp.llm.scenario.LLME2EScenario;
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 final class LLMMCPConversationTurnPlanner {
     
     private final LLMMCPConversationInstructionFactory instructionFactory;
@@ -37,11 +40,6 @@ final class LLMMCPConversationTurnPlanner {
     
     LLMMCPConversationTurnPlanner(final LLMMCPConversationInstructionFactory instructionFactory) {
         this(instructionFactory, createReadOnlyToolNames());
-    }
-    
-    LLMMCPConversationTurnPlanner(final LLMMCPConversationInstructionFactory instructionFactory, final Set<String> readOnlyToolNames) {
-        this.instructionFactory = instructionFactory;
-        this.readOnlyToolNames = readOnlyToolNames;
     }
     
     private static Set<String> createReadOnlyToolNames() {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/client/LLMChatReadinessProbe.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/llm/conversation/client/LLMChatReadinessProbe.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.llm.conversation.client;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.test.e2e.mcp.llm.config.LLME2EConfiguration;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.ReadinessProbe;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.ReadinessProbe.ReadinessResult;
@@ -26,6 +28,7 @@ import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Objects;
 
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 final class LLMChatReadinessProbe {
     
     private static final long INITIAL_READINESS_INTERVAL_MILLIS = 250L;
@@ -35,11 +38,6 @@ final class LLMChatReadinessProbe {
     private final LLME2EConfiguration config;
     
     private final LLMChatModelClient client;
-    
-    LLMChatReadinessProbe(final LLME2EConfiguration config, final LLMChatModelClient client) {
-        this.config = config;
-        this.client = client;
-    }
     
     void waitUntilReady() throws InterruptedException {
         new ReadinessProbe(config.getReadyTimeoutSeconds() * 1000L, INITIAL_READINESS_INTERVAL_MILLIS, MAX_READINESS_INTERVAL_MILLIS)

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionMySQLRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/AbstractProductionMySQLRuntimeE2ETest.java
@@ -21,6 +21,7 @@ import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
 import org.apache.shardingsphere.test.e2e.mcp.env.MCPE2ECondition;
@@ -334,16 +335,12 @@ abstract class AbstractProductionMySQLRuntimeE2ETest extends AbstractTransportPa
         return ((List<?>) value).stream().map(String::valueOf).toList();
     }
     
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class MySQLRuntimeFixture implements AutoCloseable {
         
         private final GenericContainer<?> container;
         
         private final String physicalSchemaName;
-        
-        private MySQLRuntimeFixture(final GenericContainer<?> container, final String physicalSchemaName) {
-            this.container = container;
-            this.physicalSchemaName = physicalSchemaName;
-        }
         
         private GenericContainer<?> container() {
             return container;

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMCPClientTransportFactory.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionMCPClientTransportFactory.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.runtime.production;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
@@ -45,6 +47,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class ProductionMCPClientTransportFactory {
     
     private static final String STDIO_LOGBACK_CONFIG_FILE_NAME = "mcp-e2e-sdk-stdio-logback.xml";
@@ -52,9 +55,6 @@ final class ProductionMCPClientTransportFactory {
     private static final String MASK_PLAN_TOOL_NAME = "database_gateway_plan_mask_rule";
     
     private static final List<String> SUPPORTED_PROTOCOL_VERSIONS = List.of(ProtocolVersions.MCP_2025_11_25);
-    
-    private ProductionMCPClientTransportFactory() {
-    }
     
     static McpSyncClient createElicitationClient(final McpClientTransport clientTransport, final List<McpSchema.ElicitRequest> elicitationRequests,
                                                  final BiFunction<List<McpSchema.ElicitRequest>, McpSchema.ElicitRequest, McpSchema.ElicitResult> elicitationHandler) {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionRuntimeTransportCases.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/production/ProductionRuntimeTransportCases.java
@@ -17,16 +17,16 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.runtime.production;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.RuntimeTransport;
 import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.List;
 import java.util.stream.Stream;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class ProductionRuntimeTransportCases {
-    
-    private ProductionRuntimeTransportCases() {
-    }
     
     static Stream<Arguments> transports() {
         return runtimeTransports().map(each -> Arguments.of(getTransportName(each), each));

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/AbstractHttpProgrammaticRuntimeE2ETest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/runtime/programmatic/AbstractHttpProgrammaticRuntimeE2ETest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.runtime.programmatic;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.AbstractConfigBackedRuntimeE2ETest;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.MySQLRuntimeTestSupport;
@@ -224,16 +226,12 @@ abstract class AbstractHttpProgrammaticRuntimeE2ETest extends AbstractConfigBack
         }
     }
     
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class ProgrammaticRuntimeFixture implements AutoCloseable {
         
         private final GenericContainer<?> container;
         
         private final Map<String, RuntimeDatabaseConfiguration> runtimeDatabases;
-        
-        private ProgrammaticRuntimeFixture(final GenericContainer<?> container, final Map<String, RuntimeDatabaseConfiguration> runtimeDatabases) {
-            this.container = container;
-            this.runtimeDatabases = runtimeDatabases;
-        }
         
         private GenericContainer<?> container() {
             return container;

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/OfficialMCPToolNames.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/OfficialMCPToolNames.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.support;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.api.tool.descriptor.MCPToolDescriptor;
 import org.apache.shardingsphere.mcp.core.tool.handler.ToolDefinitionRegistry;
 
@@ -25,12 +27,10 @@ import java.util.List;
 /**
  * Official MCP tool names packaged by default.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class OfficialMCPToolNames {
     
     private static final List<String> ALL = ToolDefinitionRegistry.getSupportedToolDescriptors().stream().map(MCPToolDescriptor::getName).toList();
-    
-    private OfficialMCPToolNames() {
-    }
     
     /**
      * Get official MCP tool names.

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPBaselineContractAssertions.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPBaselineContractAssertions.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.support.assertion;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
@@ -33,12 +35,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Baseline contract assertions for normalized MCP model-facing payloads.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPBaselineContractAssertions {
     
     private static final String PLAN_ID_PLACEHOLDER = "<plan_id>";
-    
-    private MCPBaselineContractAssertions() {
-    }
     
     /**
      * Assert one model-facing payload projection against a normalized baseline YAML resource.

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPModelContractAssertions.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/assertion/MCPModelContractAssertions.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.support.assertion;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mcp.support.protocol.MCPModelFacingPayloadContract;
 import org.apache.shardingsphere.mcp.support.protocol.MCPPayloadFieldNames;
 
@@ -29,10 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Assertions for model-facing MCP contracts.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MCPModelContractAssertions {
-    
-    private MCPModelContractAssertions() {
-    }
     
     /**
      * Assert that all concrete next_actions lists use the canonical action shape.

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/distribution/DockerImageHttpRuntime.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/distribution/DockerImageHttpRuntime.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.support.distribution;
 
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.ReadinessProbe;
 import org.apache.shardingsphere.test.e2e.mcp.support.runtime.ReadinessProbe.ReadinessResult;
 import org.apache.shardingsphere.test.e2e.mcp.support.transport.client.MCPHttpInteractionClient;
@@ -37,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Docker image HTTP runtime support for MCP distribution E2E tests.
  */
+@RequiredArgsConstructor
 public final class DockerImageHttpRuntime implements AutoCloseable {
     
     private static final String CONTAINER_CONFIG_FILE = "/tmp/shardingsphere-mcp-e2e.yaml";
@@ -56,11 +58,6 @@ public final class DockerImageHttpRuntime implements AutoCloseable {
     private Thread outputCollector;
     
     private int httpPort;
-    
-    public DockerImageHttpRuntime(final String imageName, final Path configFile) {
-        this.imageName = imageName;
-        this.configFile = configFile;
-    }
     
     /**
      * Open an HTTP interaction client after the Docker image becomes ready.

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/distribution/PackagedDistributionPluginFixtureSupport.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/distribution/PackagedDistributionPluginFixtureSupport.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.support.distribution;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.test.e2e.mcp.support.fixture.plugin.PluginFixtureHandlerProvider;
 import org.apache.shardingsphere.test.e2e.mcp.support.fixture.plugin.PluginFixturePingToolHandler;
 import org.apache.shardingsphere.test.e2e.mcp.support.fixture.plugin.PluginFixtureStatusResourceHandler;
@@ -34,6 +36,7 @@ import java.util.stream.Stream;
 /**
  * Test support for packaged distribution plugin discovery fixtures.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PackagedDistributionPluginFixtureSupport {
     
     private static final String HANDLER_PROVIDER_SERVICE_ENTRY = "META-INF/services/org.apache.shardingsphere.mcp.api.MCPHandlerProvider";
@@ -97,9 +100,6 @@ public final class PackagedDistributionPluginFixtureSupport {
                 meta:
                   org.apache.shardingsphere/purpose: test-fixture-plugin
             """;
-    
-    private PackagedDistributionPluginFixtureSupport() {
-    }
     
     /**
      * Create one fixture plugin jar under packaged distribution plugins directory.

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/distribution/PackagedDistributionTestSupport.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/distribution/PackagedDistributionTestSupport.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.support.distribution;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
 import org.apache.shardingsphere.mcp.bootstrap.config.HttpTransportConfiguration;
 import org.apache.shardingsphere.mcp.bootstrap.config.MCPLaunchConfiguration;
@@ -45,6 +47,7 @@ import java.util.stream.Stream;
 /**
  * Packaged distribution support for MCP E2E tests.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PackagedDistributionTestSupport {
     
     private static final String DIST_PATTERN = "apache-shardingsphere-mcp-";
@@ -56,9 +59,6 @@ public final class PackagedDistributionTestSupport {
     private static final int DOCKER_HTTP_PORT = 18088;
     
     private static final String DEFAULT_ENDPOINT_PATH = "/mcp";
-    
-    private PackagedDistributionTestSupport() {
-    }
     
     /**
      * Prepare one packaged MCP distribution copy for E2E tests.

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/runtime/MySQLRuntimeDockerSupport.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/runtime/MySQLRuntimeDockerSupport.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.support.runtime;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.test.e2e.env.runtime.EnvironmentPropertiesLoader;
 import org.testcontainers.DockerClientFactory;
 
@@ -24,10 +26,8 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.Properties;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class MySQLRuntimeDockerSupport {
-    
-    private MySQLRuntimeDockerSupport() {
-    }
     
     static String getMySQLImage() {
         return getMySQLImage(EnvironmentPropertiesLoader.loadProperties());

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/runtime/ProxyEncryptWorkflowRuntimeTestSupport.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/runtime/ProxyEncryptWorkflowRuntimeTestSupport.java
@@ -18,8 +18,9 @@
 package org.apache.shardingsphere.test.e2e.mcp.support.runtime;
 
 import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mcp.support.database.metadata.jdbc.RuntimeDatabaseConfiguration;
@@ -35,6 +36,7 @@ import java.util.Map;
 /**
  * Proxy-backed runtime fixture support for workflow E2E tests.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ProxyEncryptWorkflowRuntimeTestSupport {
     
     private static final String LOGICAL_DATABASE_NAME = "logic_db";
@@ -44,9 +46,6 @@ public final class ProxyEncryptWorkflowRuntimeTestSupport {
     private static final String PROXY_USER = "proxy";
     
     private static final String PROXY_PASSWORD = "Proxy@123";
-    
-    private ProxyEncryptWorkflowRuntimeTestSupport() {
-    }
     
     /**
      * Create Proxy-backed runtime fixture.

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/AbstractMCPInteractionClientTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/AbstractMCPInteractionClientTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.support.transport.client;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -119,6 +121,7 @@ class AbstractMCPInteractionClientTest {
                 "argument", Map.of("name", "schema", "value", "pub"))));
     }
     
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class FakeMCPInteractionClient extends AbstractMCPInteractionClient {
         
         private final Map<String, Object> response;
@@ -130,10 +133,6 @@ class AbstractMCPInteractionClientTest {
         private String method;
         
         private Map<String, Object> params = Map.of();
-        
-        private FakeMCPInteractionClient(final Map<String, Object> response) {
-            this.response = response;
-        }
         
         @Override
         public void open() {

--- a/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/MCPHttpInteractionClientTest.java
+++ b/test/e2e/mcp/src/test/java/org/apache/shardingsphere/test/e2e/mcp/support/transport/client/MCPHttpInteractionClientTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.mcp.support.transport.client;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
@@ -194,6 +196,7 @@ class MCPHttpInteractionClientTest {
     private record QueuedResponse(int statusCode, Map<String, List<String>> headers, String body) {
     }
     
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     private static final class StringHttpResponse implements HttpResponse<String> {
         
         private final HttpRequest request;
@@ -203,13 +206,6 @@ class MCPHttpInteractionClientTest {
         private final Map<String, List<String>> rawHeaders;
         
         private final String body;
-        
-        private StringHttpResponse(final HttpRequest request, final int statusCode, final Map<String, List<String>> rawHeaders, final String body) {
-            this.request = request;
-            this.statusCode = statusCode;
-            this.rawHeaders = rawHeaders;
-            this.body = body;
-        }
         
         @Override
         public int statusCode() {

--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/sql/it/sql/dql/DQLExclusiveExecutionDetector.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/sql/it/sql/dql/DQLExclusiveExecutionDetector.java
@@ -17,12 +17,15 @@
 
 package org.apache.shardingsphere.test.e2e.sql.it.sql.dql;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
 /**
  * Exclusive execution detector for SQL E2E tests.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DQLExclusiveExecutionDetector {
     
     private static final Pattern SELECT_PATTERN = Pattern.compile("\\bSELECT\\b");
@@ -41,9 +44,6 @@ public final class DQLExclusiveExecutionDetector {
     private static final Pattern KEEP_LOCKS_PATTERN = Pattern.compile("\\bWITH\\s+(?:RR|RS|CS)\\s+USE\\s+AND\\s+KEEP\\s+(?:UPDATE|EXCLUSIVE|SHARE)\\s+LOCKS\\b");
     
     private static final Pattern WITH_LOCK_PATTERN = Pattern.compile("\\bWITH\\s+LOCK\\b(?!\\s+AS\\b)");
-    
-    private DQLExclusiveExecutionDetector() {
-    }
     
     /**
      * Judge whether SQL requires exclusive execution.


### PR DESCRIPTION
Replace equivalent hand-written boilerplate constructors with narrow Lombok constructor annotations in non-agent modules. Keep enum constructor code manual where Lombok would not preserve language-level constructor semantics.