### PR TITLE
Use View Identifier Policy for Federation View Refreshes

### DIFF
--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/AlterViewFederationMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/AlterViewFederationMetaDataRefresher.java
@@ -38,7 +38,7 @@ public final class AlterViewFederationMetaDataRefresher implements FederationMet
     @Override
     public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService,
                         final DatabaseType databaseType, final ShardingSphereDatabase database, final String schemaName, final AlterViewStatement sqlStatement) {
-        String viewName = TableRefreshUtils.getTableName(sqlStatement.getView().getTableName().getIdentifier(), databaseType);
+        String viewName = TableRefreshUtils.getViewLoadCandidateName(database, sqlStatement.getView().getTableName().getIdentifier());
         Optional<SimpleTableSegment> renameView = sqlStatement.getRenameView();
         Collection<ShardingSphereView> alteredViews = new LinkedList<>();
         Collection<String> droppedViews = new LinkedList<>();

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/AlterViewFederationMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/AlterViewFederationMetaDataRefresher.java
@@ -43,7 +43,7 @@ public final class AlterViewFederationMetaDataRefresher implements FederationMet
         Collection<ShardingSphereView> alteredViews = new LinkedList<>();
         Collection<String> droppedViews = new LinkedList<>();
         if (renameView.isPresent()) {
-            String renameViewName = renameView.get().getTableName().getIdentifier().getValue();
+            String renameViewName = TableRefreshUtils.getViewLoadCandidateName(database, renameView.get().getTableName().getIdentifier());
             String originalView = database.getSchema(schemaName).getView(viewName).getViewDefinition();
             alteredViews.add(new ShardingSphereView(renameViewName, originalView));
             droppedViews.add(viewName);

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/CreateViewFederationMetaDataRefresher.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/CreateViewFederationMetaDataRefresher.java
@@ -35,7 +35,7 @@ public final class CreateViewFederationMetaDataRefresher implements FederationMe
     @Override
     public void refresh(final MetaDataManagerPersistService metaDataManagerPersistService,
                         final DatabaseType databaseType, final ShardingSphereDatabase database, final String schemaName, final CreateViewStatement sqlStatement) {
-        String viewName = TableRefreshUtils.getTableName(sqlStatement.getView().getTableName().getIdentifier(), databaseType);
+        String viewName = TableRefreshUtils.getViewLoadCandidateName(database, sqlStatement.getView().getTableName().getIdentifier());
         metaDataManagerPersistService.alterViews(database, schemaName, Collections.singleton(new ShardingSphereView(viewName, sqlStatement.getViewDefinition())));
     }
     

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtils.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtils.java
@@ -24,8 +24,6 @@ import org.apache.shardingsphere.database.connector.core.metadata.database.enums
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierCasePolicy;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.IdentifierScope;
 import org.apache.shardingsphere.database.connector.core.metadata.identifier.LookupMode;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
-import org.apache.shardingsphere.database.connector.core.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -52,19 +50,6 @@ import java.util.function.Function;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class TableRefreshUtils {
-    
-    /**
-     * Get table name.
-     *
-     * @param tableIdentifierValue table identifier value
-     * @param databaseType database type
-     * @return table name
-     */
-    public static String getTableName(final IdentifierValue tableIdentifierValue, final DatabaseType databaseType) {
-        return QuoteCharacter.NONE == tableIdentifierValue.getQuoteCharacter()
-                ? new DatabaseTypeRegistry(databaseType).formatIdentifierPattern(tableIdentifierValue.getValue())
-                : tableIdentifierValue.getValue();
-    }
     
     /**
      * Get table load candidate name.

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/AlterViewFederationMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/AlterViewFederationMetaDataRefresherTest.java
@@ -18,7 +18,10 @@
 package org.apache.shardingsphere.mode.metadata.refresher.federation.type;
 
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
+import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereView;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
@@ -35,8 +38,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -45,7 +50,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AlterViewFederationMetaDataRefresherTest {
@@ -59,9 +63,6 @@ class AlterViewFederationMetaDataRefresherTest {
     @Mock
     private MetaDataManagerPersistService metaDataManagerPersistService;
     
-    @Mock
-    private ShardingSphereDatabase database;
-    
     private AlterViewStatement sqlStatement;
     
     @BeforeEach
@@ -72,8 +73,7 @@ class AlterViewFederationMetaDataRefresherTest {
     @SuppressWarnings("unchecked")
     @Test
     void assertRefreshWithRenameView() {
-        ShardingSphereSchema schema = new ShardingSphereSchema(schemaName, databaseType, Collections.emptyList(), Collections.singleton(new ShardingSphereView("foo_view", "SELECT * FROM foo_tbl")));
-        when(database.getSchema(schemaName)).thenReturn(schema);
+        ShardingSphereDatabase database = createDatabase(new ShardingSphereView("foo_view", "SELECT * FROM foo_tbl"));
         sqlStatement.setView(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("foo_view"))));
         sqlStatement.setRenameView(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("bar_view"))));
         refresher.refresh(metaDataManagerPersistService, databaseType, database, schemaName, sqlStatement);
@@ -92,6 +92,7 @@ class AlterViewFederationMetaDataRefresherTest {
     @SuppressWarnings("unchecked")
     @Test
     void assertRefreshWithViewDefinition() {
+        ShardingSphereDatabase database = createDatabase();
         sqlStatement.setView(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("foo_view"))));
         String expectedViewDefinition = "SELECT * FROM foo_tbl";
         sqlStatement.setViewDefinition(expectedViewDefinition);
@@ -106,5 +107,10 @@ class AlterViewFederationMetaDataRefresherTest {
         assertThat(actualView.getName(), is("foo_view"));
         assertThat(actualView.getViewDefinition(), is(expectedViewDefinition));
         assertTrue(droppedViewsCaptor.getValue().isEmpty());
+    }
+    
+    private ShardingSphereDatabase createDatabase(final ShardingSphereView... views) {
+        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()),
+                Collections.singleton(new ShardingSphereSchema(schemaName, databaseType, Collections.emptyList(), Arrays.asList(views))), new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/CreateViewFederationMetaDataRefresherTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/federation/type/CreateViewFederationMetaDataRefresherTest.java
@@ -18,7 +18,11 @@
 package org.apache.shardingsphere.mode.metadata.refresher.federation.type;
 
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.database.resource.ResourceMetaData;
+import org.apache.shardingsphere.infra.metadata.database.rule.RuleMetaData;
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereView;
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.mode.metadata.refresher.federation.FederationMetaDataRefresher;
@@ -35,6 +39,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,9 +61,6 @@ class CreateViewFederationMetaDataRefresherTest {
     @Mock
     private MetaDataManagerPersistService metaDataManagerPersistService;
     
-    @Mock
-    private ShardingSphereDatabase database;
-    
     private CreateViewStatement sqlStatement;
     
     @BeforeEach
@@ -69,6 +72,7 @@ class CreateViewFederationMetaDataRefresherTest {
     @Test
     void assertRefresh() {
         String schemaName = "foo_schema";
+        ShardingSphereDatabase database = createDatabase(schemaName);
         sqlStatement.setView(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("foo_view"))));
         String expectedViewDefinition = "SELECT * FROM foo_tbl";
         sqlStatement.setViewDefinition(expectedViewDefinition);
@@ -81,5 +85,10 @@ class CreateViewFederationMetaDataRefresherTest {
         ShardingSphereView actualView = alteredViews.iterator().next();
         assertThat(actualView.getName(), is("foo_view"));
         assertThat(actualView.getViewDefinition(), is(expectedViewDefinition));
+    }
+    
+    private ShardingSphereDatabase createDatabase(final String schemaName) {
+        return new ShardingSphereDatabase("foo_db", databaseType, new ResourceMetaData(Collections.emptyMap()), new RuleMetaData(Collections.emptyList()),
+                Collections.singleton(new ShardingSphereSchema(schemaName, databaseType, Collections.emptyList(), Collections.emptyList())), new ConfigurationProperties(new Properties()));
     }
 }

--- a/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtilsTest.java
+++ b/mode/core/src/test/java/org/apache/shardingsphere/mode/metadata/refresher/util/TableRefreshUtilsTest.java
@@ -17,10 +17,6 @@
 
 package org.apache.shardingsphere.mode.metadata.refresher.util;
 
-import org.apache.shardingsphere.database.connector.core.metadata.database.enums.QuoteCharacter;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.DialectDatabaseMetaData;
-import org.apache.shardingsphere.database.connector.core.metadata.database.metadata.option.IdentifierPatternType;
-import org.apache.shardingsphere.database.connector.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.database.connector.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
@@ -42,57 +38,23 @@ import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.Iden
 import org.apache.shardingsphere.test.infra.framework.extension.mock.AutoMockExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.MockedStatic;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Properties;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(AutoMockExtension.class)
 class TableRefreshUtilsTest {
     
     private final DatabaseType fixtureDatabaseType = TypedSPILoader.getService(DatabaseType.class, "FIXTURE");
-    
-    @Test
-    void assertGetTableNameFormatsWithIdentifierPattern() {
-        assertThat(TableRefreshUtils.getTableName(new IdentifierValue("Foo_Table"), fixtureDatabaseType), is("Foo_Table"));
-    }
-    
-    @Test
-    void assertGetTableNameWithQuotedIdentifierReturnsOriginal() {
-        assertThat(TableRefreshUtils.getTableName(new IdentifierValue("FooTable", QuoteCharacter.QUOTE), fixtureDatabaseType), is("FooTable"));
-    }
-    
-    @Test
-    void assertGetTableNameFormatsUpperCase() {
-        DatabaseType upperCaseDatabaseType = mock(DatabaseType.class);
-        DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class);
-        when(dialectDatabaseMetaData.getIdentifierPatternType()).thenReturn(IdentifierPatternType.UPPER_CASE);
-        try (MockedStatic<DatabaseTypedSPILoader> mockedStatic = mockStatic(DatabaseTypedSPILoader.class)) {
-            mockedStatic.when(() -> DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, upperCaseDatabaseType)).thenReturn(dialectDatabaseMetaData);
-            assertThat(TableRefreshUtils.getTableName(new IdentifierValue("foo_table"), upperCaseDatabaseType), is("FOO_TABLE"));
-        }
-    }
-    
-    @Test
-    void assertGetTableNameFormatsLowerCase() {
-        DatabaseType lowerCaseDatabaseType = mock(DatabaseType.class);
-        DialectDatabaseMetaData dialectDatabaseMetaData = mock(DialectDatabaseMetaData.class);
-        when(dialectDatabaseMetaData.getIdentifierPatternType()).thenReturn(IdentifierPatternType.LOWER_CASE);
-        try (MockedStatic<DatabaseTypedSPILoader> mockedStatic = mockStatic(DatabaseTypedSPILoader.class)) {
-            mockedStatic.when(() -> DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, lowerCaseDatabaseType)).thenReturn(dialectDatabaseMetaData);
-            assertThat(TableRefreshUtils.getTableName(new IdentifierValue("Foo_Table"), lowerCaseDatabaseType), is("foo_table"));
-        }
-    }
     
     @Test
     void assertGetActualTableNameUsesExistingTableName() {


### PR DESCRIPTION

Changes proposed in this pull request:
  - Use View Identifier Policy for Federation View Refreshes

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
