### PR TITLE
Remove the useless props parameter for TableRefreshUtils

### DIFF
--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/index/AlterIndexPushDownMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/index/AlterIndexPushDownMetaDataRefresher.java
@@ -55,16 +55,16 @@ public final class AlterIndexPushDownMetaDataRefresher implements PushDownMetaDa
         IndexSegment indexSegment = sqlStatement.getIndex().get();
         String actualSchemaName = SchemaRefreshUtils.getActualSchemaName(database,
                 indexSegment.getOwner().map(OwnerSegment::getIdentifier).orElse(new IdentifierValue(schemaName)));
-        String actualTableName = TableRefreshUtils.findActualTableNameByIndex(database, actualSchemaName, indexSegment.getIndexName().getIdentifier(), props)
+        String actualTableName = TableRefreshUtils.findActualTableNameByIndex(database, actualSchemaName, indexSegment.getIndexName().getIdentifier())
                 .orElseThrow(() -> new IndexNotFoundException(indexSegment.getIndexName().getIdentifier().getValue(), actualSchemaName));
-        String indexName = TableRefreshUtils.getActualIndexName(database, actualSchemaName, actualTableName, indexSegment.getIndexName().getIdentifier(), props);
+        String indexName = TableRefreshUtils.getActualIndexName(database, actualSchemaName, actualTableName, indexSegment.getIndexName().getIdentifier());
         ShardingSpherePreconditions.checkState(database.containsSchema(actualSchemaName), () -> new SchemaNotFoundException(actualSchemaName));
         ShardingSphereSchema schema = database.getSchema(actualSchemaName);
         ShardingSpherePreconditions.checkState(schema.containsTable(actualTableName), () -> new TableNotFoundException(actualTableName));
         ShardingSphereTable table = schema.getTable(actualTableName);
         ShardingSphereTable newTable = new ShardingSphereTable(table.getName(), table.getAllColumns(), table.getAllIndexes(), table.getAllConstraints(), table.getType());
         newTable.removeIndex(indexName);
-        String renameIndexName = TableRefreshUtils.getActualIndexName(database, actualSchemaName, actualTableName, renameIndex.get().getIndexName().getIdentifier(), props);
+        String renameIndexName = TableRefreshUtils.getActualIndexName(database, actualSchemaName, actualTableName, renameIndex.get().getIndexName().getIdentifier());
         newTable.putIndex(new ShardingSphereIndex(renameIndexName, new LinkedList<>(), false));
         metaDataManagerPersistService.alterTables(database, actualSchemaName, Collections.singleton(newTable));
     }

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/index/CreateIndexPushDownMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/index/CreateIndexPushDownMetaDataRefresher.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.mode.metadata.refresher.pushdown.PushDownMetaDa
 import org.apache.shardingsphere.mode.metadata.refresher.util.TableRefreshUtils;
 import org.apache.shardingsphere.mode.persist.service.MetaDataManagerPersistService;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.index.IndexSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.attribute.type.IndexSQLStatementAttribute;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.type.ddl.index.CreateIndexStatement;
 import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
