### PR TITLE
Refine MCP architecture boundary and sharding request merge

### DIFF
--- a/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/MCPArchitectureBoundaryTest.java
+++ b/mcp/bootstrap/src/test/java/org/apache/shardingsphere/mcp/bootstrap/MCPArchitectureBoundaryTest.java
@@ -37,11 +37,15 @@ class MCPArchitectureBoundaryTest {
             "mcp/bootstrap/src/main/java");
     
     private static final List<String> FEATURE_PACKAGE_IMPORTS = List.of(
+            "org.apache.shardingsphere.mcp.feature.broadcast",
             "org.apache.shardingsphere.mcp.feature.encrypt",
-            "org.apache.shardingsphere.mcp.feature.mask");
+            "org.apache.shardingsphere.mcp.feature.mask",
+            "org.apache.shardingsphere.mcp.feature.readwritesplitting",
+            "org.apache.shardingsphere.mcp.feature.shadow",
+            "org.apache.shardingsphere.mcp.feature.sharding");
     
     @Test
-    void assertGenericModulesDoNotImportEncryptOrMaskFeatures() throws IOException {
+    void assertGenericModulesDoNotImportFeatures() throws IOException {
         Path projectRoot = findProjectRoot();
         for (String each : GENERIC_MODULE_SOURCE_DIRECTORIES) {
             assertNoFeatureImport(projectRoot.resolve(each));
@@ -52,7 +56,7 @@ class MCPArchitectureBoundaryTest {
         try (Stream<Path> paths = Files.walk(sourceDirectory)) {
             List<Path> actualViolations = paths.filter(Files::isRegularFile).filter(each -> each.toString().endsWith(".java"))
                     .filter(this::containsFeaturePackageImport).toList();
-            assertTrue(actualViolations.isEmpty(), () -> "Generic MCP modules must not import encrypt/mask feature packages: " + actualViolations);
+            assertTrue(actualViolations.isEmpty(), () -> "Generic MCP modules must not import feature packages: " + actualViolations);
         }
     }
     

--- a/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/model/ShardingWorkflowRequest.java
+++ b/mcp/features/sharding/src/main/java/org/apache/shardingsphere/mcp/feature/sharding/tool/model/ShardingWorkflowRequest.java
@@ -73,12 +73,13 @@ public final class ShardingWorkflowRequest extends WorkflowRequest {
      * @return merged request
      */
     public static ShardingWorkflowRequest merge(final WorkflowRequest previous, final ShardingWorkflowRequest current) {
-        if (!(previous instanceof ShardingWorkflowRequest)) {
-            return current.copy();
-        }
-        ShardingWorkflowRequest result = ((ShardingWorkflowRequest) previous).copy();
+        ShardingWorkflowRequest result = copyPreviousRequest(previous);
         current.overlayTo(result);
         return result;
+    }
+    
+    private static ShardingWorkflowRequest copyPreviousRequest(final WorkflowRequest previous) {
+        return previous instanceof ShardingWorkflowRequest ? ((ShardingWorkflowRequest) previous).copy() : copyFieldsTo(previous, new ShardingWorkflowRequest());
     }
     
     @Override

--- a/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/model/ShardingWorkflowRequestTest.java
+++ b/mcp/features/sharding/src/test/java/org/apache/shardingsphere/mcp/feature/sharding/tool/model/ShardingWorkflowRequestTest.java
@@ -60,11 +60,22 @@ class ShardingWorkflowRequestTest {
     }
     
     @Test
-    void assertMergeUsesCurrentWhenPreviousIsGeneric() {
-        ShardingWorkflowRequest current = createRequest();
-        ShardingWorkflowRequest actual = ShardingWorkflowRequest.merge(new WorkflowRequest(), current);
+    void assertMergeWithGenericPrevious() {
+        WorkflowRequest previous = new WorkflowRequest();
+        previous.setPlanId("plan-1");
+        previous.setDatabase("logic_db");
+        previous.setTable("t_order");
+        previous.setOperationType("create");
+        ShardingWorkflowRequest current = new ShardingWorkflowRequest();
+        current.setRuleName("ref_rule");
+        current.setShardingColumns("order_id");
+        ShardingWorkflowRequest actual = ShardingWorkflowRequest.merge(previous, current);
+        assertThat(actual.getPlanId(), is("plan-1"));
         assertThat(actual.getDatabase(), is("logic_db"));
+        assertThat(actual.getTable(), is("t_order"));
+        assertThat(actual.getOperationType(), is("create"));
         assertThat(actual.getRuleName(), is("ref_rule"));
+        assertThat(actual.getShardingColumns(), is("order_id"));
     }
     
     private ShardingWorkflowRequest createRequest() {

--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogYamlSwapper.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/descriptor/MCPDescriptorCatalogYamlSwapper.java
@@ -76,21 +76,23 @@ final class MCPDescriptorCatalogYamlSwapper {
     private static void swapFixedResourceDescriptors(final Collection<YamlMCPResourceDescriptor> yamlDescriptors, final Collection<MCPResourceDescriptor> resources,
                                                      final Collection<ShardingSphereMCPResourceMetadata> resourceMetadata) {
         for (YamlMCPResourceDescriptor each : emptyIfNull(yamlDescriptors)) {
-            ShardingSphereMCPResourceMetadata metadata = swapShardingSphereResourceMetadata(each.getUri(), each.getShardingSphereMetadata());
-            resources.add(new MCPResourceDescriptor(each.getUri(), each.getName(), each.getTitle(), each.getDescription(), each.getMimeType(),
-                    swapResourceAnnotations(each.getAnnotations()), createResourceMeta(each.getUri(), emptyMapIfNull(each.getMeta()), metadata)));
-            resourceMetadata.add(metadata);
+            swapResourceDescriptor(each.getUri(), each, resources, resourceMetadata);
         }
     }
     
     private static void swapResourceTemplateDescriptors(final Collection<YamlMCPResourceDescriptor> yamlDescriptors, final Collection<MCPResourceDescriptor> resourceTemplates,
                                                         final Collection<ShardingSphereMCPResourceMetadata> resourceMetadata) {
         for (YamlMCPResourceDescriptor each : emptyIfNull(yamlDescriptors)) {
-            ShardingSphereMCPResourceMetadata metadata = swapShardingSphereResourceMetadata(each.getUriTemplate(), each.getShardingSphereMetadata());
-            resourceTemplates.add(new MCPResourceDescriptor(each.getUriTemplate(), each.getName(), each.getTitle(), each.getDescription(), each.getMimeType(),
-                    swapResourceAnnotations(each.getAnnotations()), createResourceMeta(each.getUriTemplate(), emptyMapIfNull(each.getMeta()), metadata)));
-            resourceMetadata.add(metadata);
+            swapResourceDescriptor(each.getUriTemplate(), each, resourceTemplates, resourceMetadata);
         }
+    }
+    
+    private static void swapResourceDescriptor(final String uriTemplate, final YamlMCPResourceDescriptor yamlDescriptor, final Collection<MCPResourceDescriptor> resources,
+                                               final Collection<ShardingSphereMCPResourceMetadata> resourceMetadata) {
+        ShardingSphereMCPResourceMetadata metadata = swapShardingSphereResourceMetadata(uriTemplate, yamlDescriptor.getShardingSphereMetadata());
+        resources.add(new MCPResourceDescriptor(uriTemplate, yamlDescriptor.getName(), yamlDescriptor.getTitle(), yamlDescriptor.getDescription(), yamlDescriptor.getMimeType(),
+                swapResourceAnnotations(yamlDescriptor.getAnnotations()), createResourceMeta(uriTemplate, emptyMapIfNull(yamlDescriptor.getMeta()), metadata)));
+        resourceMetadata.add(metadata);
     }
     
     private static ShardingSphereMCPResourceMetadata swapShardingSphereResourceMetadata(final String uriTemplate, final YamlShardingSphereMCPResourceMetadata yamlMetadata) {


### PR DESCRIPTION
- cover all MCP feature packages in the generic module boundary test
- preserve generic workflow request fields when merging sharding requests
- reuse descriptor resource swap construction for fixed and template resources