### PR TITLE
Remove the useless annotations of ShardingSphereSchema

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchema.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereSchema.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.infra.metadata.database.schema.model;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
@@ -47,16 +46,12 @@ public final class ShardingSphereSchema {
     @Getter
     private final DatabaseType protocolType;
     
-    @Getter(AccessLevel.NONE)
     private DatabaseIdentifierContext identifierContext;
     
-    @Getter(AccessLevel.NONE)
     private IdentifierIndex<ShardingSphereTable> tableIndex;
     
-    @Getter(AccessLevel.NONE)
     private IdentifierIndex<ShardingSphereTable> logicalTableIndex;
     
-    @Getter(AccessLevel.NONE)
     private IdentifierIndex<ShardingSphereView> viewIndex;
     
     /**


### PR DESCRIPTION

Changes proposed in this pull request:
  - Remove the useless annotations of ShardingSphereSchema

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