@@ -48,17 +49,17 @@ public final class CreateIndexPushDownMetaDataRefresher implements PushDownMetaD
                         final String schemaName, final DatabaseType databaseType, final CreateIndexStatement sqlStatement, final ConfigurationProperties props) {
         Collection<IndexSegment> indexes = sqlStatement.getAttributes().getAttribute(IndexSQLStatementAttribute.class).getIndexes();
         Preconditions.checkArgument(1 == indexes.size());
-        String tableName = TableRefreshUtils.getActualTableName(database, schemaName, sqlStatement.getTable().getTableName().getIdentifier(), props);
+        String tableName = TableRefreshUtils.getActualTableName(database, schemaName, sqlStatement.getTable().getTableName().getIdentifier());
         ShardingSpherePreconditions.checkState(database.containsSchema(schemaName), () -> new SchemaNotFoundException(schemaName));
         ShardingSphereSchema schema = database.getSchema(schemaName);
         ShardingSpherePreconditions.checkState(schema.containsTable(tableName), () -> new TableNotFoundException(tableName));
         ShardingSphereTable table = schema.getTable(tableName);
         ShardingSphereTable newTable = new ShardingSphereTable(table.getName(), table.getAllColumns(), table.getAllIndexes(), table.getAllConstraints(), table.getType());
         IdentifierValue indexIdentifier = indexes.iterator().next().getIndexName().getIdentifier();
-        String actualIndexName = TableRefreshUtils.getActualIndexName(database, schemaName, tableName, indexIdentifier, props);
+        String actualIndexName = TableRefreshUtils.getActualIndexName(database, schemaName, tableName, indexIdentifier);
         newTable.putIndex(new ShardingSphereIndex(actualIndexName,
                 TableRefreshUtils.getActualColumnNames(database, schemaName, tableName,
-                        sqlStatement.getColumns().stream().map(each -> each.getIdentifier()).collect(java.util.stream.Collectors.toList()), props),
+                        sqlStatement.getColumns().stream().map(ColumnSegment::getIdentifier).collect(java.util.stream.Collectors.toList())),
                 false));
         metaDataManagerPersistService.alterTables(database, schemaName, Collections.singleton(newTable));
     }

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/index/DropIndexPushDownMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/index/DropIndexPushDownMetaDataRefresher.java
@@ -58,7 +58,7 @@ public final class DropIndexPushDownMetaDataRefresher implements PushDownMetaDat
             ShardingSpherePreconditions.checkState(schema.containsTable(logicTableName.get()), () -> new TableNotFoundException(logicTableName.get()));
             ShardingSphereTable table = schema.getTable(logicTableName.get());
             ShardingSphereTable newTable = new ShardingSphereTable(table.getName(), table.getAllColumns(), table.getAllIndexes(), table.getAllConstraints(), table.getType());
-            newTable.removeIndex(TableRefreshUtils.getActualIndexName(database, actualSchemaName, logicTableName.get(), each.getIndexName().getIdentifier(), props));
+            newTable.removeIndex(TableRefreshUtils.getActualIndexName(database, actualSchemaName, logicTableName.get(), each.getIndexName().getIdentifier()));
             metaDataManagerPersistService.alterTables(database, actualSchemaName, Collections.singleton(newTable));
         }
     }
@@ -67,9 +67,9 @@ public final class DropIndexPushDownMetaDataRefresher implements PushDownMetaDat
                                                  final DropIndexStatement sqlStatement, final IndexSegment indexSegment, final ConfigurationProperties props) {
         Optional<SimpleTableSegment> simpleTableSegment = sqlStatement.getSimpleTable();
         if (simpleTableSegment.isPresent()) {
-            return Optional.of(TableRefreshUtils.getActualTableName(database, schemaName, simpleTableSegment.get().getTableName().getIdentifier(), props));
+            return Optional.of(TableRefreshUtils.getActualTableName(database, schemaName, simpleTableSegment.get().getTableName().getIdentifier()));
         }
-        return TableRefreshUtils.findActualTableNameByIndex(database, schemaName, indexSegment.getIndexName().getIdentifier(), props);
+        return TableRefreshUtils.findActualTableNameByIndex(database, schemaName, indexSegment.getIndexName().getIdentifier());
     }
     
     @Override

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/AlterTablePushDownMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/AlterTablePushDownMetaDataRefresher.java
@@ -40,7 +40,7 @@ public final class AlterTablePushDownMetaDataRefresher implements PushDownMetaDa
     @Override
     public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService, final ShardingSphereDatabase database, final String logicDataSourceName,
                         final String schemaName, final DatabaseType databaseType, final AlterTableStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
-        String actualTableName = TableRefreshUtils.getActualTableName(database, schemaName, sqlStatement.getTable().getTableName().getIdentifier(), props);
+        String actualTableName = TableRefreshUtils.getActualTableName(database, schemaName, sqlStatement.getTable().getTableName().getIdentifier());
         Collection<ShardingSphereTable> alteredTables = new LinkedList<>();
         Collection<String> droppedTables = new LinkedList<>();
         if (sqlStatement.getRenameTable().isPresent()) {

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/CreateTablePushDownMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/CreateTablePushDownMetaDataRefresher.java
@@ -60,7 +60,7 @@ public final class CreateTablePushDownMetaDataRefresher implements PushDownMetaD
             return database.getAllSchemas();
         }
         Collection<ShardingSphereSchema> result = new LinkedList<>(database.getAllSchemas());
