### PR TITLE
Use actual schema to instead of lowercase schema for federation

### DIFF
--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/FederationMetaDataRefreshEngine.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/FederationMetaDataRefreshEngine.java
@@ -64,7 +64,7 @@ public final class FederationMetaDataRefreshEngine {
             return;
         }
         refresher.get().refresh(metaDataManagerPersistService, sqlStatementContext.getSqlStatement().getDatabaseType(),
-                database, SchemaRefreshUtils.getSchemaName(database, sqlStatementContext), sqlStatementContext.getSqlStatement());
+                database, SchemaRefreshUtils.getActualSchemaName(database, sqlStatementContext), sqlStatementContext.getSqlStatement());
     }
     
     @SuppressWarnings("rawtypes")

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/util/SchemaRefreshUtils.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/util/SchemaRefreshUtils.java
@@ -40,17 +40,6 @@ import java.util.Optional;
 public final class SchemaRefreshUtils {
     
     /**
-     * Get schema name.
-     *
-     * @param database database
-     * @param sqlStatementContext SQL statement context
-     * @return schema name
-     */
-    public static String getSchemaName(final ShardingSphereDatabase database, final SQLStatementContext sqlStatementContext) {
-        return getRawSchemaName(database, sqlStatementContext).getValue().toLowerCase();
-    }
-    
-    /**
      * Get actual schema name.
      *
      * @param database database

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/federation/FederationMetaDataRefreshEngineTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/federation/FederationMetaDataRefreshEngineTest.java
@@ -88,7 +88,7 @@ class FederationMetaDataRefreshEngineTest {
         when(sqlStatementContext.getSqlStatement()).thenReturn(sqlStatement);
         FederationMetaDataRefresher<CreateViewStatement> refresher = mock(FederationMetaDataRefresher.class);
         when(TypedSPILoader.findService(FederationMetaDataRefresher.class, CreateViewStatement.class)).thenReturn(Optional.of(refresher));
-        when(SchemaRefreshUtils.getSchemaName(database, sqlStatementContext)).thenReturn("foo_schema");
+        when(SchemaRefreshUtils.getActualSchemaName(database, sqlStatementContext)).thenReturn("foo_schema");
         new FederationMetaDataRefreshEngine(sqlStatementContext).refresh(metaDataManagerPersistService, database);
         verify(refresher).refresh(metaDataManagerPersistService, databaseType, database, "foo_schema", sqlStatement);
     }
@@ -99,7 +99,7 @@ class FederationMetaDataRefreshEngineTest {
         when(sqlStatementContext.getSqlStatement()).thenReturn(sqlStatement);
         FederationMetaDataRefresher<AlterViewStatement> refresher = mock(FederationMetaDataRefresher.class);
         when(TypedSPILoader.findService(FederationMetaDataRefresher.class, AlterViewStatement.class)).thenReturn(Optional.of(refresher));
-        when(SchemaRefreshUtils.getSchemaName(database, sqlStatementContext)).thenReturn("bar_schema");
+        when(SchemaRefreshUtils.getActualSchemaName(database, sqlStatementContext)).thenReturn("bar_schema");
         new FederationMetaDataRefreshEngine(sqlStatementContext).refresh(metaDataManagerPersistService, database);
         verify(refresher).refresh(metaDataManagerPersistService, databaseType, database, "bar_schema", sqlStatement);
     }
@@ -117,7 +117,7 @@ class FederationMetaDataRefreshEngineTest {
         when(sqlStatementContext.getSqlStatement()).thenReturn(sqlStatement);
         FederationMetaDataRefresher<CreateViewStatement> refresher = mock(FederationMetaDataRefresher.class);
         when(TypedSPILoader.findService(FederationMetaDataRefresher.class, CreateViewStatement.class)).thenReturn(Optional.of(refresher));
-        when(SchemaRefreshUtils.getSchemaName(database, sqlStatementContext)).thenReturn("foo_schema");
+        when(SchemaRefreshUtils.getActualSchemaName(database, sqlStatementContext)).thenReturn("foo_schema");
         FederationMetaDataRefreshEngine engine = new FederationMetaDataRefreshEngine(sqlStatementContext);
         engine.refresh(metaDataManagerPersistService, database);
         engine.refresh(metaDataManagerPersistService, database);

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/SchemaRefreshUtilsTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/SchemaRefreshUtilsTest.java
@@ -50,16 +50,6 @@ class SchemaRefreshUtilsTest {
     private final DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
     
     @Test
-    void assertGetSchemaNameWithSchemaFromContext() {
-        assertThat(SchemaRefreshUtils.getSchemaName(createDatabase(), createSQLStatementContextWithSchema("Foo_Schema")), is("foo_schema"));
-    }
-    
-    @Test
-    void assertGetSchemaNameWithDefaultSchema() {
-        assertThat(SchemaRefreshUtils.getSchemaName(createDatabase(), createSQLStatementContextWithoutSchema()), is("foo_db"));
-    }
-    
-    @Test
     void assertGetActualSchemaNameWithInsensitiveProps() {
         assertThat(SchemaRefreshUtils.getActualSchemaName(createDatabase(), new IdentifierValue("Foo_Schema")), is("foo_schema"));
     }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Use actual schema to instead of lowercase schema for federation

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
