### PR TITLE
Deprecated the useless constructor of ShardingSphereMetaData

### DIFF
--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/fixture/EncryptGeneratorFixtureBuilder.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/fixture/EncryptGeneratorFixtureBuilder.java
@@ -113,7 +113,7 @@ public final class EncryptGeneratorFixtureBuilder {
     public static InsertStatementContext createInsertStatementContext(final List<Object> params) {
         ShardingSphereDatabase database = createDatabase();
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()),
-                new RuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()));
+                new RuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()), database.getProtocolType());
         InsertStatementContext result = new InsertStatementContext(createInsertStatement(), metaData, "foo_db");
         result.bindParameters(params);
         return result;
@@ -227,7 +227,7 @@ public final class EncryptGeneratorFixtureBuilder {
     public static InsertStatementContext createInsertSelectStatementContext(final boolean containsInsertColumns) {
         ShardingSphereDatabase database = createDatabase();
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singleton(database), new ResourceMetaData(Collections.emptyMap(), Collections.emptyMap()),
-                new RuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()));
+                new RuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()), database.getProtocolType());
         return new InsertStatementContext(createInsertSelectStatement(containsInsertColumns), metaData, "foo_db");
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/ShardingSphereMetaData.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/ShardingSphereMetaData.java
@@ -77,21 +77,14 @@ public final class ShardingSphereMetaData implements AutoCloseable {
      * @param globalResourceMetaData global resource meta data
      * @param globalRuleMetaData global rule meta data
      * @param props configuration properties
+     * @deprecated Will be deleted, currently only testing references
      */
+    @Deprecated
     public ShardingSphereMetaData(final Collection<ShardingSphereDatabase> databases, final ResourceMetaData globalResourceMetaData,
                                   final RuleMetaData globalRuleMetaData, final ConfigurationProperties props) {
         this(databases, globalResourceMetaData, globalRuleMetaData, props, resolveProtocolType(databases, props), DatabaseIdentifierContextFactory.createDefault());
     }
     
-    /**
-     * Construct metadata with protocol-aware identifier rules.
-     *
-     * @param databases databases
-     * @param globalResourceMetaData global resource meta data
-     * @param globalRuleMetaData global rule meta data
-     * @param props configuration properties
-     * @param protocolType protocol type
-     */
     public ShardingSphereMetaData(final Collection<ShardingSphereDatabase> databases, final ResourceMetaData globalResourceMetaData,
                                   final RuleMetaData globalRuleMetaData, final ConfigurationProperties props, final DatabaseType protocolType) {
         this(databases, globalResourceMetaData, globalRuleMetaData, props, protocolType, DatabaseIdentifierContextFactory.create(protocolType, props));


### PR DESCRIPTION

Changes proposed in this pull request:
  - Deprecated the useless constructor of ShardingSphereMetaData

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