-        String tableName = TableRefreshUtils.getTableLoadCandidateName(database, sqlStatement.getTable().getTableName().getIdentifier(), props);
+        String tableName = TableRefreshUtils.getTableLoadCandidateName(database, sqlStatement.getTable().getTableName().getIdentifier());
         result.add(new ShardingSphereSchema(schemaName, database.getProtocolType(),
                 Collections.singleton(new ShardingSphereTable(tableName, Collections.emptyList(), indexes, Collections.emptyList())), Collections.emptyList()));
         return result;

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/DropTablePushDownMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/DropTablePushDownMetaDataRefresher.java
@@ -40,7 +40,7 @@ public final class DropTablePushDownMetaDataRefresher implements PushDownMetaDat
                         final String schemaName, final DatabaseType databaseType, final DropTableStatement sqlStatement, final ConfigurationProperties props) {
         String actualSchemaName = SchemaRefreshUtils.getActualSchemaName(database, new IdentifierValue(schemaName));
         Collection<String> tableNames = TableRefreshUtils.getActualTableNames(database, actualSchemaName,
-                sqlStatement.getTables().stream().map(each -> each.getTableName().getIdentifier()).collect(Collectors.toList()), props);
+                sqlStatement.getTables().stream().map(each -> each.getTableName().getIdentifier()).collect(Collectors.toList()));
         metaDataManagerPersistService.dropTables(database, actualSchemaName, tableNames);
     }
     

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/RenameTablePushDownMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/RenameTablePushDownMetaDataRefresher.java
@@ -44,10 +44,10 @@ public final class RenameTablePushDownMetaDataRefresher implements PushDownMetaD
         Collection<ShardingSphereTable> alteredTables = new LinkedList<>();
         Collection<String> droppedTables = new LinkedList<>();
         for (RenameTableDefinitionSegment each : sqlStatement.getRenameTables()) {
-            String toBeRenamedTableName = TableRefreshUtils.getActualTableName(database, actualSchemaName, each.getTable().getTableName().getIdentifier(), props);
+            String toBeRenamedTableName = TableRefreshUtils.getActualTableName(database, actualSchemaName, each.getTable().getTableName().getIdentifier());
             ShardingSphereTable toBeRenamedTable = database.getSchema(actualSchemaName).getTable(toBeRenamedTableName);
             alteredTables.add(new ShardingSphereTable(
-                    TableRefreshUtils.getActualTableName(database, actualSchemaName, each.getRenameTable().getTableName().getIdentifier(), props),
+                    TableRefreshUtils.getActualTableName(database, actualSchemaName, each.getRenameTable().getTableName().getIdentifier()),
                     toBeRenamedTable.getAllColumns(), toBeRenamedTable.getAllIndexes(), toBeRenamedTable.getAllConstraints()));
             droppedTables.add(toBeRenamedTableName);
         }

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/TableMetaDataRefresherLoader.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/table/TableMetaDataRefresherLoader.java
@@ -77,7 +77,7 @@ public final class TableMetaDataRefresherLoader {
     private ShardingSphereTable loadTable(final ShardingSphereDatabase database, final String logicDataSourceName, final String schemaName,
                                           final IdentifierValue tableIdentifierValue, final ConfigurationProperties props, final boolean fallbackWhenMissing,
                                           final Collection<ShardingSphereSchema> revisionCandidateSchemas) throws SQLException {
-        String candidateTableName = TableRefreshUtils.getTableLoadCandidateName(database, tableIdentifierValue, props);
+        String candidateTableName = TableRefreshUtils.getTableLoadCandidateName(database, tableIdentifierValue);
         RuleMetaData ruleMetaData = new RuleMetaData(new LinkedList<>(database.getRuleMetaData().getRules()));
         boolean singleTable = TableRefreshUtils.isSingleTable(candidateTableName, database);
         if (singleTable) {

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/AlterViewPushDownMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/AlterViewPushDownMetaDataRefresher.java
@@ -44,7 +44,7 @@ public final class AlterViewPushDownMetaDataRefresher implements PushDownMetaDat
     @Override
     public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService, final ShardingSphereDatabase database, final String logicDataSourceName,
                         final String schemaName, final DatabaseType databaseType, final AlterViewStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
-        String actualViewName = TableRefreshUtils.getActualViewName(database, schemaName, sqlStatement.getView().getTableName().getIdentifier(), props);
+        String actualViewName = TableRefreshUtils.getActualViewName(database, schemaName, sqlStatement.getView().getTableName().getIdentifier());
         Collection<ShardingSphereTable> alteredTables = new LinkedList<>();
         Collection<ShardingSphereView> alteredViews = new LinkedList<>();
         Collection<String> droppedTables = new LinkedList<>();

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/DropViewPushDownMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/DropViewPushDownMetaDataRefresher.java
@@ -43,7 +43,7 @@ public final class DropViewPushDownMetaDataRefresher implements PushDownMetaData
         String actualSchemaName = SchemaRefreshUtils.getActualSchemaName(database, new IdentifierValue(schemaName));
         Collection<IdentifierValue> viewIdentifierValues = sqlStatement.getViews().stream().map(SimpleTableSegment::getTableName)
                 .map(TableNameSegment::getIdentifier).collect(Collectors.toList());
-        Collection<String> actualViewNames = TableRefreshUtils.getActualViewNames(database, actualSchemaName, viewIdentifierValues, props);
+        Collection<String> actualViewNames = TableRefreshUtils.getActualViewNames(database, actualSchemaName, viewIdentifierValues);
         metaDataManagerPersistService.dropTables(database, actualSchemaName, actualViewNames);
         metaDataManagerPersistService.dropViews(database, actualSchemaName, actualViewNames);
     }

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/ViewMetaDataRefresherLoader.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/pushdown/type/view/ViewMetaDataRefresherLoader.java
@@ -54,7 +54,7 @@ public final class ViewMetaDataRefresherLoader {
      */
     public ShardingSphereTable loadCreatedView(final ShardingSphereDatabase database, final String logicDataSourceName,
                                                final String schemaName, final IdentifierValue viewIdentifierValue, final ConfigurationProperties props) throws SQLException {
-        String candidateViewName = TableRefreshUtils.getViewLoadCandidateName(database, viewIdentifierValue, props);
+        String candidateViewName = TableRefreshUtils.getViewLoadCandidateName(database, viewIdentifierValue);
         RuleMetaData ruleMetaData = new RuleMetaData(new LinkedList<>(database.getRuleMetaData().getRules()));
         boolean singleTable = TableRefreshUtils.isSingleTable(candidateViewName, database);
         if (singleTable) {
@@ -89,7 +89,7 @@ public final class ViewMetaDataRefresherLoader {
      */
     public ShardingSphereSchema loadAlteredView(final ShardingSphereDatabase database, final String logicDataSourceName, final String schemaName,
                                                 final IdentifierValue viewIdentifierValue, final String viewDefinition, final ConfigurationProperties props) throws SQLException {
-        String candidateViewName = TableRefreshUtils.getViewLoadCandidateName(database, viewIdentifierValue, props);
+        String candidateViewName = TableRefreshUtils.getViewLoadCandidateName(database, viewIdentifierValue);
         RuleMetaData ruleMetaData = new RuleMetaData(new LinkedList<>(database.getRuleMetaData().getRules()));
         boolean singleTable = TableRefreshUtils.isSingleTable(candidateViewName, database);
         if (singleTable) {

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtils.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtils.java
@@ -26,7 +26,6 @@ import org.apache.shardingsphere.database.connector.core.metadata.identifier.Ide
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.LookupMode;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
-import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -72,11 +71,10 @@ public final class TableRefreshUtils {
      *
      * @param database database
      * @param tableIdentifierValue table identifier value
-     * @param props configuration properties
      * @return table load candidate name
      */
-    public static String getTableLoadCandidateName(final ShardingSphereDatabase database, final IdentifierValue tableIdentifierValue, final ConfigurationProperties props) {
-        return getLoadCandidateName(database, tableIdentifierValue, IdentifierScope.TABLE, props);
+    public static String getTableLoadCandidateName(final ShardingSphereDatabase database, final IdentifierValue tableIdentifierValue) {
+        return getLoadCandidateName(database, tableIdentifierValue, IdentifierScope.TABLE);
     }
     
     /**
@@ -84,11 +82,10 @@ public final class TableRefreshUtils {
      *
      * @param database database
      * @param viewIdentifierValue view identifier value
-     * @param props configuration properties
      * @return view load candidate name
      */
-    public static String getViewLoadCandidateName(final ShardingSphereDatabase database, final IdentifierValue viewIdentifierValue, final ConfigurationProperties props) {
-        return getLoadCandidateName(database, viewIdentifierValue, IdentifierScope.VIEW, props);
+    public static String getViewLoadCandidateName(final ShardingSphereDatabase database, final IdentifierValue viewIdentifierValue) {
+        return getLoadCandidateName(database, viewIdentifierValue, IdentifierScope.VIEW);
     }
     
     /**
@@ -97,12 +94,11 @@ public final class TableRefreshUtils {
      * @param database database
      * @param schemaName schema name
      * @param tableIdentifierValue table identifier value
-     * @param props configuration properties
      * @return actual table name
      */
     public static String getActualTableName(final ShardingSphereDatabase database, final String schemaName,
-                                            final IdentifierValue tableIdentifierValue, final ConfigurationProperties props) {
-        return getActualObjectName(database, schemaName, tableIdentifierValue, props, IdentifierScope.TABLE,
+                                            final IdentifierValue tableIdentifierValue) {
+        return getActualObjectName(database, schemaName, tableIdentifierValue, IdentifierScope.TABLE,
                 schema -> schema.getAllTables().stream().map(ShardingSphereTable::getName));
     }
     
@@ -112,14 +108,13 @@ public final class TableRefreshUtils {
      * @param database database
      * @param schemaName schema name
      * @param tableIdentifierValues table identifier values
-     * @param props configuration properties
      * @return actual table names
      */
     public static Collection<String> getActualTableNames(final ShardingSphereDatabase database, final String schemaName,
-                                                         final Collection<IdentifierValue> tableIdentifierValues, final ConfigurationProperties props) {
+                                                         final Collection<IdentifierValue> tableIdentifierValues) {
         Collection<String> result = new LinkedList<>();
         for (IdentifierValue each : tableIdentifierValues) {
-            String actualTableName = getActualTableName(database, schemaName, each, props);
+            String actualTableName = getActualTableName(database, schemaName, each);
             if (null != actualTableName) {
                 result.add(actualTableName);
             }
@@ -133,14 +128,13 @@ public final class TableRefreshUtils {
      * @param database database
      * @param schemaName schema name
      * @param viewIdentifierValues view identifier values
-     * @param props configuration properties
      * @return actual view names
      */
     public static Collection<String> getActualViewNames(final ShardingSphereDatabase database, final String schemaName,
-                                                        final Collection<IdentifierValue> viewIdentifierValues, final ConfigurationProperties props) {
+                                                        final Collection<IdentifierValue> viewIdentifierValues) {
         Collection<String> result = new LinkedList<>();
         for (IdentifierValue each : viewIdentifierValues) {
-            String actualViewName = getActualViewName(database, schemaName, each, props);
+            String actualViewName = getActualViewName(database, schemaName, each);
             if (null != actualViewName) {
                 result.add(actualViewName);
             }
@@ -154,12 +148,11 @@ public final class TableRefreshUtils {
      * @param database database
      * @param schemaName schema name
      * @param viewIdentifierValue view identifier value
-     * @param props configuration properties
      * @return actual view name
      */
     public static String getActualViewName(final ShardingSphereDatabase database, final String schemaName,
-                                           final IdentifierValue viewIdentifierValue, final ConfigurationProperties props) {
-        return getActualObjectName(database, schemaName, viewIdentifierValue, props, IdentifierScope.VIEW,
+                                           final IdentifierValue viewIdentifierValue) {
+        return getActualObjectName(database, schemaName, viewIdentifierValue, IdentifierScope.VIEW,
                 schema -> schema.getAllViews().stream().map(ShardingSphereView::getName));
     }
     
@@ -170,12 +163,11 @@ public final class TableRefreshUtils {
      * @param schemaName schema name
      * @param tableName table name
      * @param indexIdentifierValue index identifier value
-     * @param props configuration properties
      * @return actual index name
      */
     public static String getActualIndexName(final ShardingSphereDatabase database, final String schemaName, final String tableName,
-                                            final IdentifierValue indexIdentifierValue, final ConfigurationProperties props) {
-        return getActualObjectName(database, schemaName, tableName, indexIdentifierValue, props, IdentifierScope.INDEX,
+                                            final IdentifierValue indexIdentifierValue) {
+        return getActualObjectName(database, schemaName, tableName, indexIdentifierValue, IdentifierScope.INDEX,
                 ShardingSphereTable::getAllIndexes, ShardingSphereIndex::getName);
     }
     
@@ -186,14 +178,13 @@ public final class TableRefreshUtils {
      * @param schemaName schema name
      * @param tableName table name
      * @param columnIdentifierValues column identifier values
-     * @param props configuration properties
      * @return actual column names
      */
     public static Collection<String> getActualColumnNames(final ShardingSphereDatabase database, final String schemaName, final String tableName,
-                                                          final Collection<IdentifierValue> columnIdentifierValues, final ConfigurationProperties props) {
+                                                          final Collection<IdentifierValue> columnIdentifierValues) {
         Collection<String> result = new LinkedList<>();
         for (IdentifierValue each : columnIdentifierValues) {
-            String actualColumnName = getActualObjectName(database, schemaName, tableName, each, props, IdentifierScope.COLUMN,
+            String actualColumnName = getActualObjectName(database, schemaName, tableName, each, IdentifierScope.COLUMN,
                     ShardingSphereTable::getAllColumns, ShardingSphereColumn::getName);
             if (null != actualColumnName) {
                 result.add(actualColumnName);
@@ -208,11 +199,10 @@ public final class TableRefreshUtils {
      * @param database database
      * @param schemaName schema name
      * @param indexIdentifierValue index identifier value
-     * @param props configuration properties
      * @return actual table name
      */
     public static Optional<String> findActualTableNameByIndex(final ShardingSphereDatabase database, final String schemaName,
-                                                              final IdentifierValue indexIdentifierValue, final ConfigurationProperties props) {
+                                                              final IdentifierValue indexIdentifierValue) {
         IdentifierCasePolicy policy = database.getIdentifierContext().getPolicy(IdentifierScope.INDEX);
         String actualSchemaName = SchemaRefreshUtils.getActualSchemaName(database, new IdentifierValue(schemaName));
         ShardingSphereSchema schema = database.getSchema(actualSchemaName);
@@ -288,7 +278,7 @@ public final class TableRefreshUtils {
         return Joiner.on(".").join(segments);
     }
     
-    private static String getLoadCandidateName(final ShardingSphereDatabase database, final IdentifierValue identifierValue, final IdentifierScope scope, final ConfigurationProperties props) {
+    private static String getLoadCandidateName(final ShardingSphereDatabase database, final IdentifierValue identifierValue, final IdentifierScope scope) {
         IdentifierCasePolicy policy = database.getIdentifierContext().getPolicy(scope);
         return QuoteCharacter.NONE == identifierValue.getQuoteCharacter() && LookupMode.NORMALIZED == policy.getLookupMode(identifierValue.getQuoteCharacter())
                 ? policy.normalize(identifierValue.getValue())
@@ -296,7 +286,7 @@ public final class TableRefreshUtils {
     }
     
     private static String getActualObjectName(final ShardingSphereDatabase database, final String schemaName,
-                                              final IdentifierValue objectIdentifierValue, final ConfigurationProperties props,
+                                              final IdentifierValue objectIdentifierValue,
                                               final IdentifierScope scope, final Function<ShardingSphereSchema, java.util.stream.Stream<String>> actualNameStream) {
         IdentifierCasePolicy policy = database.getIdentifierContext().getPolicy(scope);
         String actualSchemaName = SchemaRefreshUtils.getActualSchemaName(database, new IdentifierValue(schemaName));
@@ -314,13 +304,13 @@ public final class TableRefreshUtils {
     }
     
     private static <T> String getActualObjectName(final ShardingSphereDatabase database, final String schemaName, final String tableName,
-                                                  final IdentifierValue objectIdentifierValue, final ConfigurationProperties props, final IdentifierScope scope,
+                                                  final IdentifierValue objectIdentifierValue, final IdentifierScope scope,
                                                   final Function<ShardingSphereTable, Collection<T>> actualObjects, final Function<T, String> actualNameMapper) {
         IdentifierCasePolicy policy = database.getIdentifierContext().getPolicy(scope);
         String actualSchemaName = SchemaRefreshUtils.getActualSchemaName(database, new IdentifierValue(schemaName));
         ShardingSphereSchema schema = database.getSchema(actualSchemaName);
         if (null != schema) {
-            String actualTableName = getActualTableName(database, actualSchemaName, new IdentifierValue(tableName), props);
+            String actualTableName = getActualTableName(database, actualSchemaName, new IdentifierValue(tableName));
             ShardingSphereTable table = schema.getTable(actualTableName);
             Optional<String> matchedName = getMatchedObjectName(table, objectIdentifierValue, policy, actualObjects, actualNameMapper);
             if (matchedName.isPresent()) {

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtilsIdentifierTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtilsIdentifierTest.java
@@ -44,57 +44,51 @@ class TableRefreshUtilsIdentifierTest {
     
     @Test
     void assertGetActualTableNameUsesExistingTableName() {
-        assertThat(TableRefreshUtils.getActualTableName(createDatabase(), "foo_schema", new IdentifierValue("foo_tbl"),
-                new ConfigurationProperties(new Properties())), is("Foo_Tbl"));
+        assertThat(TableRefreshUtils.getActualTableName(createDatabase(), "foo_schema", new IdentifierValue("foo_tbl")), is("Foo_Tbl"));
     }
     
     @Test
     void assertGetActualTableNamesUsesExistingTableNames() {
-        assertThat(TableRefreshUtils.getActualTableNames(createDatabase(), "foo_schema", Arrays.asList(new IdentifierValue("foo_tbl"), new IdentifierValue("bar_tbl")),
-                new ConfigurationProperties(new Properties())), is(Arrays.asList("Foo_Tbl", "Bar_Tbl")));
+        assertThat(TableRefreshUtils.getActualTableNames(createDatabase(), "foo_schema", Arrays.asList(new IdentifierValue("foo_tbl"), new IdentifierValue("bar_tbl"))),
+                is(Arrays.asList("Foo_Tbl", "Bar_Tbl")));
     }
     
     @Test
     void assertGetActualViewNamesUsesExistingViewNames() {
-        assertThat(TableRefreshUtils.getActualViewNames(createDatabase(), "foo_schema", Arrays.asList(new IdentifierValue("foo_view"), new IdentifierValue("bar_view")),
-                new ConfigurationProperties(new Properties())), is(Arrays.asList("Foo_View", "Bar_View")));
+        assertThat(TableRefreshUtils.getActualViewNames(createDatabase(), "foo_schema", Arrays.asList(new IdentifierValue("foo_view"), new IdentifierValue("bar_view"))),
+                is(Arrays.asList("Foo_View", "Bar_View")));
     }
     
     @Test
     void assertGetActualViewNameUsesExistingViewName() {
-        assertThat(TableRefreshUtils.getActualViewName(createDatabase(), "foo_schema", new IdentifierValue("foo_view"),
-                new ConfigurationProperties(new Properties())), is("Foo_View"));
+        assertThat(TableRefreshUtils.getActualViewName(createDatabase(), "foo_schema", new IdentifierValue("foo_view")), is("Foo_View"));
     }
     
     @Test
     void assertGetActualIndexNameUsesExistingIndexName() {
-        assertThat(TableRefreshUtils.getActualIndexName(createDatabase(), "foo_schema", "foo_tbl", new IdentifierValue("idx_foo"),
-                new ConfigurationProperties(new Properties())), is("Idx_Foo"));
+        assertThat(TableRefreshUtils.getActualIndexName(createDatabase(), "foo_schema", "foo_tbl", new IdentifierValue("idx_foo")), is("Idx_Foo"));
     }
     
     @Test
     void assertGetActualColumnNamesUsesExistingColumnNames() {
         assertThat(TableRefreshUtils.getActualColumnNames(createDatabase(), "foo_schema", "foo_tbl",
-                Arrays.asList(new IdentifierValue("order_id"), new IdentifierValue("user_id")), new ConfigurationProperties(new Properties())),
+                Arrays.asList(new IdentifierValue("order_id"), new IdentifierValue("user_id"))),
                 is(Arrays.asList("Order_ID", "User_ID")));
     }
     
     @Test
     void assertFindActualTableNameByIndexUsesExistingIndexName() {
-        assertThat(TableRefreshUtils.findActualTableNameByIndex(createDatabase(), "foo_schema", new IdentifierValue("idx_foo"),
-                new ConfigurationProperties(new Properties())).get(), is("Foo_Tbl"));
+        assertThat(TableRefreshUtils.findActualTableNameByIndex(createDatabase(), "foo_schema", new IdentifierValue("idx_foo")).get(), is("Foo_Tbl"));
     }
     
     @Test
     void assertGetTableLoadCandidateNameUsesNormalizedRule() {
-        assertThat(TableRefreshUtils.getTableLoadCandidateName(createDatabase(), new IdentifierValue("Foo_Tbl"),
-                new ConfigurationProperties(new Properties())), is("foo_tbl"));
+        assertThat(TableRefreshUtils.getTableLoadCandidateName(createDatabase(), new IdentifierValue("Foo_Tbl")), is("foo_tbl"));
     }
     
     @Test
     void assertGetViewLoadCandidateNameUsesNormalizedRule() {
-        assertThat(TableRefreshUtils.getViewLoadCandidateName(createDatabase(), new IdentifierValue("Foo_View"),
-                new ConfigurationProperties(new Properties())), is("foo_view"));
+        assertThat(TableRefreshUtils.getViewLoadCandidateName(createDatabase(), new IdentifierValue("Foo_View")), is("foo_view"));
     }
     
     private ShardingSphereDatabase createDatabase() {

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtilsTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtilsTest.java
@@ -97,22 +97,21 @@ class TableRefreshUtilsTest {
     @Test
     void assertGetActualTableNameUsesExistingTableName() {
         ShardingSphereDatabase database = createDatabase();
-        assertThat(TableRefreshUtils.getActualTableName(database, "foo_schema", new IdentifierValue("foo_tbl"),
-                new ConfigurationProperties(new Properties())), is("Foo_Tbl"));
+        assertThat(TableRefreshUtils.getActualTableName(database, "foo_schema", new IdentifierValue("foo_tbl")), is("Foo_Tbl"));
     }
     
     @Test
     void assertGetActualTableNamesUsesExistingTableNames() {
         ShardingSphereDatabase database = createDatabase();
-        assertThat(TableRefreshUtils.getActualTableNames(database, "foo_schema", Arrays.asList(new IdentifierValue("foo_tbl"), new IdentifierValue("bar_tbl")),
-                new ConfigurationProperties(new Properties())), is(Arrays.asList("Foo_Tbl", "Bar_Tbl")));
+        assertThat(TableRefreshUtils.getActualTableNames(database, "foo_schema", Arrays.asList(new IdentifierValue("foo_tbl"), new IdentifierValue("bar_tbl"))),
+                is(Arrays.asList("Foo_Tbl", "Bar_Tbl")));
     }
     
     @Test
     void assertGetActualViewNamesUsesExistingViewNames() {
         ShardingSphereDatabase database = createDatabase();
-        assertThat(TableRefreshUtils.getActualViewNames(database, "foo_schema", Arrays.asList(new IdentifierValue("foo_view"), new IdentifierValue("bar_view")),
-                new ConfigurationProperties(new Properties())), is(Arrays.asList("Foo_View", "Bar_View")));
+        assertThat(TableRefreshUtils.getActualViewNames(database, "foo_schema", Arrays.asList(new IdentifierValue("foo_view"), new IdentifierValue("bar_view"))),
+                is(Arrays.asList("Foo_View", "Bar_View")));
     }
     
     @Test


### PR DESCRIPTION

Changes proposed in this pull request:
  - Remove the useless props parameter for TableRefreshUtils

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
