### PR TITLE
Remove MCP legacy system schema fallback

### DIFF
--- a/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseDialect.java
+++ b/mcp/support/src/main/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseDialect.java
@@ -32,9 +32,6 @@ import java.util.Optional;
  */
 public final class MCPDatabaseDialect {
     
-    private static final Collection<String> LEGACY_SYSTEM_SCHEMAS = List.of(
-            "information_schema", "mysql", "performance_schema", "pg_catalog", "shardingsphere", "sys", "system_lobs");
-    
     private final String databaseType;
     
     private final Optional<MCPDatabaseCapabilityOption> option;
@@ -126,7 +123,7 @@ public final class MCPDatabaseDialect {
             return false;
         }
         Collection<String> systemSchemas = option.map(MCPDatabaseCapabilityOption::getSystemSchemas).orElseGet(List::of);
-        return containsSystemSchema(systemSchemas, actualSchemaName) || containsSystemSchema(LEGACY_SYSTEM_SCHEMAS, actualSchemaName);
+        return containsSystemSchema(systemSchemas, actualSchemaName);
     }
     
     /**

--- a/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseDialectTest.java
+++ b/mcp/support/src/test/java/org/apache/shardingsphere/mcp/support/database/capability/MCPDatabaseDialectTest.java
@@ -100,9 +100,15 @@ class MCPDatabaseDialectTest {
     }
     
     @Test
-    void assertIsSystemSchemaWithUnknownDatabaseType() {
+    void assertIsSystemSchemaIgnoresUnknownDatabaseType() {
         boolean actual = MCPDatabaseDialect.of("FixtureDB").isSystemSchema("INFORMATION_SCHEMA");
-        assertTrue(actual);
+        assertFalse(actual);
+    }
+    
+    @Test
+    void assertIsSystemSchemaIgnoresOtherDatabaseType() {
+        boolean actual = MCPDatabaseDialect.of("SQLServer").isSystemSchema("pg_catalog");
+        assertFalse(actual);
     }
     
     private static Stream<Arguments> getIdentifierQuoteCharacterArguments() {


### PR DESCRIPTION
Make MCP database dialect system schema checks rely only on each database capability option, so unknown database types no longer inherit centralized schema assumptions. Add focused tests for unknown database types and cross-dialect system schema isolation.
